### PR TITLE
Add menu and icon bar to Director root

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/DirGodotMainMenu.cs
+++ b/src/Director/LingoEngine.Director.LGodot/DirGodotMainMenu.cs
@@ -1,0 +1,31 @@
+using Godot;
+
+namespace LingoEngine.Director.LGodot;
+
+/// <summary>
+/// Top application menu bar with a follow-up icon bar.
+/// </summary>
+internal partial class DirGodotMainMenu : Control
+{
+    private readonly HBoxContainer _menuBar = new HBoxContainer();
+    private readonly MenuButton _fileMenu = new MenuButton();
+    private readonly HBoxContainer _iconBar = new HBoxContainer();
+
+    public DirGodotMainMenu()
+    {
+        AddChild(_menuBar);
+        _menuBar.SizeFlagsHorizontal = SizeFlags.ExpandFill;
+
+        _fileMenu.Text = "File";
+        var popup = _fileMenu.GetPopup();
+        popup.AddItem("Quit", 1);
+        popup.IdPressed += id => { if (id == 1) GetTree().Quit(); };
+        _menuBar.AddChild(_fileMenu);
+
+        AddChild(_iconBar);
+        _iconBar.Position = new Vector2(0, 20);
+        _iconBar.SizeFlagsHorizontal = SizeFlags.ExpandFill;
+    }
+
+    public HBoxContainer IconBar => _iconBar;
+}

--- a/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
@@ -2,6 +2,7 @@ using Godot;
 using LingoEngine.Director.Core.Events;
 using LingoEngine.Director.LGodot.Scores;
 using LingoEngine.Director.LGodot.Movies;
+using LingoEngine.Director.LGodot;
 using LingoEngine.FrameworkCommunication;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -21,6 +22,12 @@ namespace LingoEngine.Director.LGodot
                         var overlay = new DirGodotScoreWindow(p.GetRequiredService<IDirectorEventMediator>()) { Visible = false };
                         rootNode.AddChild(overlay);
                         return overlay;
+                    })
+                    .AddSingleton(p =>
+                    {
+                        var menu = new DirGodotMainMenu();
+                        rootNode.AddChild(menu);
+                        return menu;
                     });
 
             });

--- a/src/Director/LingoEngine.Director.LGodot/Movies/DirGodotStageWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Movies/DirGodotStageWindow.cs
@@ -16,7 +16,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, ILingoFrameworkSta
     public DirGodotStageWindow(Node root)
         : base("Stage")
     {
-        Position = new Vector2(20, 20);
+        Position = new Vector2(20, 60);
         Size = new Vector2(640, 480);
         CustomMinimumSize = Size;
         root.AddChild(this);

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -30,7 +30,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
         : base("Score")
     {
         _directorMediator = directorMediator;
-        Position = new Vector2(0, 30);
+        Position = new Vector2(0, 60);
         Size = new Vector2(800, 600);
         CustomMinimumSize = Size;
         _grid = new DirGodotScoreGrid(directorMediator);


### PR DESCRIPTION
## Summary
- add global `DirGodotMainMenu` with a menu bar and icon bar
- register `DirGodotMainMenu` in `DirGodotSetup`
- move stage and score windows down to account for the new bars

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7547dc708332918b21c1c1fc7f81