### PR TITLE
Fix comment for key event subscription

### DIFF
--- a/src/LingoEngine/Inputs/LingoKey.cs
+++ b/src/LingoEngine/Inputs/LingoKey.cs
@@ -90,7 +90,7 @@ namespace LingoEngine.Core
                 action(subscription);
         }
         /// <summary>
-        /// Subscribe to mouse events
+        /// Subscribe to key events.
         /// </summary>
         public LingoKey Subscribe(ILingoKeyEventHandler handler)
         {


### PR DESCRIPTION
## Summary
- correct the XML comment on `LingoKey.Subscribe` to clarify it is for key events

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b29c494d88332bed870f0e4a99eee