### PR TITLE
Apply director theme via DI

### DIFF
--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/LingoEngine.Demo.TetriGrounds.Godot.csproj
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/LingoEngine.Demo.TetriGrounds.Godot.csproj
@@ -11,7 +11,7 @@
 	  <EmbeddedResource Remove="obj\**" />
 	</ItemGroup>
 	<ItemGroup>
-	  <None Include="directorTheme.tres" />
+  <!-- <None Include="directorTheme.tres" /> Theme moved to DirectorStyle.cs -->
 	  <None Include="Medias\Data\100_bell0031.png">
 	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </None>

--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/directorTheme.tres
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/directorTheme.tres
@@ -1,34 +1,35 @@
-[gd_resource type="Theme" format=3 uid="uid://xc6qaca8t4t6"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_x1qcu"]
-bg_color = Color(0.39215687, 0.03137255, 0.03137255, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bskpx"]
-bg_color = Color(0.39215687, 0.03137255, 0.03137255, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0q5se"]
-bg_color = Color(0.23529412, 0.011764706, 0.011764706, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_vdb74"]
-bg_color = Color(0.6666667, 0.08627451, 0.08235294, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qagqd"]
-bg_color = Color(0.23529412, 0.011764706, 0.011764706, 1)
-
-[resource]
-Button/font_sizes/font_size = 10
-CloseButton/base_type = &"Button"
-CloseButton/colors/font_color = Color(1, 1, 1, 1)
-CloseButton/font_sizes/font_size = 10
-CloseButton/styles/focus = SubResource("StyleBoxFlat_x1qcu")
-CloseButton/styles/hover = SubResource("StyleBoxFlat_bskpx")
-CloseButton/styles/hover_pressed = null
-CloseButton/styles/hover_pressed_mirrored = SubResource("StyleBoxFlat_0q5se")
-CloseButton/styles/normal = SubResource("StyleBoxFlat_vdb74")
-CloseButton/styles/pressed = SubResource("StyleBoxFlat_qagqd")
-Label/font_sizes/font_size = 13
-LineEdit/font_sizes/font_size = 13
-TabBar/font_sizes/font_size = 10
-TextEdit/font_sizes/font_size = 13
-Tree/font_sizes/font_size = 11
-Tree/font_sizes/title_button_font_size = 12
+; Director style is now defined in DirectorStyle.cs
+; [gd_resource type="Theme" format=3 uid="uid://xc6qaca8t4t6"]
+;
+; [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_x1qcu"]
+; bg_color = Color(0.39215687, 0.03137255, 0.03137255, 1)
+;
+; [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bskpx"]
+; bg_color = Color(0.39215687, 0.03137255, 0.03137255, 1)
+;
+; [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0q5se"]
+; bg_color = Color(0.23529412, 0.011764706, 0.011764706, 1)
+;
+; [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_vdb74"]
+; bg_color = Color(0.6666667, 0.08627451, 0.08235294, 1)
+;
+; [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qagqd"]
+; bg_color = Color(0.23529412, 0.011764706, 0.011764706, 1)
+;
+; [resource]
+; Button/font_sizes/font_size = 10
+; CloseButton/base_type = &"Button"
+; CloseButton/colors/font_color = Color(1, 1, 1, 1)
+; CloseButton/font_sizes/font_size = 10
+; CloseButton/styles/focus = SubResource("StyleBoxFlat_x1qcu")
+; CloseButton/styles/hover = SubResource("StyleBoxFlat_bskpx")
+; CloseButton/styles/hover_pressed = null
+; CloseButton/styles/hover_pressed_mirrored = SubResource("StyleBoxFlat_0q5se")
+; CloseButton/styles/normal = SubResource("StyleBoxFlat_vdb74")
+; CloseButton/styles/pressed = SubResource("StyleBoxFlat_qagqd")
+; Label/font_sizes/font_size = 13
+; LineEdit/font_sizes/font_size = 13
+; TabBar/font_sizes/font_size = 10
+; TextEdit/font_sizes/font_size = 13
+; Tree/font_sizes/font_size = 11
+; Tree/font_sizes/title_button_font_size = 12

--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/project.godot
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/project.godot
@@ -27,7 +27,7 @@ project/assembly_name="LingoEngine.Demo.TetriGrounds.Godot"
 
 [gui]
 
-theme/custom="uid://xc6qaca8t4t6"
+; theme/custom="uid://xc6qaca8t4t6" ; replaced by DirectorStyle.CreateTheme()
 
 [rendering]
 

--- a/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
@@ -1,6 +1,7 @@
 using Godot;
 using LingoEngine.Director.Core;
 using LingoEngine.LGodot;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace LingoEngine.Director.LGodot
 {
@@ -14,6 +15,8 @@ namespace LingoEngine.Director.LGodot
                 ;
             engineRegistration.Services(s =>
             {
+                s.AddSingleton<DirectorStyle>();
+                s.AddSingleton<Theme>(p => p.GetRequiredService<DirectorStyle>().Theme);
 
                 //IServiceCollection serviceCollection = s
                   //  .AddSingleton<ILingoFrameworkStageWindow>(p => new DirGodotStageWindow(rootNode))

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
@@ -10,6 +10,7 @@ using LingoEngine.LGodot;
 using LingoEngine.Director.LGodot.Casts;
 using LingoEngine.Director.LGodot.Inspector;
 using LingoEngine.Director.LGodot.Movies;
+using LingoEngine.Director.LGodot;
 using System.Reflection.Emit;
 
 namespace LingoEngine.Director.LGodot.Gfx
@@ -34,6 +35,9 @@ namespace LingoEngine.Director.LGodot.Gfx
             // set up root
             var parent = (Node2D)serviceProvider.GetRequiredService<LingoGodotRootNode>().RootNode;
             parent.AddChild(_directorParent);
+
+            // Apply Director UI theme from IoC
+            _directorParent.Theme = serviceProvider.GetRequiredService<Theme>();
 
             // Setup stage
             var stageContainer = (LingoGodotStageContainer)serviceProvider.GetRequiredService<ILingoFrameworkStageContainer>();

--- a/src/Director/LingoEngine.Director.LGodot/Styles/DirectorStyle.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Styles/DirectorStyle.cs
@@ -1,0 +1,46 @@
+using Godot;
+
+namespace LingoEngine.Director.LGodot;
+
+/// <summary>
+/// Provides the default theme used by the Director UI.
+/// Converted from directorTheme.tres.
+/// </summary>
+public sealed class DirectorStyle
+{
+    public Theme Theme { get; }
+
+    public DirectorStyle()
+    {
+        Theme = BuildTheme();
+    }
+
+    private static Theme BuildTheme()
+    {
+        var theme = new Theme();
+
+        var focus = new StyleBoxFlat { BgColor = new Color("#640808") };
+        var hover = new StyleBoxFlat { BgColor = new Color("#640808") };
+        var hoverPressedMirrored = new StyleBoxFlat { BgColor = new Color("#3c0303") };
+        var normal = new StyleBoxFlat { BgColor = new Color("#aa1615") };
+        var pressed = new StyleBoxFlat { BgColor = new Color("#3c0303") };
+
+        theme.SetTypeVariation("CloseButton", "Button");
+        theme.SetStylebox("focus", "CloseButton", focus);
+        theme.SetStylebox("hover", "CloseButton", hover);
+        theme.SetStylebox("hover_pressed_mirrored", "CloseButton", hoverPressedMirrored);
+        theme.SetStylebox("normal", "CloseButton", normal);
+        theme.SetStylebox("pressed", "CloseButton", pressed);
+        theme.SetColor("font_color", "CloseButton", Colors.White);
+        theme.SetFontSize("font_size", "Button", 10);
+        theme.SetFontSize("font_size", "CloseButton", 10);
+        theme.SetFontSize("font_size", "Label", 13);
+        theme.SetFontSize("font_size", "LineEdit", 13);
+        theme.SetFontSize("font_size", "TabBar", 10);
+        theme.SetFontSize("font_size", "TextEdit", 13);
+        theme.SetFontSize("font_size", "Tree", 11);
+        theme.SetFontSize("title_button_font_size", "Tree", 12);
+
+        return theme;
+    }
+}


### PR DESCRIPTION
## Summary
- define DirectorStyle using hex colors for readability
- register DirectorStyle and the resulting Theme in DI in `DirGodotSetup`
- fetch Theme from DI when building `LingoGodotDirectorRoot`

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685230e7ea20833280386e489760c9bd