### PR TITLE
Fix subscriber script names

### DIFF
--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/ParentScripts/ClassSubscribeParentScript.cs
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/ParentScripts/ClassSubscribeParentScript.cs
@@ -6,12 +6,12 @@ using System.Reflection;
 namespace LingoEngine.Demo.TetriGrounds.Core.ParentScripts
 {
     // Converted from 19_ClassSubscibe.ls
-    public class ClassSubscibeParentScript : LingoParentScript
+    public class ClassSubscribeParentScript : LingoParentScript
     {
         private readonly List<object> mySubscribers = new();
         private readonly List<Dictionary<string, string>> mySubscribersData = new();
 
-        public ClassSubscibeParentScript(ILingoMovieEnvironment env) : base(env) { }
+        public ClassSubscribeParentScript(ILingoMovieEnvironment env) : base(env) { }
 
         public int Subscribe(object obj, string function)
         {
@@ -30,7 +30,7 @@ namespace LingoEngine.Demo.TetriGrounds.Core.ParentScripts
             return mySubscribers[val - 1];
         }
 
-        public void ExecuteAllSubscibed(string data)
+        public void ExecuteAllSubscribed(string data)
         {
             for (int i = 0; i < mySubscribers.Count; i++)
             {
@@ -45,7 +45,7 @@ namespace LingoEngine.Demo.TetriGrounds.Core.ParentScripts
             }
         }
 
-        public void Subscriberdestroy()
+        public void SubscribersDestroy()
         {
             mySubscribers.Clear();
             mySubscribersData.Clear();

--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/ParentScripts/ScoreSaveParentScript.cs
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/ParentScripts/ScoreSaveParentScript.cs
@@ -12,11 +12,11 @@ namespace LingoEngine.Demo.TetriGrounds.Core.ParentScripts
         private bool myDone;
         private string myErr = string.Empty;
         private int phpErr;
-        private readonly ClassSubscibeParentScript ancestor;
+        private readonly ClassSubscribeParentScript ancestor;
 
         public ScoreSaveParentScript(ILingoMovieEnvironment env) : base(env)
         {
-            ancestor = new ClassSubscibeParentScript(env);
+            ancestor = new ClassSubscribeParentScript(env);
         }
 
         public void SetURL(string scriptURL) => myURL = scriptURL;
@@ -45,7 +45,7 @@ namespace LingoEngine.Demo.TetriGrounds.Core.ParentScripts
 
         public void Destroy()
         {
-            ancestor.Subscriberdestroy();
+            ancestor.SubscribersDestroy();
             _Movie.ActorList.Remove(this);
         }
 

--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/TetriGroundsSetup.cs
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/TetriGroundsSetup.cs
@@ -54,7 +54,7 @@ namespace LingoEngine.Demo.TetriGrounds.Core
                             .AddParentScript<SpriteManagerParentScript>()
                             .AddParentScript<ScoreGetParentScript>()
                             .AddParentScript<ScoreSaveParentScript>()
-                            .AddParentScript<ClassSubscibeParentScript>()
+                            .AddParentScript<ClassSubscribeParentScript>()
                             .AddParentScript<StartDataGetParentScript>()
                             .AddParentScript<StartDataSaveParentScript>()
                             // Other


### PR DESCRIPTION
## Summary
- rename `ClassSubscibeParentScript` to `ClassSubscribeParentScript`
- update usage in setup and ScoreSave

## Testing
- `dotnet build LingoEngine.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1e6ecef8833292e64c1d61dec0eb