### PR TITLE
Add motion path precaching

### DIFF
--- a/src/LingoEngine.IO.Data/DTO/LingoColorDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoColorDTO.cs
@@ -1,0 +1,10 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public struct LingoColorDTO
+{
+    public int Code { get; set; }
+    public string Name { get; set; }
+    public byte R { get; set; }
+    public byte G { get; set; }
+    public byte B { get; set; }
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoColorKeyFrameDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoColorKeyFrameDTO.cs
@@ -1,0 +1,8 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public class LingoColorKeyFrameDTO
+{
+    public int Frame { get; set; }
+    public LingoColorDTO Value { get; set; }
+    public LingoEaseTypeDTO Ease { get; set; }
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoEaseTypeDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoEaseTypeDTO.cs
@@ -1,0 +1,9 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public enum LingoEaseTypeDTO
+{
+    Linear,
+    EaseIn,
+    EaseOut,
+    EaseInOut
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoFloatKeyFrameDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoFloatKeyFrameDTO.cs
@@ -1,0 +1,8 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public class LingoFloatKeyFrameDTO
+{
+    public int Frame { get; set; }
+    public float Value { get; set; }
+    public LingoEaseTypeDTO Ease { get; set; }
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoPointKeyFrameDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoPointKeyFrameDTO.cs
@@ -1,0 +1,8 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public class LingoPointKeyFrameDTO
+{
+    public int Frame { get; set; }
+    public LingoPointDTO Value { get; set; }
+    public LingoEaseTypeDTO Ease { get; set; }
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoSpeedChangeTypeDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoSpeedChangeTypeDTO.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public enum LingoSpeedChangeTypeDTO
+{
+    Sharp,
+    Smooth
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoSpriteAnimatorDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoSpriteAnimatorDTO.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace LingoEngine.IO.Data.DTO;
+
+public class LingoSpriteAnimatorDTO
+{
+    public List<LingoPointKeyFrameDTO> Position { get; set; } = new();
+    public LingoTweenOptionsDTO PositionOptions { get; set; } = new();
+
+    public List<LingoFloatKeyFrameDTO> Rotation { get; set; } = new();
+    public LingoTweenOptionsDTO RotationOptions { get; set; } = new();
+
+    public List<LingoFloatKeyFrameDTO> Skew { get; set; } = new();
+    public LingoTweenOptionsDTO SkewOptions { get; set; } = new();
+
+    public List<LingoColorKeyFrameDTO> ForegroundColor { get; set; } = new();
+    public LingoTweenOptionsDTO ForegroundColorOptions { get; set; } = new();
+
+    public List<LingoColorKeyFrameDTO> BackgroundColor { get; set; } = new();
+    public LingoTweenOptionsDTO BackgroundColorOptions { get; set; } = new();
+
+    public List<LingoFloatKeyFrameDTO> Blend { get; set; } = new();
+    public LingoTweenOptionsDTO BlendOptions { get; set; } = new();
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoSpriteDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoSpriteDTO.cs
@@ -19,4 +19,6 @@ public class LingoSpriteDTO
     public float Height { get; set; }
     public int BeginFrame { get; set; }
     public int EndFrame { get; set; }
+
+    public LingoSpriteAnimatorDTO? Animator { get; set; }
 }

--- a/src/LingoEngine.IO.Data/DTO/LingoTweenOptionsDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoTweenOptionsDTO.cs
@@ -1,0 +1,11 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public class LingoTweenOptionsDTO
+{
+    public bool Enabled { get; set; }
+    public float Curvature { get; set; }
+    public bool ContinuousAtEndpoints { get; set; }
+    public LingoSpeedChangeTypeDTO SpeedChange { get; set; }
+    public float EaseIn { get; set; }
+    public float EaseOut { get; set; }
+}

--- a/src/LingoEngine.LGodot/GodotFactory.cs
+++ b/src/LingoEngine.LGodot/GodotFactory.cs
@@ -62,6 +62,7 @@ namespace LingoEngine.LGodot
                 Type t when t == typeof(LingoMemberText) => (CreateMemberText(cast, numberInCast, name) as T)!,
                 Type t when t == typeof(LingoMemberField) => (CreateMemberField(cast, numberInCast, name) as T)!,
                 Type t when t == typeof(LingoMemberSound) => (CreateMemberSound(cast, numberInCast, name) as T)!,
+                Type t when t == typeof(LingoMemberFilmLoop) => (CreateMemberFilmLoop(cast, numberInCast, name) as T)!,
             };
         }
         public LingoMemberSound CreateMemberSound(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default)
@@ -71,6 +72,14 @@ namespace LingoEngine.LGodot
             lingoMemberSound.Init(memberSound);
             _disposables.Add(lingoMemberSound);
             return memberSound;
+        }
+        public LingoMemberFilmLoop CreateMemberFilmLoop(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default)
+        {
+            var impl = new LingoGodotMemberFilmLoop();
+            var member = new LingoMemberFilmLoop(impl, (LingoCast)cast, numberInCast, name, fileName ?? "", regPoint);
+            impl.Init(member);
+            _disposables.Add(impl);
+            return member;
         }
         public LingoMemberPicture CreateMemberPicture(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default)
         {

--- a/src/LingoEngine.LGodot/Pictures/LingoGodotMemberFilmLoop.cs
+++ b/src/LingoEngine.LGodot/Pictures/LingoGodotMemberFilmLoop.cs
@@ -1,0 +1,73 @@
+using Godot;
+using LingoEngine.Pictures;
+
+namespace LingoEngine.LGodot.Pictures
+{
+    /// <summary>
+    /// Godot framework implementation for film loop members.
+    /// </summary>
+    public class LingoGodotMemberFilmLoop : ILingoFrameworkMemberFilmLoop, IDisposable
+    {
+        private LingoMemberFilmLoop _member = null!;
+        public bool IsLoaded { get; private set; }
+        public byte[]? Media { get; set; }
+        public LingoFilmLoopFraming Framing { get; set; } = LingoFilmLoopFraming.Auto;
+        public bool Loop { get; set; } = true;
+
+        public LingoGodotMemberFilmLoop()
+        {
+        }
+
+        internal void Init(LingoMemberFilmLoop member)
+        {
+            _member = member;
+        }
+
+        public void Preload()
+        {
+            IsLoaded = true;
+        }
+
+        public void Unload()
+        {
+            IsLoaded = false;
+        }
+
+        public void Erase()
+        {
+            Media = null;
+            Unload();
+        }
+
+        public void ImportFileInto()
+        {
+            // Placeholder for future import logic
+        }
+
+        public void CopyToClipboard()
+        {
+            if (Media == null) return;
+            var base64 = Convert.ToBase64String(Media);
+            DisplayServer.ClipboardSet(base64);
+        }
+
+        public void PasteClipboardInto()
+        {
+            var data = DisplayServer.ClipboardGet();
+            if (string.IsNullOrEmpty(data)) return;
+            try
+            {
+                Media = Convert.FromBase64String(data);
+            }
+            catch
+            {
+                // ignore malformed clipboard data
+            }
+        }
+
+        public void Dispose()
+        {
+            Unload();
+        }
+    }
+}

--- a/src/LingoEngine.SDL2/Pictures/SdlMemberFilmLoop.cs
+++ b/src/LingoEngine.SDL2/Pictures/SdlMemberFilmLoop.cs
@@ -1,0 +1,62 @@
+using System;
+using LingoEngine.Pictures;
+using LingoEngine.SDL2;
+
+namespace LingoEngine.SDL2.Pictures;
+
+public class SdlMemberFilmLoop : ILingoFrameworkMemberFilmLoop, IDisposable
+{
+    private LingoMemberFilmLoop _member = null!;
+    public bool IsLoaded { get; private set; }
+    public byte[]? Media { get; set; }
+    public LingoFilmLoopFraming Framing { get; set; } = LingoFilmLoopFraming.Auto;
+    public bool Loop { get; set; } = true;
+
+    internal void Init(LingoMemberFilmLoop member)
+    {
+        _member = member;
+    }
+
+    public void Preload()
+    {
+        IsLoaded = true;
+    }
+
+    public void Unload()
+    {
+        IsLoaded = false;
+    }
+
+    public void Erase()
+    {
+        Media = null;
+        Unload();
+    }
+
+    public void ImportFileInto()
+    {
+        // not implemented
+    }
+
+    public void CopyToClipboard()
+    {
+        if (Media == null) return;
+        var base64 = Convert.ToBase64String(Media);
+        SdlClipboard.SetText(base64);
+    }
+
+    public void PasteClipboardInto()
+    {
+        var data = SdlClipboard.GetText();
+        if (string.IsNullOrEmpty(data)) return;
+        try
+        {
+            Media = Convert.FromBase64String(data);
+        }
+        catch
+        {
+        }
+    }
+
+    public void Dispose() { Unload(); }
+}

--- a/src/LingoEngine.SDL2/SdlFactory.cs
+++ b/src/LingoEngine.SDL2/SdlFactory.cs
@@ -60,6 +60,7 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
             Type t when t == typeof(LingoMemberText) => (CreateMemberText(cast, numberInCast, name) as T)!,
             Type t when t == typeof(LingoMemberField) => (CreateMemberField(cast, numberInCast, name) as T)!,
             Type t when t == typeof(LingoMemberSound) => (CreateMemberSound(cast, numberInCast, name) as T)!,
+            Type t when t == typeof(LingoMemberFilmLoop) => (CreateMemberFilmLoop(cast, numberInCast, name) as T)!,
             _ => throw new NotSupportedException()
         };
     }
@@ -67,6 +68,14 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
     {
         var impl = new SdlMemberSound();
         var member = new LingoMemberSound(impl, (LingoCast)cast, numberInCast, name, fileName ?? "");
+        impl.Init(member);
+        _disposables.Add(impl);
+        return member;
+    }
+    public LingoMemberFilmLoop CreateMemberFilmLoop(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default)
+    {
+        var impl = new SdlMemberFilmLoop();
+        var member = new LingoMemberFilmLoop(impl, (LingoCast)cast, numberInCast, name, fileName ?? "", regPoint);
         impl.Init(member);
         _disposables.Add(impl);
         return member;

--- a/src/LingoEngine/Animations/LingoSpeedChangeType.cs
+++ b/src/LingoEngine/Animations/LingoSpeedChangeType.cs
@@ -1,0 +1,11 @@
+namespace LingoEngine.Animations
+{
+    /// <summary>
+    /// Specifies how animation speed is interpolated between keyframes.
+    /// </summary>
+    public enum LingoSpeedChangeType
+    {
+        Sharp,
+        Smooth
+    }
+}

--- a/src/LingoEngine/Animations/LingoSpriteAnimator.cs
+++ b/src/LingoEngine/Animations/LingoSpriteAnimator.cs
@@ -1,14 +1,21 @@
 using LingoEngine.Primitives;
 using LingoEngine.Movies;
 using LingoEngine.Events;
+using System.Linq;
 
 namespace LingoEngine.Animations
 {
-    public class LingoSpriteAnimator : IHasEnterFrameEvent
+    public class LingoSpriteAnimator : IPlayableActor
     {
         public LingoTween<LingoPoint> Position { get; } = new();
         public LingoTween<float> Rotation { get; } = new();
         public LingoTween<float> Skew { get; } = new();
+        public LingoTween<LingoColor> ForegroundColor { get; } = new();
+        public LingoTween<LingoColor> BackgroundColor { get; } = new();
+        public LingoTween<float> Blend { get; } = new();
+
+        private LingoSpriteMotionPath _cachedPath = new();
+        private bool _cacheDirty = true;
 
         private readonly LingoSprite _sprite;
         private readonly ILingoMovie _movie;
@@ -22,24 +29,124 @@ namespace LingoEngine.Animations
             _mediator.Subscribe(this);
         }
 
-        public void AddKeyFrame(int frame, float x, float y, float rotation, float skew)
+        public void SetTweenOptions(bool positionEnabled, bool rotationEnabled, bool skewEnabled,
+            bool foreColorEnabled, bool backColorEnabled, bool blendEnabled,
+            float curvature, bool continuousAtEnds, bool smoothSpeed, float easeIn, float easeOut)
+        {
+            Position.Options.Enabled = positionEnabled;
+            Rotation.Options.Enabled = rotationEnabled;
+            Skew.Options.Enabled = skewEnabled;
+            ForegroundColor.Options.Enabled = foreColorEnabled;
+            BackgroundColor.Options.Enabled = backColorEnabled;
+            Blend.Options.Enabled = blendEnabled;
+
+            var list = new[] { Position.Options, Rotation.Options, Skew.Options,
+                ForegroundColor.Options, BackgroundColor.Options, Blend.Options };
+            foreach (var opt in list)
+            {
+                opt.Curvature = curvature;
+                opt.ContinuousAtEndpoints = continuousAtEnds;
+                opt.SpeedChange = smoothSpeed ? LingoSpeedChangeType.Smooth : LingoSpeedChangeType.Sharp;
+                opt.EaseIn = easeIn;
+                opt.EaseOut = easeOut;
+            }
+        }
+
+        public void AddKeyFrame(int frame, float x, float y, float rotation, float skew,
+            LingoColor? foreColor = null, LingoColor? backColor = null, float? blend = null)
         {
             Position.AddKeyFrame(frame, new LingoPoint(x, y));
             Rotation.AddKeyFrame(frame, rotation);
             Skew.AddKeyFrame(frame, skew);
+            if (foreColor.HasValue) ForegroundColor.AddKeyFrame(frame, foreColor.Value);
+            if (backColor.HasValue) BackgroundColor.AddKeyFrame(frame, backColor.Value);
+            if (blend.HasValue) Blend.AddKeyFrame(frame, blend.Value);
+            _cacheDirty = true;
+        }
+
+        public void UpdateKeyFrame(int frame, float x, float y, float rotation, float skew,
+            LingoColor? foreColor = null, LingoColor? backColor = null, float? blend = null)
+        {
+            Position.UpdateKeyFrame(frame, new LingoPoint(x, y));
+            Rotation.UpdateKeyFrame(frame, rotation);
+            Skew.UpdateKeyFrame(frame, skew);
+            if (foreColor.HasValue) ForegroundColor.UpdateKeyFrame(frame, foreColor.Value);
+            if (backColor.HasValue) BackgroundColor.UpdateKeyFrame(frame, backColor.Value);
+            if (blend.HasValue) Blend.UpdateKeyFrame(frame, blend.Value);
+            _cacheDirty = true;
+        }
+
+        internal void AddKeyFrames(params (int Frame, float X, float Y, float Rotation, float Skew)[] keyframes)
+        {
+            foreach (var (frame, x, y, rot, skew) in keyframes)
+                AddKeyFrame(frame, x, y, rot, skew);
+            RecalculateCache();
         }
 
         private void Apply(int frame)
         {
-            var p = Position.GetValue(frame);
-            _sprite.Loc = p;
-            _sprite.Rotation = Rotation.GetValue(frame);
-            _sprite.Skew = Skew.GetValue(frame);
+            if (Position.Options.Enabled)
+                _sprite.Loc = Position.GetValue(frame);
+            if (Rotation.Options.Enabled)
+                _sprite.Rotation = Rotation.GetValue(frame);
+            if (Skew.Options.Enabled)
+                _sprite.Skew = Skew.GetValue(frame);
+            if (ForegroundColor.Options.Enabled)
+                _sprite.ForeColor = ForegroundColor.GetValue(frame);
+            if (BackgroundColor.Options.Enabled)
+                _sprite.BackColor = BackgroundColor.GetValue(frame);
+            if (Blend.Options.Enabled)
+                _sprite.Blend = Blend.GetValue(frame);
         }
 
-        public void EnterFrame()
+        public void BeginSprite()
         {
-            //Apply(_movie.CurrentFrame);
+            EnsureCache();
+            Apply(_movie.CurrentFrame);
+        }
+
+        public void StepFrame()
+        {
+            Apply(_movie.CurrentFrame);
+        }
+
+        public void EndSprite()
+        {
+        }
+
+        internal LingoSpriteMotionPath GetMotionPath(int startFrame, int endFrame)
+        {
+            EnsureCache();
+            var path = new LingoSpriteMotionPath();
+            foreach (var f in _cachedPath.Frames)
+            {
+                if (f.Frame < startFrame || f.Frame > endFrame) continue;
+                path.Frames.Add(f);
+            }
+            return path;
+        }
+
+        internal void EnsureCache()
+        {
+            if (!_cacheDirty) return;
+            RecalculateCache();
+        }
+
+        internal void RecalculateCache()
+        {
+            _cachedPath = new LingoSpriteMotionPath();
+            if (Position.KeyFrames.Count > 0)
+            {
+                int start = Position.KeyFrames.First().Frame;
+                int end = Position.KeyFrames.Last().Frame;
+                for (int frame = start; frame <= end; frame++)
+                {
+                    var pos = Position.GetValue(frame);
+                    bool isKey = Position.KeyFrames.Any(k => k.Frame == frame);
+                    _cachedPath.Frames.Add(new LingoSpriteMotionFrame(frame, pos, isKey));
+                }
+            }
+            _cacheDirty = false;
         }
     }
 }

--- a/src/LingoEngine/Animations/LingoSpriteMotion.cs
+++ b/src/LingoEngine/Animations/LingoSpriteMotion.cs
@@ -1,0 +1,15 @@
+namespace LingoEngine.Animations
+{
+    /// <summary>
+    /// Represents a position of a sprite for a specific frame.
+    /// </summary>
+    public record LingoSpriteMotionFrame(int Frame, Primitives.LingoPoint Position, bool IsKeyFrame);
+
+    /// <summary>
+    /// Contains a collection of sprite motion frames describing its motion path.
+    /// </summary>
+    public class LingoSpriteMotionPath
+    {
+        public List<LingoSpriteMotionFrame> Frames { get; } = new();
+    }
+}

--- a/src/LingoEngine/Animations/LingoTween.cs
+++ b/src/LingoEngine/Animations/LingoTween.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using LingoEngine.Primitives;
 
@@ -6,12 +7,28 @@ namespace LingoEngine.Animations
     public class LingoTween<T>
     {
         private readonly List<LingoKeyFrame<T>> _keys = new();
+        public IReadOnlyList<LingoKeyFrame<T>> KeyFrames => _keys;
+        public LingoTweenOptions Options { get; } = new();
 
         public void AddKeyFrame(int frame, T value, LingoEaseType ease = LingoEaseType.Linear)
         {
             var k = new LingoKeyFrame<T>(frame, value) { Ease = ease };
             _keys.Add(k);
             _keys.Sort((a, b) => a.Frame.CompareTo(b.Frame));
+        }
+
+        public void UpdateKeyFrame(int frame, T value, LingoEaseType ease = LingoEaseType.Linear)
+        {
+            var idx = _keys.FindIndex(k => k.Frame == frame);
+            if (idx >= 0)
+            {
+                _keys[idx].Value = value;
+                _keys[idx].Ease = ease;
+            }
+            else
+            {
+                AddKeyFrame(frame, value, ease);
+            }
         }
 
         public T GetValue(int frame)
@@ -31,6 +48,13 @@ namespace LingoEngine.Animations
                 {
                     float t = (frame - k0.Frame) / (float)(k1.Frame - k0.Frame);
                     t = ApplyEase(t, k1.Ease);
+                    t = ApplySpeedChange(t, Options.SpeedChange);
+                    if (Options.EaseIn != 0)
+                        t = MathF.Pow(t, 1 + Options.EaseIn);
+                    if (Options.EaseOut != 0)
+                        t = 1 - MathF.Pow(1 - t, 1 + Options.EaseOut);
+                    if (Options.Curvature != 0)
+                        t = t + Options.Curvature * t * (1 - t);
                     return Lerp(k0.Value, k1.Value, t);
                 }
             }
@@ -46,6 +70,11 @@ namespace LingoEngine.Animations
                 LingoEaseType.EaseInOut => t < 0.5f ? 2 * t * t : -1 + (4 - 2 * t) * t,
                 _ => t,
             };
+        }
+
+        private static float ApplySpeedChange(float t, LingoSpeedChangeType type)
+        {
+            return type == LingoSpeedChangeType.Smooth ? t * t * (3 - 2 * t) : t;
         }
 
         private static T Lerp(T a, T b, float t)

