### PR TITLE
Add cast window topbar and tweaks

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/BaseGodotWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/BaseGodotWindow.cs
@@ -8,6 +8,7 @@ namespace LingoEngine.Director.LGodot
         private bool _resizing;
         private readonly Label _label = new Label();
         private readonly Button _closeButton = new Button();
+        protected const int TitleBarHeight = 20;
         private const int ResizeHandle = 10;
 
         public BaseGodotWindow(string name)
@@ -27,8 +28,8 @@ namespace LingoEngine.Director.LGodot
 
         public override void _Draw()
         {
-            DrawRect(new Rect2(0, 0, Size.X, 20), new Color("#d2e0ed"));
-            DrawLine(new Vector2(0, 20), new Vector2(Size.X, 20), Colors.Black);
+            DrawRect(new Rect2(0, 0, Size.X, TitleBarHeight), new Color("#d2e0ed"));
+            DrawLine(new Vector2(0, TitleBarHeight), new Vector2(Size.X, TitleBarHeight), Colors.Black);
             _closeButton.Position = new Vector2(Size.X - 22, 2);
             // draw resize handle
             DrawLine(new Vector2(Size.X - ResizeHandle, Size.Y), new Vector2(Size.X, Size.Y - ResizeHandle), Colors.DarkGray);
@@ -40,7 +41,7 @@ namespace LingoEngine.Director.LGodot
             if (@event is InputEventMouseButton mb && mb.ButtonIndex == MouseButton.Left)
             {
                 Vector2 pos = GetLocalMousePosition();
-                if (pos.Y < 20)
+                if (pos.Y < TitleBarHeight)
                 {
                     _dragging = mb.Pressed;
                     _resizing = false;

--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastView.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastView.cs
@@ -9,6 +9,9 @@ namespace LingoEngine.Director.LGodot.Casts
     {
         private readonly TabContainer _tabs;
         private readonly DirGodotCastMemberPropViewer _selectedItem;
+        private readonly HBoxContainer _topBar;
+        private readonly Button _rewindButton;
+        private readonly Button _playButton;
 
         private readonly ILingoMovie _lingoMovie;
         private bool _wasToggleKey;
@@ -22,9 +25,17 @@ namespace LingoEngine.Director.LGodot.Casts
             Position = new Vector2(650, 20);
             Size = new Vector2(360, 620);
             CustomMinimumSize = Size;
+            _topBar = new HBoxContainer();
+            _topBar.Position = new Vector2(0, TitleBarHeight);
+            _rewindButton = new Button { Text = "<<" };
+            _playButton = new Button { Text = "Play" };
+            _topBar.AddChild(_rewindButton);
+            _topBar.AddChild(_playButton);
+            AddChild(_topBar);
+
             _tabs = new TabContainer();
             InitTabs();
-            _tabs.Position = new Vector2(0, 20);
+            _tabs.Position = new Vector2(0, TitleBarHeight + 20);
 
             parent.AddChild(this);
             _lingoMovie = lingoMovie;
@@ -42,6 +53,24 @@ namespace LingoEngine.Director.LGodot.Casts
             }
             _selectedItem = new DirGodotCastMemberPropViewer();
             parent.AddChild(_selectedItem);
+
+            _rewindButton.Pressed += () => _lingoMovie.GoTo(1);
+            _playButton.Pressed += OnPlayPressed;
+            UpdatePlayButton();
+        }
+
+        private void OnPlayPressed()
+        {
+            if (_lingoMovie.IsPlaying)
+                _lingoMovie.Halt();
+            else
+                _lingoMovie.Play();
+            UpdatePlayButton();
+        }
+
+        private void UpdatePlayButton()
+        {
+            _playButton.Text = _lingoMovie.IsPlaying ? "Stop" : "Play";
         }
 
         public void Toggle()

--- a/src/Director/LingoEngine.Director.LGodot/Movies/DirGodotStageWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Movies/DirGodotStageWindow.cs
@@ -7,8 +7,6 @@ namespace LingoEngine.Director.LGodot.Movies;
 
 internal partial class DirGodotStageWindow : BaseGodotWindow, ILingoFrameworkStageWindow, ILingoFrameworkStage
 {
-    private readonly Button _rewindButton = new Button();
-    private readonly Button _playButton = new Button();
     private bool _toggleKey;
     private LingoMovie? _movie;
     private ILingoFrameworkStage? _stage;
@@ -20,38 +18,8 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, ILingoFrameworkSta
         Size = new Vector2(640, 480);
         CustomMinimumSize = Size;
         root.AddChild(this);
-
-        _rewindButton.Position = new Vector2(3, 2);
-        _rewindButton.CustomMinimumSize = new Vector2(20, 16);
-        _rewindButton.Text = "<<";
-        AddChild(_rewindButton);
-
-        _playButton.Position = new Vector2(26, 2);
-        _playButton.CustomMinimumSize = new Vector2(40, 16);
-        _playButton.Text = "Play";
-        AddChild(_playButton);
-
-        _rewindButton.Pressed += () => _movie?.GoTo(1);
-        _playButton.Pressed += OnPlayPressed;
     }
 
-    private void OnPlayPressed()
-    {
-        if (_movie == null) return;
-        if (_movie.IsPlaying)
-            _movie.Halt();
-        else
-            _movie.Play();
-        UpdatePlayButton();
-    }
-
-    private void UpdatePlayButton()
-    {
-        if (_movie == null)
-            _playButton.Text = "Play";
-        else
-            _playButton.Text = _movie.IsPlaying ? "Stop" : "Play";
-    }
 
     public void SetStage(ILingoFrameworkStage stage)
     {
@@ -64,7 +32,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, ILingoFrameworkSta
                 AddChild(node);
             }
             if (node is Node2D node2D)
-                node2D.Position = new Vector2(0, 20);
+                node2D.Position = new Vector2(0, TitleBarHeight);
         }
     }
 
@@ -72,7 +40,6 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, ILingoFrameworkSta
     {
         _stage?.SetActiveMovie(movie);
         _movie = movie;
-        UpdatePlayButton();
     }
 
     public override void _Process(double delta)

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -320,7 +320,7 @@ internal partial class DirGodotScoreGrid : Control
         int channelCount = _movie.MaxSpriteChannelCount;
         int frameCount = _movie.FrameCount;
         var font = ThemeDB.FallbackFont;
-        const int ExtraMargin = 10;
+        const int ExtraMargin = 16;
         Size = new Vector2(ChannelInfoWidth + frameCount * FrameWidth + ExtraMargin,
             channelCount * ChannelHeight + ExtraMargin);
         CustomMinimumSize = Size;


### PR DESCRIPTION
## Summary
- expose TitleBarHeight in BaseGodotWindow
- remove playback buttons from the stage window
- add a top bar with rewind and play/stop controls to the cast window
- leave extra margin around the score grid

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684e85072a988332821df080e036047b