### PR TITLE
Extend C# project with initial Lingo decompiler

### DIFF
--- a/LingoEngine.sln
+++ b/LingoEngine.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.SDL2", "src\Lin
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Z_Experimental.ScummVMDotNet", "Z_Analysis\ScummVM.DotNet\Z_Experimental.ScummVMDotNet.csproj", "{B39DC8A4-9B09-4B2D-BA27-9C25F759B056}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectorRays.DotNet", "Z_Analysis\ProjectorRays.DotNet\ProjectorRays.DotNet.csproj", "{1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.Lingo.Core", "src\LingoEngine.Lingo.Core\LingoEngine.Lingo.Core.csproj", "{21317C8D-4C69-4A21-875D-B3C0F795C67E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.Lingo.Core.Tests", "src\LingoEngine.Lingo.Core.Tests\LingoEngine.Lingo.Core.Tests.csproj", "{14F3B01A-EF1E-4EA9-834D-594AE01541D2}"
@@ -172,6 +174,24 @@ Global
 		{B39DC8A4-9B09-4B2D-BA27-9C25F759B056}.ExportRelease|x64.Build.0 = Release|x64
 		{B39DC8A4-9B09-4B2D-BA27-9C25F759B056}.ExportRelease|x86.ActiveCfg = Release|x86
 {B39DC8A4-9B09-4B2D-BA27-9C25F759B056}.ExportRelease|x86.Build.0 = Release|x86
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.Debug|x64.ActiveCfg = Release|x64
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.Debug|x64.Build.0 = Release|x64
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.Debug|x86.ActiveCfg = Debug|x86
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.Debug|x86.Build.0 = Debug|x86
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.ExportDebug|Any CPU.ActiveCfg = Debug|Any CPU
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.ExportDebug|Any CPU.Build.0 = Debug|Any CPU
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.ExportDebug|x64.ActiveCfg = Debug|x64
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.ExportDebug|x64.Build.0 = Debug|x64
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.ExportDebug|x86.ActiveCfg = Debug|x86
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.ExportDebug|x86.Build.0 = Debug|x86
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.ExportRelease|Any CPU.ActiveCfg = Release|Any CPU
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.ExportRelease|Any CPU.Build.0 = Release|Any CPU
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.ExportRelease|x64.ActiveCfg = Release|x64
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.ExportRelease|x64.Build.0 = Release|x64
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.ExportRelease|x86.ActiveCfg = Release|x86
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC}.ExportRelease|x86.Build.0 = Release|x86
                 {21317C8D-4C69-4A21-875D-B3C0F795C67E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
                 {21317C8D-4C69-4A21-875D-B3C0F795C67E}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {21317C8D-4C69-4A21-875D-B3C0F795C67E}.Debug|x64.ActiveCfg = Release|x64
@@ -274,6 +294,7 @@ Global
 		{E81C83CB-2444-45E5-8C9E-B2B97352346C} = {3AA856C9-CA3F-4C36-8D8E-90C760E726CF}
 		{0C252B64-B132-4DAC-BD29-BA521E058844} = {3AA856C9-CA3F-4C36-8D8E-90C760E726CF}
 		{B39DC8A4-9B09-4B2D-BA27-9C25F759B056} = {3AA856C9-CA3F-4C36-8D8E-90C760E726CF}
+                {1A63ED2A-74E9-402F-A5C7-BC38232BE8FC} = {3AA856C9-CA3F-4C36-8D8E-90C760E726CF}
 		{B70E95C8-D8DB-40CF-A358-67122A25ABBB} = {1C86A253-18C3-48D2-8819-99254C79E608}
 		{E36DC08A-76EA-41BE-9270-9FC54C7C62D5} = {1C86A253-18C3-48D2-8819-99254C79E608}
                 {1A989944-B93E-4A33-9F7E-B5B78DAF0B63} = {1C86A253-18C3-48D2-8819-99254C79E608}

--- a/Z_Analysis/ProjectorRays.DotNet/Program.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/Program.cs
@@ -1,0 +1,45 @@
+namespace ProjectorRays;
+
+using ProjectorRays.Common;
+using ProjectorRays.IO;
+using ProjectorRays.Director;
+using ProjectorRays.LingoDec;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        // Demonstrate JSON writer and streams
+        var writer = new JSONWriter("\n");
+        writer.StartObject();
+        writer.WriteField("message", "Hello from ProjectorRays");
+
+        // simple stream demo
+        byte[] buffer = new byte[16];
+        var ws = new WriteStream(buffer, buffer.Length, Endianness.BigEndian);
+        ws.WriteUint16(0x1234);
+        ws.WriteString("Hi");
+
+        var rs = new ReadStream(buffer, buffer.Length, Endianness.BigEndian);
+        uint val = rs.ReadUint16();
+        string str = rs.ReadString(2);
+
+        writer.WriteField("value", val);
+        writer.WriteField("text", str);
+        writer.WriteField("humanVersion", Util.HumanVersion(1922));
+
+        // demo bytecode decompilation
+        var handler = new Handler(new Script(500));
+        handler.BytecodeArray.Add(new Bytecode((byte)OpCode.kOpPushInt32, 42, 0));
+        handler.BytecodeArray.Add(new Bytecode((byte)OpCode.kOpPushInt32, 100, 1));
+        handler.BytecodeArray.Add(new Bytecode((byte)OpCode.kOpAdd, 0, 2));
+        var cw = new CodeWriter("\n");
+        handler.WriteBytecodeText(cw, false);
+        writer.WriteField("bytecode", cw.ToString().Trim());
+        writer.EndObject();
+
+        string output = writer.ToString();
+        System.Console.WriteLine(output);
+        FileIO.WriteFile("output.json", output);
+    }
+}

--- a/Z_Analysis/ProjectorRays.DotNet/ProjectorRays.DotNet.csproj
+++ b/Z_Analysis/ProjectorRays.DotNet/ProjectorRays.DotNet.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <RootNamespace>ProjectorRays</RootNamespace>
+    <OutputType>Exe</OutputType>
+    <Platforms>AnyCPU;x64;x86</Platforms>
+  </PropertyGroup>
+</Project>

--- a/Z_Analysis/ProjectorRays.DotNet/common/CodeWriter.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/common/CodeWriter.cs
@@ -1,0 +1,81 @@
+using System.Text;
+
+namespace ProjectorRays.Common;
+
+public class CodeWriter
+{
+    protected StringBuilder _stream = new();
+    protected readonly string _lineEnding;
+    protected readonly string _indentation;
+    protected int _indentationLevel = 0;
+    protected bool _indentationWritten = false;
+    protected int _lineWidth = 0;
+    protected int _size = 0;
+
+    public bool DoIndentation = true;
+
+    public CodeWriter(string lineEnding, string indentation = "  ")
+    {
+        _lineEnding = lineEnding;
+        _indentation = indentation;
+    }
+
+    public void Write(string str)
+    {
+        if (string.IsNullOrEmpty(str))
+            return;
+        WriteIndentation();
+        _stream.Append(str);
+        _lineWidth += str.Length;
+        _size += str.Length;
+    }
+
+    public void Write(char ch)
+    {
+        WriteIndentation();
+        _stream.Append(ch);
+        _lineWidth += 1;
+        _size += 1;
+    }
+
+    public void WriteLine(string str)
+    {
+        if (string.IsNullOrEmpty(str))
+        {
+            _stream.Append(_lineEnding);
+        }
+        else
+        {
+            WriteIndentation();
+            _stream.Append(str).Append(_lineEnding);
+        }
+        _indentationWritten = false;
+        _lineWidth = 0;
+        _size += str.Length + _lineEnding.Length;
+    }
+
+    public void WriteLine() => WriteLine(string.Empty);
+
+    public void Indent() => _indentationLevel++;
+
+    public void Unindent()
+    {
+        if (_indentationLevel > 0)
+            _indentationLevel--;
+    }
+
+    public override string ToString() => _stream.ToString();
+    public int LineWidth => _lineWidth;
+    public int Size => _size;
+
+    protected void WriteIndentation()
+    {
+        if (_indentationWritten || !DoIndentation)
+            return;
+        for (int i = 0; i < _indentationLevel; i++)
+            _stream.Append(_indentation);
+        _indentationWritten = true;
+        _lineWidth = _indentationLevel * _indentation.Length;
+        _size += _lineWidth;
+    }
+}