--- a/src/LingoEngine/Animations/LingoTweenOptions.cs
+++ b/src/LingoEngine/Animations/LingoTweenOptions.cs
@@ -1,0 +1,15 @@
+namespace LingoEngine.Animations
+{
+    /// <summary>
+    /// Additional configuration for sprite tweening.
+    /// </summary>
+    public class LingoTweenOptions
+    {
+        public bool Enabled { get; set; } = true;
+        public float Curvature { get; set; } = 0f;
+        public bool ContinuousAtEndpoints { get; set; } = true;
+        public LingoSpeedChangeType SpeedChange { get; set; } = LingoSpeedChangeType.Sharp;
+        public float EaseIn { get; set; } = 0f;
+        public float EaseOut { get; set; } = 0f;
+    }
+}

--- a/src/LingoEngine/Core/LingoCast.cs
+++ b/src/LingoEngine/Core/LingoCast.cs
@@ -81,8 +81,9 @@ namespace LingoEngine.Core
             switch (type)
             {
                 case LingoMemberType.Bitmap:return  _factory.CreateMemberPicture(this, numberInCast, name, fileName, regPoint); 
-                case LingoMemberType.Sound: return _factory.CreateMemberSound(this, numberInCast, name, fileName, regPoint); 
-                case LingoMemberType.Text: return _factory.CreateMemberText(this, numberInCast, name, fileName, regPoint); 
+                case LingoMemberType.Sound: return _factory.CreateMemberSound(this, numberInCast, name, fileName, regPoint);
+                case LingoMemberType.FilmLoop: return _factory.CreateMemberFilmLoop(this, numberInCast, name, fileName, regPoint);
+                case LingoMemberType.Text: return _factory.CreateMemberText(this, numberInCast, name, fileName, regPoint);
                 case LingoMemberType.Field: return _factory.CreateMemberField(this, numberInCast, name, fileName, regPoint); 
                 default:
                     return _factory.CreateEmpty(this, numberInCast, name, fileName, regPoint);

--- a/src/LingoEngine/Core/LingoMemberFactory.cs
+++ b/src/LingoEngine/Core/LingoMemberFactory.cs
@@ -11,6 +11,7 @@ namespace LingoEngine.Core
         T Member<T>(int numberInCast = 0, string name = "") where T : LingoMember;
         LingoMemberPicture Picture(int numberInCast = 0, string name = "");
         LingoMemberSound Sound(int numberInCast = 0, string name = "");
+        LingoMemberFilmLoop FilmLoop(int numberInCast = 0, string name = "");
         LingoMemberText Text(int numberInCast = 0, string name = "");
     }
 
