### PR TITLE
Add project settings configuration method

### DIFF
--- a/src/Director/LingoEngine.Director.Core/DirectorProjectManager.cs
+++ b/src/Director/LingoEngine.Director.Core/DirectorProjectManager.cs
@@ -1,0 +1,61 @@
+using LingoEngine.Core;
+using LingoEngine.Director.Core.Events;
+using LingoEngine.IO;
+using System.IO;
+using LingoEngine;
+
+namespace LingoEngine.Director.Core;
+
+/// <summary>
+/// Handles project level operations such as saving and loading movies.
+/// Subscribes to menu events from <see cref="IDirectorEventMediator"/>.
+/// </summary>
+public class DirectorProjectManager
+{
+    private readonly ProjectSettings _settings;
+    private readonly LingoPlayer _player;
+    private readonly IDirectorEventMediator _mediator;
+    private readonly JsonStateRepository _repo = new();
+
+    public DirectorProjectManager(ProjectSettings settings, LingoPlayer player, IDirectorEventMediator mediator)
+    {
+        _settings = settings;
+        _player = player;
+        _mediator = mediator;
+
+        _mediator.SubscribeToMenu(MenuCodes.FileSave, SaveMovie);
+        _mediator.SubscribeToMenu(MenuCodes.FileLoad, LoadMovie);
+    }
+
+    private bool SaveMovie()
+    {
+        if (!_settings.HasValidSettings)
+        {
+            _mediator.RaiseMenuSelected(MenuCodes.ProjectSettingsWindow);
+            return true;
+        }
+        if (_player.ActiveMovie is not LingoMovie movie)
+            return true;
+
+        Directory.CreateDirectory(_settings.ProjectFolder);
+        var path = _settings.GetMoviePath(_settings.ProjectName);
+        _repo.Save(path, movie);
+        return true;
+    }
+
+    private bool LoadMovie()
+    {
+        if (!_settings.HasValidSettings)
+        {
+            _mediator.RaiseMenuSelected(MenuCodes.ProjectSettingsWindow);
+            return true;
+        }
+        var path = _settings.GetMoviePath(_settings.ProjectName);
+        if (!File.Exists(path))
+            return true;
+
+        var movie = _repo.Load(path, _player);
+        _player.SetActiveMovie(movie);
+        return true;
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/DirectorSetup.cs
+++ b/src/Director/LingoEngine.Director.Core/DirectorSetup.cs
@@ -1,4 +1,5 @@
 using LingoEngine.Director.Core.Events;
+using LingoEngine;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LingoEngine.Director.Core
@@ -12,6 +13,8 @@ namespace LingoEngine.Director.Core
 
                 IServiceCollection serviceCollection = s
                     .AddSingleton<IDirectorEventMediator, DirectorEventMediator>()
+                    .AddSingleton<ProjectSettings>()
+                    .AddSingleton<DirectorProjectManager>()
                     ;
 
             });

--- a/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
@@ -2,6 +2,7 @@ using Godot;
 using LingoEngine.Director.Core;
 using LingoEngine.LGodot;
 using Microsoft.Extensions.DependencyInjection;
