### PR TITLE
Improve score grid visuals

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/BaseGodotWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/BaseGodotWindow.cs
@@ -5,17 +5,22 @@ namespace LingoEngine.Director.LGodot
     public  abstract partial class BaseGodotWindow : Control
     {
         private bool _dragging;
-        private Label _label = new Label();
+        private readonly Label _label = new Label();
 
         public BaseGodotWindow(string name)
         {
-            DrawRect(new Rect2(0, 0, 800, 20), new Color(0.3f, 0.3f, 0.2f));
             AddChild(_label);
             _label.Position = new Vector2(30, 3);
             _label.LabelSettings = new LabelSettings();
             _label.LabelSettings.FontSize = 12;
             _label.LabelSettings.FontColor = new Color(1, 0.3f, 0.2f);
             _label.Text = name;
+        }
+
+        public override void _Draw()
+        {
+            DrawRect(new Rect2(0, 0, Size.X, 20), new Color(0.3f, 0.3f, 0.2f));
+            DrawLine(new Vector2(0, 20), new Vector2(Size.X, 20), Colors.Black);
         }
 
         public override void _GuiInput(InputEvent @event)

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -12,8 +12,9 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
 {
     private bool wasToggleKey;
     private LingoMovie? _movie;
-    private ScrollContainer _scroller = new ScrollContainer();
-    private DirGodotScoreGrid _grid;
+    private readonly ScrollContainer _scroller = new ScrollContainer();
+    private readonly DirGodotScoreGrid _grid;
+    private readonly DirGodotFrameHeader _header;
     private bool _dragging;
 
     public DirGodotScoreWindow()
@@ -21,10 +22,13 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
     {
         Position = new Vector2(0, 30);
         _grid = new DirGodotScoreGrid();
+        _header = new DirGodotFrameHeader();
+        AddChild(_header);
         AddChild(_scroller);
-        _scroller.AddChild( _grid );
-        _scroller.Size = new Vector2(800, 600);
-        _scroller.Position = new Vector2(0, 20);
+        _scroller.AddChild(_grid);
+        _scroller.Size = new Vector2(800, 580);
+        _scroller.Position = new Vector2(0, 40);
+        _header.Position = new Vector2(0, 20);
     }
 
     public void Toggle()
@@ -37,6 +41,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
     {
         _movie = movie;
         _grid.SetMovie(movie);
+        _header.SetMovie(movie);
     }
     public override void _GuiInput(InputEvent @event)
     {
@@ -56,12 +61,43 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
         base.Dispose(disposing);
     }
 }
+
+internal partial class DirGodotFrameHeader : Control
+{
+    private LingoMovie? _movie;
+    private const int ChannelHeight = 16;
+    private const int FrameWidth = 9;
+    private const int ChannelLabelWidth = 54;
+    private const int ChannelInfoWidth = ChannelHeight + ChannelLabelWidth;
+
+    public void SetMovie(LingoMovie? movie) => _movie = movie;
+
+    public override void _Draw()
+    {
+        if (_movie == null) return;
+        int frameCount = _movie.FrameCount;
+        var font = ThemeDB.FallbackFont;
+        Size = new Vector2(ChannelInfoWidth + frameCount * FrameWidth, 20);
+        DrawRect(new Rect2(0, 0, Size.X, 20), new Color("#f0f0f0"));
+        for (int f = 0; f <= frameCount; f++)
+        {
+            float x = ChannelInfoWidth + f * FrameWidth;
+            if (f % 5 == 0)
+                DrawString(font, new Vector2(x + 1, font.GetAscent()), f.ToString(),
+                    HorizontalAlignment.Left, -1, 10, new Color("#a0a0a0"));
+        }
+    }
+}
 internal partial class DirGodotScoreGrid : Control
 {
     private LingoMovie? _movie;
     private const int ChannelHeight = 16;
     private const int FrameWidth = 9;
-    private const int ChannelNumberWidth = 32; // includes visibility square
+    private const int ChannelLabelWidth = 54;
+    private const int ChannelInfoWidth = ChannelHeight + ChannelLabelWidth;
+    private ILingoSprite? _dragSprite;
+    private bool _dragBegin;
+    private bool _dragEnd;
 
 
     public void SetMovie(LingoMovie? movie) => _movie = movie;
@@ -69,19 +105,69 @@ internal partial class DirGodotScoreGrid : Control
     public override void _Input(InputEvent @event)
     {
         if (!Visible || _movie == null) return;
-        if (@event is InputEventMouseButton mb && mb.Pressed)
+        if (@event is InputEventMouseButton mb)
         {
             Vector2 pos = GetLocalMousePosition();
             int channel = (int)(pos.Y / ChannelHeight);
-            if (channel >= 0 && _movie != null && channel < _movie.MaxSpriteChannelCount)
+            if (mb.ButtonIndex == MouseButton.Left)
             {
-                if (pos.X >= 0 && pos.X < ChannelHeight)
+                if (mb.Pressed)
                 {
-                    var ch = _movie.Channel(channel);
-                    ch.Visibility = !ch.Visibility;
-                    QueueRedraw();
+                    if (channel >= 0 && channel < _movie.MaxSpriteChannelCount)
+                    {
+                        if (pos.X >= 0 && pos.X < ChannelHeight)
+                        {
+                            var ch = _movie.Channel(channel);
+                            ch.Visibility = !ch.Visibility;
+                            QueueRedraw();
+                            return;
+                        }
+
+                        int idx = 1;
+                        while (_movie.TryGetAllTimeSprite(idx, out var sp))
+                        {
+                            int sc = sp.SpriteNum - 1;
+                            if (sc == channel)
+                            {
+                                float sx = ChannelInfoWidth + (sp.BeginFrame - 1) * FrameWidth;
+                                float ex = ChannelInfoWidth + sp.EndFrame * FrameWidth;
+                                if (pos.X >= sx && pos.X <= ex)
+                                {
+                                    if (Math.Abs(pos.X - sx) < 3)
+                                    {
+                                        _dragSprite = sp;
+                                        _dragBegin = true;
+                                        _dragEnd = false;
+                                    }
+                                    else if (Math.Abs(pos.X - ex) < 3)
+                                    {
+                                        _dragSprite = sp;
+                                        _dragBegin = false;
+                                        _dragEnd = true;
+                                    }
+                                    break;
+                                }
+                            }
+                            idx++;
+                        }
+                    }
+                }
+                else
+                {
+                    _dragSprite = null;
+                    _dragBegin = _dragEnd = false;
                 }
             }
+        }
+        else if (@event is InputEventMouseMotion motion && _dragSprite != null)
+        {
+            float frame = (GetLocalMousePosition().X - ChannelInfoWidth) / FrameWidth;
+            int newFrame = Math.Max(1, Mathf.RoundToInt(frame) + 1);
+            if (_dragBegin)
+                _dragSprite.BeginFrame = Math.Min(newFrame, _dragSprite.EndFrame);
+            else if (_dragEnd)
+                _dragSprite.EndFrame = Math.Max(newFrame, _dragSprite.BeginFrame);
+            QueueRedraw();
         }
     }
 
@@ -98,44 +184,55 @@ internal partial class DirGodotScoreGrid : Control
         int channelCount = _movie.MaxSpriteChannelCount;
         int frameCount = _movie.FrameCount;
         var font = ThemeDB.FallbackFont;
-        Size = new Vector2(channelCount* FrameWidth + 80, frameCount* ChannelHeight);
+        Size = new Vector2(ChannelInfoWidth + frameCount * FrameWidth, channelCount * ChannelHeight);
 
         for (int f = 0; f < frameCount; f++)
         {
-            float x = ChannelNumberWidth + f * FrameWidth;
-            // Frames per 5
+            float x = ChannelInfoWidth + f * FrameWidth;
             if (f % 5 == 0)
                 DrawRect(new Rect2(x, 0, FrameWidth, channelCount * ChannelHeight), new Color(0.3f, 0.3f, 0.3f, 0.2f));
         }
 
         for (int f = 0; f <= frameCount; f++)
         {
-            float x = ChannelNumberWidth + f * FrameWidth;
+            float x = ChannelInfoWidth + f * FrameWidth;
             DrawLine(new Vector2(x, 0), new Vector2(x, channelCount * ChannelHeight), Colors.DarkGray);
-            // Frames per 5
-            if (f % 5 == 0)
-            {
-                DrawRect(new Rect2(0, 0, FrameWidth, channelCount* ChannelHeight), Colors.Green);
-                DrawString(font, new Vector2(x -(f.ToString().Length*8), -12 + font.GetHeight()), f.ToString(), HorizontalAlignment.Center, -1, 10, Colors.White);
-            }
         }
 
         for (int c = 0; c <= channelCount; c++)
         {
             float y = c * ChannelHeight;
-            DrawLine(new Vector2(0, y), new Vector2(ChannelNumberWidth + frameCount * FrameWidth, y), Colors.DarkGray);
+            DrawLine(new Vector2(0, y), new Vector2(ChannelInfoWidth + frameCount * FrameWidth, y), Colors.DarkGray);
             if (c < channelCount)
             {
                 var ch = _movie.Channel(c);
                 Color vis = ch.Visibility ? Colors.LightGray : new Color(0.2f, 0.2f, 0.2f);
+                DrawRect(new Rect2(0, y, ChannelInfoWidth, ChannelHeight), new Color("#f0f0f0"));
                 DrawRect(new Rect2(0, y, ChannelHeight, ChannelHeight), vis);
-                DrawString(font, new Vector2(ChannelHeight + 2, y + font.GetAscent()- 6), (c + 1).ToString(), HorizontalAlignment.Left, -1,11, Colors.White);
+                DrawString(font, new Vector2(ChannelHeight + 2, y + font.GetAscent() - 6), (c + 1).ToString(),
+                    HorizontalAlignment.Left, -1, 11, new Color("#a0a0a0"));
             }
+        }
+
+        // Draw sprites
+        int index = 1;
+        while (_movie.TryGetAllTimeSprite(index, out var sprite))
+        {
+            int ch = sprite.SpriteNum - 1;
+            if (ch < 0 || ch >= channelCount) { index++; continue; }
+            float x = ChannelInfoWidth + (sprite.BeginFrame - 1) * FrameWidth;
+            float width = (sprite.EndFrame - sprite.BeginFrame + 1) * FrameWidth;
+            float y = ch * ChannelHeight;
+            DrawRect(new Rect2(x, y, width, ChannelHeight), new Color("#ccccff"));
+            if (sprite.Member != null)
+                DrawString(font, new Vector2(x + 2, y + font.GetAscent() - 2), sprite.Member.Name ?? string.Empty,
+                    HorizontalAlignment.Left, width - 4, 11, Colors.Black);
+            index++;
         }
 
         int cur = _movie.CurrentFrame - 1;
         if (cur < 0) cur = 0;
-        float barX = ChannelNumberWidth + cur * FrameWidth + FrameWidth / 2f;
+        float barX = ChannelInfoWidth + cur * FrameWidth + FrameWidth / 2f;
         DrawLine(new Vector2(barX, 0), new Vector2(barX, channelCount * ChannelHeight), Colors.Red, 2);
     }
 }


### PR DESCRIPTION
## Summary
- adjust BaseGodotWindow drawing
- add frame header and show sprites on the score grid
- allow dragging sprite begin/end frames
- fix grid sizing and colors

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2241cdc08332a347b264f191ba10