### PR TITLE
Add SDL and Godot debug overlay

### DIFF
--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/Scenes/RootNodeTetriGrounds.cs
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/Scenes/RootNodeTetriGrounds.cs
@@ -1,6 +1,8 @@
 using Godot;
 using LingoEngine.Demo.TetriGrounds.Core;
 using LingoEngine.Godot;
+using LingoEngine.Godot.Movies;
+using LingoEngine.Movies;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 
@@ -43,8 +45,8 @@ public partial class RootNodeTetriGrounds : Node2D
             var serviePrider = _services.BuildServiceProvider();
 
             var movie = TetriGroundsSetup.SetupGame(serviePrider);
-            //_controller = new LingoGodotPlayerControler((Node2D)serviePrider.GetRequiredService<LingoGodotRootNode>().RootNode, movie);
-            TetriGroundsSetup.StartGame(serviePrider);
+            var game = TetriGroundsSetup.StartGame(serviePrider);
+            game.LingoPlayer.Stage.Framework<LingoGodotStage>().SetPlayer(game.LingoPlayer);
         }
         catch (Exception ex)
         {

--- a/src/LingoEngine.Godot/Core/LingoGodotDebugOverlay.cs
+++ b/src/LingoEngine.Godot/Core/LingoGodotDebugOverlay.cs
@@ -1,0 +1,47 @@
+using Godot;
+using LingoEngine.FrameworkCommunication;
+using System.Collections.Generic;
+
+namespace LingoEngine.Godot.Core;
+
+public partial class LingoGodotDebugOverlay : CanvasLayer, ILingoFrameworkDebugOverlay
+{
+    private readonly List<Label> _labels = new();
+    private int _index;
+
+    public LingoGodotDebugOverlay(Node root)
+    {
+        Name = "DebugOverlay";
+        root.AddChild(this);
+    }
+
+    public void Begin()
+    {
+        _index = 0;
+    }
+
+    public void RenderLine(int x, int y, string text)
+    {
+        Label label;
+        if (_labels.Count <= _index)
+        {
+            label = new Label();
+            AddChild(label);
+            _labels.Add(label);
+        }
+        else
+        {
+            label = _labels[_index];
+            label.Visible = true;
+        }
+        label.Position = new Vector2(x, y);
+        label.Text = text;
+        _index++;
+    }
+
+    public void End()
+    {
+        for (int i = _index; i < _labels.Count; i++)
+            _labels[i].Visible = false;
+    }
+}

--- a/src/LingoEngine.Godot/GodotFactory.cs
+++ b/src/LingoEngine.Godot/GodotFactory.cs
@@ -8,6 +8,7 @@ using LingoEngine.Godot.Pictures;
 using LingoEngine.Godot.Sounds;
 using LingoEngine.Godot.Texts;
 using LingoEngine.Inputs;
+using LingoEngine.Core;
 using LingoEngine.Movies;
 using LingoEngine.Pictures.LingoEngine;
 using LingoEngine.Primitives;
@@ -108,7 +109,8 @@ namespace LingoEngine.Godot
 
         public LingoStage CreateStage(LingoClock lingoClock)
         {
-            var godotInstance = new LingoGodotStage(_rootNode, lingoClock);
+            var overlay = new LingoDebugOverlay(new Core.LingoGodotDebugOverlay(_rootNode));
+            var godotInstance = new LingoGodotStage(_rootNode, lingoClock, overlay);
             var lingoInstance = new LingoStage(godotInstance);
             godotInstance.Init(lingoInstance);
             _disposables.Add(godotInstance);
@@ -147,6 +149,15 @@ namespace LingoEngine.Godot
             var godotInstance = new LingoGodotMouse(_rootNode, new Lazy<LingoMouse>(() => mouse!));
             mouse = new LingoMouse(stage, godotInstance);
             return mouse;
+        }
+
+        public LingoKey CreateKey()
+        {
+            LingoKey? key = null;
+            var impl = new LingoGodotKey(_rootNode, new Lazy<LingoKey>(() => key!));
+            key = new LingoKey(impl);
+            impl.SetLingoKey(key);
+            return key;
         }
     }
 }

