### PR TITLE
Add LingoSpriteAnimator event-based tweening

### DIFF
--- a/src/LingoEngine.LGodot/LingoGodotSprite.cs
+++ b/src/LingoEngine.LGodot/LingoGodotSprite.cs
@@ -67,6 +67,18 @@ namespace LingoEngine.LGodot
         public float SetDesiredWidth { get => _DesiredWidth; set { _DesiredWidth = value; IsDirty = true; } }
         public float SetDesiredHeight { get => _DesiredHeight; set { _DesiredHeight = value; IsDirty = true; } }
 
+        public float Rotation { get => _Sprite2D.RotationDegrees; set => _Sprite2D.RotationDegrees = value; }
+        public float SkewX
+        {
+            get => _Sprite2D.Skew.X;
+            set { var s = _Sprite2D.Skew; s.X = value; _Sprite2D.Skew = s; }
+        }
+        public float SkewY
+        {
+            get => _Sprite2D.Skew.Y;
+            set { var s = _Sprite2D.Skew; s.Y = value; _Sprite2D.Skew = s; }
+        }
+
 
 #pragma warning disable CS8618
         public LingoGodotSprite(LingoSprite lingoSprite, Node2D parentNode, Action<LingoGodotSprite> showMethod, Action<LingoGodotSprite> hideMethod, Action<LingoGodotSprite> removeMethod)

--- a/src/LingoEngine.SDL2/SdlSprite.cs
+++ b/src/LingoEngine.SDL2/SdlSprite.cs
@@ -1,3 +1,4 @@
+using System;
 using LingoEngine.Core;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Movies;
@@ -44,6 +45,9 @@ public class SdlSprite : ILingoFrameworkSprite, IDisposable
     public float SetDesiredHeight { get; set; }
     public float SetDesiredWidth { get; set; }
     public int ZIndex { get; set; }
+    public float Rotation { get; set; }
+    public float SkewX { get; set; }
+    public float SkewY { get; set; }
 
     public void RemoveMe() { _remove(this); Dispose(); }
     public void Dispose()
@@ -91,14 +95,49 @@ public class SdlSprite : ILingoFrameworkSprite, IDisposable
             }
         }
 
-        SDL.SDL_Rect dst = new SDL.SDL_Rect
+        var baseX = X + offset.X;
+        var baseY = Y + offset.Y;
+        if (Math.Abs(SkewX) < 0.0001f && Math.Abs(SkewY) < 0.0001f)
         {
-            x = (int)(X + offset.X),
-            y = (int)(Y + offset.Y),
-            w = (int)Width,
-            h = (int)Height
-        };
-        SDL.SDL_RenderCopy(renderer, _texture, nint.Zero, ref dst);
+            SDL.SDL_FRect dst = new SDL.SDL_FRect
+            {
+                x = baseX,
+                y = baseY,
+                w = Width,
+                h = Height
+            };
+            SDL.SDL_FPoint center = new SDL.SDL_FPoint { x = Width / 2, y = Height / 2 };
+            SDL.SDL_RenderCopyExF(renderer, _texture, nint.Zero, ref dst, Rotation, ref center, SDL.SDL_RendererFlip.SDL_FLIP_NONE);
+        }
+        else
+        {
+            float radRot = Rotation * (float)Math.PI / 180f;
+            float cos = (float)Math.Cos(radRot);
+            float sin = (float)Math.Sin(radRot);
+            float tanX = (float)Math.Tan(SkewX * Math.PI / 180f);
+            float tanY = (float)Math.Tan(SkewY * Math.PI / 180f);
+
+            SDL.SDL_Vertex[] verts = new SDL.SDL_Vertex[4];
+            float[] xs = new float[] { 0, Width, Width, 0 };
+            float[] ys = new float[] { 0, 0, Height, Height };
+            float cx = Width / 2f;
+            float cy = Height / 2f;
+            for (int i = 0; i < 4; i++)
+            {
+                float vx = xs[i] - cx;
+                float vy = ys[i] - cy;
+                float sx = vx + vy * tanX;
+                float sy = vy + vx * tanY;
+                float rx = sx * cos - sy * sin;
+                float ry = sx * sin + sy * cos;
+
+                verts[i].position = new SDL.SDL_FPoint { x = baseX + cx + rx, y = baseY + cy + ry };
+                verts[i].tex_coord = new SDL.SDL_FPoint { x = xs[i] / Width, y = ys[i] / Height };
+                verts[i].color = new SDL.SDL_Color { r = 255, g = 255, b = 255, a = 255 };
+            }
+            int[] indices = new int[] { 0, 1, 2, 0, 2, 3 };
+            SDL.SDL_RenderGeometry(renderer, _texture, verts, verts.Length, indices, indices.Length);
+        }
     }
 
     private void UpdateMember()

