### PR TITLE
Improve documentation and interface comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # LingoEngine
-A library to port old games from Macromedia Director Lingo to c#
+
+**LingoEngine** is a C# runtime for games originally written in Macromedia Director's Lingo language. It provides a modern, modular architecture so existing Lingo projects can run on top of different rendering frameworks.
+
+## Projects
+
+| Folder | Description |
+|-------|------------|
+| `src/LingoEngine` | Core Lingo runtime and abstractions |
+| `src/LingoEngine.LGodot` | Adapter for the [Godot](https://godotengine.org/) engine |
+| `src/LingoEngine.SDL2` | Adapter for SDL2 based applications |
+| `src/Director` | Experimental Director API re‑implementations |
+| `Demo/TetriGrounds` | Sample game showing how to integrate with Godot and SDL2 |
+
+See the [Architecture overview](docs/Architecture.md) for details on how these pieces fit together.
+
+## Getting Started
+
+Clone the repository and open `LingoEngine.sln` in your preferred C# IDE. To build a demo project, choose the corresponding solution inside `Demo/TetriGrounds`.
+
+Detailed setup instructions are available for:
+
+- [Godot](docs/GodotSetup.md)
+- [SDL2](docs/SDLSetup.md)
+
+## License
+
+This project is licensed under the terms of the [MIT License](LICENSE).

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,34 @@
+# Architecture Overview
+
+LingoEngine is split into several layers:
+
+1. **Core** – The language runtime implementing the Lingo VM.
+2. **Framework adapters** – Front‑ends for different rendering frameworks. Currently Godot and SDL2 are provided.
+3. **Director** – Optional higher level APIs mirroring Macromedia Director behaviours.
+4. **Demo projects** – Sample games demonstrating how to use the engine with each framework.
+
+Each adapter exposes common interfaces so the core can run unchanged on multiple platforms.
+
+## Interfaces and Implementations
+
+The `src/LingoEngine` project defines interfaces for engine concepts such as
+`ILingoFrameworkSprite`, `ILingoFrameworkMovie`, and `ILingoFrameworkStage`.
+Rendering adapters like **LingoEngine.LGodot** and **LingoEngine.SDL2** provide
+concrete classes that implement these interfaces. The core engine interacts only
+with the interfaces, allowing the same game logic to run on any framework.
+
+### Factory Pattern
+
+A central `ILingoFrameworkFactory` creates the platform specific objects. Each
+adapter implements this factory to produce stages, sprites, members, and input
+handlers. The core asks the factory for objects without knowing the underlying
+framework.
+
+```csharp
+ILingoFrameworkFactory factory = new GodotFactory(serviceProvider, root);
+var stage = factory.CreateStage(new LingoPlayer());
+var movie = factory.AddMovie(stage, new LingoMovie("Demo"));
+```
+
+Adapters may register their factory with a dependency injection container so the
+game can resolve the correct implementation at runtime.

--- a/docs/GodotSetup.md
+++ b/docs/GodotSetup.md
@@ -1,0 +1,16 @@
+# Setting Up the Godot Runtime
+
+This guide explains how to build and run the Godot front‑end for LingoEngine.
+
+1. Install **Godot 4** from the [official website](https://godotengine.org/).
+2. Open `LingoEngine.Demo.TetriGrounds.Godot.sln` with your C# IDE or open the `project.godot` file directly in Godot.
+3. Ensure the Godot C# tools are configured. In the Godot editor, open **Project → Tools → C#** and set the path to `dotnet` if required.
+4. Build and run the project from within Godot. The demo project demonstrates how LingoEngine integrates with Godot scenes and nodes.
+
+```csharp
+// RootNodeTetriGrounds.cs excerpt
+TetriGroundsSetup.AddTetriGrounds(_services, c =>
+    c.WithLingoGodotEngine(this));
+var provider = _services.BuildServiceProvider();
+TetriGroundsSetup.StartGame(provider);
+```

--- a/docs/SDLSetup.md
+++ b/docs/SDLSetup.md
@@ -1,0 +1,16 @@
+# Setting Up the SDL2 Runtime
+
+This document describes how to build the SDL2 front‑end for LingoEngine.
+
+1. Install the **SDL2** development libraries for your operating system.
+2. Open `LingoEngine.Demo.TetriGrounds.SDL2.csproj` with your favorite C# IDE.
+3. Restore the NuGet packages. This ensures the SDL2-CS bindings referenced by the project are available.
+4. Build and run the project. The demo shows how LingoEngine can operate with a pure SDL window.
+
+```csharp
+// Program.cs excerpt
+var services = new ServiceCollection();
+services.AddTetriGrounds(c => c.WithLingoSdlEngine("TetriGrounds", 640, 480));
+var provider = services.BuildServiceProvider();
+provider.GetRequiredService<SdlRootContext>().Run();
+```

--- a/src/Director/LingoEngine.Director.Core/ReadMe.md
+++ b/src/Director/LingoEngine.Director.Core/ReadMe.md
@@ -1,4 +1,3 @@
-# Macromedia Director in c# : Core components
+# LingoEngine.Director.Core
 
-These are the core componentes, framework independant
-
+Framework‑independent implementation of classic Director behaviours. These APIs mimic the original Director runtime and are consumed by framework adapters like `LingoEngine.Director.LGodot`.

--- a/src/Director/LingoEngine.Director.LGodot/ReadMe.md
+++ b/src/Director/LingoEngine.Director.LGodot/ReadMe.md
@@ -1,4 +1,3 @@
-# Macromedia Director in c#  : With the Godot framework
+# LingoEngine.Director.LGodot
 
-This is director in c# with the Godot framework as UI Engine
-
+Godot front‑end for the Director API. This package binds Director style components to Godot nodes, allowing existing Lingo content to run inside the Godot engine.

--- a/src/LingoEngine.IO/ReadMe.md
+++ b/src/LingoEngine.IO/ReadMe.md
@@ -1,0 +1,3 @@
+# LingoEngine.IO
+
+Utility project containing parsers and import/export helpers for classic Director file formats.

--- a/src/LingoEngine.LGodot/ReadMe.md
+++ b/src/LingoEngine.LGodot/ReadMe.md
@@ -1,4 +1,7 @@
 # Macromedia Lingo in c# : With the Godot framework
 
-This is the Lingo Engine in c# with the Godot framework as UI Engine
+## Package: LingoEngine.LGodot
 
+Adapter layer that plugs the core Lingo runtime into Godot. It implements the interfaces defined in `src/LingoEngine` using Godot nodes and resources.
+
+See [docs/GodotSetup.md](../../docs/GodotSetup.md) for build instructions and example code.

--- a/src/LingoEngine.SDL2/ReadMe.md
+++ b/src/LingoEngine.SDL2/ReadMe.md
@@ -1,4 +1,7 @@
 # Macromedia Lingo in c# : With the SDL2 framework
 
-This is the Lingo Engine in c# with the SDL2 framework as UI Engine
+## Package: LingoEngine.SDL2
 
+Adapter layer that binds the core Lingo runtime to SDL2 using the SDL2-CS bindings. Useful for lightweight desktop applications without a heavy engine.
+
+See [docs/SDLSetup.md](../../docs/SDLSetup.md) for build instructions and example code.

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkDebugOverlay.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkDebugOverlay.cs
@@ -1,13 +1,21 @@
 namespace LingoEngine.FrameworkCommunication
 {
+    /// <summary>
+    /// Provides a debug overlay that can display text information while the
+    /// engine is running.
+    /// </summary>
     public interface ILingoFrameworkDebugOverlay
     {
+        /// <summary>Prepares a line of debug text.</summary>
         int PrepareLine(int id,string text);
         void ShowDebugger();
         void HideDebugger();
 
+        /// <summary>Begins a debug drawing batch.</summary>
         void Begin();
+        /// <summary>Sets the text for a prepared line.</summary>
         void SetLineText(int id, string text);
+        /// <summary>Ends the debug drawing batch.</summary>
         void End();
     }
 }

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
@@ -8,32 +8,57 @@ using LingoEngine.Texts;
 
 namespace LingoEngine.FrameworkCommunication
 {
+    /// <summary>
+    /// Factory used by the core engine to create framework-specific
+    /// implementations of stages, sprites, members and input handlers.
+    /// Each rendering adapter provides its own implementation.
+    /// </summary>
     public interface ILingoFrameworkFactory
     {
+        /// <summary>
+        /// Creates the main <see cref="LingoStage"/> for a <see cref="LingoPlayer"/>.
+        /// </summary>
+        /// <param name="lingoPlayer">Current player instance.</param>
         LingoStage CreateStage(LingoPlayer lingoPlayer);
+        /// <summary>
+        /// Adds a movie to the specified stage.
+        /// </summary>
         LingoMovie AddMovie(LingoStage stage, LingoMovie lingoMovie);
 
 
         #region Members
+        /// <summary>Creates a new cast member instance.</summary>
         T CreateMember<T>(ILingoCast cast, int numberInCast, string name = "") where T : LingoMember;
-        LingoMemberPicture CreateMemberPicture(ILingoCast cast,int numberInCast, string name = "", string? fileName = null, 
+        /// <summary>Creates a picture member.</summary>
+        LingoMemberPicture CreateMemberPicture(ILingoCast cast,int numberInCast, string name = "", string? fileName = null,
             LingoPoint regPoint = default);
+        /// <summary>Creates a sound member.</summary>
         LingoMemberSound CreateMemberSound(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default);
+        /// <summary>Creates a field member.</summary>
         LingoMemberField CreateMemberField(ILingoCast cast, int numberInCast, string name = "", string? fileName = null,
-            LingoPoint regPoint = default); 
+            LingoPoint regPoint = default);
+        /// <summary>Creates a text member.</summary>
         LingoMemberText CreateMemberText(ILingoCast cast, int numberInCast, string name = "", string? fileName = null,
             LingoPoint regPoint = default);
+        /// <summary>Creates a placeholder member.</summary>
         LingoMember CreateEmpty(ILingoCast cast, int numberInCast, string name = "", string? fileName = null,
             LingoPoint regPoint = default);
         #endregion
 
+        /// <summary>Creates a sound instance.</summary>
         LingoSound CreateSound(ILingoCastLibsContainer castLibsContainer);
+        /// <summary>Creates a sound channel.</summary>
         LingoSoundChannel CreateSoundChannel(int number);
+        /// <summary>Creates a mouse handler bound to the stage.</summary>
         LingoMouse CreateMouse(LingoStage stage);
+        /// <summary>Creates a keyboard handler.</summary>
         LingoKey CreateKey();
 
+        /// <summary>Creates a sprite instance.</summary>
         T CreateSprite<T>(ILingoMovie movie, Action<LingoSprite> onRemoveMe) where T : LingoSprite;
+        /// <summary>Creates a sprite behaviour.</summary>
         T CreateBehavior<T>(LingoMovie lingoMovie) where T : LingoSpriteBehavior;
+        /// <summary>Creates a movie script.</summary>
         T CreateMovieScript<T>(LingoMovie lingoMovie) where T : LingoMovieScript;
     }
 }

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkKey.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkKey.cs
@@ -1,15 +1,24 @@
 namespace LingoEngine.FrameworkCommunication
 {
+    /// <summary>
+    /// Keyboard state abstraction provided by the framework.
+    /// </summary>
     public interface ILingoFrameworkKey
     {
+        /// <summary>Indicates whether the Command key is held.</summary>
         bool CommandDown { get; }
         bool ControlDown { get; }
         bool OptionDown { get; }
         bool ShiftDown { get; }
+        /// <summary>Checks if a key of the given type is pressed.</summary>
         bool KeyPressed(LingoEngine.Inputs.LingoKeyType key);
+        /// <summary>Checks if a character key is pressed.</summary>
         bool KeyPressed(char key);
+        /// <summary>Checks if a key code is pressed.</summary>
         bool KeyPressed(int keyCode);
+        /// <summary>Gets the last pressed key as a string.</summary>
         string Key { get; }
+        /// <summary>Gets the numeric code of the last pressed key.</summary>
         int KeyCode { get; }
     }
 }

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkMouse.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkMouse.cs
@@ -3,10 +3,16 @@ using LingoEngine.Pictures.LingoEngine;
 
 namespace LingoEngine.FrameworkCommunication
 {
+    /// <summary>
+    /// Interface for mouse operations provided by the framework.
+    /// </summary>
     public interface ILingoFrameworkMouse
     {
+        /// <summary>Shows or hides the mouse cursor.</summary>
         void HideMouse(bool state);
+        /// <summary>Sets a custom cursor image.</summary>
         void SetCursor(LingoMemberPicture image);
+        /// <summary>Sets a predefined cursor shape.</summary>
         void SetCursor(LingoMouseCursor value);
     }
 }

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkMovie.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkMovie.cs
@@ -2,10 +2,17 @@
 
 namespace LingoEngine.FrameworkCommunication
 {
+    /// <summary>
+    /// Interface implemented by platform specific movie objects. It connects a
+    /// <see cref="LingoMovie"/> to the underlying rendering framework.
+    /// </summary>
     public interface ILingoFrameworkMovie
     {
+        /// <summary>Updates the associated stage after the movie changes.</summary>
         void UpdateStage();
+        /// <summary>Removes the movie from the stage.</summary>
         void RemoveMe();
+        /// <summary>Retrieves the current mouse position in global coordinates.</summary>
         LingoPoint GetGlobalMousePosition();
     }
 }

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkMovieStage.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkMovieStage.cs
@@ -3,8 +3,13 @@ using LingoEngine.Movies;
 
 namespace LingoEngine.FrameworkCommunication
 {
+    /// <summary>
+    /// Represents the top-level window or stage. Implementations update the
+    /// display when the active <see cref="LingoMovie"/> changes.
+    /// </summary>
     public interface ILingoFrameworkStage
     {
+        /// <summary>Sets the currently active movie.</summary>
         void SetActiveMovie(LingoMovie? lingoMovie);
     }
 }

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkSprite.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkSprite.cs
@@ -2,8 +2,13 @@
 
 namespace LingoEngine.FrameworkCommunication
 {
+    /// <summary>
+    /// Defines sprite functionality required by the engine. Implemented by
+    /// rendering back-ends to represent a sprite on screen.
+    /// </summary>
     public interface ILingoFrameworkSprite
     {
+        /// <summary>Controls the sprite's visibility.</summary>
         bool Visibility { get; set; }
         float Blend { get; set; }
         float X { get; set; }
@@ -16,11 +21,16 @@ namespace LingoEngine.FrameworkCommunication
         float SetDesiredWidth { get; set; }
         int ZIndex { get; set; }
 
+        /// <summary>Notify that the underlying member changed.</summary>
         void MemberChanged();
 
+        /// <summary>Remove the sprite from the stage.</summary>
         void RemoveMe();
+        /// <summary>Show the sprite.</summary>
         void Show();
+        /// <summary>Hide the sprite.</summary>
         void Hide();
+        /// <summary>Set the sprite position.</summary>
         void SetPosition(LingoPoint point);
     }
 }

--- a/src/LingoEngine/Movies/LingoSpriteChannel.cs
+++ b/src/LingoEngine/Movies/LingoSpriteChannel.cs
@@ -4,9 +4,9 @@ using LingoEngine.Primitives;
 namespace LingoEngine.Movies
 {
     /// <summary>
-    /// Sprite Channel
+    /// Sprite Channel.
     /// Represents an individual sprite channel in the Score.
-    /// A Sprite object covers a sprite span, which is a range of frames in a given sprite channel. A Sprite 
+    /// A <see cref="LingoSprite"/> object covers a sprite span, which is a range of frames in a given sprite channel. A <see cref="LingoSprite"/>
     /// Channel object represents an entire sprite channel, regardless of the number of sprites it contains.
     /// Sprite channels are controlled by the Score by default. Use the Sprite Channel object to switch
     /// control of a sprite channel over to script during a Score recording session.
@@ -41,7 +41,7 @@ namespace LingoEngine.Movies
         bool Scripted { get; }
 
         /// <summary>
-        /// Gets the sprite currently assigned to the sprite channel.
+        /// Gets the <see cref="LingoSprite"/> currently assigned to the sprite channel.
         /// </summary>
         ILingoSprite? Sprite { get; }
         /// <summary>
@@ -52,6 +52,8 @@ namespace LingoEngine.Movies
         /// <summary>
         /// Creates a scripted sprite that can be controlled by script.
         /// </summary>
+        /// <param name="member">Optional <see cref="LingoMember"/> to assign to the new sprite.</param>
+        /// <param name="loc">Optional <see cref="LingoPoint"/> location.</param>
         void MakeScriptedSprite(LingoMember? member = null, LingoPoint? loc = null);
 
         /// <summary>

--- a/src/LingoEngine/Pictures/LingoMemberPicture.cs
+++ b/src/LingoEngine/Pictures/LingoMemberPicture.cs
@@ -15,10 +15,10 @@ namespace LingoEngine.Pictures
             private readonly ILingoFrameworkMemberPicture _lingoFrameworkMemberPicture;
 
             /// <summary>
-            /// Gets the framework object that implements the ILingoFrameworkMemberPicture interface.
+            /// Gets the framework object that implements the <see cref="ILingoFrameworkMemberPicture"/> interface.
             /// </summary>
             /// <typeparam name="T">The type of the framework object.</typeparam>
-            /// <returns>Framework object implementing ILingoFrameworkMemberPicture.</returns>
+            /// <returns>Framework object implementing <see cref="ILingoFrameworkMemberPicture"/>.</returns>
             public T Framework<T>() where T : class, ILingoFrameworkMemberPicture => (T)_lingoFrameworkMemberPicture;
 
             /// <summary>
@@ -39,10 +39,10 @@ namespace LingoEngine.Pictures
             public string Format => _lingoFrameworkMemberPicture.Format;
 
             /// <summary>
-            /// Initializes a new instance of the LingoMemberPicture class.
+            /// Initializes a new instance of the <see cref="LingoMemberPicture"/> class.
             /// </summary>
             /// <param name="lingoFrameworkMemberPicture">The framework picture object.</param>
-            /// <param name="number">The number of the member.</param>
+            /// <param name="numberInCast">The number of the member in the <see cref="LingoCast"/>.</param>
             /// <param name="name">The name of the member.</param>
             public LingoMemberPicture(LingoCast cast, ILingoFrameworkMemberPicture lingoFrameworkMemberPicture, int numberInCast, string name = "", string fileName = "", LingoPoint regPoint = default)
                 : base(lingoFrameworkMemberPicture, LingoMemberType.Picture, cast, numberInCast, name, fileName, regPoint)
@@ -59,19 +59,19 @@ namespace LingoEngine.Pictures
 
 
             /// <summary>
-            /// Preloads the picture into memory.
+            /// Preloads the picture into memory using <see cref="ILingoFrameworkMemberPicture.Preload"/>.
             /// Corresponds to: member.picture.preload
             /// </summary>
             public override void Preload() => _lingoFrameworkMemberPicture.Preload();
 
             /// <summary>
-            /// Unloads the picture from memory.
+            /// Unloads the picture from memory using <see cref="ILingoFrameworkMemberPicture.Unload"/>.
             /// Corresponds to: member.picture.unload
             /// </summary>
             public override void Unload() => _lingoFrameworkMemberPicture.Unload();
 
             /// <summary>
-            /// Erases the picture.
+            /// Erases the picture using <see cref="ILingoFrameworkMemberPicture.Erase"/>.
             /// Corresponds to: member.picture.erase
             /// </summary>
             public override void Erase() => _lingoFrameworkMemberPicture.Erase();

--- a/src/LingoEngine/README.md
+++ b/src/LingoEngine/README.md
@@ -1,0 +1,3 @@
+# LingoEngine Core
+
+Contains the language runtime and high level abstractions used across all framework adapters.


### PR DESCRIPTION
## Summary
- restore original README headings for adapter projects
- extend SDL2 and Godot setup guides with code snippets
- describe interfaces and factory pattern in architecture doc
- document framework interfaces in the core project

## Testing
- `dotnet build LingoEngine.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0da8633083328a74cab6f5031b08