### PR TITLE
Fix Lingo AST numeric parsing and solution paths

### DIFF
--- a/LingoEngine.sln
+++ b/LingoEngine.sln
@@ -7,13 +7,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine", "src\LingoEng
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.Director.Core", "src\Director\LingoEngine.Director.Core\LingoEngine.Director.Core.csproj", "{FE6899B0-5293-47AF-A9AE-F1F3AF17DD6F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.Director.Godot", "src\Director\LingoEngine.Director.Godot\LingoEngine.Director.Godot.csproj", "{2009218F-69F3-4EEB-9271-B2A7B5263DA8}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.Director.LGodot", "src\Director\LingoEngine.Director.LGodot\LingoEngine.Director.LGodot.csproj", "{2009218F-69F3-4EEB-9271-B2A7B5263DA8}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Director", "Director", "{C39BDD3F-275A-45C4-B17D-2E9B6FD7F43F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.IO", "src\LingoEngine.IO\LingoEngine.IO.csproj", "{8E913D86-3D01-4C79-9302-2A05071A2EDF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.Godot", "src\LingoEngine.Godot\LingoEngine.Godot.csproj", "{E81C83CB-2444-45E5-8C9E-B2B97352346C}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.LGodot", "src\LingoEngine.LGodot\LingoEngine.LGodot.csproj", "{E81C83CB-2444-45E5-8C9E-B2B97352346C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.SDL2", "src\LingoEngine.SDL2\LingoEngine.SDL2.csproj", "{0C252B64-B132-4DAC-BD29-BA521E058844}"
 EndProject
@@ -21,7 +21,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Z_Experimental.ScummVMDotNe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.Lingo.Core", "src\LingoEngine.Lingo.Core\LingoEngine.Lingo.Core.csproj", "{21317C8D-4C69-4A21-875D-B3C0F795C67E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.Lingo.Core.Tests", "src\LingoEngine.Lingo.Core.Tests\LingoEngine.Lingo.Core.Tests.csproj", "{14F3B01A-EF1E-4EA9-834D-594AE01541D2}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.Lingo.Core.Tests", "Test\LingoEngine.Lingo.Core.Tests\LingoEngine.Lingo.Core.Tests.csproj", "{14F3B01A-EF1E-4EA9-834D-594AE01541D2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GodotEngine", "GodotEngine", "{3AA856C9-CA3F-4C36-8D8E-90C760E726CF}"
 EndProject

--- a/src/LingoEngine.Lingo.Core/LingoCodeWriterVisitor.cs
+++ b/src/LingoEngine.Lingo.Core/LingoCodeWriterVisitor.cs
@@ -1,5 +1,6 @@
 ﻿using LingoEngine.Lingo.Core.Tokenizer;
 using System.Text;
+using System.Collections.Generic;
 
 namespace LingoEngine.Lingo.Core
 {

--- a/src/LingoEngine.Lingo.Core/Tokenizer/Datum.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/Datum.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Collections.Generic;
 
 namespace LingoEngine.Lingo.Core.Tokenizer
 {

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
@@ -137,10 +137,37 @@
             switch (_currentToken.Type)
             {
                 case LingoTokenType.Number:
-                case LingoTokenType.String:
-                    var literal = new LingoDatumNode(new LingoDatum(_currentToken.Lexeme));
+                    var text = _currentToken.Lexeme;
+                    LingoDatum datum;
+                    if (text.StartsWith("$"))
+                    {
+                        if (int.TryParse(text[1..], System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture, out var hex))
+                            datum = new LingoDatum(hex);
+                        else
+                            datum = new LingoDatum(text);
+                    }
+                    else if (text.Contains('.'))
+                    {
+                        if (float.TryParse(text, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var f))
+                            datum = new LingoDatum(f);
+                        else
+                            datum = new LingoDatum(text);
+                    }
+                    else if (int.TryParse(text, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var i))
+                    {
+                        datum = new LingoDatum(i);
+                    }
+                    else
+                    {
+                        datum = new LingoDatum(text);
+                    }
                     AdvanceToken();
-                    return literal;
+                    return new LingoDatumNode(datum);
+
+                case LingoTokenType.String:
+                    var strLiteral = new LingoDatumNode(new LingoDatum(_currentToken.Lexeme));
+                    AdvanceToken();
+                    return strLiteral;
 
                 case LingoTokenType.Identifier:
                     var ident = new LingoDatumNode(new LingoDatum(_currentToken.Lexeme, isSymbol: true));

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoHandler.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoHandler.cs
@@ -1,4 +1,6 @@
-﻿namespace LingoEngine.Lingo.Core.Tokenizer
+﻿using System.Collections.Generic;
+
+namespace LingoEngine.Lingo.Core.Tokenizer
 {
   /// <summary>
     /// Represents a Lingo handler (method or event).

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoNodes.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoNodes.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using System.Collections.Generic;
+
 namespace LingoEngine.Lingo.Core.Tokenizer
 {
     public abstract class LingoNode

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoTokenizer.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoTokenizer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using System.Text;
+using System.Collections.Generic;
 
 namespace LingoEngine.Lingo.Core.Tokenizer
 {


### PR DESCRIPTION
## Summary
- fix incorrect number literal handling in `ParseExpression`
- update solution to reference correct project paths

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_684e5ba50ab88332bbc9b6747e5cbb89