### PR TITLE
Implement SDL2 backend skeleton

### DIFF
--- a/src/LingoEngine.SDL2/Core/SdlFontManager.cs
+++ b/src/LingoEngine.SDL2/Core/SdlFontManager.cs
@@ -1,0 +1,23 @@
+using LingoEngine.FrameworkCommunication.Events;
+
+namespace LingoEngineSDL2.Core;
+
+internal class SdlFontManager : ILingoFontManager
+{
+    private readonly List<(string Name,string FileName)> _fontsToLoad = new();
+    private readonly Dictionary<string, object> _loadedFonts = new();
+    public ILingoFontManager AddFont(string name, string pathAndName)
+    {
+        _fontsToLoad.Add((name, pathAndName));
+        return this;
+    }
+    public void LoadAll()
+    {
+        foreach(var font in _fontsToLoad)
+            _loadedFonts[font.Name] = font.FileName; // placeholder
+        _fontsToLoad.Clear();
+    }
+    public T? Get<T>(string name) where T:class
+        => _loadedFonts.TryGetValue(name, out var f) ? f as T : null;
+    public object GetTyped(string name) => _loadedFonts[name];
+}

--- a/src/LingoEngine.SDL2/Core/SdlFrameworkMemberEmpty.cs
+++ b/src/LingoEngine.SDL2/Core/SdlFrameworkMemberEmpty.cs
@@ -1,0 +1,14 @@
+using LingoEngine.FrameworkCommunication;
+
+namespace LingoEngineSDL2.Core;
+
+public class SdlFrameworkMemberEmpty : ILingoFrameworkMemberEmpty
+{
+    public bool IsLoaded => true;
+    public void CopyToClipboard() { }
+    public void Erase() { }
+    public void ImportFileInto() { }
+    public void PasteClipboardInto() { }
+    public void Preload() { }
+    public void Unload() { }
+}

--- a/src/LingoEngine.SDL2/LingoEngine.SDL2.csproj
+++ b/src/LingoEngine.SDL2/LingoEngine.SDL2.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\LingoEngine\LingoEngine.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/LingoEngine.SDL2/Movies/SdlMovie.cs
+++ b/src/LingoEngine.SDL2/Movies/SdlMovie.cs
@@ -1,0 +1,50 @@
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Movies;
+using LingoEngine.Primitives;
+
+namespace LingoEngineSDL2.Movies;
+
+public class SdlMovie : ILingoFrameworkMovie, IDisposable
+{
+    private readonly SdlStage _stage;
+    private readonly Action<SdlMovie> _removeMethod;
+    private readonly HashSet<SdlSprite> _drawnSprites = new();
+    private readonly HashSet<SdlSprite> _allSprites = new();
+    private LingoMovie _movie;
+
+    public SdlMovie(SdlStage stage, LingoMovie movie, Action<SdlMovie> removeMethod)
+    {
+        _stage = stage;
+        _movie = movie;
+        _removeMethod = removeMethod;
+        stage.ShowMovie(this);
+    }
+
+    internal void Show() => _stage.ShowMovie(this);
+    internal void Hide() => _stage.HideMovie(this);
+
+    public void UpdateStage()
+    {
+        foreach(var s in _drawnSprites)
+            s.Update();
+    }
+
+    internal void CreateSprite<T>(T lingoSprite) where T : LingoSprite
+    {
+        var sprite = new SdlSprite(lingoSprite, s => _drawnSprites.Add(s), s => _drawnSprites.Remove(s), s => { _drawnSprites.Remove(s); _allSprites.Remove(s); });
+        _allSprites.Add(sprite);
+    }
+
+    public void RemoveMe()
+    {
+        _removeMethod(this);
+    }
+
+    LingoPoint ILingoFrameworkMovie.GetGlobalMousePosition() => (0,0);
+
+    public void Dispose()
+    {
+        Hide();
+        RemoveMe();
+    }
+}