--- a/Z_Analysis/ProjectorRays.DotNet/common/JSONWriter.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/common/JSONWriter.cs
@@ -1,0 +1,147 @@
+namespace ProjectorRays.Common;
+
+public class JSONWriter : CodeWriter
+{
+    private enum Context
+    {
+        Start,
+        OpenBrace,
+        Key,
+        Value
+    }
+
+    private Context _context = Context.Start;
+
+    public JSONWriter(string lineEnding, string indentation = "  ")
+        : base(lineEnding, indentation)
+    {
+    }
+
+    public void StartObject()
+    {
+        WriteValuePrefix();
+        Write("{");
+        Indent();
+        _context = Context.OpenBrace;
+    }
+
+    public void WriteKey(string key)
+    {
+        WriteValuePrefix();
+        WriteString(key);
+        Write(": ");
+        _context = Context.Key;
+    }
+
+    public void EndObject()
+    {
+        WriteCloseBracePrefix();
+        Unindent();
+        Write("}");
+        _context = Context.Value;
+        WriteValueSuffix();
+    }
+
+    public void StartArray()
+    {
+        WriteValuePrefix();
+        Write("[");
+        Indent();
+        _context = Context.OpenBrace;
+    }
+
+    public void EndArray()
+    {
+        WriteCloseBracePrefix();
+        Unindent();
+        Write("]");
+        _context = Context.Value;
+        WriteValueSuffix();
+    }
+
+    public void WriteVal(uint val)
+    {
+        WriteValuePrefix();
+        Write(val.ToString());
+        _context = Context.Value;
+        WriteValueSuffix();
+    }
+
+    public void WriteVal(int val)
+    {
+        WriteValuePrefix();
+        Write(val.ToString());
+        _context = Context.Value;
+        WriteValueSuffix();
+    }
+
+    public void WriteVal(double val)
+    {
+        WriteValuePrefix();
+        Write(Util.FloatToString(val));
+        _context = Context.Value;
+        WriteValueSuffix();
+    }
+
+    public void WriteVal(string val)
+    {
+        WriteValuePrefix();
+        WriteString(val);
+        _context = Context.Value;
+        WriteValueSuffix();
+    }
+
+    public void WriteNull()
+    {
+        WriteValuePrefix();
+        Write("null");
+        _context = Context.Value;
+        WriteValueSuffix();
+    }
+
+    public void WriteFourCC(uint val)
+    {
+        WriteValuePrefix();
+        Write("\"");
+        Write(Util.FourCCToString(val));
+        Write("\"");
+        _context = Context.Value;
+        WriteValueSuffix();
+    }
+
+    public void WriteField(string key, uint val) { WriteKey(key); WriteVal(val); }
+    public void WriteField(string key, int val) { WriteKey(key); WriteVal(val); }
+    public void WriteField(string key, double val) { WriteKey(key); WriteVal(val); }
+    public void WriteField(string key, string val) { WriteKey(key); WriteVal(val); }
+    public void WriteNullField(string key) { WriteKey(key); WriteNull(); }
+    public void WriteFourCCField(string key, uint val) { WriteKey(key); WriteFourCC(val); }
+
+    public new string ToString() => base.ToString();
+
+    private void WriteString(string str)
+    {
+        Write("\"");
+        Write(Util.EscapeString(str));
+        Write("\"");
+    }
+
+    private void WriteValuePrefix()
+    {
+        if (_context == Context.Value)
+            Write(",");
+        if (_context == Context.Value || _context == Context.OpenBrace)
+            WriteLine();
+    }
+
+    private void WriteValueSuffix()
+    {
+        if (_indentationLevel == 0)
+            WriteLine();
+    }
+
+    private void WriteCloseBracePrefix()
+    {
+        if (_context == Context.Value)
+            WriteLine();
+    }
+}

--- a/Z_Analysis/ProjectorRays.DotNet/common/Log.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/common/Log.cs
@@ -1,0 +1,38 @@
+namespace ProjectorRays.Common;
+
+public static class Log
+{
+    public static bool Verbose = false;
+
+    public static void Write(string msg)
+    {
+        System.Console.WriteLine(msg);
+    }
+
+    public static void Write(System.FormattableString msg)
+    {
+        System.Console.WriteLine(msg.ToString());
+    }
+
+    public static void Debug(string msg)
+    {
+        if (Verbose)
+            Write(msg);
+    }
+
+    public static void Debug(System.FormattableString msg)
+    {
+        if (Verbose)
+            Write(msg);
+    }
+
+    public static void Warning(string msg)
+    {
+        System.Console.Error.WriteLine(msg);
+    }
+
+    public static void Warning(System.FormattableString msg)
+    {
+        System.Console.Error.WriteLine(msg.ToString());
+    }
+}