@@ -28,6 +29,7 @@ namespace LingoEngine.Core
 
         public LingoMemberPicture Picture(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberPicture(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
         public LingoMemberSound Sound(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberSound(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
+        public LingoMemberFilmLoop FilmLoop(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberFilmLoop(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
         public LingoMemberText Text(int numberInCast= 0, string name = "") => _frameworkFactory.CreateMemberText(_environment.CastLibsContainer.ActiveCast, numberInCast,name);
     }
 }

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
@@ -34,6 +34,8 @@ namespace LingoEngine.FrameworkCommunication
             LingoPoint regPoint = default);
         /// <summary>Creates a sound member.</summary>
         LingoMemberSound CreateMemberSound(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default);
+        /// <summary>Creates a film loop member.</summary>
+        LingoMemberFilmLoop CreateMemberFilmLoop(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default);
         /// <summary>Creates a field member.</summary>
         LingoMemberField CreateMemberField(ILingoCast cast, int numberInCast, string name = "", string? fileName = null,
             LingoPoint regPoint = default);

--- a/src/LingoEngine/Movies/IPlayableActor.cs
+++ b/src/LingoEngine/Movies/IPlayableActor.cs
@@ -1,0 +1,9 @@
+namespace LingoEngine.Movies
+{
+    /// <summary>
+    /// Represents an internal sprite actor that participates in the begin/step/end sprite lifecycle.
+    /// </summary>
+    internal interface IPlayableActor : Events.IHasBeginSpriteEvent, Events.IHasStepFrameEvent, Events.IHasEndSpriteEvent
+    {
+    }
+}

--- a/src/LingoEngine/Movies/LingoFilmLoopPlayer.cs
+++ b/src/LingoEngine/Movies/LingoFilmLoopPlayer.cs
@@ -1,0 +1,65 @@
+using LingoEngine.Events;
+using LingoEngine.Pictures;
+
+namespace LingoEngine.Movies
+{
+    /// <summary>
+    /// Internal helper that plays a <see cref="LingoMemberFilmLoop"/> on a sprite.
+    /// It subscribes to sprite events but is not exposed as a behaviour.
+    /// </summary>
+    internal class LingoFilmLoopPlayer : IPlayableActor
+    {
+        private readonly LingoSprite _sprite;
+        private readonly ILingoEventMediator _mediator;
+        private int _currentIndex;
+
+        internal LingoFilmLoopPlayer(LingoSprite sprite, ILingoMovieEnvironment env)
+        {
+            _sprite = sprite;
+            _mediator = env.Events;
+            _mediator.Subscribe(this);
+        }
+
+        private LingoMemberFilmLoop? FilmLoop => _sprite.Member as LingoMemberFilmLoop;
+
+        public void BeginSprite()
+        {
+            _currentIndex = 0;
+            ApplyFrame();
+        }
+
+        public void StepFrame()
+        {
+            var fl = FilmLoop;
+            if (fl == null || fl.Frames.Count == 0)
+                return;
+
+            _currentIndex++;
+            if (_currentIndex >= fl.Frames.Count)
+            {
+                if (fl.Loop)
+                    _currentIndex = 0;
+                else
+                {
+                    _currentIndex = fl.Frames.Count - 1;
+                    return;
+                }
+            }
+            ApplyFrame();
+        }
+
+        public void EndSprite()
+        {
+            // nothing to clean up
+        }
+
+        private void ApplyFrame()
+        {
+            var fl = FilmLoop;
+            if (fl == null || _currentIndex >= fl.Frames.Count)
+                return;
+            var frame = fl.Frames[_currentIndex];
+            _sprite.SetMember(frame.MemberNum, frame.CastLibNum);
+        }
+    }
+}

--- a/src/LingoEngine/Movies/LingoStage.cs
+++ b/src/LingoEngine/Movies/LingoStage.cs
@@ -34,7 +34,24 @@ namespace LingoEngine.Movies
             if (!RecordKeyframes || ActiveMovie == null)
                 return;
             int frame = ActiveMovie.CurrentFrame;
-            sprite.Animator.AddKeyFrame(frame, sprite.LocH, sprite.LocV, sprite.Rotation, sprite.Skew);
+            sprite.AddKeyframes((frame, sprite.LocH, sprite.LocV, sprite.Rotation, sprite.Skew));
+        }
+
+        internal void UpdateKeyFrame(LingoSprite sprite)
+        {
+            if (!RecordKeyframes || ActiveMovie == null)
+                return;
+            int frame = ActiveMovie.CurrentFrame;
+            sprite.UpdateKeyframe(frame, sprite.LocH, sprite.LocV, sprite.Rotation, sprite.Skew);
+        }
+
+        internal void SetSpriteTweenOptions(LingoSprite sprite, bool positionEnabled, bool rotationEnabled,
+            bool skewEnabled, bool foregroundColorEnabled, bool backgroundColorEnabled, bool blendEnabled,
+            float curvature, bool continuousAtEnds, bool speedSmooth, float easeIn, float easeOut)
+        {
+            sprite.SetSpriteTweenOptions(positionEnabled, rotationEnabled, skewEnabled,
+                foregroundColorEnabled, backgroundColorEnabled, blendEnabled,
+                curvature, continuousAtEnds, speedSmooth, easeIn, easeOut);
         }
 
         public void SetActiveMovie(LingoMovie? lingoMovie)
@@ -52,6 +69,13 @@ namespace LingoEngine.Movies
         {
             if (ActiveMovie == null) return null;
             return ActiveMovie.GetSpriteUnderMouse();
+        }
+
+        public Animations.LingoSpriteMotionPath? GetSpriteMotionPath(LingoSprite sprite)
+        {
+            if (sprite == null) return null;
+            return sprite.CallActor<Animations.LingoSpriteAnimator, Animations.LingoSpriteMotionPath>(
+                a => a.GetMotionPath(sprite.BeginFrame, sprite.EndFrame));
         }
     }
 }