--- a/src/LingoEngine.SDL2/Movies/SdlStage.cs
+++ b/src/LingoEngine.SDL2/Movies/SdlStage.cs
@@ -1,0 +1,42 @@
+using LingoEngine.Core;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Movies;
+
+namespace LingoEngineSDL2.Movies;
+
+public class SdlStage : ILingoFrameworkStage, IDisposable
+{
+    private readonly LingoClock _clock;
+    private LingoStage _stage = null!;
+    private SdlMovie? _activeMovie;
+
+    public SdlStage(LingoClock clock)
+    {
+        _clock = clock;
+    }
+
+    internal void Init(LingoStage stage)
+    {
+        _stage = stage;
+    }
+
+    internal void ShowMovie(SdlMovie movie)
+    {
+        // TODO: add to SDL window
+    }
+    internal void HideMovie(SdlMovie movie)
+    {
+        // TODO: remove from SDL window
+    }
+
+    public void SetActiveMovie(LingoMovie? lingoMovie)
+    {
+        _activeMovie?.Hide();
+        if (lingoMovie == null) { _activeMovie = null; return; }
+        var movie = lingoMovie.Framework<SdlMovie>();
+        _activeMovie = movie;
+        movie.Show();
+    }
+
+    public void Dispose() { }
+}

--- a/src/LingoEngine.SDL2/Pictures/SdlMemberPicture.cs
+++ b/src/LingoEngine.SDL2/Pictures/SdlMemberPicture.cs
@@ -1,0 +1,27 @@
+using LingoEngine.Pictures;
+using LingoEngine.Pictures.LingoEngine;
+
+namespace LingoEngineSDL2.Pictures;
+
+public class SdlMemberPicture : ILingoFrameworkMemberPicture, IDisposable
+{
+    private LingoMemberPicture _member = null!;
+    public byte[]? ImageData { get; private set; }
+    public bool IsLoaded { get; private set; }
+    public string Format { get; private set; } = "image/unknown";
+    public int Width { get; private set; }
+    public int Height { get; private set; }
+
+    internal void Init(LingoMemberPicture member)
+    {
+        _member = member;
+    }
+
+    public void Preload() { IsLoaded = true; }
+    public void Unload() { IsLoaded = false; }
+    public void Erase() { Unload(); ImageData = null; }
+    public void Dispose() { }
+    public void CopyToClipboard() { }
+    public void ImportFileInto() { }
+    public void PasteClipboardInto() { }
+}