--- a/Z_Analysis/ProjectorRays.DotNet/common/Stream.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/common/Stream.cs
@@ -1,0 +1,334 @@
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+
+namespace ProjectorRays.Common;
+
+public enum Endianness
+{
+    BigEndian = 0,
+    LittleEndian = 1
+}
+
+public class BufferView
+{
+    protected byte[] _data;
+    protected int _offset;
+    protected int _size;
+
+    public BufferView()
+    {
+        _data = Array.Empty<byte>();
+        _offset = 0;
+        _size = 0;
+    }
+
+    public BufferView(byte[] data, int size)
+        : this(data, 0, size) {}
+
+    public BufferView(byte[] data, int offset, int size)
+    {
+        _data = data;
+        _offset = offset;
+        _size = size;
+    }
+
+    public int Size => _size;
+    public byte[] Data => _data;
+    public int Offset => _offset;
+}
+
+public class Stream : BufferView
+{
+    protected int _pos;
+    public Endianness Endianness { get; set; }
+
+    public Stream(byte[] d, int s, Endianness e = Endianness.BigEndian, int p = 0)
+        : base(d, 0, s)
+    {
+        _pos = p;
+        Endianness = e;
+    }
+
+    public Stream(BufferView view, Endianness e = Endianness.BigEndian, int p = 0)
+        : base(view.Data, view.Offset, view.Size)
+    {
+        _pos = p;
+        Endianness = e;
+    }
+
+    public int Pos => _pos;
+
+    public long Seek(long offset, SeekOrigin whence)
+    {
+        switch (whence)
+        {
+            case SeekOrigin.Begin:
+                _pos = (int)offset;
+                break;
+            case SeekOrigin.Current:
+                _pos += (int)offset;
+                break;
+            case SeekOrigin.End:
+                _pos = _size + (int)offset;
+                break;
+            default:
+                return -1;
+        }
+        return _pos;
+    }
+
+    public void Seek(int pos) => _pos = pos;
+
+    public void Skip(long offset) => _pos += (int)offset;
+
+    public bool Eof => _pos >= _size;
+
+    public bool PastEOF => _pos > _size;
+}
+
+public class ReadStream : Stream
+{
+    public ReadStream(byte[] d, int s, Endianness e = Endianness.BigEndian, int p = 0)
+        : base(d, s, e, p) { }
+
+    public ReadStream(BufferView view, Endianness e = Endianness.BigEndian, int p = 0)
+        : base(view, e, p) { }
+
+    public BufferView ReadByteView(int len)
+    {
+        var view = new BufferView(_data, _offset + _pos, len);
+        _pos += len;
+        return view;
+    }
+
+    public int ReadUpToBytes(int len, byte[] dest)
+    {
+        if (Eof)
+            return 0;
+        if (_pos + len > _size)
+            len = _size - _pos;
+        Array.Copy(_data, _offset + _pos, dest, 0, len);
+        _pos += len;
+        return len;
+    }
+
+    public int ReadZlibBytes(int len, byte[] dest, int destLen)
+    {
+        var view = ReadByteView(len);
+        if (PastEOF)
+            throw new InvalidOperationException("ReadStream.ReadZlibBytes: Read past end of stream!");
+
+        using var ms = new MemoryStream(view.Data, view.Offset, view.Size);
+        using var zs = new ZLibStream(ms, CompressionMode.Decompress);
+        return zs.Read(dest, 0, destLen);
+    }
+
+    public byte ReadUint8()
+    {
+        int p = _pos;
+        _pos += 1;
+        if (PastEOF)
+            throw new InvalidOperationException("ReadStream.ReadUint8: Read past end of stream!");
+        return _data[_offset + p];
+    }
+
+    public sbyte ReadInt8() => (sbyte)ReadUint8();
+
+    public ushort ReadUint16()
+    {
+        int p = _pos;
+        _pos += 2;
+        if (PastEOF)
+            throw new InvalidOperationException("ReadStream.ReadUint16: Read past end of stream!");
+        return Endianness == Endianness.LittleEndian
+            ? BinaryPrimitives.ReadUInt16LittleEndian(_data.AsSpan(_offset + p, 2))
+            : BinaryPrimitives.ReadUInt16BigEndian(_data.AsSpan(_offset + p, 2));
+    }
+
+    public short ReadInt16() => (short)ReadUint16();
+
+    public uint ReadUint32()
+    {
+        int p = _pos;
+        _pos += 4;
+        if (PastEOF)
+            throw new InvalidOperationException("ReadStream.ReadUint32: Read past end of stream!");
+        return Endianness == Endianness.LittleEndian
+            ? BinaryPrimitives.ReadUInt32LittleEndian(_data.AsSpan(_offset + p, 4))
+            : BinaryPrimitives.ReadUInt32BigEndian(_data.AsSpan(_offset + p, 4));
+    }
+
+    public int ReadInt32() => (int)ReadUint32();
+
+    public double ReadDouble()
+    {
+        int p = _pos;
+        _pos += 8;
+        if (PastEOF)
+            throw new InvalidOperationException("ReadStream.ReadDouble: Read past end of stream!");
+        ulong val = Endianness == Endianness.LittleEndian
+            ? BinaryPrimitives.ReadUInt64LittleEndian(_data.AsSpan(_offset + p, 8))
+            : BinaryPrimitives.ReadUInt64BigEndian(_data.AsSpan(_offset + p, 8));
+        return BitConverter.Int64BitsToDouble((long)val);
+    }
+
+    public double ReadAppleFloat80()
+    {
+        int p = _pos;
+        _pos += 10;
+        if (PastEOF)
+            throw new InvalidOperationException("ReadStream.ReadAppleFloat80: Read past end of stream!");
+
+        ushort exponent = BinaryPrimitives.ReadUInt16BigEndian(_data.AsSpan(_offset + p, 2));
+        ulong f64sign = (ulong)(exponent & 0x8000) << 48;
+        exponent &= 0x7fff;
+        ulong fraction = BinaryPrimitives.ReadUInt64BigEndian(_data.AsSpan(_offset + p + 2, 8));
+        fraction &= 0x7fffffffffffffffUL;
+        ulong f64exp = 0;
+        if (exponent == 0)
+        {
+            f64exp = 0;
+        }
+        else if (exponent == 0x7fff)
+        {
+            f64exp = 0x7ff;
+        }
+        else
+        {
+            int normexp = (int)exponent - 0x3fff;
+            if (-0x3fe > normexp || normexp >= 0x3ff)
+                throw new InvalidOperationException("Constant float exponent too big for a double");
+            f64exp = (ulong)(normexp + 0x3ff);
+        }
+        f64exp <<= 52;
+        ulong f64fract = fraction >> 11;
+        ulong f64bin = f64sign | f64exp | f64fract;
+        return BitConverter.Int64BitsToDouble((long)f64bin);
+    }
+
+    public uint ReadVarInt()
+    {
+        uint val = 0;
+        byte b;
+        do
+        {
+            b = ReadUint8();
+            val = (val << 7) | (uint)(b & 0x7f);
+        } while ((b >> 7) != 0);
+        return val;
+    }
+
+    public string ReadString(int len)
+    {
+        int p = _pos;
+        _pos += len;
+        if (PastEOF)
+            throw new InvalidOperationException("ReadStream.ReadString: Read past end of stream!");
+        return Encoding.ASCII.GetString(_data, _offset + p, len);
+    }
+
+    public string ReadCString()
+    {
+        var sb = new StringBuilder();
+        byte ch = ReadUint8();
+        while (ch != 0)
+        {
+            sb.Append((char)ch);
+            ch = ReadUint8();
+        }
+        return sb.ToString();
+    }
+
+    public string ReadPascalString()
+    {
+        int len = ReadUint8();
+        return ReadString(len);
+    }
+}
+
+public class WriteStream : Stream
+{
+    public WriteStream(byte[] d, int s, Endianness e = Endianness.BigEndian, int p = 0)
+        : base(d, s, e, p) { }
+
+    public WriteStream(BufferView view, Endianness e = Endianness.BigEndian, int p = 0)
+        : base(view, e, p) { }
+
+    public int WriteBytes(ReadOnlySpan<byte> data)
+    {
+        int p = _pos;
+        _pos += data.Length;
+        if (PastEOF)
+            throw new InvalidOperationException("WriteStream.WriteBytes: Write past end of stream!");
+        data.CopyTo(_data.AsSpan(_offset + p, data.Length));
+        return data.Length;
+    }
+
+    public int WriteBytes(BufferView view) => WriteBytes(view.Data.AsSpan(view.Offset, view.Size));
+
+    public void WriteUint8(byte value)
+    {
+        int p = _pos;
+        _pos += 1;
+        if (PastEOF)
+            throw new InvalidOperationException("WriteStream.WriteUint8: Write past end of stream!");
+        _data[_offset + p] = value;
+    }
+
+    public void WriteInt8(sbyte value) => WriteUint8((byte)value);
+
+    public void WriteUint16(ushort value)
+    {
+        int p = _pos;
+        _pos += 2;
+        if (PastEOF)
+            throw new InvalidOperationException("WriteStream.WriteUint16: Write past end of stream!");
+        if (Endianness == Endianness.LittleEndian)
+            BinaryPrimitives.WriteUInt16LittleEndian(_data.AsSpan(_offset + p, 2), value);
+        else
+            BinaryPrimitives.WriteUInt16BigEndian(_data.AsSpan(_offset + p, 2), value);
+    }
+
+    public void WriteInt16(short value) => WriteUint16((ushort)value);
+
+    public void WriteUint32(uint value)
+    {
+        int p = _pos;
+        _pos += 4;
+        if (PastEOF)
+            throw new InvalidOperationException("WriteStream.WriteUint32: Write past end of stream!");
+        if (Endianness == Endianness.LittleEndian)
+            BinaryPrimitives.WriteUInt32LittleEndian(_data.AsSpan(_offset + p, 4), value);
+        else
+            BinaryPrimitives.WriteUInt32BigEndian(_data.AsSpan(_offset + p, 4), value);
+    }
+
+    public void WriteInt32(int value) => WriteUint32((uint)value);
+
+    public void WriteDouble(double value)
+    {
+        int p = _pos;
+        _pos += 8;
+        if (PastEOF)
+            throw new InvalidOperationException("WriteStream.WriteDouble: Write past end of stream!");
+        ulong v = (ulong)BitConverter.DoubleToInt64Bits(value);
+        if (Endianness == Endianness.LittleEndian)
+            BinaryPrimitives.WriteUInt64LittleEndian(_data.AsSpan(_offset + p, 8), v);
+        else
+            BinaryPrimitives.WriteUInt64BigEndian(_data.AsSpan(_offset + p, 8), v);
+    }
+
+    public void WriteString(string value)
+    {
+        WriteBytes(Encoding.ASCII.GetBytes(value));
+    }
+
+    public void WritePascalString(string value)
+    {
+        WriteUint8((byte)value.Length);
+        WriteString(value);
+    }
+}

--- a/Z_Analysis/ProjectorRays.DotNet/common/Util.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/common/Util.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace ProjectorRays.Common;
+
+public static class Util
+{
+    public static string FourCCToString(uint fourcc)
+    {
+        char[] chars = new char[4];
+        chars[0] = (char)(fourcc >> 24);
+        chars[1] = (char)(fourcc >> 16);
+        chars[2] = (char)(fourcc >> 8);
+        chars[3] = (char)fourcc;
+        return EscapeString(new string(chars));
+    }
+
+    public static string FloatToString(double value)
+    {
+        string res = value.ToString("G17", CultureInfo.InvariantCulture);
+        if (res.Contains(".") && res.EndsWith("0"))
+        {
+            res = res.TrimEnd('0');
+            if (res.EndsWith("."))
+                res = res.TrimEnd('.');
+        }
+        return res;
+    }
+
+    public static string ByteToString(byte b) => b.ToString("X2", CultureInfo.InvariantCulture);
+
+    public static string EscapeString(string str) => EscapeString(str.AsSpan());
+
+    public static string EscapeString(ReadOnlySpan<char> span)
+    {
+        StringBuilder res = new();
+        foreach (char ch in span)
+        {
+            switch (ch)
+            {
+                case '"': res.Append("\\\""); break;
+                case '\\': res.Append("\\\\"); break;
+                case '\b': res.Append("\\b"); break;
+                case '\f': res.Append("\\f"); break;
+                case '\n': res.Append("\\n"); break;
+                case '\r': res.Append("\\r"); break;
+                case '\t': res.Append("\\t"); break;
+                case '\v': res.Append("\\v"); break;
+                default:
+                    if (ch < 0x20 || ch > 0x7F)
+                    {
+                        res.Append("\\x").Append(ByteToString((byte)ch));
+                    }
+                    else
+                    {
+                        res.Append(ch);
+                    }
+                    break;
+            }
+        }
+        return res.ToString();
+    }
+
+    public static int Stricmp(string a, string b) => string.Compare(a, b, StringComparison.OrdinalIgnoreCase);
+
+    public static int CompareIgnoreCase(string a, string b) => Stricmp(a, b);
+}

