### PR TITLE
Add dotnet prerequisite note

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ Detailed setup instructions are available for:
 - [Godot](docs/GodotSetup.md)
 - [SDL2](docs/SDLSetup.md)
 
+## Running Tests
+
+This repository uses the **.NET SDK**. Make sure `dotnet` is available in your
+`PATH` before running the test suite:
+
+```bash
+dotnet test
+```
+
+Refer to the [official installation guide](https://learn.microsoft.com/dotnet/core/install/) if the `dotnet` command is missing.
+
+You can automatically install the SDK by executing the helper script:
+
+```bash
+./scripts/install-dotnet.sh
+```
+
 ## License
 
 This project is licensed under the terms of the [MIT License](LICENSE).

--- a/scripts/install-dotnet.sh
+++ b/scripts/install-dotnet.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+if command -v dotnet >/dev/null 2>&1; then
+  echo ".NET SDK already installed: $(dotnet --version)"
+  exit 0
+fi
+
+# Download and run Microsoft's install script
+curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+chmod +x dotnet-install.sh
+./dotnet-install.sh --channel LTS
+rm dotnet-install.sh
+
+echo "Installation complete. Add \$HOME/.dotnet to your PATH if needed."


### PR DESCRIPTION
## Summary
- document that `dotnet` must be installed to run tests
- add helper script for installing the .NET SDK

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*
- `./scripts/install-dotnet.sh` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_684e5a72afb08332b4aaca580fc5db8a