--- a/src/LingoEngine.Godot/LingoGodotKey.cs
+++ b/src/LingoEngine.Godot/LingoGodotKey.cs
@@ -1,0 +1,72 @@
+using Godot;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Inputs;
+using System.Collections.Generic;
+
+namespace LingoEngine.Godot;
+
+public partial class LingoGodotKey : Node, ILingoFrameworkKey
+{
+    private readonly List<Key> _pressed = new();
+    private Lazy<LingoKey> _lingoKey;
+    private string _lastKey = string.Empty;
+    private int _lastCode;
+
+    public LingoGodotKey(Node root, Lazy<LingoKey> key)
+    {
+        Name = "KeyConnector";
+        _lingoKey = key;
+        root.AddChild(this);
+    }
+
+    internal void SetLingoKey(LingoKey key)
+    {
+        _lingoKey = new Lazy<LingoKey>(() => key);
+    }
+
+    public override void _Input(InputEvent @event)
+    {
+        if (@event is InputEventKey k)
+        {
+            if (k.Pressed)
+            {
+                if (!_pressed.Contains(k.Keycode))
+                    _pressed.Add(k.Keycode);
+                _lastCode = (int)k.Keycode;
+                _lastKey = k.KeyLabel;
+                _lingoKey.Value.DoKeyDown();
+            }
+            else
+            {
+                _pressed.Remove(k.Keycode);
+                _lastCode = (int)k.Keycode;
+                _lastKey = k.KeyLabel;
+                _lingoKey.Value.DoKeyUp();
+            }
+        }
+    }
+
+    public bool CommandDown => Input.IsKeyPressed((int)Key.Meta);
+    public bool ControlDown => Input.IsKeyPressed((int)Key.Ctrl);
+    public bool OptionDown => Input.IsKeyPressed((int)Key.Alt);
+    public bool ShiftDown => Input.IsKeyPressed((int)Key.Shift);
+
+    public bool KeyPressed(LingoKeyType key) => key switch
+    {
+        LingoKeyType.BACKSPACE => _pressed.Contains(Key.Backspace),
+        LingoKeyType.ENTER or LingoKeyType.RETURN => _pressed.Contains(Key.Enter),
+        LingoKeyType.QUOTE => _pressed.Contains(Key.Quoteleft),
+        LingoKeyType.SPACE => _pressed.Contains(Key.Space),
+        LingoKeyType.TAB => _pressed.Contains(Key.Tab),
+        _ => false
+    };
+
+    public bool KeyPressed(char key)
+        => _pressed.Contains((Key)char.ToUpperInvariant(key));
+
+    public bool KeyPressed(int keyCode)
+        => _pressed.Contains((Key)keyCode);
+
+    public string Key => _lastKey;
+    public int KeyCode => _lastCode;
+}

--- a/src/LingoEngine.Godot/Movies/LingoGodotStage.cs
+++ b/src/LingoEngine.Godot/Movies/LingoGodotStage.cs
@@ -2,6 +2,7 @@
 using LingoEngine.Core;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Movies;
+using LingoEngine.Inputs;
 
 namespace LingoEngine.Godot.Movies
 {
@@ -9,12 +10,16 @@ namespace LingoEngine.Godot.Movies
     {
         private LingoStage _LingoStage;
         private readonly LingoClock _lingoClock;
+        private readonly LingoDebugOverlay _overlay;
+        private LingoPlayer? _player;
+        private bool _f1Down;
 
         private LingoGodotMovie? _activeMovie;
 
-        public LingoGodotStage(Node rootNode, LingoClock lingoClock)
+        public LingoGodotStage(Node rootNode, LingoClock lingoClock, LingoDebugOverlay overlay)
         {
             _lingoClock = lingoClock;
+            _overlay = overlay;
             rootNode.AddChild(this);
         }
 
@@ -26,10 +31,24 @@ namespace LingoEngine.Godot.Movies
         {
             base._Process(delta);
             _lingoClock.Tick((float)delta);
+            if (_player != null)
+            {
+                _overlay.Update((float)delta, _player);
+                bool f1 = _player.Key.KeyPressed((int)Key.F1);
+                if (_player.Key.ControlDown && f1 && !_f1Down)
+                    _overlay.Toggle();
+                _f1Down = f1;
+                _overlay.Render();
+            }
         }
         internal void Init(LingoStage lingoInstance)
         {
             _LingoStage = lingoInstance;
+        }
+
+        internal void SetPlayer(LingoPlayer player)
+        {
+            _player = player;
         }
      
 
@@ -42,7 +61,7 @@ namespace LingoEngine.Godot.Movies
             RemoveChild(lingoGodotMovie.GetNode2D());
         }
 
-        public void SetActiveMovie(LingoMovie? lingoMovie)
+    public void SetActiveMovie(LingoMovie? lingoMovie)
         {
             if (_activeMovie != null)
                 _activeMovie.Hide();

--- a/src/LingoEngine.SDL2/Core/SdlDebugOverlay.cs
+++ b/src/LingoEngine.SDL2/Core/SdlDebugOverlay.cs
@@ -1,0 +1,21 @@
+using LingoEngine.SDL2.SDLL;
+using LingoEngine.FrameworkCommunication;
+
+namespace LingoEngine.SDL2.Core;
+
+internal class SdlDebugOverlay : ILingoFrameworkDebugOverlay
+{
+    private readonly nint _renderer;
+
+    public SdlDebugOverlay(nint renderer)
+    {
+        _renderer = renderer;
+    }
+
+    public void Begin() { }
+    public void RenderLine(int x, int y, string text)
+    {
+        SDL2_gfx.stringColor(_renderer, x, y, text, 0xFFFFFFFF);
+    }
+    public void End() { }
+}

--- a/src/LingoEngine.SDL2/Movies/SdlMovie.cs
+++ b/src/LingoEngine.SDL2/Movies/SdlMovie.cs
@@ -35,6 +35,7 @@ public class SdlMovie : ILingoFrameworkMovie, IDisposable
             s.Update();
             s.Render(renderer);
         }
+        _stage.RootContext.DebugOverlay.Render();
         SDL.SDL_RenderPresent(renderer);
     }
 