--- a/src/LingoEngine/Animations/LingoEaseType.cs
+++ b/src/LingoEngine/Animations/LingoEaseType.cs
@@ -1,0 +1,10 @@
+namespace LingoEngine.Animations
+{
+    public enum LingoEaseType
+    {
+        Linear,
+        EaseIn,
+        EaseOut,
+        EaseInOut
+    }
+}

--- a/src/LingoEngine/Animations/LingoKeyFrame.cs
+++ b/src/LingoEngine/Animations/LingoKeyFrame.cs
@@ -1,0 +1,15 @@
+namespace LingoEngine.Animations
+{
+    public class LingoKeyFrame<T>
+    {
+        public int Frame { get; set; }
+        public T Value { get; set; }
+        public LingoEaseType Ease { get; set; } = LingoEaseType.Linear;
+
+        public LingoKeyFrame(int frame, T value)
+        {
+            Frame = frame;
+            Value = value;
+        }
+    }
+}

--- a/src/LingoEngine/Animations/LingoSpriteAnimator.cs
+++ b/src/LingoEngine/Animations/LingoSpriteAnimator.cs
@@ -1,0 +1,45 @@
+using LingoEngine.Primitives;
+using LingoEngine.Movies;
+using LingoEngine.Events;
+
+namespace LingoEngine.Animations
+{
+    public class LingoSpriteAnimator : IHasEnterFrameEvent
+    {
+        public LingoTween<LingoPoint> Position { get; } = new();
+        public LingoTween<float> Rotation { get; } = new();
+        public LingoTween<float> Skew { get; } = new();
+
+        private readonly LingoSprite _sprite;
+        private readonly ILingoMovie _movie;
+        private readonly ILingoEventMediator _mediator;
+
+        public LingoSpriteAnimator(LingoSprite sprite, ILingoMovieEnvironment env)
+        {
+            _sprite = sprite;
+            _movie = env.Movie;
+            _mediator = env.Events;
+            _mediator.Subscribe(this);
+        }
+
+        public void AddKeyFrame(int frame, float x, float y, float rotation, float skew)
+        {
+            Position.AddKeyFrame(frame, new LingoPoint(x, y));
+            Rotation.AddKeyFrame(frame, rotation);
+            Skew.AddKeyFrame(frame, skew);
+        }
+
+        private void Apply(int frame)
+        {
+            var p = Position.GetValue(frame);
+            _sprite.Loc = p;
+            _sprite.Rotation = Rotation.GetValue(frame);
+            _sprite.Skew = Skew.GetValue(frame);
+        }
+
+        public void EnterFrame()
+        {
+            Apply(_movie.CurrentFrame);
+        }
+    }
+}

