### PR TITLE
Add playback controls to score window

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -20,12 +20,14 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
     private readonly DirGodotFrameHeader _header;
     private readonly DirGodotFrameScriptsBar _frameScripts;
     private readonly DirGodotScoreLabelsBar _labelBar;
-    private bool _dragging;
+    private readonly Button _playButton = new Button();
 
     public DirGodotScoreWindow()
         : base("Score")
     {
         Position = new Vector2(0, 30);
+        Size = new Vector2(800, 600);
+        CustomMinimumSize = Size;
         _grid = new DirGodotScoreGrid();
         _header = new DirGodotFrameHeader();
         _frameScripts = new DirGodotFrameScriptsBar();
@@ -41,6 +43,12 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
         _scrollContent.AddChild(_frameScripts);
         _scrollContent.AddChild(_header);
         _scrollContent.AddChild(_vScroller);
+
+        AddChild(_playButton);
+        _playButton.Position = new Vector2(3, 2);
+        _playButton.CustomMinimumSize = new Vector2(40, 16);
+        _playButton.Text = "Play";
+        _playButton.Pressed += OnPlayButtonPressed;
 
         _vScroller.ScrollHorizontalEnabled = false;
         _vScroller.AddChild(_grid);
@@ -65,10 +73,28 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
         _header.SetMovie(movie);
         _frameScripts.SetMovie(movie);
         _labelBar.SetMovie(movie);
+        UpdatePlayButton();
+    }
+    private void OnPlayButtonPressed()
+    {
+        if (_movie == null) return;
+        if (_movie.IsPlaying)
+            _movie.Halt();
+        else
+            _movie.Play();
+        UpdatePlayButton();
+    }
+
+    private void UpdatePlayButton()
+    {
+        if (_movie == null)
+            _playButton.Text = "Play";
+        else
+            _playButton.Text = _movie.IsPlaying ? "Stop" : "Play";
     }
     public override void _GuiInput(InputEvent @event)
     {
-
+        base._GuiInput(@event);
     }
     public override void _Process(double delta)
     {
@@ -111,6 +137,18 @@ public override void _Draw()
             if (f % 5 == 0)
                 DrawString(font, new Vector2(x + 1, font.GetAscent()), f.ToString(),
                     HorizontalAlignment.Left, -1, 10, new Color("#a0a0a0"));
+        }
+    }
+
+    public override void _GuiInput(InputEvent @event)
+    {
+        if (@event is InputEventMouseButton mb && mb.ButtonIndex == MouseButton.Left && mb.Pressed)
+        {
+            if (_movie == null) return;
+            Vector2 pos = GetLocalMousePosition();
+            int frame = Mathf.RoundToInt((pos.X - ChannelInfoWidth) / FrameWidth) + 1;
+            if (frame >= 1 && frame <= _movie.FrameCount)
+                _movie.GoTo(frame);
         }
     }
 }


### PR DESCRIPTION
## Summary
- make score window draggable and visible by setting its size
- add play/stop toggle button to the score window header
- update button text when movie state changes
- allow clicking the frame number bar to jump to a frame

## Testing
- `dotnet build LingoEngine.sln -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3bf60b808332a02466936741a2f0