--- a/src/LingoEngine/Pictures/ILingoFrameworkMemberFilmLoop.cs
+++ b/src/LingoEngine/Pictures/ILingoFrameworkMemberFilmLoop.cs
@@ -1,0 +1,27 @@
+using LingoEngine.FrameworkCommunication;
+
+namespace LingoEngine.Pictures
+{
+    /// <summary>
+    /// Framework specific implementation details for a film loop member.
+    /// </summary>
+    public interface ILingoFrameworkMemberFilmLoop : ILingoFrameworkMember
+    {
+        /// <summary>
+        /// Raw data representing the film loop media. The exact format is framework dependent.
+        /// </summary>
+        byte[]? Media { get; set; }
+
+        /// <summary>
+        /// Determines how the film loop should be framed within its sprite rectangle.
+        /// Mirrors the Lingo <c>framing</c> property with values <c>#crop</c>, <c>#scale</c>, or <c>#auto</c>.
+        /// </summary>
+        LingoFilmLoopFraming Framing { get; set; }
+
+        /// <summary>
+        /// Controls whether playback should loop when the last frame is reached.
+        /// Corresponds to the Lingo <c>loop</c> property used with film loop sprites.
+        /// </summary>
+        bool Loop { get; set; }
+    }
+}

--- a/src/LingoEngine/Pictures/LingoFilmLoopFrameRef.cs
+++ b/src/LingoEngine/Pictures/LingoFilmLoopFrameRef.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.Pictures
+{
+    /// <summary>
+    /// Represents a reference to a cast member used as a frame within a film loop.
+    /// </summary>
+    public readonly record struct LingoFilmLoopFrameRef(int CastLibNum, int MemberNum);
+}