--- a/src/LingoEngine.SDL2/SdlFactory.cs
+++ b/src/LingoEngine.SDL2/SdlFactory.cs
@@ -1,0 +1,137 @@
+using LingoEngine.Core;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Movies;
+using LingoEngine.Pictures;
+using LingoEngine.Pictures.LingoEngine;
+using LingoEngine.Primitives;
+using LingoEngine.Sounds;
+using LingoEngine.Texts;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LingoEngineSDL2;
+
+public class SdlFactory : ILingoFrameworkFactory, IDisposable
+{
+    private readonly List<IDisposable> _disposables = new();
+    private readonly IServiceProvider _serviceProvider;
+
+    public SdlFactory(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public T CreateBehavior<T>(LingoMovie movie) where T : LingoSpriteBehavior
+        => movie.GetServiceProvider().GetRequiredService<T>();
+    public T CreateMovieScript<T>(LingoMovie movie) where T : LingoMovieScript
+        => movie.GetServiceProvider().GetRequiredService<T>();
+
+    #region Sound
+    public LingoSound CreateSound(ILingoCastLibsContainer castLibsContainer)
+    {
+        var impl = new SdlSound();
+        var sound = new LingoSound(impl, castLibsContainer, this);
+        impl.Init(sound);
+        return sound;
+    }
+    public LingoSoundChannel CreateSoundChannel(int number)
+    {
+        var impl = new SdlSoundChannel(number);
+        var channel = new LingoSoundChannel(impl, number);
+        impl.Init(channel);
+        _disposables.Add(impl);
+        return channel;
+    }
+    #endregion
+
+    #region Members
+    public T CreateMember<T>(ILingoCast cast, int numberInCast, string name = "") where T : LingoMember
+    {
+        return typeof(T) switch
+        {
+            Type t when t == typeof(LingoMemberPicture) => (CreateMemberPicture(cast, numberInCast, name) as T)!,
+            Type t when t == typeof(LingoMemberText) => (CreateMemberText(cast, numberInCast, name) as T)!,
+            Type t when t == typeof(LingoMemberField) => (CreateMemberField(cast, numberInCast, name) as T)!,
+            Type t when t == typeof(LingoMemberSound) => (CreateMemberSound(cast, numberInCast, name) as T)!,
+            _ => throw new NotSupportedException()
+        };
+    }
+    public LingoMemberSound CreateMemberSound(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default)
+    {
+        var impl = new SdlMemberSound();
+        var member = new LingoMemberSound(impl, (LingoCast)cast, numberInCast, name, fileName ?? "");
+        impl.Init(member);
+        _disposables.Add(impl);
+        return member;
+    }
+    public LingoMemberPicture CreateMemberPicture(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default)
+    {
+        var impl = new SdlMemberPicture();
+        var member = new LingoMemberPicture((LingoCast)cast, impl, numberInCast, name, fileName ?? "", regPoint);
+        impl.Init(member);
+        _disposables.Add(impl);
+        return member;
+    }
+    public LingoMemberField CreateMemberField(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default)
+    {
+        var impl = new SdlMemberField(new SdlFontManager());
+        var member = new LingoMemberField((LingoCast)cast, impl, numberInCast, name, fileName ?? "", regPoint);
+        impl.Init(member);
+        _disposables.Add(impl);
+        return member;
+    }
+    public LingoMemberText CreateMemberText(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default)
+    {
+        var impl = new SdlMemberText(new SdlFontManager());
+        var member = new LingoMemberText((LingoCast)cast, impl, numberInCast, name, fileName ?? "", regPoint);
+        impl.Init(member);
+        _disposables.Add(impl);
+        return member;
+    }
+    public LingoMember CreateEmpty(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default)
+    {
+        var impl = new SdlFrameworkMemberEmpty();
+        var member = new LingoMember(impl, LingoMemberType.Empty, (LingoCast)cast, numberInCast, name, fileName ?? "", regPoint);
+        return member;
+    }
+    #endregion
+
+    public LingoStage CreateStage(LingoClock clock)
+    {
+        var impl = new SdlStage(clock);
+        var stage = new LingoStage(impl);
+        impl.Init(stage);
+        _disposables.Add(impl);
+        return stage;
+    }
+    public LingoMovie AddMovie(LingoStage stage, LingoMovie movie)
+    {
+        var sdlStage = stage.Framework<SdlStage>();
+        var impl = new SdlMovie(sdlStage, movie, m => _disposables.Remove(m));
+        movie.Init(impl);
+        _disposables.Add(impl);
+        return movie;
+    }
+
+    public T CreateSprite<T>(ILingoMovie movie, Action<LingoSprite> onRemoveMe) where T : LingoSprite
+    {
+        var movieTyped = (LingoMovie)movie;
+        var sprite = movieTyped.GetServiceProvider().GetRequiredService<T>();
+        sprite.SetOnRemoveMe(onRemoveMe);
+        movieTyped.Framework<SdlMovie>().CreateSprite(sprite);
+        return sprite;
+    }
+
+    public void Dispose()
+    {
+        foreach(var d in _disposables)
+            d.Dispose();
+    }
+
+    public LingoMouse CreateMouse(LingoStage stage)
+    {
+        var mouseImpl = new SdlMouse(new Lazy<LingoMouse>(() => null!));
+        var mouse = new LingoMouse(stage, mouseImpl);
+        mouseImpl.SetLingoMouse(mouse);
+        return mouse;
+    }
+}

--- a/src/LingoEngine.SDL2/SdlMouse.cs
+++ b/src/LingoEngine.SDL2/SdlMouse.cs
@@ -1,0 +1,21 @@
+using LingoEngine.Core;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Pictures.LingoEngine;
+
+namespace LingoEngineSDL2;
+
+public class SdlMouse : ILingoFrameworkMouse
+{
+    private Lazy<LingoMouse> _lingoMouse;
+
+    public SdlMouse(Lazy<LingoMouse> mouse)
+    {
+        _lingoMouse = mouse;
+    }
+
+    internal void SetLingoMouse(LingoMouse mouse) => _lingoMouse = new Lazy<LingoMouse>(() => mouse);
+
+    public void HideMouse(bool state) { }
+    public void SetCursor(LingoMemberPicture image) { }
+    public void SetCursor(LingoMouseCursor value) { }
+}

--- a/src/LingoEngine.SDL2/SdlRootContext.cs
+++ b/src/LingoEngine.SDL2/SdlRootContext.cs
@@ -1,0 +1,13 @@
+namespace LingoEngineSDL2;
+
+public class SdlRootContext
+{
+    public IntPtr Window { get; }
+    public IntPtr Renderer { get; }
+
+    public SdlRootContext(IntPtr window, IntPtr renderer)
+    {
+        Window = window;
+        Renderer = renderer;
+    }
+}

--- a/src/LingoEngine.SDL2/SdlSetup.cs
+++ b/src/LingoEngine.SDL2/SdlSetup.cs
@@ -1,0 +1,19 @@
+using LingoEngine;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.FrameworkCommunication.Events;
+using LingoEngineSDL2.Core;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LingoEngineSDL2;
+
+public static class SdlSetup
+{
+    public static ILingoEngineRegistration WithLingoSdlEngine(this ILingoEngineRegistration reg, Action<SdlFactory>? setup = null)
+    {
+        reg.Services(s => s
+            .AddSingleton<ILingoFrameworkFactory, SdlFactory>()
+            .AddSingleton<ILingoFontManager, SdlFontManager>()
+        ).WithFrameworkFactory(setup);
+        return reg;
+    }
+}

--- a/src/LingoEngine.SDL2/SdlSprite.cs
+++ b/src/LingoEngine.SDL2/SdlSprite.cs
@@ -1,0 +1,51 @@
+using LingoEngine.Core;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Movies;
+using LingoEngine.Pictures.LingoEngine;
+using LingoEngine.Primitives;
+using LingoEngine.Texts;
+
+namespace LingoEngineSDL2;
+
+public class SdlSprite : ILingoFrameworkSprite, IDisposable
+{
+    private readonly Action<SdlSprite> _show;
+    private readonly Action<SdlSprite> _hide;
+    private readonly Action<SdlSprite> _remove;
+    private readonly LingoSprite _lingoSprite;
+    internal bool IsDirty { get; set; } = true;
+    internal bool IsDirtyMember { get; set; } = true;
+
+    public SdlSprite(LingoSprite sprite, Action<SdlSprite> show, Action<SdlSprite> hide, Action<SdlSprite> remove)
+    {
+        _lingoSprite = sprite;
+        _show = show;
+        _hide = hide;
+        _remove = remove;
+        sprite.Init(this);
+        ZIndex = sprite.SpriteNum;
+    }
+
+    public bool Visibility { get; set; }
+    public float Blend { get; set; }
+    public float X { get; set; }
+    public float Y { get; set; }
+    public float Width { get; private set; }
+    public float Height { get; private set; }
+    public string Name { get; set; } = string.Empty;
+    public LingoPoint RegPoint { get; set; }
+    public float SetDesiredHeight { get; set; }
+    public float SetDesiredWidth { get; set; }
+    public int ZIndex { get; set; }
+
+    public void RemoveMe() { _remove(this); Dispose(); }
+    public void Dispose() { }
+    public void Show() { _show(this); Update(); }
+    public void Hide() { _hide(this); }
+    public void SetPosition(LingoPoint point) { X = point.X; Y = point.Y; }
+
+    public void MemberChanged() { IsDirtyMember = true; }
+
+    internal void Update() { }
+    public void Resize(float w, float h) { Width = w; Height = h; }
+}

--- a/src/LingoEngine.SDL2/Sounds/SdlMemberSound.cs
+++ b/src/LingoEngine.SDL2/Sounds/SdlMemberSound.cs
@@ -1,0 +1,22 @@
+using LingoEngine.Sounds;
+
+namespace LingoEngineSDL2.Sounds;
+
+public class SdlMemberSound : ILingoFrameworkMemberSound, IDisposable
+{
+    private LingoMemberSound _member = null!;
+    public bool Stereo { get; private set; }
+    public double Length { get; private set; }
+    internal void Init(LingoMemberSound member)
+    {
+        _member = member;
+    }
+    public void Dispose() { }
+    public void CopyToClipboard() { }
+    public void Erase() { }
+    public void ImportFileInto() { }
+    public void PasteClipboardInto() { }
+    public void Preload() { }
+    public void Unload() { }
+    public bool IsLoaded => true;
+}

--- a/src/LingoEngine.SDL2/Sounds/SdlSound.cs
+++ b/src/LingoEngine.SDL2/Sounds/SdlSound.cs
@@ -1,0 +1,22 @@
+using LingoEngine.Sounds;
+
+namespace LingoEngineSDL2.Sounds;
+
+public class SdlSound : ILingoFrameworkSound
+{
+    private LingoSound _lingoSound = null!;
+    private readonly List<LingoSoundDevice> _devices = new();
+
+    public List<LingoSoundDevice> SoundDeviceList => _devices;
+    public int SoundLevel { get; set; }
+    public bool SoundEnable { get; set; } = true;
+
+    internal void Init(LingoSound sound)
+    {
+        _lingoSound = sound;
+    }
+
+    public void Beep() { }
+    public LingoSoundChannel Channel(int number) => _lingoSound.Channel(number);
+    public void UpdateDeviceList() { }
+}

--- a/src/LingoEngine.SDL2/Sounds/SdlSoundChannel.cs
+++ b/src/LingoEngine.SDL2/Sounds/SdlSoundChannel.cs
@@ -1,0 +1,36 @@
+using LingoEngine.Sounds;
+
+namespace LingoEngineSDL2.Sounds;
+
+public class SdlSoundChannel : ILingoFrameworkSoundChannel, IDisposable
+{
+    private LingoSoundChannel _channel = null!;
+    public int ChannelNumber { get; }
+    public int SampleRate => 44100;
+    public int Volume { get; set; }
+    public int Pan { get; set; }
+    public float CurrentTime { get; set; }
+    public bool IsPlaying { get; private set; }
+    public int ChannelCount => 2;
+    public int SampleCount => 0;
+    public float ElapsedTime => CurrentTime;
+    public float StartTime { get; set; }
+    public float EndTime { get; set; }
+
+    public SdlSoundChannel(int number)
+    {
+        ChannelNumber = number;
+    }
+    internal void Init(LingoSoundChannel channel)
+    {
+        _channel = channel;
+    }
+
+    public void PlayFile(string stringFilePath) { IsPlaying = true; }
+    public void PlayNow(LingoMemberSound member) { IsPlaying = true; }
+    public void Stop() { IsPlaying = false; }
+    public void Rewind() { CurrentTime = 0; }
+    public void Pause() { IsPlaying = !IsPlaying; }
+    public void Repeat() { CurrentTime = StartTime; IsPlaying = true; }
+    public void Dispose() { }
+}

--- a/src/LingoEngine.SDL2/Texts/SdlLabelExtensions.cs
+++ b/src/LingoEngine.SDL2/Texts/SdlLabelExtensions.cs
@@ -1,0 +1,12 @@
+using LingoEngine.FrameworkCommunication.Events;
+using LingoEngine.Primitives;
+
+namespace LingoEngineSDL2.Texts;
+
+public static class SdlLabelExtensions
+{
+    public static object SetLingoFont(this object label, ILingoFontManager manager, string fontName) => label;
+    public static object SetLingoFontSize(this object label, int size) => label;
+    public static object SetLingoColor(this object label, LingoColor color) => label;
+    public static LingoColor GetLingoColor(this object label) => LingoColor.FromRGB(0,0,0);
+}

--- a/src/LingoEngine.SDL2/Texts/SdlMemberField.cs
+++ b/src/LingoEngine.SDL2/Texts/SdlMemberField.cs
@@ -1,0 +1,8 @@
+using LingoEngine.Texts;
+
+namespace LingoEngineSDL2.Texts;
+
+public class SdlMemberField : SdlMemberTextBase<LingoMemberField>, ILingoFrameworkMemberField
+{
+    public SdlMemberField(ILingoFontManager fontManager) : base(fontManager) { }
+}

--- a/src/LingoEngine.SDL2/Texts/SdlMemberText.cs
+++ b/src/LingoEngine.SDL2/Texts/SdlMemberText.cs
@@ -1,0 +1,8 @@
+using LingoEngine.Texts;
+
+namespace LingoEngineSDL2.Texts;
+
+public class SdlMemberText : SdlMemberTextBase<LingoMemberText>, ILingoFrameworkMemberText
+{
+    public SdlMemberText(ILingoFontManager fontManager) : base(fontManager) { }
+}

--- a/src/LingoEngine.SDL2/Texts/SdlMemberTextBase.cs
+++ b/src/LingoEngine.SDL2/Texts/SdlMemberTextBase.cs
@@ -1,0 +1,45 @@
+using LingoEngine.FrameworkCommunication.Events;
+using LingoEngine.Primitives;
+using LingoEngine.Texts;
+
+namespace LingoEngineSDL2.Texts;
+
+public abstract class SdlMemberTextBase<TText> : ILingoFrameworkMemberTextBase, IDisposable where TText : ILingoMemberTextBase
+{
+    protected TText _lingoMemberText = default!;
+    protected string _text = string.Empty;
+    protected ILingoFontManager _fontManager;
+
+    protected SdlMemberTextBase(ILingoFontManager fontManager)
+    {
+        _fontManager = fontManager;
+    }
+
+    internal void Init(TText member)
+    {
+        _lingoMemberText = member;
+    }
+
+    public string Text { get => _text; set => _text = value; }
+    public bool WordWrap { get; set; }
+    public int ScrollTop { get; set; }
+    public string FontName { get; set; } = string.Empty;
+    public int FontSize { get; set; }
+    public LingoTextStyle FontStyle { get; set; }
+    public LingoColor TextColor { get; set; } = LingoColor.FromRGB(0,0,0);
+    public LingoTextAlignment Alignment { get; set; }
+    public int Margin { get; set; }
+    public bool IsLoaded { get; private set; }
+
+    public void Dispose() { }
+    public void Copy(string text) { }
+    public string PasteClipboard() => string.Empty;
+    public string ReadText() => string.Empty;
+    public string ReadTextRtf() => string.Empty;
+    public void CopyToClipboard() { }
+    public void Erase() { }
+    public void ImportFileInto() { }
+    public void PasteClipboardInto() { }
+    public void Preload() { IsLoaded = true; }
+    public void Unload() { IsLoaded = false; }
+}


### PR DESCRIPTION
## Summary
- scaffold `LingoEngine.SDL2` project with SDL2-based framework classes
- add `SdlFactory` implementing `ILingoFrameworkFactory`
- create placeholder implementations for stage, movie, sprite, mouse, sounds, text and picture members
- expose setup helper `SdlSetup` and add project reference to `LingoEngine`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684bb1d77d348332a31942146bb23980