### PR TITLE
Add selected member highlight

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
@@ -8,6 +8,7 @@ namespace LingoEngine.Director.LGodot.Casts
     internal partial class DirGodotCastItem : VBoxContainer
     {
         private readonly ColorRect _bg;
+        private readonly ColorRect _selectionBg;
         //private readonly CenterContainer _spriteContainer;
         private readonly Sprite2D _Sprite2D;
         private readonly ILingoMember _lingoMember;
@@ -17,11 +18,29 @@ namespace LingoEngine.Director.LGodot.Casts
         public int Width { get; set; } = 50;
         public int Height { get; set; } = 50;
         public ILingoMember LingoMember => _lingoMember;
-        public DirGodotCastItem(ILingoMember element, int number, Action<DirGodotCastItem> onSelect)
+        public void SetSelected(bool selected)
+        {
+            _selectionBg.Visible = selected;
+        }
+        public DirGodotCastItem(ILingoMember element, int number, Action<DirGodotCastItem> onSelect, Color selectedColor)
         {
             _lingoMember = element;
             _onSelect = onSelect;
             CustomMinimumSize = new Vector2(50, 50);
+
+            // Selection background - slightly larger than the item itself
+            _selectionBg = new ColorRect { Color = selectedColor, Visible = false };
+            _selectionBg.SizeFlagsHorizontal = Control.SizeFlags.ExpandFill;
+            _selectionBg.SizeFlagsVertical = Control.SizeFlags.ExpandFill;
+            _selectionBg.AnchorLeft = 0;
+            _selectionBg.AnchorTop = 0;
+            _selectionBg.AnchorRight = 1;
+            _selectionBg.AnchorBottom = 1;
+            _selectionBg.OffsetLeft = -1;
+            _selectionBg.OffsetTop = -1;
+            _selectionBg.OffsetRight = 1;
+            _selectionBg.OffsetBottom = 1;
+            AddChild(_selectionBg);
 
             // Solid background
             _bg = new ColorRect { Color = Colors.DimGray };

--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastView.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastView.cs
@@ -1,6 +1,7 @@
 ﻿using Godot;
 using LingoEngine.Core;
 using LingoEngine.Director.Core.Casts;
+using LingoEngine.Director.LGodot;
 
 namespace LingoEngine.Director.LGodot.Casts
 {
@@ -10,10 +11,11 @@ namespace LingoEngine.Director.LGodot.Casts
         private readonly ScrollContainer _ScrollContainer;
         private readonly List<DirGodotCastItem> _elements = new List<DirGodotCastItem>();
         private readonly Action<DirGodotCastItem> _onSelectItem;
+        private readonly DirectorStyle _style;
 
         public Node Node => _ScrollContainer;
 
-        public DirGodotCastView(Action<DirGodotCastItem> onSelect)
+        public DirGodotCastView(Action<DirGodotCastItem> onSelect, DirectorStyle style)
         {
             _ScrollContainer = new ScrollContainer();
             _ScrollContainer.SizeFlagsVertical = Control.SizeFlags.ExpandFill;
@@ -24,6 +26,7 @@ namespace LingoEngine.Director.LGodot.Casts
             _elementsContainer.SizeFlagsHorizontal = Control.SizeFlags.ExpandFill;
             _ScrollContainer.AddChild(_elementsContainer);
             _onSelectItem = onSelect;
+            _style = style;
         }
 
         public void Show(ILingoCast cast)
@@ -32,7 +35,7 @@ namespace LingoEngine.Director.LGodot.Casts
             var i = 0;
             foreach (var castItem in cast.GetAll())
             {
-                var dirCastItem = new DirGodotCastItem(castItem, i+1, _onSelectItem);
+                var dirCastItem = new DirGodotCastItem(castItem, i+1, _onSelectItem, _style.SelectedColor);
                 dirCastItem.Init();
                 _elements.Add(dirCastItem);
                 _elementsContainer.AddChild(dirCastItem);

--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastWindow.cs
@@ -2,6 +2,7 @@
 using LingoEngine.Core;
 using LingoEngine.Director.Core.Events;
 using LingoEngine.Director.LGodot.Gfx;
+using LingoEngine.Director.LGodot;
 using LingoEngine.Movies;
 
 namespace LingoEngine.Director.LGodot.Casts
@@ -13,14 +14,17 @@ namespace LingoEngine.Director.LGodot.Casts
 
         private readonly ILingoMovie _lingoMovie;
         private readonly IDirectorEventMediator _mediator;
+        private readonly DirectorStyle _style;
+        private DirGodotCastItem? _selectedItem;
 
         public ILingoCast? ActiveCastLib { get; private set; }
 
-        public DirGodotCastWindow(IDirectorEventMediator mediator, ILingoMovie lingoMovie)
+        public DirGodotCastWindow(IDirectorEventMediator mediator, ILingoMovie lingoMovie, DirectorStyle style)
             : base("Cast")
         {
             _lingoMovie = lingoMovie;
             _mediator = mediator;
+            _style = style;
             _mediator.SubscribeToMenu(MenuCodes.CastWindow, () => Visible = !Visible);
 
             Size = new Vector2(360, 620);
@@ -35,7 +39,7 @@ namespace LingoEngine.Director.LGodot.Casts
 
             foreach (var cast in lingoMovie.CastLib.GetAll())
             {
-                var castLibViewer = new DirGodotCastView(OnSelectElement);
+                var castLibViewer = new DirGodotCastView(OnSelectElement, _style);
                 castLibViewer.Show(cast);
                 var tabContent = new VBoxContainer
                 {
@@ -73,8 +77,11 @@ namespace LingoEngine.Director.LGodot.Casts
 
         private void OnSelectElement(DirGodotCastItem castItem)
         {
+            _selectedItem?.SetSelected(false);
+            castItem.SetSelected(true);
+            _selectedItem = castItem;
             _mediator.RaiseMemberSelected(castItem.LingoMember);
-            
+
         }
         public void Activate(int castlibNum)
         {

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
@@ -38,6 +38,7 @@ namespace LingoEngine.Director.LGodot.Gfx
 
             // Apply Director UI theme from IoC
             _directorParent.Theme = serviceProvider.GetRequiredService<Theme>();
+            var style = serviceProvider.GetRequiredService<DirectorStyle>();
 
             // Setup stage
             var stageContainer = (LingoGodotStageContainer)serviceProvider.GetRequiredService<ILingoFrameworkStageContainer>();
@@ -45,7 +46,7 @@ namespace LingoEngine.Director.LGodot.Gfx
 
 
             _dirGodotMainMenu = new DirGodotMainMenu(_mediator, lingoMovie);
-            _castViewer = new DirGodotCastWindow(_mediator, lingoMovie);
+            _castViewer = new DirGodotCastWindow(_mediator, lingoMovie, style);
             _scoreWindow = new DirGodotScoreWindow(_mediator);
             _inspector = new DirGodotObjectInspector(_mediator);
             _scoreWindow.SetMovie((LingoMovie)lingoMovie);

--- a/src/Director/LingoEngine.Director.LGodot/Styles/DirectorStyle.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Styles/DirectorStyle.cs
@@ -9,6 +9,10 @@ namespace LingoEngine.Director.LGodot;
 public sealed class DirectorStyle
 {
     public Theme Theme { get; }
+    /// <summary>
+    /// Highlight color for selected elements in the Director UI.
+    /// </summary>
+    public Color SelectedColor { get; } = Colors.DodgerBlue;
 
     public DirectorStyle()
     {


### PR DESCRIPTION
## Summary
- show blue highlight in cast view
- track selected member and toggle highlight on click
- provide selected color in `DirectorStyle`
- use style-selected color when drawing cast items
- pass style object to cast view

## Testing
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj -v q --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685238ef48648332b3c88e5b7b40da39