### PR TITLE
Update score window layout

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/BaseGodotWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/BaseGodotWindow.cs
@@ -19,7 +19,7 @@ namespace LingoEngine.Director.LGodot
 
         public override void _Draw()
         {
-            DrawRect(new Rect2(0, 0, Size.X, 20), new Color(0.3f, 0.3f, 0.2f));
+            DrawRect(new Rect2(0, 0, Size.X, 20), new Color("#d2e0ed"));
             DrawLine(new Vector2(0, 20), new Vector2(Size.X, 20), Colors.Black);
         }
 


### PR DESCRIPTION
## Summary
- colorize window title bar
- separate horizontal and vertical scrolling in score window
- show frame scripts above frame numbers
- center score label indicator vertically
- remove frame scripts from score grid

## Testing
- `dotnet build LingoEngine.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c382bc3608332b0c6ad020d2cf366