### PR TITLE
Move sprite selection event to Director.Core

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Events/DirectorEventMediator.cs
+++ b/src/Director/LingoEngine.Director.Core/Events/DirectorEventMediator.cs
@@ -1,0 +1,31 @@
+using LingoEngine.Movies;
+
+namespace LingoEngine.Director.Core.Events
+{
+    public interface IDirectorEventMediator
+    {
+        void Subscribe(object listener);
+        void Unsubscribe(object listener);
+        void RaiseSpriteSelected(LingoSprite sprite);
+    }
+
+    internal class DirectorEventMediator : IDirectorEventMediator
+    {
+        private readonly List<IHasSpriteSelectedEvent> _spriteSelected = new();
+
+        public void Subscribe(object listener)
+        {
+            if (listener is IHasSpriteSelectedEvent spriteSelected)
+                _spriteSelected.Add(spriteSelected);
+        }
+
+        public void Unsubscribe(object listener)
+        {
+            if (listener is IHasSpriteSelectedEvent spriteSelected)
+                _spriteSelected.Remove(spriteSelected);
+        }
+
+        public void RaiseSpriteSelected(LingoSprite sprite)
+            => _spriteSelected.ForEach(x => x.SpriteSelected(sprite));
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Events/IHasSpriteSelectedEvent.cs
+++ b/src/Director/LingoEngine.Director.Core/Events/IHasSpriteSelectedEvent.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.Director.Core.Events
+{
+    public interface IHasSpriteSelectedEvent
+    {
+        void SpriteSelected(LingoEngine.Movies.LingoSprite sprite);
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
@@ -1,4 +1,5 @@
 using Godot;
+using LingoEngine.Director.Core.Events;
 using LingoEngine.Director.LGodot.Scores;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,15 +9,17 @@ namespace LingoEngine.Director.LGodot
     {
         public static ILingoEngineRegistration WithDirectorGodotEngine(this ILingoEngineRegistration engineRegistration, Node rootNode)
         {
-            //engineRegistration.Services(s =>
-            //{
-            //    IServiceCollection serviceCollection = s.AddSingleton(p =>
-            //    {
-            //        var overlay = new DirGodotScoreWindow { Visible = false };
-            //        rootNode.AddChild(overlay);
-            //        return overlay;
-            //    });
-            //});
+            engineRegistration.Services(s =>
+            {
+                IServiceCollection serviceCollection = s
+                    .AddSingleton<IDirectorEventMediator, DirectorEventMediator>()
+                    .AddSingleton(p =>
+                    {
+                        var overlay = new DirGodotScoreWindow(p.GetRequiredService<IDirectorEventMediator>()) { Visible = false };
+                        rootNode.AddChild(overlay);
+                        return overlay;
+                    });
+            });
             return engineRegistration;
         }
 

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -1,5 +1,6 @@
 using Godot;
 using LingoEngine.Movies;
+using LingoEngine.Director.Core.Events;
 using System;
 using System.Collections.Generic;
 
@@ -21,14 +22,16 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
     private readonly DirGodotFrameScriptsBar _frameScripts;
     private readonly DirGodotScoreLabelsBar _labelBar;
     private readonly Button _playButton = new Button();
+    private readonly IDirectorEventMediator _directorMediator;
 
-    public DirGodotScoreWindow()
+    public DirGodotScoreWindow(IDirectorEventMediator directorMediator)
         : base("Score")
     {
+        _directorMediator = directorMediator;
         Position = new Vector2(0, 30);
         Size = new Vector2(800, 600);
         CustomMinimumSize = Size;
-        _grid = new DirGodotScoreGrid();
+        _grid = new DirGodotScoreGrid(directorMediator);
         _header = new DirGodotFrameHeader();
         _frameScripts = new DirGodotFrameScriptsBar();
         _labelBar = new DirGodotScoreLabelsBar();
@@ -222,6 +225,12 @@ internal partial class DirGodotScoreGrid : Control
     private bool _dragEnd;
     private readonly List<DirGodotScoreSprite> _sprites = new();
     private DirGodotScoreSprite? _selected;
+    private readonly IDirectorEventMediator _mediator;
+
+    public DirGodotScoreGrid(IDirectorEventMediator mediator)
+    {
+        _mediator = mediator;
+    }
 
     public void SetMovie(LingoMovie? movie)
     {
@@ -244,7 +253,7 @@ internal partial class DirGodotScoreGrid : Control
         if (_selected != null)
         {
             _selected.Selected = true;
-            _movie?.RaiseSpriteSelected(_selected.Sprite);
+            _mediator.RaiseSpriteSelected(_selected.Sprite);
         }
         QueueRedraw();
     }

--- a/src/LingoEngine/Events/IHasMouseDownEvent.cs
+++ b/src/LingoEngine/Events/IHasMouseDownEvent.cs
@@ -101,9 +101,4 @@ namespace LingoEngine.Events
         void Blur();
     }
 
-    public interface IHasSpriteSelectedEvent
-    {
-        void SpriteSelected(LingoEngine.Movies.LingoSprite sprite);
-    }
-
 }

--- a/src/LingoEngine/Events/LingoEventMediator.cs
+++ b/src/LingoEngine/Events/LingoEventMediator.cs
@@ -22,7 +22,6 @@ namespace LingoEngine.Events
         private readonly List<IHasExitFrameEvent> _exitFrames = new();
         private readonly List<IHasFocusEvent> _focuss = new();
         private readonly List<IHasBlurEvent> _blurs = new();
-        private readonly List<IHasSpriteSelectedEvent> _spriteSelected = new();
         private readonly List<IHasKeyUpEvent> _keyUps = new();
         private readonly List<IHasKeyDownEvent> _keyDowns = new();
 
@@ -45,7 +44,6 @@ namespace LingoEngine.Events
             if (ms is IHasExitFrameEvent exitFrameEvent) _exitFrames.Add(exitFrameEvent);
             if (ms is IHasFocusEvent focusEvent) _focuss.Add(focusEvent);
             if (ms is IHasBlurEvent blurEvent) _blurs.Add(blurEvent);
-            if (ms is IHasSpriteSelectedEvent spriteSelected) _spriteSelected.Add(spriteSelected);
             if (ms is IHasKeyUpEvent keyUpEvent) _keyUps.Add(keyUpEvent);
             if (ms is IHasKeyDownEvent keyDownEvent) _keyDowns.Add(keyDownEvent);
         }
@@ -67,7 +65,6 @@ namespace LingoEngine.Events
             if (ms is IHasExitFrameEvent exitFrameEvent) _exitFrames.Remove(exitFrameEvent);
             if (ms is IHasFocusEvent focusEvent) _focuss.Remove(focusEvent);
             if (ms is IHasBlurEvent blurEvent) _blurs.Remove(blurEvent);
-            if (ms is IHasSpriteSelectedEvent spriteSelected) _spriteSelected.Remove(spriteSelected);
             if (ms is IHasKeyUpEvent keyUpEvent) _keyUps.Remove(keyUpEvent);
             if (ms is IHasKeyDownEvent keyDownEvent) _keyDowns.Remove(keyDownEvent);
         }
@@ -89,7 +86,6 @@ namespace LingoEngine.Events
         public void RaiseBlur() => _blurs.ForEach(x => x.Blur());
         public void RaiseKeyUp(LingoKey key) => _keyUps.ForEach(x => x.KeyUp(key));
         public void RaiseKeyDown(LingoKey key) => _keyDowns.ForEach(x => x.KeyDown(key));
-        public void RaiseSpriteSelected(LingoSprite sprite) => _spriteSelected.ForEach(x => x.SpriteSelected(sprite));
 
 
     }

--- a/src/LingoEngine/Movies/LingoMovie.cs
+++ b/src/LingoEngine/Movies/LingoMovie.cs
@@ -590,9 +590,5 @@ namespace LingoEngine.Movies
         public LingoMember? MouseMemberUnderMouse() // todo : implement
             => null;
 
-        public void RaiseSpriteSelected(LingoSprite sprite)
-        {
-            _EventMediator.RaiseSpriteSelected(sprite);
-        }
     }
 }

--- a/src/LingoEngine/Movies/LingoMovieEnvironment.cs
+++ b/src/LingoEngine/Movies/LingoMovieEnvironment.cs
@@ -101,9 +101,5 @@ namespace LingoEngine.Movies
 
         T? ILingoMovieEnvironment.GetMember<T>(string name, int? castLibNum = null) where T : class => _castLibsContainer.GetMember<T>(name, castLibNum);
 
-        public void RaiseSpriteSelected(LingoSprite sprite)
-        {
-            _eventMediator.RaiseSpriteSelected(sprite);
-        }
     }
 }


### PR DESCRIPTION
## Summary
- create `DirectorEventMediator` and `IHasSpriteSelectedEvent` in Director.Core
- register mediator and update DirGodot setup
- wire DirGodotScoreWindow and grid to new mediator
- drop sprite selection handling from LingoEngine

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e5805021c8332b52b7c454520503c