--- a/src/LingoEngine/Animations/LingoTween.cs
+++ b/src/LingoEngine/Animations/LingoTween.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.Animations
+{
+    public class LingoTween<T>
+    {
+        private readonly List<LingoKeyFrame<T>> _keys = new();
+
+        public void AddKeyFrame(int frame, T value, LingoEaseType ease = LingoEaseType.Linear)
+        {
+            var k = new LingoKeyFrame<T>(frame, value) { Ease = ease };
+            _keys.Add(k);
+            _keys.Sort((a, b) => a.Frame.CompareTo(b.Frame));
+        }
+
+        public T GetValue(int frame)
+        {
+            if (_keys.Count == 0)
+                return default!;
+            if (frame <= _keys[0].Frame)
+                return _keys[0].Value;
+            if (frame >= _keys[^1].Frame)
+                return _keys[^1].Value;
+
+            for (int i = 0; i < _keys.Count - 1; i++)
+            {
+                var k0 = _keys[i];
+                var k1 = _keys[i + 1];
+                if (frame >= k0.Frame && frame <= k1.Frame)
+                {
+                    float t = (frame - k0.Frame) / (float)(k1.Frame - k0.Frame);
+                    t = ApplyEase(t, k1.Ease);
+                    return Lerp(k0.Value, k1.Value, t);
+                }
+            }
+            return _keys[^1].Value;
+        }
+
+        private static float ApplyEase(float t, LingoEaseType ease)
+        {
+            return ease switch
+            {
+                LingoEaseType.EaseIn => t * t,
+                LingoEaseType.EaseOut => t * (2 - t),
+                LingoEaseType.EaseInOut => t < 0.5f ? 2 * t * t : -1 + (4 - 2 * t) * t,
+                _ => t,
+            };
+        }
+
+        private static T Lerp(T a, T b, float t)
+        {
+            if (typeof(T) == typeof(float))
+            {
+                float aa = (float)(object)a;
+                float bb = (float)(object)b;
+                return (T)(object)(aa + (bb - aa) * t);
+            }
+            if (typeof(T) == typeof(LingoPoint))
+            {
+                var pa = (LingoPoint)(object)a;
+                var pb = (LingoPoint)(object)b;
+                return (T)(object)(pa + (pb - pa) * t);
+            }
+            return t < 1 ? a : b;
+        }
+    }
+}

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkSprite.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkSprite.cs
@@ -21,6 +21,15 @@ namespace LingoEngine.FrameworkCommunication
         float SetDesiredWidth { get; set; }
         int ZIndex { get; set; }
 
+        /// <summary>Rotation of the sprite in degrees.</summary>
+        float Rotation { get; set; }
+
+        /// <summary>Horizontal skew angle of the sprite in degrees.</summary>
+        float SkewX { get; set; }
+
+        /// <summary>Vertical skew angle of the sprite in degrees.</summary>
+        float SkewY { get; set; }
+
         /// <summary>Notify that the underlying member changed.</summary>
         void MemberChanged();
 

--- a/src/LingoEngine/Movies/ILingoSprite.cs
+++ b/src/LingoEngine/Movies/ILingoSprite.cs
@@ -121,6 +121,16 @@ namespace LingoEngine.Movies
         int LocZ { get; set; }
 
         /// <summary>
+        /// Rotation of the sprite in degrees.
+        /// </summary>
+        float Rotation { get; set; }
+
+        /// <summary>
+        /// Skew angle of the sprite in degrees.
+        /// </summary>
+        float Skew { get; set; }
+
+        /// <summary>
         /// List of script instance names or types attached to the sprite.
         /// </summary>
         List<string> ScriptInstanceList { get; }

--- a/src/LingoEngine/Movies/LingoSprite.cs
+++ b/src/LingoEngine/Movies/LingoSprite.cs
@@ -3,6 +3,7 @@ using LingoEngine.Events;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Inputs;
 using LingoEngine.Primitives;