--- a/src/LingoEngine/Pictures/LingoFilmLoopFraming.cs
+++ b/src/LingoEngine/Pictures/LingoFilmLoopFraming.cs
@@ -1,0 +1,14 @@
+namespace LingoEngine.Pictures
+{
+    /// <summary>
+    /// Determines how a film loop is framed within its sprite rectangle.
+    /// Corresponds to the Lingo film loop framing property with values
+    /// <c>#crop</c>, <c>#scale</c>, and <c>#auto</c>.
+    /// </summary>
+    public enum LingoFilmLoopFraming
+    {
+        Crop,
+        Scale,
+        Auto
+    }
+}

--- a/src/LingoEngine/Pictures/LingoMemberFilmLoop.cs
+++ b/src/LingoEngine/Pictures/LingoMemberFilmLoop.cs
@@ -1,13 +1,67 @@
-﻿using LingoEngine.Core;
-using LingoEngine.FrameworkCommunication;
+using LingoEngine.Core;
 using LingoEngine.Primitives;
 
 namespace LingoEngine.Pictures
 {
+    /// <summary>
+    /// Represents a film loop cast member.
+    /// </summary>
     public class LingoMemberFilmLoop : LingoMember
     {
-        public LingoMemberFilmLoop(ILingoFrameworkMember frameworkMember, LingoCast cast, int numberInCast, string name = "", string fileName = "", LingoPoint regPoint = default) : base(frameworkMember, LingoMemberType.FilmLoop, cast, numberInCast, name, fileName, regPoint)
+        private readonly ILingoFrameworkMemberFilmLoop _frameworkFilmLoop;
+
+        /// <summary>
+        /// The sequence of cast members that make up this film loop. Each entry
+        /// references a cast library number and member number pair.
+        /// </summary>
+        public List<LingoFilmLoopFrameRef> Frames { get; } = new();
+
+        /// <summary>
+        /// Gets the framework specific implementation for this film loop.
+        /// </summary>
+        public T Framework<T>() where T : class, ILingoFrameworkMemberFilmLoop => (T)_frameworkFilmLoop;
+
+        /// <summary>
+        /// The media data representing the frames and channels selection.
+        /// Lingo: the media of member
+        /// </summary>
+        public byte[]? Media
         {
+            get => _frameworkFilmLoop.Media;
+            set => _frameworkFilmLoop.Media = value;
         }
+
+        /// <summary>
+        /// How the film loop content is framed within the sprite rectangle.
+        /// Lingo: member.framing (#crop, #scale, #auto)
+        /// </summary>
+        public LingoFilmLoopFraming Framing
+        {
+            get => _frameworkFilmLoop.Framing;
+            set => _frameworkFilmLoop.Framing = value;
+        }
+
+        /// <summary>
+        /// Whether the film loop should restart automatically after the last frame.
+        /// Lingo: sprite.loop when used with film loops
+        /// </summary>
+        public bool Loop
+        {
+            get => _frameworkFilmLoop.Loop;
+            set => _frameworkFilmLoop.Loop = value;
+        }
+
+        public LingoMemberFilmLoop(ILingoFrameworkMemberFilmLoop frameworkMember, LingoCast cast, int numberInCast, string name = "", string fileName = "", LingoPoint regPoint = default)
+            : base(frameworkMember, LingoMemberType.FilmLoop, cast, numberInCast, name, fileName, regPoint)
+        {
+            _frameworkFilmLoop = frameworkMember;
+        }
+
+        public override void Preload() => _frameworkFilmLoop.Preload();
+        public override void Unload() => _frameworkFilmLoop.Unload();
+        public override void Erase() => _frameworkFilmLoop.Erase();
+        public override void ImportFileInto() => _frameworkFilmLoop.ImportFileInto();
+        public override void CopyToClipBoard() => _frameworkFilmLoop.CopyToClipboard();
+        public override void PasteClipBoardInto() => _frameworkFilmLoop.PasteClipboardInto();
     }
 }

--- a/src/LingoEngine/Texts/LingoWords.cs
+++ b/src/LingoEngine/Texts/LingoWords.cs
@@ -54,7 +54,7 @@ namespace LingoEngine.Texts
 
         private void Parse()
         {
-            _words = _text.Split([' '], StringSplitOptions.RemoveEmptyEntries).Select(x => new LingoWords(x)).ToArray();
+            _words = _text.Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(x => new LingoWords(x)).ToArray();
             _hasParsed = true;
         }
 


### PR DESCRIPTION
## Summary
- cache motion paths inside `LingoSpriteAnimator`
- bulk-add keyframes recompute the cache once
- expose cache recalculation for sprite keyframe updates
- include sprite actor info (animator/filmloop) in state save
- load movies from JSON with `JsonStateRepository`
- don't persist transient film loop player index

## Testing
- `dotnet build src/LingoEngine/LingoEngine.csproj -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500594a91083329b8ca6f4470286e7