### PR TITLE
Add lock support for sprites

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotObjectInspector.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotObjectInspector.cs
@@ -109,7 +109,22 @@ public partial class DirGodotObjectInspector : BaseGodotWindow, IHasSpriteSelect
             h.AddChild(label);
             Control editor;
             object? val = prop.GetValue(obj);
-            if (prop.PropertyType == typeof(bool))
+            if (obj is ILingoSprite && prop.Name == "Lock" && prop.PropertyType == typeof(bool))
+            {
+                var btn = new Button { Text = val is bool b && b ? "🔒" : "🔓" };
+                if (prop.CanWrite)
+                    btn.Pressed += () =>
+                    {
+                        bool current = prop.GetValue(obj) is bool b && b;
+                        bool newVal = !current;
+                        prop.SetValue(obj, newVal);
+                        btn.Text = newVal ? "🔒" : "🔓";
+                    };
+                else
+                    btn.Disabled = true;
+                editor = btn;
+            }
+            else if (prop.PropertyType == typeof(bool))
             {
                 var cb = new CheckBox { ButtonPressed = val is bool b && b };
                 if (prop.CanWrite)

--- a/src/LingoEngine.IO.Data/DTO/LingoSpriteDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoSpriteDTO.cs
@@ -8,6 +8,7 @@ public class LingoSpriteDTO
     public int SpriteNum { get; set; }
     public int MemberNum { get; set; }
     public bool Puppet { get; set; }
+    public bool Lock { get; set; }
     public bool Visibility { get; set; }
     public float LocH { get; set; }
     public float LocV { get; set; }

--- a/src/LingoEngine.IO/JsonStateRepository.cs
+++ b/src/LingoEngine.IO/JsonStateRepository.cs
@@ -82,6 +82,7 @@ public class JsonStateRepository
             var sprite = movie.AddSprite<LingoSprite>(sDto.SpriteNum, sDto.Name, s =>
             {
                 s.Puppet = sDto.Puppet;
+                s.Lock = sDto.Lock;
                 s.Visibility = sDto.Visibility;
                 s.LocH = sDto.LocH;
                 s.LocV = sDto.LocV;
@@ -259,6 +260,7 @@ public class JsonStateRepository
             SpriteNum = sprite.SpriteNum,
             MemberNum = sprite.MemberNum,
             Puppet = sprite.Puppet,
+            Lock = sprite.Lock,
             Visibility = sprite.Visibility,
             LocH = sprite.LocH,
             LocV = sprite.LocV,

--- a/src/LingoEngine/Movies/ILingoSprite.cs
+++ b/src/LingoEngine/Movies/ILingoSprite.cs
@@ -153,7 +153,8 @@ namespace LingoEngine.Movies
         /// <summary>
         /// Controls whether the sprite is visible on the Stage. Read/write.
         /// </summary>
-        bool Visibility { get; set; } 
+        bool Visibility { get; set; }
+        bool Lock { get; set; }
         int MemberNum { get; }
         bool Puppet { get; set; }
 

--- a/src/LingoEngine/Movies/LingoSprite.cs
+++ b/src/LingoEngine/Movies/LingoSprite.cs
@@ -22,6 +22,7 @@ namespace LingoEngine.Movies
         private bool isMouseInside = false;
         private bool isDragging = false;
         private bool isDraggable = false;  // A flag to control dragging behavior
+        private bool _lock = false;
         private LingoMember? _Member;
         private Action<LingoSprite>? _onRemoveMe;
         private bool _isFocus = false;
@@ -83,6 +84,11 @@ namespace LingoEngine.Movies
         public int EndFrame { get; set; }
 
         public bool Editable { get; set; }
+        public bool Lock
+        {
+            get => _lock;
+            set => _lock = value;
+        }
         public bool IsDraggable
         {
             get => isDraggable;

--- a/src/LingoEngine/Movies/LingoSpriteChannel.cs
+++ b/src/LingoEngine/Movies/LingoSpriteChannel.cs
@@ -120,6 +120,7 @@ namespace LingoEngine.Movies
         public LingoCast? Cast => _sprite.Cast;
         public LingoColor Color { get => _sprite.Color; set => _sprite.Color = value; }
         public bool Editable { get => _sprite.Editable; set => _sprite.Editable = value; }
+        public bool Lock { get => _sprite.Lock; set => _sprite.Lock = value; }
         public int EndFrame { get => _sprite.EndFrame; set => _sprite.EndFrame = value; }
         public LingoColor ForeColor { get => _sprite.ForeColor; set => _sprite.ForeColor = value; }
         public bool Hilite { get => _sprite.Hilite; set => _sprite.Hilite = value; }


### PR DESCRIPTION
## Summary
- add `Lock` boolean property to `ILingoSprite` and implement it in `LingoSprite`
- propagate lock state through sprite channels and JSON serialization
- show a lock/unlock button in the Godot object inspector

## Testing
- `dotnet test` *(fails: Could not find file `TextCast.cst`)*

------
https://chatgpt.com/codex/tasks/task_e_6852c5c26de88332aec0bcb4a78210a4