+using LingoEngine.Director.LGodot.Gfx;
 
 namespace LingoEngine.Director.LGodot
 {
@@ -17,7 +18,8 @@ namespace LingoEngine.Director.LGodot
             {
                 s.AddSingleton<DirectorStyle>();
                 s.AddSingleton<Theme>(p => p.GetRequiredService<DirectorStyle>().Theme);
-
+                s.AddSingleton<DirGodotProjectSettingsWindow>();
+            
                 //IServiceCollection serviceCollection = s
                   //  .AddSingleton<ILingoFrameworkStageWindow>(p => new DirGodotStageWindow(rootNode))
                   //  .AddSingleton(p =>

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotMainMenu.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotMainMenu.cs
@@ -12,6 +12,7 @@ internal partial class DirGodotMainMenu : Control
 {
     private readonly HBoxContainer _menuBar = new HBoxContainer();
     private readonly MenuButton _fileMenu = new MenuButton() { Text = "File" };
+    private readonly MenuButton _editMenu = new MenuButton() { Text = "Edit" };
     private readonly MenuButton _WindowMenu = new MenuButton() { Text = "Window" };
     private readonly HBoxContainer _iconBar = new HBoxContainer();
     private IDirectorEventMediator _mediator;
@@ -54,10 +55,28 @@ internal partial class DirGodotMainMenu : Control
         // FileMenu
         _menuBar.AddChild(_fileMenu);
         var popupFile = _fileMenu.GetPopup();
+        popupFile.AddItem("Save", 2);
+        popupFile.AddItem("Load", 3);
         popupFile.AddItem("Quit", 1);
         popupFile.IdPressed += id =>
         {
-            if (id == 1) GetTree().Quit();
+            switch (id)
+            {
+                case 1:
+                    // TODO: check project for unsaved changes before quitting
+                    GetTree().Quit();
+                    break;
+                case 2: mediator.RaiseMenuSelected(MenuCodes.FileSave); break;
+                case 3: mediator.RaiseMenuSelected(MenuCodes.FileLoad); break;
+            }
+        };
+
+        _menuBar.AddChild(_editMenu);
+        var popupEdit = _editMenu.GetPopup();
+        popupEdit.AddItem("Project Settings", 20);
+        popupEdit.IdPressed += id =>
+        {
+            if (id == 20) mediator.RaiseMenuSelected(MenuCodes.ProjectSettingsWindow);
         };
 
         // Window Menu
@@ -103,7 +122,6 @@ internal partial class DirGodotMainMenu : Control
     {
         _playButton.Text = _lingoMovie != null && _lingoMovie.IsPlaying ? "Stop" : "Play";
     }
-
 
     public HBoxContainer IconBar => _iconBar;
 

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotProjectSettingsWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotProjectSettingsWindow.cs
@@ -1,0 +1,50 @@
+using Godot;
+using LingoEngine.Director.Core;
+using LingoEngine.Director.Core.Events;
+using LingoEngine;
+
+namespace LingoEngine.Director.LGodot.Gfx;
+
+internal partial class DirGodotProjectSettingsWindow : BaseGodotWindow
+{
+    private readonly ProjectSettings _settings;
+    private readonly LineEdit _nameEdit = new LineEdit();
+    private readonly LineEdit _folderEdit = new LineEdit();
+
+    public DirGodotProjectSettingsWindow(IDirectorEventMediator mediator, ProjectSettings settings)
+        : base("Project Settings")
+    {
+        _settings = settings;
+        mediator.SubscribeToMenu(MenuCodes.ProjectSettingsWindow, () => Visible = !Visible);
+
+        Size = new Vector2(300, 120);
+        CustomMinimumSize = Size;
+
+        var vbox = new VBoxContainer();
+        vbox.Position = new Vector2(5, TitleBarHeight + 5);
+        AddChild(vbox);
+
+        var h1 = new HBoxContainer();
+        h1.AddChild(new Label { Text = "Project Name", CustomMinimumSize = new Vector2(100, 16) });
+        _nameEdit.Text = settings.ProjectName;
+        h1.AddChild(_nameEdit);
+        vbox.AddChild(h1);
+
+        var h2 = new HBoxContainer();
+        h2.AddChild(new Label { Text = "Project Folder", CustomMinimumSize = new Vector2(100, 16) });
+        _folderEdit.Text = settings.ProjectFolder;
+        h2.AddChild(_folderEdit);
+        vbox.AddChild(h2);
+
+        var save = new Button { Text = "Save" };
+        save.Pressed += OnSavePressed;
+        vbox.AddChild(save);
+    }
+
+    private void OnSavePressed()
+    {
+        _settings.ProjectName = _nameEdit.Text.Trim();
+        _settings.ProjectFolder = _folderEdit.Text.Trim();
+        Visible = false;
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
@@ -12,6 +12,7 @@ using LingoEngine.Director.LGodot.Casts;
 using LingoEngine.Director.LGodot.Inspector;
 using LingoEngine.Director.LGodot.Movies;
 using LingoEngine.Director.LGodot;
+using LingoEngine.Director.Core;
 using System.Reflection.Emit;
 
 namespace LingoEngine.Director.LGodot.Gfx
@@ -27,6 +28,8 @@ namespace LingoEngine.Director.LGodot.Gfx
         private readonly DirGodotStageWindow _stageWindow;
         private readonly DirGodotMainMenu _dirGodotMainMenu;
         private readonly LingoPlayer _player;
+        private readonly DirGodotProjectSettingsWindow _projectSettingsWindow;
+        private readonly DirectorProjectManager _projectManager;
 
 
         public LingoGodotDirectorRoot(ILingoMovie lingoMovie, LingoPlayer player, IServiceProvider serviceProvider)
@@ -34,6 +37,8 @@ namespace LingoEngine.Director.LGodot.Gfx
             _mediator = serviceProvider.GetRequiredService<IDirectorEventMediator>();
             _lingoMovie = lingoMovie;
             _player = player;
+            _projectSettingsWindow = serviceProvider.GetRequiredService<DirGodotProjectSettingsWindow>();
+            _projectManager = serviceProvider.GetRequiredService<DirectorProjectManager>();
 
             // set up root
             var parent = (Node2D)serviceProvider.GetRequiredService<LingoGodotRootNode>().RootNode;
@@ -54,6 +59,7 @@ namespace LingoEngine.Director.LGodot.Gfx
             _inspector = new DirGodotObjectInspector(_mediator);
             _scoreWindow.SetMovie((LingoMovie)lingoMovie);
             _directorParent.AddChild(_dirGodotMainMenu);
+            _directorParent.AddChild(_projectSettingsWindow);
             _directorParent.AddChild(_castViewer);
             _directorParent.AddChild(_scoreWindow);
 

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/MenuCodes.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/MenuCodes.cs
@@ -8,5 +8,8 @@
         public const string ObjectInspector = "ObjectInspector";
         public const string CastWindow = "CastWindow";
         public const string ScoreWindow = "ScoreWindow";
+        public const string ProjectSettingsWindow = "ProjectSettingsWindow";
+        public const string FileSave = "FileSave";
+        public const string FileLoad = "FileLoad";
     }
 }

--- a/src/LingoEngine/LingoEngineRegistration.cs
+++ b/src/LingoEngine/LingoEngineRegistration.cs
@@ -12,6 +12,7 @@ namespace LingoEngine
         ILingoEngineRegistration AddFont(string name,string pathAndName);
         ILingoEngineRegistration ForMovie(string name, Action<IMovieRegistration> action);
         ILingoEngineRegistration WithFrameworkFactory<T>(Action<T>? setup = null) where T : class, ILingoFrameworkFactory;
+        ILingoEngineRegistration WithProjectSettings(Action<ProjectSettings> setup);
         LingoPlayer Build();
         LingoPlayer Build(IServiceProvider serviceProvider);
     }
@@ -38,6 +39,7 @@ namespace LingoEngine
         private readonly Dictionary<string, MovieRegistration> _Movies = new();
         private readonly List<(string Name, string FileName)> _Fonts = new();
         private Action<ILingoFrameworkFactory>? _FrameworkFactorySetup;
+        private ProjectSettings? _projectSettings;
         private IServiceProvider? _serviceProvider;
 
         public LingoEngineRegistration(IServiceCollection container)
@@ -62,6 +64,14 @@ namespace LingoEngine
             _container.AddSingleton<ILingoFrameworkFactory, T>();
             if (setup != null)
                 _FrameworkFactorySetup = f => setup((T)f);
+            return this;
+        }
+
+        public ILingoEngineRegistration WithProjectSettings(Action<ProjectSettings> setup)
+        {
+            _projectSettings = new ProjectSettings();
+            setup(_projectSettings);
+            _container.AddSingleton(_projectSettings);
             return this;
         }
      

--- a/src/LingoEngine/ProjectSettings.cs
+++ b/src/LingoEngine/ProjectSettings.cs
@@ -1,0 +1,19 @@
+namespace LingoEngine;
+
+using System.IO;
+
+public class ProjectSettings
+{
+    public string ProjectName { get; set; } = string.Empty;
+    public string ProjectFolder { get; set; } = string.Empty;
+
+    public bool HasValidSettings =>
+        !string.IsNullOrWhiteSpace(ProjectName) &&
+        !string.IsNullOrWhiteSpace(ProjectFolder);
+
+    public string GetMoviePath(string movieName)
+    {
+        var file = movieName + ".json";
+        return Path.Combine(ProjectFolder, file);
+    }
+}


### PR DESCRIPTION
## Summary
- migrate `ProjectSettings` class to core engine
- provide `WithProjectSettings` registration method for configuring project settings
- update Director services to use new `ProjectSettings`
- add TODO for unsaved changes check in main menu

## Testing
- `dotnet build LingoEngine.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68524669288c8332b8ddd8380a1e4328