--- a/src/LingoEngine.SDL2/SdlFactory.cs
+++ b/src/LingoEngine.SDL2/SdlFactory.cs
@@ -142,4 +142,12 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
         mouseImpl.SetLingoMouse(mouse);
         return mouse;
     }
+
+    public LingoKey CreateKey()
+    {
+        var impl = _rootContext.Key;
+        var key = new LingoKey(impl);
+        impl.SetLingoKey(key);
+        return key;
+    }
 }

--- a/src/LingoEngine.SDL2/SdlKey.cs
+++ b/src/LingoEngine.SDL2/SdlKey.cs
@@ -1,0 +1,56 @@
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Inputs;
+using LingoEngine.SDL2.SDLL;
+using System.Collections.Generic;
+
+namespace LingoEngine.SDL2;
+
+internal class SdlKey : ILingoFrameworkKey
+{
+    private readonly HashSet<SDL.SDL_Keycode> _keys = new();
+    private LingoKey? _lingoKey;
+    private string _lastKey = string.Empty;
+    private int _lastCode;
+
+    internal void SetLingoKey(LingoKey key) => _lingoKey = key;
+
+    public void ProcessEvent(SDL.SDL_Event e)
+    {
+        if (e.type == SDL.SDL_EventType.SDL_KEYDOWN && e.key.repeat == 0)
+        {
+            _keys.Add(e.key.keysym.sym);
+            _lastCode = (int)e.key.keysym.sym;
+            _lastKey = SDL.SDL_GetKeyName(e.key.keysym.sym);
+            _lingoKey?.DoKeyDown();
+        }
+        else if (e.type == SDL.SDL_EventType.SDL_KEYUP)
+        {
+            _keys.Remove(e.key.keysym.sym);
+            _lastCode = (int)e.key.keysym.sym;
+            _lastKey = SDL.SDL_GetKeyName(e.key.keysym.sym);
+            _lingoKey?.DoKeyUp();
+        }
+    }
+
+    public bool CommandDown => (SDL.SDL_GetModState() & SDL.SDL_Keymod.KMOD_GUI) != 0;
+    public bool ControlDown => (SDL.SDL_GetModState() & SDL.SDL_Keymod.KMOD_CTRL) != 0;
+    public bool OptionDown => (SDL.SDL_GetModState() & SDL.SDL_Keymod.KMOD_ALT) != 0;
+    public bool ShiftDown => (SDL.SDL_GetModState() & SDL.SDL_Keymod.KMOD_SHIFT) != 0;
+
+    public bool KeyPressed(LingoKeyType key) => key switch
+    {
+        LingoKeyType.BACKSPACE => _keys.Contains(SDL.SDL_Keycode.SDLK_BACKSPACE),
+        LingoKeyType.ENTER or LingoKeyType.RETURN => _keys.Contains(SDL.SDL_Keycode.SDLK_RETURN),
+        LingoKeyType.QUOTE => _keys.Contains(SDL.SDL_Keycode.SDLK_QUOTE),
+        LingoKeyType.SPACE => _keys.Contains(SDL.SDL_Keycode.SDLK_SPACE),
+        LingoKeyType.TAB => _keys.Contains(SDL.SDL_Keycode.SDLK_TAB),
+        _ => false
+    };
+
+    public bool KeyPressed(char key) => _keys.Contains((SDL.SDL_Keycode)char.ToUpperInvariant(key));
+
+    public bool KeyPressed(int keyCode) => _keys.Contains((SDL.SDL_Keycode)keyCode);
+
+    public string Key => _lastKey;
+    public int KeyCode => _lastCode;
+}