--- a/Z_Analysis/ProjectorRays.DotNet/director/Guid.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/director/Guid.cs
@@ -1,0 +1,70 @@
+using ProjectorRays.Common;
+
+namespace ProjectorRays.Director;
+
+public unsafe struct MoaID
+{
+    public uint Data1;
+    public ushort Data2;
+    public ushort Data3;
+    public fixed byte Data4[8];
+
+    public MoaID(uint d1, ushort d2, ushort d3,
+        byte d40, byte d41, byte d42, byte d43,
+        byte d44, byte d45, byte d46, byte d47)
+    {
+        Data1 = d1;
+        Data2 = d2;
+        Data3 = d3;
+        Data4[0] = d40; Data4[1] = d41; Data4[2] = d42; Data4[3] = d43;
+        Data4[4] = d44; Data4[5] = d45; Data4[6] = d46; Data4[7] = d47;
+    }
+
+    public void Read(ReadStream stream)
+    {
+        Data1 = stream.ReadUint32();
+        Data2 = stream.ReadUint16();
+        Data3 = stream.ReadUint16();
+        for (int i = 0; i < 8; i++)
+            Data4[i] = stream.ReadUint8();
+    }
+
+    public override readonly string ToString()
+    {
+        unsafe
+        {
+            fixed (byte* d = Data4)
+            {
+                return string.Format(
+                    "{0:X8}-{1:X4}-{2:X4}-{3:X2}{4:X2}-{5:X2}{6:X2}{7:X2}{8:X2}{9:X2}{10:X2}",
+                    Data1, Data2, Data3,
+                    d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
+            }
+        }
+    }
+
+    public readonly bool Equals(MoaID other)
+    {
+        if (Data1 != other.Data1 || Data2 != other.Data2 || Data3 != other.Data3)
+            return false;
+        for (int i = 0; i < 8; i++)
+            if (Data4[i] != other.Data4[i])
+                return false;
+        return true;
+    }
+
+    public static bool operator ==(MoaID left, MoaID right) => left.Equals(right);
+    public static bool operator !=(MoaID left, MoaID right) => !left.Equals(right);
+
+    public override bool Equals(object? obj) => obj is MoaID other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(Data1, Data2, Data3,
+        Data4[0], Data4[1], Data4[2], Data4[3], Data4[4], Data4[5], Data4[6], Data4[7]);
+}
+
+public static class GuidConstants
+{
+    public static readonly MoaID FONTMAP_COMPRESSION_GUID = new(0x8A4679A1, 0x3720, 0x11D0, 0x92, 0x23, 0x00, 0xA0, 0xC9, 0x08, 0x68, 0xB1);
+    public static readonly MoaID NULL_COMPRESSION_GUID = new(0xAC99982E, 0x005D, 0x0D50, 0x00, 0x00, 0x08, 0x00, 0x07, 0x37, 0x7A, 0x34);
+    public static readonly MoaID SND_COMPRESSION_GUID = new(0x7204A889, 0xAFD0, 0x11CF, 0xA2, 0x22, 0x00, 0xA0, 0x24, 0x53, 0x44, 0x4C);
+    public static readonly MoaID ZLIB_COMPRESSION_GUID = new(0xAC99E904, 0x0070, 0x0B36, 0x00, 0x00, 0x08, 0x00, 0x07, 0x37, 0x7A, 0x34);
+}

--- a/Z_Analysis/ProjectorRays.DotNet/director/Util.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/director/Util.cs
@@ -1,0 +1,55 @@
+namespace ProjectorRays.Director;
+
+public static class Util
+{
+    public static uint HumanVersion(uint ver)
+    {
+        if (ver >= 1951) return 1200;
+        if (ver >= 1922) return 1150;
+        if (ver >= 1921) return 1100;
+        if (ver >= 1851) return 1000;
+        if (ver >= 1700) return 850;
+        if (ver >= 1410) return 800;
+        if (ver >= 1224) return 700;
+        if (ver >= 1218) return 600;
+        if (ver >= 1201) return 500;
+        if (ver >= 1117) return 404;
+        if (ver >= 1115) return 400;
+        if (ver >= 1029) return 310;
+        if (ver >= 1028) return 300;
+        return 200;
+    }
+
+    public static string VersionNumber(uint ver, string fverVersionString)
+    {
+        uint major = ver / 100;
+        uint minor = (ver / 10) % 10;
+        uint patch = ver % 10;
+
+        if (string.IsNullOrEmpty(fverVersionString))
+        {
+            string res = major + "." + minor;
+            if (patch != 0)
+                res += "." + patch;
+            return res;
+        }
+        else
+        {
+            return fverVersionString;
+        }
+    }
+
+    public static string VersionString(uint ver, string fverVersionString)
+    {
+        uint major = ver / 100;
+        string versionNum = VersionNumber(ver, fverVersionString);
+
+        if (major >= 11)
+            return "Adobe Director " + versionNum;
+        if (major == 10)
+            return "Macromedia Director MX 2004 (" + versionNum + ")";
+        if (major == 9)
+            return "Macromedia Director MX (" + versionNum + ")";
+        return "Macromedia Director " + versionNum;
+    }
+}

--- a/Z_Analysis/ProjectorRays.DotNet/io/FileIO.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/io/FileIO.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace ProjectorRays.IO;
+
+using ProjectorRays.Common;
+
+public static class FileIO
+{
+    public static readonly string PlatformLineEnding = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "\r\n" : "\n";
+
+    public static bool ReadFile(string path, List<byte> buf)
+    {
+        try
+        {
+            byte[] data = File.ReadAllBytes(path);
+            buf.Clear();
+            buf.AddRange(data);
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+
+    public static void WriteFile(string path, string contents)
+    {
+        File.WriteAllText(path, contents);
+    }
+
+    public static void WriteFile(string path, byte[] contents)
+    {
+        File.WriteAllBytes(path, contents);
+    }
+
+    public static void WriteFile(string path, BufferView view)
+    {
+        byte[] slice = new byte[view.Size];
+        Array.Copy(view.Data, view.Offset, slice, 0, view.Size);
+        File.WriteAllBytes(path, slice);
+    }
+
+    public static string CleanFileName(string fileName)
+    {
+        var res = new System.Text.StringBuilder();
+        foreach (char ch in fileName)
+        {
+            switch (ch)
+            {
+                case '<':
+                case '>':
+                case ':':
+                case '"':
+                case '/':
+                case '\\':
+                case '|':
+                case '?':
+                case '*':
+                    res.Append('_');
+                    break;
+                default:
+                    res.Append(ch);
+                    break;
+            }
+        }
+        return res.ToString();
+    }
+}

--- a/Z_Analysis/ProjectorRays.DotNet/lingodec/AST.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/lingodec/AST.cs
@@ -1,0 +1,59 @@
+using ProjectorRays.Common;
+using System.Collections.Generic;
+
+namespace ProjectorRays.LingoDec;
+
+public class Datum
+{
+    public DatumType Type;
+    public int I;
+    public double F;
+    public string S = string.Empty;
+    public List<Datum> L = new();
+
+    public Datum() { Type = DatumType.kDatumVoid; }
+    public Datum(int val) { Type = DatumType.kDatumInt; I = val; }
+    public Datum(double val) { Type = DatumType.kDatumFloat; F = val; }
+    public Datum(DatumType t, string val) { Type = t; S = val; }
+
+    public int ToInt()
+    {
+        return Type switch
+        {
+            DatumType.kDatumInt => I,
+            DatumType.kDatumFloat => (int)F,
+            _ => 0
+        };
+    }
+
+    public void WriteScriptText(CodeWriter code, bool dot, bool sum)
+    {
+        switch (Type)
+        {
+            case DatumType.kDatumVoid:
+                code.Write("VOID");
+                break;
+            case DatumType.kDatumSymbol:
+                code.Write("#" + S);
+                break;
+            case DatumType.kDatumVarRef:
+                code.Write(S);
+                break;
+            case DatumType.kDatumString:
+                if (S.Length == 0)
+                    code.Write("EMPTY");
+                else
+                    code.Write('"' + S + '"');
+                break;
+            case DatumType.kDatumInt:
+                code.Write(I.ToString());
+                break;
+            case DatumType.kDatumFloat:
+                code.Write(Util.FloatToString(F));
+                break;
+            default:
+                code.Write("LIST");
+                break;
+        }
+    }
+}

--- a/Z_Analysis/ProjectorRays.DotNet/lingodec/Context.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/lingodec/Context.cs
@@ -1,0 +1,108 @@
+using ProjectorRays.Common;
+using System.Collections.Generic;
+
+namespace ProjectorRays.LingoDec;
+
+public interface ChunkResolver
+{
+    Script? GetScript(int id);
+    ScriptNames? GetScriptNames(int id);
+}
+
+public class ScriptContext
+{
+    public int Unknown0;
+    public int Unknown1;
+    public uint EntryCount;
+    public uint EntryCount2;
+    public ushort EntriesOffset;
+    public short Unknown2;
+    public int Unknown3;
+    public int Unknown4;
+    public int Unknown5;
+    public int LnamSectionID;
+    public ushort ValidCount;
+    public ushort Flags;
+    public short FreePointer;
+
+    public uint Version;
+    public ChunkResolver Resolver;
+    public ScriptNames? Lnam;
+    public List<ScriptContextMapEntry> SectionMap = new();
+    public Dictionary<uint, Script> Scripts = new();
+
+    public ScriptContext(uint version, ChunkResolver resolver)
+    {
+        Version = version;
+        Resolver = resolver;
+    }
+
+    public void Read(ReadStream stream)
+    {
+        stream.Endianness = Endianness.BigEndian;
+        Unknown0 = stream.ReadInt32();
+        Unknown1 = stream.ReadInt32();
+        EntryCount = stream.ReadUint32();
+        EntryCount2 = stream.ReadUint32();
+        EntriesOffset = stream.ReadUint16();
+        Unknown2 = stream.ReadInt16();
+        Unknown3 = stream.ReadInt32();
+        Unknown4 = stream.ReadInt32();
+        Unknown5 = stream.ReadInt32();
+        LnamSectionID = stream.ReadInt32();
+        ValidCount = stream.ReadUint16();
+        Flags = stream.ReadUint16();
+        FreePointer = stream.ReadInt16();
+
+        stream.Seek(EntriesOffset);
+        SectionMap.Clear();
+        for (int i = 0; i < EntryCount; i++)
+        {
+            var entry = new ScriptContextMapEntry();
+            entry.Read(stream);
+            SectionMap.Add(entry);
+        }
+
+        Lnam = Resolver.GetScriptNames(LnamSectionID);
+        for (uint i = 1; i <= EntryCount; i++)
+        {
+            var section = SectionMap[(int)i - 1];
+            if (section.SectionID > -1)
+            {
+                var script = Resolver.GetScript(section.SectionID);
+                if (script != null)
+                {
+                    script.SetContext(this);
+                    Scripts[i] = script;
+                }
+            }
+        }
+        foreach (var script in Scripts.Values)
+        {
+            if (script.IsFactory())
+            {
+                var parent = Scripts[(uint)script.ParentNumber + 1];
+                parent.Factories.Add(script);
+            }
+        }
+    }
+
+    public bool ValidName(int id) => Lnam != null && Lnam.ValidName(id);
+    public string GetName(int id) => Lnam != null ? Lnam.GetName(id) : $"NAME_{id}";
+}
+
+public class ScriptContextMapEntry
+{
+    public int Unknown0;
+    public int SectionID;
+    public ushort Unknown1;
+    public ushort Unknown2;
+
+    public void Read(ReadStream stream)
+    {
+        Unknown0 = stream.ReadInt32();
+        SectionID = stream.ReadInt32();
+        Unknown1 = stream.ReadUint16();
+        Unknown2 = stream.ReadUint16();
+    }
+}

--- a/Z_Analysis/ProjectorRays.DotNet/lingodec/Enums.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/lingodec/Enums.cs
@@ -1,0 +1,151 @@
+namespace ProjectorRays.LingoDec;
+
+public enum OpCode : byte
+{
+    // single-byte
+    kOpRet = 0x01,
+    kOpRetFactory = 0x02,
+    kOpPushZero = 0x03,
+    kOpMul = 0x04,
+    kOpAdd = 0x05,
+    kOpSub = 0x06,
+    kOpDiv = 0x07,
+    kOpMod = 0x08,
+    kOpInv = 0x09,
+    kOpJoinStr = 0x0a,
+    kOpJoinPadStr = 0x0b,
+    kOpLt = 0x0c,
+    kOpLtEq = 0x0d,
+    kOpNtEq = 0x0e,
+    kOpEq = 0x0f,
+    kOpGt = 0x10,
+    kOpGtEq = 0x11,
+    kOpAnd = 0x12,
+    kOpOr = 0x13,
+    kOpNot = 0x14,
+    kOpContainsStr = 0x15,
+    kOpContains0Str = 0x16,
+    kOpGetChunk = 0x17,
+    kOpHiliteChunk = 0x18,
+    kOpOntoSpr = 0x19,
+    kOpIntoSpr = 0x1a,
+    kOpGetField = 0x1b,
+    kOpStartTell = 0x1c,
+    kOpEndTell = 0x1d,
+    kOpPushList = 0x1e,
+    kOpPushPropList = 0x1f,
+    kOpSwap = 0x21,
+
+    // multi-byte
+    kOpPushInt8 = 0x41,
+    kOpPushArgListNoRet = 0x42,
+    kOpPushArgList = 0x43,
+    kOpPushCons = 0x44,
+    kOpPushSymb = 0x45,
+    kOpPushVarRef = 0x46,
+    kOpGetGlobal2 = 0x48,
+    kOpGetGlobal = 0x49,
+    kOpGetProp = 0x4a,
+    kOpGetParam = 0x4b,
+    kOpGetLocal = 0x4c,
+    kOpSetGlobal2 = 0x4e,
+    kOpSetGlobal = 0x4f,
+    kOpSetProp = 0x50,
+    kOpSetParam = 0x51,
+    kOpSetLocal = 0x52,
+    kOpJmp = 0x53,
+    kOpEndRepeat = 0x54,
+    kOpJmpIfZ = 0x55,
+    kOpLocalCall = 0x56,
+    kOpExtCall = 0x57,
+    kOpObjCallV4 = 0x58,
+    kOpPut = 0x59,
+    kOpPutChunk = 0x5a,
+    kOpDeleteChunk = 0x5b,
+    kOpGet = 0x5c,
+    kOpSet = 0x5d,
+    kOpGetMovieProp = 0x5f,
+    kOpSetMovieProp = 0x60,
+    kOpGetObjProp = 0x61,
+    kOpSetObjProp = 0x62,
+    kOpTellCall = 0x63,
+    kOpPeek = 0x64,
+    kOpPop = 0x65,
+    kOpTheBuiltin = 0x66,
+    kOpObjCall = 0x67,
+    kOpPushChunkVarRef = 0x6d,
+    kOpPushInt16 = 0x6e,
+    kOpPushInt32 = 0x6f,
+    kOpGetChainedProp = 0x70,
+    kOpPushFloat32 = 0x71,
+    kOpGetTopLevelProp = 0x72,
+    kOpNewObj = 0x73
+}
+
+public enum DatumType
+{
+    kDatumVoid,
+    kDatumSymbol,
+    kDatumVarRef,
+    kDatumString,
+    kDatumInt,
+    kDatumFloat,
+    kDatumList,
+    kDatumArgList,
+    kDatumArgListNoRet,
+    kDatumPropList
+}
+
+public enum ChunkExprType
+{
+    kChunkChar = 0x01,
+    kChunkWord = 0x02,
+    kChunkItem = 0x03,
+    kChunkLine = 0x04
+}
+
+public enum PutType
+{
+    kPutInto = 0x01,
+    kPutAfter = 0x02,
+    kPutBefore = 0x03
+}
+
+public enum BytecodeTag
+{
+    kTagNone,
+    kTagSkip,
+    kTagRepeatWhile,
+    kTagRepeatWithIn,
+    kTagRepeatWithTo,
+    kTagRepeatWithDownTo,
+    kTagNextRepeatTarget,
+    kTagEndCase
+}
+
+public enum ScriptFlag : uint
+{
+    kScriptFlagUnused = 1 << 0,
+    kScriptFlagFuncsGlobal = 1 << 1,
+    kScriptFlagVarsGlobal = 1 << 2,
+    kScriptFlagUnk3 = 1 << 3,
+    kScriptFlagFactoryDef = 1 << 4,
+    kScriptFlagUnk5 = 1 << 5,
+    kScriptFlagUnk6 = 1 << 6,
+    kScriptFlagUnk7 = 1 << 7,
+    kScriptFlagHasFactory = 1 << 8,
+    kScriptFlagEventScript = 1 << 9,
+    kScriptFlagEventScript2 = 1 << 10,
+    kScriptFlagUnkB = 1 << 11,
+    kScriptFlagUnkC = 1 << 12,
+    kScriptFlagUnkD = 1 << 13,
+    kScriptFlagUnkE = 1 << 14,
+    kScriptFlagUnkF = 1U << 15
+}
+
+public enum LiteralType
+{
+    kLiteralString = 1,
+    kLiteralInt = 4,
+    kLiteralFloat = 9
+}

--- a/Z_Analysis/ProjectorRays.DotNet/lingodec/Handler.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/lingodec/Handler.cs
@@ -1,0 +1,236 @@
+using ProjectorRays.Common;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ProjectorRays.LingoDec;
+
+public class Handler
+{
+    public short NameID;
+    public ushort VectorPos;
+    public uint CompiledLen;
+    public uint CompiledOffset;
+    public ushort ArgumentCount;
+    public uint ArgumentOffset;
+    public ushort LocalsCount;
+    public uint LocalsOffset;
+    public ushort GlobalsCount;
+    public uint GlobalsOffset;
+    public uint Unknown1;
+    public ushort Unknown2;
+    public ushort LineCount;
+    public uint LineOffset;
+    public uint StackHeight;
+
+    public List<short> ArgumentNameIDs = new();
+    public List<short> LocalNameIDs = new();
+    public List<short> GlobalNameIDs = new();
+
+    public Script Script;
+    public List<Bytecode> BytecodeArray = new();
+    public Dictionary<uint, int> BytecodePosMap = new();
+    public List<string> ArgumentNames = new();
+    public List<string> LocalNames = new();
+    public List<string> GlobalNames = new();
+    public string Name = string.Empty;
+
+    public bool IsGenericEvent = false;
+
+    public Handler(Script script)
+    {
+        Script = script;
+    }
+
+    public void ReadRecord(ReadStream stream)
+    {
+        NameID = (short)stream.ReadInt16();
+        VectorPos = stream.ReadUint16();
+        CompiledLen = stream.ReadUint32();
+        CompiledOffset = stream.ReadUint32();
+        ArgumentCount = stream.ReadUint16();
+        ArgumentOffset = stream.ReadUint32();
+        LocalsCount = stream.ReadUint16();
+        LocalsOffset = stream.ReadUint32();
+        GlobalsCount = stream.ReadUint16();
+        GlobalsOffset = stream.ReadUint32();
+        Unknown1 = stream.ReadUint32();
+        Unknown2 = stream.ReadUint16();
+        LineCount = stream.ReadUint16();
+        LineOffset = stream.ReadUint32();
+        if (Script.Version >= 850)
+            StackHeight = stream.ReadUint32();
+    }
+
+    public void ReadData(ReadStream stream)
+    {
+        stream.Seek((int)CompiledOffset);
+        while (stream.Pos < CompiledOffset + CompiledLen)
+        {
+            uint pos = (uint)(stream.Pos - CompiledOffset);
+            byte op = stream.ReadUint8();
+            OpCode opcode = op >= 0x40 ? (OpCode)(0x40 + op % 0x40) : (OpCode)op;
+            int obj = 0;
+            if (op >= 0xc0)
+            {
+                obj = stream.ReadInt32();
+            }
+            else if (op >= 0x80)
+            {
+                if (opcode == OpCode.kOpPushInt16 || opcode == OpCode.kOpPushInt8)
+                    obj = stream.ReadInt16();
+                else
+                    obj = stream.ReadUint16();
+            }
+            else if (op >= 0x40)
+            {
+                if (opcode == OpCode.kOpPushInt8)
+                    obj = stream.ReadInt8();
+                else
+                    obj = stream.ReadUint8();
+            }
+            Bytecode bytecode = new(op, obj, pos);
+            BytecodeArray.Add(bytecode);
+            BytecodePosMap[pos] = BytecodeArray.Count - 1;
+        }
+
+        ArgumentNameIDs = ReadVarnamesTable(stream, ArgumentCount, ArgumentOffset);
+        LocalNameIDs = ReadVarnamesTable(stream, LocalsCount, LocalsOffset);
+        GlobalNameIDs = ReadVarnamesTable(stream, GlobalsCount, GlobalsOffset);
+    }
+
+    public List<short> ReadVarnamesTable(ReadStream stream, ushort count, uint offset)
+    {
+        stream.Seek((int)offset);
+        var ids = new List<short>();
+        for (int i = 0; i < count; i++)
+            ids.Add((short)stream.ReadInt16());
+        return ids;
+    }
+
+    public void ReadNames()
+    {
+        if (!IsGenericEvent)
+            Name = GetName(NameID);
+        for (int i = 0; i < ArgumentNameIDs.Count; i++)
+        {
+            if (i == 0 && Script.IsFactory())
+                continue;
+            ArgumentNames.Add(GetName(ArgumentNameIDs[i]));
+        }
+        foreach (var id in LocalNameIDs)
+        {
+            if (ValidName(id))
+                LocalNames.Add(GetName(id));
+        }
+        foreach (var id in GlobalNameIDs)
+        {
+            if (ValidName(id))
+                GlobalNames.Add(GetName(id));
+        }
+    }
+
+    public bool ValidName(int id) => Script.ValidName(id);
+    public string GetName(int id) => Script.GetName(id);
+
+    public string GetArgumentName(int id)
+    {
+        if (id >= 0 && id < ArgumentNameIDs.Count)
+            return GetName(ArgumentNameIDs[id]);
+        return $"UNKNOWN_ARG_{id}";
+    }
+
+    public string GetLocalName(int id)
+    {
+        if (id >= 0 && id < LocalNameIDs.Count)
+            return GetName(LocalNameIDs[id]);
+        return $"UNKNOWN_LOCAL_{id}";
+    }
+
+    private static string PosToString(int pos)
+    {
+        return $"[{pos,3}]";
+    }
+
+    public void WriteBytecodeText(CodeWriter code, bool dotSyntax)
+    {
+        bool isMethod = Script.IsFactory();
+
+        if (!IsGenericEvent)
+        {
+            if (isMethod)
+                code.Write("method ");
+            else
+                code.Write("on ");
+            code.Write(Name);
+            if (ArgumentNames.Count > 0)
+            {
+                code.Write(" ");
+                for (int i = 0; i < ArgumentNames.Count; i++)
+                {
+                    if (i > 0)
+                        code.Write(", ");
+                    code.Write(ArgumentNames[i]);
+                }
+            }
+            code.WriteLine();
+            code.Indent();
+        }
+        foreach (var bc in BytecodeArray)
+        {
+            code.Write(PosToString((int)bc.Pos));
+            code.Write(" ");
+            code.Write(StandardNames.GetOpcodeName(bc.OpID));
+            switch (bc.Opcode)
+            {
+                case OpCode.kOpJmp:
+                case OpCode.kOpJmpIfZ:
+                    code.Write(" ");
+                    code.Write(PosToString((int)(bc.Pos + bc.Obj)));
+                    break;
+                case OpCode.kOpEndRepeat:
+                    code.Write(" ");
+                    code.Write(PosToString((int)(bc.Pos - bc.Obj)));
+                    break;
+                case OpCode.kOpPushFloat32:
+                    code.Write(" ");
+                    float f = BitConverter.Int32BitsToSingle(bc.Obj);
+                    code.Write(Util.FloatToString(f));
+                    break;
+                default:
+                    if (bc.OpID > 0x40)
+                    {
+                        code.Write(" ");
+                        code.Write(bc.Obj.ToString());
+                    }
+                    break;
+            }
+            code.WriteLine();
+        }
+        if (!IsGenericEvent)
+        {
+            code.Unindent();
+            if (!isMethod)
+                code.WriteLine("end");
+        }
+    }
+}
+
+public class Bytecode
+{
+    public byte OpID;
+    public OpCode Opcode;
+    public int Obj;
+    public uint Pos;
+    public BytecodeTag Tag;
+    public uint OwnerLoop;
+
+    public Bytecode(byte op, int obj, uint pos)
+    {
+        OpID = op;
+        Opcode = op >= 0x40 ? (OpCode)(0x40 + op % 0x40) : (OpCode)op;
+        Obj = obj;
+        Pos = pos;
+        Tag = BytecodeTag.kTagNone;
+        OwnerLoop = uint.MaxValue;
+    }
+}

--- a/Z_Analysis/ProjectorRays.DotNet/lingodec/Names.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/lingodec/Names.cs
@@ -1,0 +1,173 @@
+using ProjectorRays.Common;
+using System.Collections.Generic;
+
+namespace ProjectorRays.LingoDec;
+
+public static class StandardNames
+{
+    public static readonly Dictionary<uint, string> OpcodeNames = new()
+    {
+        // single-byte
+        { (uint)OpCode.kOpRet, "ret" },
+        { (uint)OpCode.kOpRetFactory, "retfactory" },
+        { (uint)OpCode.kOpPushZero, "pushzero" },
+        { (uint)OpCode.kOpMul, "mul" },
+        { (uint)OpCode.kOpAdd, "add" },
+        { (uint)OpCode.kOpSub, "sub" },
+        { (uint)OpCode.kOpDiv, "div" },
+        { (uint)OpCode.kOpMod, "mod" },
+        { (uint)OpCode.kOpInv, "inv" },
+        { (uint)OpCode.kOpJoinStr, "joinstr" },
+        { (uint)OpCode.kOpJoinPadStr, "joinpadstr" },
+        { (uint)OpCode.kOpLt, "lt" },
+        { (uint)OpCode.kOpLtEq, "lteq" },
+        { (uint)OpCode.kOpNtEq, "nteq" },
+        { (uint)OpCode.kOpEq, "eq" },
+        { (uint)OpCode.kOpGt, "gt" },
+        { (uint)OpCode.kOpGtEq, "gteq" },
+        { (uint)OpCode.kOpAnd, "and" },
+        { (uint)OpCode.kOpOr, "or" },
+        { (uint)OpCode.kOpNot, "not" },
+        { (uint)OpCode.kOpContainsStr, "containsstr" },
+        { (uint)OpCode.kOpContains0Str, "contains0str" },
+        { (uint)OpCode.kOpGetChunk, "getchunk" },
+        { (uint)OpCode.kOpHiliteChunk, "hilitechunk" },
+        { (uint)OpCode.kOpOntoSpr, "ontospr" },
+        { (uint)OpCode.kOpIntoSpr, "intospr" },
+        { (uint)OpCode.kOpGetField, "getfield" },
+        { (uint)OpCode.kOpStartTell, "starttell" },
+        { (uint)OpCode.kOpEndTell, "endtell" },
+        { (uint)OpCode.kOpPushList, "pushlist" },
+        { (uint)OpCode.kOpPushPropList, "pushproplist" },
+        { (uint)OpCode.kOpSwap, "swap" },
+
+        // multi-byte
+        { (uint)OpCode.kOpPushInt8, "pushint8" },
+        { (uint)OpCode.kOpPushArgListNoRet, "pusharglistnoret" },
+        { (uint)OpCode.kOpPushArgList, "pusharglist" },
+        { (uint)OpCode.kOpPushCons, "pushcons" },
+        { (uint)OpCode.kOpPushSymb, "pushsymb" },
+        { (uint)OpCode.kOpPushVarRef, "pushvarref" },
+        { (uint)OpCode.kOpGetGlobal2, "getglobal2" },
+        { (uint)OpCode.kOpGetGlobal, "getglobal" },
+        { (uint)OpCode.kOpGetProp, "getprop" },
+        { (uint)OpCode.kOpGetParam, "getparam" },
+        { (uint)OpCode.kOpGetLocal, "getlocal" },
+        { (uint)OpCode.kOpSetGlobal2, "setglobal2" },
+        { (uint)OpCode.kOpSetGlobal, "setglobal" },
+        { (uint)OpCode.kOpSetProp, "setprop" },
+        { (uint)OpCode.kOpSetParam, "setparam" },
+        { (uint)OpCode.kOpSetLocal, "setlocal" },
+        { (uint)OpCode.kOpJmp, "jmp" },
+        { (uint)OpCode.kOpEndRepeat, "endrepeat" },
+        { (uint)OpCode.kOpJmpIfZ, "jmpifz" },
+        { (uint)OpCode.kOpLocalCall, "localcall" },
+        { (uint)OpCode.kOpExtCall, "extcall" },
+        { (uint)OpCode.kOpObjCallV4, "objcallv4" },
+        { (uint)OpCode.kOpPut, "put" },
+        { (uint)OpCode.kOpPutChunk, "putchunk" },
+        { (uint)OpCode.kOpDeleteChunk, "deletechunk" },
+        { (uint)OpCode.kOpGet, "get" },
+        { (uint)OpCode.kOpSet, "set" },
+        { (uint)OpCode.kOpGetMovieProp, "getmovieprop" },
+        { (uint)OpCode.kOpSetMovieProp, "setmovieprop" },
+        { (uint)OpCode.kOpGetObjProp, "getobjprop" },
+        { (uint)OpCode.kOpSetObjProp, "setobjprop" },
+        { (uint)OpCode.kOpTellCall, "tellcall" },
+        { (uint)OpCode.kOpPeek, "peek" },
+        { (uint)OpCode.kOpPop, "pop" },
+        { (uint)OpCode.kOpTheBuiltin, "thebuiltin" },
+        { (uint)OpCode.kOpObjCall, "objcall" },
+        { (uint)OpCode.kOpPushChunkVarRef, "pushchunkvarref" },
+        { (uint)OpCode.kOpPushInt16, "pushint16" },
+        { (uint)OpCode.kOpPushInt32, "pushint32" },
+        { (uint)OpCode.kOpGetChainedProp, "getchainedprop" },
+        { (uint)OpCode.kOpPushFloat32, "pushfloat32" },
+        { (uint)OpCode.kOpGetTopLevelProp, "gettoplevelprop" },
+        { (uint)OpCode.kOpNewObj, "newobj" }
+    };
+
+    public static readonly Dictionary<uint, string> BinaryOpNames = new()
+    {
+        { (uint)OpCode.kOpMul, "*" },
+        { (uint)OpCode.kOpAdd, "+" },
+        { (uint)OpCode.kOpSub, "-" },
+        { (uint)OpCode.kOpDiv, "/" },
+        { (uint)OpCode.kOpMod, "mod" },
+        { (uint)OpCode.kOpJoinStr, "&" },
+        { (uint)OpCode.kOpJoinPadStr, "&&" },
+        { (uint)OpCode.kOpLt, "<" },
+        { (uint)OpCode.kOpLtEq, "<=" },
+        { (uint)OpCode.kOpNtEq, "<>" },
+        { (uint)OpCode.kOpEq, "=" },
+        { (uint)OpCode.kOpGt, ">" },
+        { (uint)OpCode.kOpGtEq, ">=" },
+        { (uint)OpCode.kOpAnd, "and" },
+        { (uint)OpCode.kOpOr, "or" },
+        { (uint)OpCode.kOpContainsStr, "contains" },
+        { (uint)OpCode.kOpContains0Str, "starts" }
+    };
+
+    public static readonly Dictionary<uint, string> ChunkTypeNames = new()
+    {
+        { (uint)ChunkExprType.kChunkChar, "char" },
+        { (uint)ChunkExprType.kChunkWord, "word" },
+        { (uint)ChunkExprType.kChunkItem, "item" },
+        { (uint)ChunkExprType.kChunkLine, "line" }
+    };
+
+    public static readonly Dictionary<uint, string> PutTypeNames = new()
+    {
+        { (uint)PutType.kPutInto, "into" },
+        { (uint)PutType.kPutAfter, "after" },
+        { (uint)PutType.kPutBefore, "before" }
+    };
+
+    public static string GetOpcodeName(byte id)
+    {
+        uint u = id >= 0x40 ? (uint)(0x40 + id % 0x40) : id;
+        return OpcodeNames.TryGetValue(u, out var name)
+            ? name
+            : $"unk{Util.ByteToString(id)}";
+    }
+
+    public static string GetName(Dictionary<uint, string> map, uint id)
+        => map.TryGetValue(id, out var name) ? name : "ERROR";
+}
+
+public class ScriptNames
+{
+    public int Unknown0;
+    public int Unknown1;
+    public uint Len1;
+    public uint Len2;
+    public ushort NamesOffset;
+    public ushort NamesCount;
+    public List<string> Names = new();
+    public readonly uint Version;
+
+    public ScriptNames(uint version) => Version = version;
+
+    public void Read(ReadStream stream)
+    {
+        stream.Endianness = Endianness.BigEndian;
+        Unknown0 = stream.ReadInt32();
+        Unknown1 = stream.ReadInt32();
+        Len1 = stream.ReadUint32();
+        Len2 = stream.ReadUint32();
+        NamesOffset = stream.ReadUint16();
+        NamesCount = stream.ReadUint16();
+
+        stream.Seek(NamesOffset);
+        Names.Clear();
+        for (int i = 0; i < NamesCount; i++)
+        {
+            int len = stream.ReadUint8();
+            Names.Add(stream.ReadString(len));
+        }
+    }
+
+    public bool ValidName(int id) => id >= 0 && id < Names.Count;
+
+    public string GetName(int id) => ValidName(id) ? Names[id] : $"UNKNOWN_NAME_{id}";
+}

--- a/Z_Analysis/ProjectorRays.DotNet/lingodec/Script.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/lingodec/Script.cs
@@ -1,0 +1,241 @@
+using ProjectorRays.Common;
+using System.Collections.Generic;
+
+namespace ProjectorRays.LingoDec;
+
+public class Script
+{
+    public uint TotalLength;
+    public uint TotalLength2;
+    public ushort HeaderLength;
+    public ushort ScriptNumber;
+    public short Unk20;
+    public short ParentNumber;
+
+    public uint ScriptFlags;
+    public short Unk42;
+    public int CastID;
+    public short FactoryNameID;
+    public ushort HandlerVectorsCount;
+    public uint HandlerVectorsOffset;
+    public uint HandlerVectorsSize;
+    public ushort PropertiesCount;
+    public uint PropertiesOffset;
+    public ushort GlobalsCount;
+    public uint GlobalsOffset;
+    public ushort HandlersCount;
+    public uint HandlersOffset;
+    public ushort LiteralsCount;
+    public uint LiteralsOffset;
+    public uint LiteralsDataCount;
+    public uint LiteralsDataOffset;
+
+    public List<short> PropertyNameIDs = new();
+    public List<short> GlobalNameIDs = new();
+
+    public string FactoryName = string.Empty;
+    public List<string> PropertyNames = new();
+    public List<string> GlobalNames = new();
+    public List<Handler> Handlers = new();
+    public List<LiteralStore> Literals = new();
+    public List<Script> Factories = new();
+
+    public uint Version;
+    public ScriptContext? Context;
+
+    public Script(uint version)
+    {
+        Version = version;
+    }
+
+    public void Read(ReadStream stream)
+    {
+        stream.Endianness = Endianness.BigEndian;
+        stream.Seek(8);
+        TotalLength = stream.ReadUint32();
+        TotalLength2 = stream.ReadUint32();
+        HeaderLength = stream.ReadUint16();
+        ScriptNumber = stream.ReadUint16();
+        Unk20 = stream.ReadInt16();
+        ParentNumber = stream.ReadInt16();
+        stream.Seek(38);
+        ScriptFlags = stream.ReadUint32();
+        Unk42 = stream.ReadInt16();
+        CastID = stream.ReadInt32();
+        FactoryNameID = stream.ReadInt16();
+        HandlerVectorsCount = stream.ReadUint16();
+        HandlerVectorsOffset = stream.ReadUint32();
+        HandlerVectorsSize = stream.ReadUint32();
+        PropertiesCount = stream.ReadUint16();
+        PropertiesOffset = stream.ReadUint32();
+        GlobalsCount = stream.ReadUint16();
+        GlobalsOffset = stream.ReadUint32();
+        HandlersCount = stream.ReadUint16();
+        HandlersOffset = stream.ReadUint32();
+        LiteralsCount = stream.ReadUint16();
+        LiteralsOffset = stream.ReadUint32();
+        LiteralsDataCount = stream.ReadUint32();
+        LiteralsDataOffset = stream.ReadUint32();
+
+        PropertyNameIDs = ReadVarnamesTable(stream, PropertiesCount, PropertiesOffset);
+        GlobalNameIDs = ReadVarnamesTable(stream, GlobalsCount, GlobalsOffset);
+
+        Handlers.Clear();
+        for (int i = 0; i < HandlersCount; i++)
+            Handlers.Add(new Handler(this));
+        if ((ScriptFlags & (uint)ScriptFlag.kScriptFlagEventScript) != 0 && HandlersCount > 0)
+            Handlers[0].IsGenericEvent = true;
+
+        stream.Seek((int)HandlersOffset);
+        foreach (var h in Handlers)
+            h.ReadRecord(stream);
+        foreach (var h in Handlers)
+            h.ReadData(stream);
+
+        stream.Seek((int)LiteralsOffset);
+        Literals.Clear();
+        for (int i = 0; i < LiteralsCount; i++)
+        {
+            var lit = new LiteralStore();
+            lit.ReadRecord(stream, (int)Version);
+            Literals.Add(lit);
+        }
+        foreach (var lit in Literals)
+            lit.ReadData(stream, LiteralsDataOffset);
+    }
+
+    public List<short> ReadVarnamesTable(ReadStream stream, ushort count, uint offset)
+    {
+        stream.Seek((int)offset);
+        var ids = new List<short>();
+        for (int i = 0; i < count; i++)
+            ids.Add((short)stream.ReadInt16());
+        return ids;
+    }
+
+    public bool ValidName(int id) => Context != null && Context.ValidName(id);
+    public string GetName(int id) => Context != null ? Context.GetName(id) : $"UNK_{id}";
+
+    public void SetContext(ScriptContext ctx)
+    {
+        Context = ctx;
+        if (FactoryNameID != -1)
+            FactoryName = GetName(FactoryNameID);
+        foreach (var id in PropertyNameIDs)
+        {
+            if (IsFactory() && GetName(id) == "me")
+                continue;
+            if (ValidName(id))
+                PropertyNames.Add(GetName(id));
+        }
+        foreach (var id in GlobalNameIDs)
+        {
+            if (ValidName(id))
+                GlobalNames.Add(GetName(id));
+        }
+        foreach (var h in Handlers)
+            h.ReadNames();
+    }
+
+    public void WriteVarDeclarations(CodeWriter code)
+    {
+        if (!IsFactory())
+        {
+            if (PropertyNames.Count > 0)
+            {
+                code.Write("property ");
+                for (int i = 0; i < PropertyNames.Count; i++)
+                {
+                    if (i > 0)
+                        code.Write(", ");
+                    code.Write(PropertyNames[i]);
+                }
+                code.WriteLine();
+            }
+        }
+        if (GlobalNames.Count > 0)
+        {
+            code.Write("global ");
+            for (int i = 0; i < GlobalNames.Count; i++)
+            {
+                if (i > 0)
+                    code.Write(", ");
+                code.Write(GlobalNames[i]);
+            }
+            code.WriteLine();
+        }
+    }
+
+    public void WriteBytecodeText(CodeWriter code, bool dotSyntax)
+    {
+        int orig = code.Size;
+        WriteVarDeclarations(code);
+        if (IsFactory())
+        {
+            if (code.Size != orig)
+                code.WriteLine();
+            code.Write("factory ");
+            code.WriteLine(FactoryName);
+        }
+        for (int i = 0; i < Handlers.Count; i++)
+        {
+            if ((!IsFactory() || i > 0) && code.Size != orig)
+                code.WriteLine();
+            Handlers[i].WriteBytecodeText(code, dotSyntax);
+        }
+        foreach (var f in Factories)
+        {
+            if (code.Size != orig)
+                code.WriteLine();
+            f.WriteBytecodeText(code, dotSyntax);
+        }
+    }
+
+    public bool IsFactory() => (ScriptFlags & (uint)ScriptFlag.kScriptFlagFactoryDef) != 0;
+}
+
+public class LiteralStore
+{
+    public LiteralType Type;
+    public uint Offset;
+    public Datum? Value;
+
+    public void ReadRecord(ReadStream stream, int version)
+    {
+        if (version >= 500)
+            Type = (LiteralType)stream.ReadUint32();
+        else
+            Type = (LiteralType)stream.ReadUint16();
+        Offset = stream.ReadUint32();
+    }
+
+    public void ReadData(ReadStream stream, uint start)
+    {
+        if (Type == LiteralType.kLiteralInt)
+        {
+            Value = new Datum((int)Offset);
+        }
+        else
+        {
+            stream.Seek((int)(start + Offset));
+            uint len = stream.ReadUint32();
+            if (Type == LiteralType.kLiteralString)
+            {
+                Value = new Datum(DatumType.kDatumString, stream.ReadString((int)len - 1));
+            }
+            else if (Type == LiteralType.kLiteralFloat)
+            {
+                double val = 0.0;
+                if (len == 8)
+                    val = stream.ReadDouble();
+                else if (len == 10)
+                    val = stream.ReadAppleFloat80();
+                Value = new Datum(val);
+            }
+            else
+            {
+                Value = new Datum();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add basic enums and name tables for Lingo bytecode
- implement Script, Handler and related classes for decompilation
- show a bytecode decompilation demo in Program

## Testing
- `dotnet build Z_Analysis/ProjectorRays.DotNet/ProjectorRays.DotNet.csproj -c Release` *(fails: `dotnet` not found)*
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7407de108332ae73a393bd9298dc