+using LingoEngine.Animations;
 
 namespace LingoEngine.Movies
 {
@@ -21,6 +22,7 @@ namespace LingoEngine.Movies
         private LingoMember? _Member;
         private Action<LingoSprite>? _onRemoveMe;
         private bool _isFocus = false;
+        public Animations.LingoSpriteAnimator Animator { get; private set; }
 
 
         #region Properties
@@ -62,6 +64,9 @@ namespace LingoEngine.Movies
         public float LocV { get => _frameworkSprite.Y; set => _frameworkSprite.Y = value; }
         public int LocZ { get => _frameworkSprite.ZIndex; set => _frameworkSprite.ZIndex = value; }
         public LingoPoint Loc { get => (_frameworkSprite.X, _frameworkSprite.Y); set => _frameworkSprite.SetPosition(value); }
+
+        public float Rotation { get => _frameworkSprite.Rotation; set => _frameworkSprite.Rotation = value; }
+        public float Skew { get => _frameworkSprite.SkewX; set => _frameworkSprite.SkewX = value; }
 
         public LingoPoint RegPoint { get; set; }
         public LingoColor ForeColor { get; set; }
@@ -108,11 +113,12 @@ namespace LingoEngine.Movies
 
 #pragma warning disable CS8618
         public LingoSprite(ILingoMovieEnvironment environment)
-#pragma warning restore CS8618 
+#pragma warning restore CS8618
             : base(environment)
         {
             _environment = environment;
             _eventMediator = (LingoEventMediator) _environment.Events;
+            Animator = new Animations.LingoSpriteAnimator(this, environment);
         }
         public void Init(ILingoFrameworkSprite frameworkSprite)
         {
@@ -165,6 +171,7 @@ When a movie stops, events occur in the following order:
         internal virtual void DoBeginSprite()
         {
             // Subscribe all behaviors
+            _eventMediator.Subscribe(Animator);
             _behaviors.ForEach(b =>
             {
                 _eventMediator.Subscribe(b);
@@ -182,6 +189,7 @@ When a movie stops, events occur in the following order:
                 _eventMediator.Unsubscribe(b);
                 if (b is IHasEndSpriteEvent endSpriteEvent) endSpriteEvent.EndSprite();
             });
+            _eventMediator.Unsubscribe(Animator);
             EndSprite();
         }
         protected virtual void EndSprite() { }
@@ -361,6 +369,7 @@ When a movie stops, events occur in the following order:
         {
             LocH = mouse.MouseH;
             LocV = mouse.MouseV;
+            _environment.Player.Stage.AddKeyFrame(this);
             MouseDrag(mouse);
         }
         protected virtual void MouseDrag(LingoMouse mouse) { }
@@ -404,6 +413,7 @@ When a movie stops, events occur in the following order:
             if (behavior == null) return default;
             return actionOnSpriteBehaviour(behavior);
         }
+
 
         public void RemoveMe()
         {

--- a/src/LingoEngine/Movies/LingoStage.cs
+++ b/src/LingoEngine/Movies/LingoStage.cs
@@ -10,6 +10,8 @@ namespace LingoEngine.Movies
     {
         private readonly ILingoFrameworkStage _lingoFrameworkMovieStage;
 
+        public bool RecordKeyframes { get; set; }
+
         public LingoMovie? ActiveMovie { get; private set; }
         public LingoMember? MouseMemberUnderMouse
         {
@@ -25,6 +27,14 @@ namespace LingoEngine.Movies
         public LingoStage(ILingoFrameworkStage godotInstance)
         {
             _lingoFrameworkMovieStage = godotInstance;
+        }
+
+        internal void AddKeyFrame(LingoSprite sprite)
+        {
+            if (!RecordKeyframes || ActiveMovie == null)
+                return;
+            int frame = ActiveMovie.CurrentFrame;
+            sprite.Animator.AddKeyFrame(frame, sprite.LocH, sprite.LocV, sprite.Rotation, sprite.Skew);
         }
 
         public void SetActiveMovie(LingoMovie? lingoMovie)


### PR DESCRIPTION
## Summary
- rename tweening classes to use Lingo prefix
- implement `LingoSpriteAnimator` that subscribes to `EnterFrame`
- remove sprite's direct EnterFrame handling and use animator instead
- update stage to add keyframes via the animator
- rename skew property and recording method

## Testing
- `dotnet build LingoEngine.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d47c282dc8332b75d1b1427b494ab