--- a/src/LingoEngine.SDL2/SdlRootContext.cs
+++ b/src/LingoEngine.SDL2/SdlRootContext.cs
@@ -1,20 +1,27 @@
 namespace LingoEngine.SDL2;
 using LingoEngine.Core;
 using LingoEngine.SDL2.SDLL;
+using LingoEngine.SDL2.Core;
+using LingoEngine.Inputs;
 
 public class SdlRootContext : IDisposable
 {
     public nint Window { get; }
     public nint Renderer { get; }
+    public LingoDebugOverlay DebugOverlay { get; }
+    internal SdlKey Key { get; } = new();
+    private bool _f1Pressed;
 
     public SdlRootContext(nint window, nint renderer)
     {
         Window = window;
         Renderer = renderer;
+        DebugOverlay = new LingoDebugOverlay(new SdlDebugOverlay(renderer));
     }
     public void Run(ILingoPlayer player)
     {
-        var clock = (LingoClock)((LingoPlayer)player).Clock;
+        var lp = (LingoPlayer)player;
+        var clock = (LingoClock)lp.Clock;
         bool running = true;
         uint last = SDL.SDL_GetTicks();
         while (running)
@@ -23,10 +30,16 @@ public class SdlRootContext : IDisposable
             {
                 if (e.type == SDL.SDL_EventType.SDL_QUIT)
                     running = false;
+                Key.ProcessEvent(e);
             }
             uint now = SDL.SDL_GetTicks();
             float delta = (now - last) / 1000f;
             last = now;
+            DebugOverlay.Update(delta, lp);
+            bool f1 = lp.Key.KeyPressed((int)SDL.SDL_Keycode.SDLK_F1);
+            if (lp.Key.ControlDown && f1 && !_f1Pressed)
+                DebugOverlay.Toggle();
+            _f1Pressed = f1;
             clock.Tick(delta);
         }
         Dispose();

--- a/src/LingoEngine/Core/LingoDebugOverlay.cs
+++ b/src/LingoEngine/Core/LingoDebugOverlay.cs
@@ -1,0 +1,45 @@
+using LingoEngine.FrameworkCommunication;
+
+namespace LingoEngine.Core;
+
+public class LingoDebugOverlay
+{
+    private readonly ILingoFrameworkDebugOverlay _framework;
+    private bool _enabled;
+    private float _accum;
+    private int _frames;
+    private float _fps;
+    private LingoPlayer? _player;
+
+    public LingoDebugOverlay(ILingoFrameworkDebugOverlay framework)
+    {
+        _framework = framework;
+    }
+
+    public void Toggle() => _enabled = !_enabled;
+
+    public void Update(float deltaTime, LingoPlayer player)
+    {
+        if (!_enabled) return;
+        _player = player;
+        _accum += deltaTime;
+        _frames++;
+        if (_accum >= 1f)
+        {
+            _fps = _frames / _accum;
+            _accum = 0f;
+            _frames = 0;
+        }
+    }
+
+    public void Render()
+    {
+        if (!_enabled || _player == null) return;
+        var movie = _player.ActiveMovie as Movies.LingoMovie;
+        _framework.Begin();
+        _framework.RenderLine(5, 5, $"FPS: {_fps:F1}");
+        _framework.RenderLine(5, 15, $"Sprites: {movie?.SpriteTotalCount ?? 0}");
+        _framework.RenderLine(5, 25, $"Frame: {movie?.CurrentFrame ?? 0}");
+        _framework.End();
+    }
+}

--- a/src/LingoEngine/Core/LingoPlayer.cs
+++ b/src/LingoEngine/Core/LingoPlayer.cs
@@ -31,6 +31,8 @@ namespace LingoEngine.Core
         public ILingoFrameworkFactory Factory { get; private set; }
 
         public ILingoClock Clock => _clock;
+        internal LingoKey Key => _LingoKey;
+        public LingoStage Stage => _Stage;
         /// <inheritdoc/>
         public ILingoCast ActiveCastLib => _castLibsContainer.ActiveCast;
         /// <inheritdoc/>
@@ -76,7 +78,7 @@ namespace LingoEngine.Core
             _sound = Factory.CreateSound(_castLibsContainer);
             _window = new LingoWindow();
             _clock = new LingoClock();
-            _LingoKey = new LingoKey();
+            _LingoKey = Factory.CreateKey();
             _Stage = Factory.CreateStage(_clock);
             _Mouse = Factory.CreateMouse(_Stage);
             _System = new LingoSystem();

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkDebugOverlay.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkDebugOverlay.cs
@@ -1,0 +1,9 @@
+namespace LingoEngine.FrameworkCommunication
+{
+    public interface ILingoFrameworkDebugOverlay
+    {
+        void Begin();
+        void RenderLine(int x, int y, string text);
+        void End();
+    }
+}

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
@@ -30,6 +30,7 @@ namespace LingoEngine.FrameworkCommunication
         LingoSound CreateSound(ILingoCastLibsContainer castLibsContainer);
         LingoSoundChannel CreateSoundChannel(int number);
         LingoMouse CreateMouse(LingoStage stage);
+        LingoKey CreateKey();
 
         T CreateSprite<T>(ILingoMovie movie, Action<LingoSprite> onRemoveMe) where T : LingoSprite;
         T CreateBehavior<T>(LingoMovie lingoMovie) where T : LingoSpriteBehavior;

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkKey.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkKey.cs
@@ -1,0 +1,15 @@
+namespace LingoEngine.FrameworkCommunication
+{
+    public interface ILingoFrameworkKey
+    {
+        bool CommandDown { get; }
+        bool ControlDown { get; }
+        bool OptionDown { get; }
+        bool ShiftDown { get; }
+        bool KeyPressed(LingoEngine.Inputs.LingoKeyType key);
+        bool KeyPressed(char key);
+        bool KeyPressed(int keyCode);
+        string Key { get; }
+        int KeyCode { get; }
+    }
+}

--- a/src/LingoEngine/Inputs/LingoKey.cs
+++ b/src/LingoEngine/Inputs/LingoKey.cs
@@ -52,6 +52,7 @@ namespace LingoEngine.Inputs
         /// </summary>
         /// <param name="key">A named key defined in the LingoKeyType enum.</param>
         bool KeyPressed(LingoKeyType key);
+        bool KeyPressed(int keyCode);
     }
 
     /// <summary>
