### PR TITLE
Fix score bar update when selecting frame while paused

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotFrameHeader.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotFrameHeader.cs
@@ -37,7 +37,12 @@ public override void _Draw()
             Vector2 pos = GetLocalMousePosition();
             int frame = Mathf.RoundToInt((pos.X - ChannelInfoWidth) / FrameWidth) + 1;
             if (frame >= 1 && frame <= _movie.FrameCount)
-                _movie.GoTo(frame);
+            {
+                if (_movie.IsPlaying)
+                    _movie.GoTo(frame);
+                else
+                    _movie.GoToAndStop(frame);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- update frame header input to set current frame using `GoToAndStop` when movie isn't playing

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68524a8de0b4833294a64993ef819c6a