### PR TITLE
Add sprite bounding box and stage selection event

### DIFF
--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/Scenes/RootNodeTetriGrounds.cs
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/Scenes/RootNodeTetriGrounds.cs
@@ -51,11 +51,15 @@ public partial class RootNodeTetriGrounds : Node2D
                     );
             var serviceProvider = _services.BuildServiceProvider();
 
+#if DEBUG
             var movie = TetriGroundsSetup.SetupGame(serviceProvider);
             var game = TetriGroundsSetup.StartGame(serviceProvider);
-#if DEBUG
-            _director = new LingoGodotDirectorRoot(movie, serviceProvider);
+            _director = new LingoGodotDirectorRoot(movie, game.LingoPlayer, serviceProvider);
+#else
+            TetriGroundsSetup.SetupGame(serviceProvider);
+            TetriGroundsSetup.StartGame(serviceProvider);
 #endif
+
 
         }
         catch (Exception ex)

--- a/Z_Analysis/ProjectorRays.Console/Program.cs
+++ b/Z_Analysis/ProjectorRays.Console/Program.cs
@@ -1,5 +1,6 @@
 using ProjectorRays.Common;
 using ProjectorRays.Director;
+using Microsoft.Extensions.Logging.Abstractions;
 
 if (args.Length == 0 || args[0] == "-h" || args[0] == "--help")
 {
@@ -20,7 +21,7 @@ for (int i = 1; i < args.Length; i++)
 
 byte[] data = System.IO.File.ReadAllBytes(inputPath);
 var stream = new ReadStream(data, data.Length, Endianness.BigEndian);
-var dir = new DirectorFile();
+var dir = new DirectorFile(NullLogger.Instance);
 if (!dir.Read(stream))
 {
     System.Console.WriteLine("Failed to read Director file");

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotMainMenu.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotMainMenu.cs
@@ -23,6 +23,7 @@ internal partial class DirGodotMainMenu : Control
     {
         _mediator = mediator;
         _lingoMovie = lingoMovie;
+        _lingoMovie.PlayStateChanged += OnPlayStateChanged;
 
         AddChild(_menuBar);
         _menuBar.SizeFlagsHorizontal = SizeFlags.ExpandFill;
@@ -91,6 +92,10 @@ internal partial class DirGodotMainMenu : Control
             _lingoMovie.Halt();
         else
             _lingoMovie.Play();
+    }
+
+    private void OnPlayStateChanged(bool isPlaying)
+    {
         UpdatePlayButton();
     }
 
@@ -101,4 +106,10 @@ internal partial class DirGodotMainMenu : Control
 
 
     public HBoxContainer IconBar => _iconBar;
+
+    protected override void Dispose(bool disposing)
+    {
+        _lingoMovie.PlayStateChanged -= OnPlayStateChanged;
+        base.Dispose(disposing);
+    }
 }

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
@@ -6,6 +6,7 @@ using LingoEngine.Movies;
 using LingoEngine.FrameworkCommunication;
 using Microsoft.Extensions.DependencyInjection;
 using LingoEngine.LGodot.Stages;
+using LingoEngine.Core;
 using LingoEngine.LGodot;
 using LingoEngine.Director.LGodot.Casts;
 using LingoEngine.Director.LGodot.Inspector;
@@ -24,12 +25,14 @@ namespace LingoEngine.Director.LGodot.Gfx
         private readonly IDirectorEventMediator _mediator;
         private readonly DirGodotStageWindow _stageWindow;
         private readonly DirGodotMainMenu _dirGodotMainMenu;
+        private readonly LingoPlayer _player;
 
 
-        public LingoGodotDirectorRoot(ILingoMovie lingoMovie, IServiceProvider serviceProvider)
+        public LingoGodotDirectorRoot(ILingoMovie lingoMovie, LingoPlayer player, IServiceProvider serviceProvider)
         {
             _mediator = serviceProvider.GetRequiredService<IDirectorEventMediator>();
             _lingoMovie = lingoMovie;
+            _player = player;
 
             // set up root
             var parent = (Node2D)serviceProvider.GetRequiredService<LingoGodotRootNode>().RootNode;
@@ -37,7 +40,7 @@ namespace LingoEngine.Director.LGodot.Gfx
 
             // Setup stage
             var stageContainer = (LingoGodotStageContainer)serviceProvider.GetRequiredService<ILingoFrameworkStageContainer>();
-            _stageWindow = new DirGodotStageWindow(_directorParent, stageContainer,_mediator);
+            _stageWindow = new DirGodotStageWindow(_directorParent, stageContainer,_mediator, player);
 
 
             _dirGodotMainMenu = new DirGodotMainMenu(_mediator, lingoMovie);

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
@@ -1,10 +1,11 @@
 ﻿using Godot;
 using LingoEngine.Movies;
 using LingoEngine.Director.Core.Events;
+using System.Linq;
 
 namespace LingoEngine.Director.LGodot.Scores;
 
-internal partial class DirGodotScoreGrid : Control
+internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
 {
     private LingoMovie? _movie;
     private const int ChannelHeight = 16;
@@ -36,7 +37,7 @@ internal partial class DirGodotScoreGrid : Control
         }
     }
 
-    private void SelectSprite(DirGodotScoreSprite? sprite)
+    private void SelectSprite(DirGodotScoreSprite? sprite, bool raiseEvent = true)
     {
         if (_selected == sprite) return;
         if (_selected != null) _selected.Selected = false;
@@ -44,7 +45,8 @@ internal partial class DirGodotScoreGrid : Control
         if (_selected != null)
         {
             _selected.Selected = true;
-            _mediator.RaiseSpriteSelected(_selected.Sprite);
+            if (raiseEvent)
+                _mediator.RaiseSpriteSelected(_selected.Sprite);
         }
         QueueRedraw();
     }
@@ -125,6 +127,12 @@ internal partial class DirGodotScoreGrid : Control
     {
         if (Visible)
             QueueRedraw();
+    }
+
+    public void SpriteSelected(ILingoSprite sprite)
+    {
+        var match = _sprites.FirstOrDefault(x => x.Sprite == sprite);
+        SelectSprite(match, false);
     }
     
 

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -36,6 +36,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
         Size = new Vector2(width, height);
         CustomMinimumSize = Size;
         _grid = new DirGodotScoreGrid(directorMediator);
+        _mediator.Subscribe(_grid);
         _header = new DirGodotFrameHeader();
         _frameScripts = new DirGodotFrameScriptsBar();
         _labelBar = new DirGodotScoreLabelsBar();
@@ -89,6 +90,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
         _frameScripts.Dispose();
         _vScroller.Dispose();
         _hScroller.Dispose();
+        _mediator.Unsubscribe(_grid);
         base.Dispose(disposing);
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
@@ -5,46 +5,122 @@ using LingoEngine.LGodot.Movies;
 using LingoEngine.LGodot.Stages;
 using LingoEngine.Director.Core.Events;
 using LingoEngine.Director.LGodot.Gfx;
+using LingoEngine.Core;
+using System.Linq;
 
 namespace LingoEngine.Director.LGodot.Movies;
 
-internal partial class DirGodotStageWindow : BaseGodotWindow
+internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelectedEvent
 {
+    private const int IconBarHeight = 12;
     private readonly LingoGodotStageContainer _stageContainer;
     private readonly IDirectorEventMediator _mediator;
+    private readonly ILingoPlayer _player;
+    private readonly HBoxContainer _iconBar = new HBoxContainer();
+    private readonly HSlider _zoomSlider = new HSlider();
+    private readonly Button _rewindButton = new Button();
+    private readonly Button _playButton = new Button();
+    private readonly Button _prevFrameButton = new Button();
+    private readonly Button _nextFrameButton = new Button();
+    private readonly ColorRect _stageBgRect = new ColorRect();
+    private readonly ColorRect _colorDisplay = new ColorRect();
+    private readonly ColorPickerButton _colorPicker = new ColorPickerButton();
+    private readonly ScrollContainer _scrollContainer = new ScrollContainer();
+    private readonly SelectionBox _selectionBox = new SelectionBox();
+
     private LingoMovie? _movie;
     private ILingoFrameworkStage? _stage;
+    private LingoSprite? _selectedSprite;
 
-    public DirGodotStageWindow(Node root, LingoGodotStageContainer stageContainer, IDirectorEventMediator directorEventMediator)
+    public DirGodotStageWindow(Node root, LingoGodotStageContainer stageContainer, IDirectorEventMediator directorEventMediator, ILingoPlayer player)
         : base("Stage")
     {
         _stageContainer = stageContainer;
         _mediator = directorEventMediator;
+        _player = player;
+        _player.ActiveMovieChanged += OnActiveMovieChanged;
+        _mediator.Subscribe(this);
         
         Size = new Vector2(640 +10, 480+ TitleBarHeight);
         CustomMinimumSize = Size;
-        var scrollContainer = new ScrollContainer();
         // Set anchors to stretch fully
-        scrollContainer.AnchorLeft = 0;
-        scrollContainer.AnchorTop = 0;
-        scrollContainer.AnchorRight = 1;
-        scrollContainer.AnchorBottom = 1;
+        _scrollContainer.AnchorLeft = 0;
+        _scrollContainer.AnchorTop = 0;
+        _scrollContainer.AnchorRight = 1;
+        _scrollContainer.AnchorBottom = 1;
 
         // Set offsets to 0
-        scrollContainer.OffsetLeft = 0;
-        scrollContainer.OffsetTop = 0;
-        scrollContainer.OffsetRight = -10;
-        scrollContainer.OffsetBottom = -5;
+        _scrollContainer.OffsetLeft = 0;
+        _scrollContainer.OffsetTop = 0;
+        _scrollContainer.OffsetRight = -10;
+        _scrollContainer.OffsetBottom = -IconBarHeight - 5;
         root.AddChild(this);
 
-        scrollContainer.Position = new Vector2(0, 20);
-        scrollContainer.AddChild(stageContainer.Container);
-        AddChild(scrollContainer);
+        _scrollContainer.Position = new Vector2(0, 20);
+        _stageBgRect.Color = Colors.Black;
+        _stageBgRect.CustomMinimumSize = new Vector2(640, 480);
+        _stageBgRect.SizeFlagsHorizontal = SizeFlags.ExpandFill;
+        _stageBgRect.SizeFlagsVertical = SizeFlags.ExpandFill;
+        _scrollContainer.AddChild(_stageBgRect);
+        _scrollContainer.AddChild(stageContainer.Container);
+        stageContainer.Container.AddChild(_selectionBox);
+        _selectionBox.Visible = false;
+        _selectionBox.ZIndex = 1000;
+        AddChild(_scrollContainer);
+
+        // bottom icon bar
+        AddChild(_iconBar);
+        _iconBar.Position = new Vector2(0, Size.Y - IconBarHeight);
+        _iconBar.CustomMinimumSize = new Vector2(Size.X, IconBarHeight);
+        _iconBar.SizeFlagsHorizontal = SizeFlags.ExpandFill;
+
+        _rewindButton.Text = "|<";
+        _rewindButton.CustomMinimumSize = new Vector2(20, IconBarHeight);
+        _rewindButton.Pressed += () => _movie?.GoTo(1);
+        _iconBar.AddChild(_rewindButton);
+
+        _playButton.CustomMinimumSize = new Vector2(60, IconBarHeight);
+        _playButton.AddThemeFontSizeOverride("font_size", 8);
+        _playButton.Pressed += OnPlayPressed;
+        _iconBar.AddChild(_playButton);
+
+        _prevFrameButton.Text = "<";
+        _prevFrameButton.CustomMinimumSize = new Vector2(20, IconBarHeight);
+        _prevFrameButton.Pressed += () => _movie?.PrevFrame();
+        _iconBar.AddChild(_prevFrameButton);
+
+        _nextFrameButton.Text = ">";
+        _nextFrameButton.CustomMinimumSize = new Vector2(20, IconBarHeight);
+        _nextFrameButton.Pressed += () => _movie?.NextFrame();
+        _iconBar.AddChild(_nextFrameButton);
+
+        _zoomSlider.MinValue = 0.1f;
+        _zoomSlider.MaxValue = 3f;
+        _zoomSlider.Step = 0.1f;
+        _zoomSlider.Value = 1f;
+        _zoomSlider.CustomMinimumSize = new Vector2(100, IconBarHeight);
+        _zoomSlider.SizeFlagsHorizontal = SizeFlags.ExpandFill;
+        _zoomSlider.ValueChanged += value => UpdateZoom((float)value);
+        _iconBar.AddChild(_zoomSlider);
+
+        _colorDisplay.Color = Colors.Black;
+        _colorDisplay.CustomMinimumSize = new Vector2(IconBarHeight, IconBarHeight);
+        _iconBar.AddChild(_colorDisplay);
+
+        _colorPicker.CustomMinimumSize = new Vector2(IconBarHeight, IconBarHeight);
+        _colorPicker.Color = Colors.Black;
+        _colorPicker.ColorChanged += c => OnColorChanged(c);
+        _iconBar.AddChild(_colorPicker);
+
+        UpdatePlayButton();
+
         directorEventMediator.SubscribeToMenu(MenuCodes.StageWindow, () => Visible = !Visible);
     }
     protected override void OnResizing(Vector2 size)
     {
         base.OnResizing(size);
+        _iconBar.Position = new Vector2(0, size.Y - IconBarHeight);
+        _iconBar.CustomMinimumSize = new Vector2(size.X, IconBarHeight);
     }
 
     public void SetStage(ILingoFrameworkStage stage)
@@ -64,11 +140,107 @@ internal partial class DirGodotStageWindow : BaseGodotWindow
 
     public void SetActiveMovie(LingoMovie? movie)
     {
+        if (_movie != null)
+            _movie.PlayStateChanged -= OnPlayStateChanged;
+
         _stage?.SetActiveMovie(movie);
         _movie = movie;
+        _selectedSprite = null;
+        _selectionBox.Visible = false;
+
+        if (_movie != null)
+            _movie.PlayStateChanged += OnPlayStateChanged;
+
+        UpdatePlayButton();
     }
 
-    
+    private void OnActiveMovieChanged(ILingoMovie? movie)
+    {
+        SetActiveMovie(movie as LingoMovie);
+    }
 
-   
+    private void OnPlayPressed()
+    {
+        if (_movie == null) return;
+        if (_movie.IsPlaying)
+            _movie.Halt();
+        else
+            _movie.Play();
+    }
+
+    private void OnPlayStateChanged(bool isPlaying)
+    {
+        UpdatePlayButton();
+        if (isPlaying)
+            _selectionBox.Visible = false;
+        else if (_selectedSprite != null)
+            UpdateSelectionBox(_selectedSprite);
+    }
+
+    private void UpdatePlayButton()
+    {
+        _playButton.Text = _movie != null && _movie.IsPlaying ? "stop !" : "Play >";
+    }
+
+    private void UpdateZoom(float value)
+    {
+        if (_stage is Node2D node2D)
+            node2D.Scale = new Vector2(value, value);
+    }
+
+    private void OnColorChanged(Color color)
+    {
+        _stageBgRect.Color = color;
+        _colorDisplay.Color = color;
+    }
+
+    public void SpriteSelected(ILingoSprite sprite)
+    {
+        _selectedSprite = sprite as LingoSprite;
+        if (_movie != null && !_movie.IsPlaying)
+            UpdateSelectionBox(_selectedSprite);
+    }
+
+    private void UpdateSelectionBox(LingoSprite sprite)
+    {
+        var rect = new Rect2(sprite.LocH, sprite.LocV, sprite.Width, sprite.Height);
+        _selectionBox.UpdateRect(rect);
+        _selectionBox.Visible = true;
+    }
+
+    public override void _Input(InputEvent @event)
+    {
+        base._Input(@event);
+        if (!Visible || _movie == null || _movie.IsPlaying) return;
+        if (@event is InputEventMouseButton mb && mb.ButtonIndex == MouseButton.Left && mb.Pressed)
+        {
+            var sprite = _movie.GetSpriteUnderMouse();
+            if (sprite != null)
+                _mediator.RaiseSpriteSelected(sprite);
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (_movie != null)
+            _movie.PlayStateChanged -= OnPlayStateChanged;
+        _player.ActiveMovieChanged -= OnActiveMovieChanged;
+        _mediator.Unsubscribe(this);
+        base.Dispose(disposing);
+    }
+
+    private partial class SelectionBox : Node2D
+    {
+        private Rect2 _rect;
+        public void UpdateRect(Rect2 rect)
+        {
+            _rect = rect;
+            QueueRedraw();
+        }
+
+        public override void _Draw()
+        {
+            DrawRect(_rect, Colors.Yellow, false, 1);
+        }
+    }
 }

--- a/src/LingoEngine/Core/ILingoPlayer.cs
+++ b/src/LingoEngine/Core/ILingoPlayer.cs
@@ -1,4 +1,5 @@
-﻿using LingoEngine.Movies;
+﻿using System;
+using LingoEngine.Movies;
 using LingoEngine.Sounds;
 
 namespace LingoEngine.Core
@@ -16,6 +17,15 @@ namespace LingoEngine.Core
         /// </summary>
         ILingoCast ActiveCastLib { get; }
         ILingoMovie? ActiveMovie { get; }
+        /// <summary>
+        /// Raised when <see cref="ActiveMovie"/> changes.
+        /// </summary>
+        event Action<ILingoMovie?> ActiveMovieChanged;
+        /// <summary>
+        /// Sets the active movie.
+        /// </summary>
+        /// <param name="movie">Movie to make active.</param>
+        void SetActiveMovie(ILingoMovie? movie);
         /// <summary>
         /// Provides access to the sound system (including channels and control).
         /// Lingo: the sound

--- a/src/LingoEngine/Core/LingoPlayer.cs
+++ b/src/LingoEngine/Core/LingoPlayer.cs
@@ -1,4 +1,5 @@
-﻿using LingoEngine.FrameworkCommunication;
+﻿using System;
+using LingoEngine.FrameworkCommunication;
 using LingoEngine.Inputs;
 using LingoEngine.Movies;
 using LingoEngine.Sounds;
@@ -66,6 +67,7 @@ namespace LingoEngine.Core
         /// <inheritdoc/>
         bool ILingoPlayer.SafePlayer { get; set; }
         public ILingoMovie? ActiveMovie { get; private set; }
+        public event Action<ILingoMovie?>? ActiveMovieChanged;
 
         internal LingoPlayer(IServiceProvider serviceProvider, Action<LingoMovie> actionOnNewMovie)
         {
@@ -150,8 +152,7 @@ namespace LingoEngine.Core
             // Activate him;
             if (andActivate)
             {
-                ActiveMovie = movieEnv.Movie;
-                _Stage.SetActiveMovie(movieTyped);
+                SetActiveMovie(movieTyped);
             }
             return movieEnv.Movie;
         }
@@ -180,6 +181,15 @@ namespace LingoEngine.Core
                 configure(castLib);
             return this;
         }
+
+        public void SetActiveMovie(LingoMovie? movie)
+        {
+            ActiveMovie = movie;
+            _Stage.SetActiveMovie(movie);
+            ActiveMovieChanged?.Invoke(movie);
+        }
+
+        void ILingoPlayer.SetActiveMovie(ILingoMovie? movie) => SetActiveMovie(movie as LingoMovie);
 
         internal void LoadMovieScripts(IEnumerable<LingoMovieScript> enumerable)
         {

--- a/src/LingoEngine/Movies/ILingoMovie.cs
+++ b/src/LingoEngine/Movies/ILingoMovie.cs
@@ -1,4 +1,5 @@
-﻿using LingoEngine.Core;
+﻿using System;
+using LingoEngine.Core;
 
 namespace LingoEngine.Movies
 {
@@ -38,6 +39,11 @@ namespace LingoEngine.Movies
         /// Indicates whether the movie is currently playing.
         /// </summary>
         bool IsPlaying { get; }
+
+        /// <summary>
+        /// Occurs when the play state changes. Parameter indicates whether the movie is now playing.
+        /// </summary>
+        event Action<bool> PlayStateChanged;
 
         /// <summary>
         /// Jumps to the specified frame and continues playing.

--- a/src/LingoEngine/Movies/LingoMovie.cs
+++ b/src/LingoEngine/Movies/LingoMovie.cs
@@ -1,4 +1,5 @@
-﻿using LingoEngine.Core;
+﻿using System;
+using LingoEngine.Core;
 using LingoEngine.Events;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Inputs;
@@ -86,6 +87,8 @@ namespace LingoEngine.Movies
             }
         }
         public bool IsPlaying => _isPlaying;
+
+        public event Action<bool>? PlayStateChanged;
 
         public ActorList ActorList => _actorList;
         public LingoTimeOutList TimeOutList { get; private set; } = new LingoTimeOutList();
@@ -458,6 +461,7 @@ namespace LingoEngine.Movies
             // BeginSprite
             // StartMovie
             _isPlaying = true;
+            PlayStateChanged?.Invoke(true);
             OnTick();
             _needToRaiseStartMovie = false;
            
@@ -466,6 +470,7 @@ namespace LingoEngine.Movies
         private void OnStop()
         {
             _isPlaying = false;
+            PlayStateChanged?.Invoke(false);
             DoEndSprite();
             _EventMediator.RaiseStopMovie();
             // EndSprite
@@ -500,6 +505,7 @@ namespace LingoEngine.Movies
             {
                 _currentFrame = frame;
                 _isPlaying = false;
+                PlayStateChanged?.Invoke(false);
             }
         }
 


### PR DESCRIPTION
## Summary
- listen for stage selection events in score grid and draw bounding box around the selected sprite
- expose a selection overlay in the stage window and raise sprite selection when clicking
- hook the score grid to the event mediator
- fix console sample to use `NullLogger`

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: Could not find TestData files)*

------
https://chatgpt.com/codex/tasks/task_e_6852328f10648332ab6b00d5214ef13e