@@ -72,15 +73,24 @@ namespace LingoEngine.Inputs
     public class LingoKey : ILingoKey
     {
         private HashSet<ILingoKeyEventHandler> _subscriptions = new();
+        private readonly FrameworkCommunication.ILingoFrameworkKey _frameworkObj;
 
-        public bool ControlDown => false;
-        public bool CommandDown => false;
-        public bool OptionDown => false;
-        public bool ShiftDown => false;
-        public bool KeyPressed(LingoKeyType key) => false;
-        public bool KeyPressed(char key) => false;
-        public string Key => "";
-        public int KeyCode => 10;
+        public LingoKey(FrameworkCommunication.ILingoFrameworkKey frameworkObj)
+        {
+            _frameworkObj = frameworkObj;
+        }
+
+        internal T Framework<T>() where T : FrameworkCommunication.ILingoFrameworkKey => (T)_frameworkObj;
+
+        public bool ControlDown => _frameworkObj.ControlDown;
+        public bool CommandDown => _frameworkObj.CommandDown;
+        public bool OptionDown => _frameworkObj.OptionDown;
+        public bool ShiftDown => _frameworkObj.ShiftDown;
+        public bool KeyPressed(LingoKeyType key) => _frameworkObj.KeyPressed(key);
+        public bool KeyPressed(char key) => _frameworkObj.KeyPressed(key);
+        public bool KeyPressed(int keyCode) => _frameworkObj.KeyPressed(keyCode);
+        public string Key => _frameworkObj.Key;
+        public int KeyCode => _frameworkObj.KeyCode;
 
         public void DoKeyUp() => DoOnAll(x => x.RaiseKeyUp(this));
         public void DoKeyDown() => DoOnAll(x => x.RaiseKeyDown(this));


### PR DESCRIPTION
## Summary
- add abstraction for debug overlay and framework keys
- implement SDL and Godot key connectors
- compute overlay information in `LingoDebugOverlay`
- toggle overlay with `Ctrl+F1` via key states
- remove framework reference from `LingoPlayer` and set player for Godot stage in demo

## Testing
- `dotnet build LingoEngine.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf07beb0c83328e4c8d66c1462dfd