### PR TITLE
Restore text parser and parse style tables

### DIFF
--- a/Test/TestData/CST_All_Diffs.md
+++ b/Test/TestData/CST_All_Diffs.md
@@ -32,6 +32,9 @@ Compared with `Text_Hallo.cst`. Showing first 5 differing bytes and length diffe
 | Text_Hallo_subscript.cst | length 7352 vs 3213 | 0x0004:86->B0, 0x0005:0C->1C, 0x0018:2C->40, 0x0019:00->1A, 0x002C:70->2A |
 | Text_Hallo_superscript.cst | length 6776 vs 3213 | 0x0004:86->70, 0x0005:0C->1A, 0x0018:2C->00, 0x0019:00->18 |
 | Text_Hallo_with_name.cst | length 4982 vs 3213 | 0x0004:86->6E, 0x0005:0C->13, 0x0018:2C->FE, 0x0019:00->10 |
+| Text_Multi_Line_Multi_Style.cst | length 11165 vs 3213 | 0x0004:86->96, 0x0005:0C->2B, 0x0018:2C->5E, 0x0019:00->07, 0x002C:70->2A |
+| Text_Single_Line_Multi_Style.cst | length 10904 vs 3213 | 0x0004:86->90, 0x0005:0C->2A, 0x0018:2C->6A, 0x0019:00->07, 0x002C:70->2A |
+| Text_Wider_Width4.cst | length 6642 vs 3213 | 0x0004:86->EA, 0x0005:0C->19, 0x0018:2C->7A, 0x0019:00->17 |
 
 ## Extracted text and font (heuristic)
 
@@ -59,6 +62,9 @@ Compared with `Text_Hallo.cst`. Showing first 5 differing bytes and length diffe
 | Text_Hallo_subscript.cst | Hallo | Arcade * |
 | Text_Hallo_superscript.cst | Hallo | Arcade * |
 | Text_Hallo_with_name.cst | Hallo | Arcade * |
+| Text_Multi_Line_Multi_Style.cst | This text is red, Arial,12px, centered\rThe text is yellow, Tahoma, 9px, left aligned, bold, italic, underline\rThe text is green, font Terminal, 18px, left aligned, with spacing of 39\rThe text is orange, Tahoma, 9px, left aligned, bold, italic, underline\rThis text is red, Arial,12px, centered again | Arial |
+| Text_Single_Line_Multi_Style.cst | This text is red, Arial,12px, The text is yellow, Tahoma, 9px, bold, italic, underline The text is green, font Terminal, 18px, with spacing of 39 The text is orange, Tahoma, 9px, bold, italic, underline This text is red, Arial,12px, again | Arial |
+| Text_Wider_Width4.cst | Hallo | Arcade * |
 
 ### Multi-font run example
 
@@ -94,6 +100,35 @@ finally "Arcade *" again.
 | Text_Hallo_subscript.cst | 5, | Hallo | 3030303030303030 | 30303034303030303030303930303030 |
 | Text_Hallo_superscript.cst | 5, | Hallo | 3030303030303030 | 30303034303030303030303930303030 |
 | Text_Hallo_with_name.cst | 5, | Hallo | 3030303030303030 | 30303034303030303030303930303030 |
+| Text_Multi_Line_Multi_Style.cst | 5, | This text is red, Arial,12px, centered\rThe text is yellow, Tahoma, 9px, left aligned, bold, italic, underline\rThe text is green, font Terminal, 18px, left aligned, with spacing of 39\rThe text is orange, Tahoma, 9px, left aligned, bold, italic, underline\rThis text is red, Arial,12px, centered again | 3030303030303030 | 30303034303030303030303930303030 |
+| Text_Single_Line_Multi_Style.cst | 5, | This text is red, Arial,12px,  The text is yellow, Tahoma, 9px,  bold, italic, underline The text is green, font Terminal, 18px, with spacing of 39 The text is orange, Tahoma, 9px, bold, italic, underline This text is red, Arial,12px, again | 3030303030303030 | 30303034303030303030303930303030 |
+| Text_Wider_Width4.cst | 5, | Hallo | 3030303030303030 | 30303034303030303030303930303030 |
+# Differences: Text_Hallo_subscript.cst vs Text_Hallo.cst
+
+The table below lists the first few bytes that differ when comparing `Text_Hallo_subscript.cst` against `Text_Hallo.cst`.
+
+| Offset | Base value | Subscript value |
+|-------:|-----------:|----------------:|
+| 0x0004 | 0x86 | 0xB0 |
+| 0x0005 | 0x0C | 0x1C |
+| 0x0018 | 0x2C | 0x40 |
+| 0x0019 | 0x00 | 0x1A |
+| 0x002C | 0x70 | 0x2A |
+| 0x002D | 0x61 | 0x59 |
+| 0x002E | 0x6D | 0x45 |
+| 0x002F | 0x6D | 0x4B |
+
+# Differences: Text_Hallo_superscript.cst vs Text_Hallo.cst
+
+The table below lists the first few bytes that differ when comparing `Text_Hallo_superscript.cst` against `Text_Hallo.cst`.
+
+| Offset | Base value | Superscript value |
+|-------:|-----------:|------------------:|
+| 0x0004 | 0x86 | 0x70 |
+| 0x0005 | 0x0C | 0x1A |
+| 0x0018 | 0x2C | 0x00 |
+| 0x0019 | 0x00 | 0x18 |
+
 | Text_Hallo_multiLine.cst | 1F, | Hallomulti lineis longerYES! | 3030303030303030 | 30303034303030303030304130303030 |
 | Text_Hallo_tab_true.cst | 5, | Hallo | 3030303030303030 | 30303034303030303030303930303030 |
 | Text_Hallo_textAlignLeft.cst | 5, | Hallo | 3030303030303030 | 30303034303030303030303930303030 |
@@ -250,6 +285,9 @@ files do not include these names.
 `FF0000` value seen in the other text casts. The first changed long at offset
 `0x0018` (`0x000017D2`) appears to encode this color.
 
+Subscript uses style byte `0x40` while superscript uses `0x00`. Their flag bytes at
+offset `0x0019` are `0x1A` and `0x18` respectively.
+
 ### Color table bytes
 
 The ASCII sequence `FFFF0000 000600040001` appears in both casts. In the color
@@ -327,6 +365,130 @@ Example byte locations:
 The snippet below comes from `Text_Hallo_multifont.cst`. It shows the text run followed by the two font table entries used in that cast.
 
 The region just before the font strings contains a block of numbers that appear
+### Style blocks in multi-style samples
+
+`Text_Multi_Line_Multi_Style.cst` and `Text_Single_Line_Multi_Style.cst`
+include a larger table of similar entries. Each line style appears as a
+20‑digit ASCII sequence of five four‑digit numbers. Two copies of this table
+occur in the multi-line file. The first few offsets are:
+
+```
+00001334: 00040000002900000008
+00001371: 00050000001F00000006
+000013A4: 0006000002730000000B
+0000162B: 00070000007000000003
+000016AF: 00080000036600000005
+00001A29: 00090000001500000002
+
+0000230C: 00040000002900000008
+00002349: 00050000001F00000006
+0000237C: 0006000002730000000B
+00002603: 00070000007000000003
+00002687: 00080000036600000005
+00002A01: 00090000001500000002
+```
+
+The single-line variant stores a comparable list near the end of the file:
+
+```
+000022CB: 00040000001E00000006
+000022FD: 00050000000A00000002
+0000231B: 0006000001FF00000009
+0000252E: 00070000004800000002
+0000258A: 00080000036600000005
+00002904: 00090000001300000002
+
+### Example style block
+
+The first table entry `00040000002900000008` describes the line
+"This text is red, Arial,12px, centered again". A nearby style
+record begins at offset `0x16A8`:
+
+```
+000016A8: 3082 C1 03 C2 12 03 30 30 30 38 30 30 30 30
+000016B8: 33 36 36 30 30 30 30 30 30 30 35 00 34 30 2C 05
+000016C8: 41 72 69 61 6C 00 ...
+```
+
+These bytes repeat the style ID `0008` and embed the font
+name `Arial`. About 0x18 bytes into the block appears the
+sequence `30 30 35`, matching the style/flag pair offsets in
+other single-style casts. The small `40,` fragment directly
+before the font name likely stores a font-size value. This
+structure resembles the single-style blocks but lists each
+style sequentially.
+
+### Multi-style entry table
+
+The 20-digit strings split into five four-digit fields.  Field five
+matches the style record's ID while field three appears to reflect the
+length of the associated text line.
+
+| Offset | F1 | F2 | F3 | F4 | F5 | Notes |
+|------:|----:|----:|----:|----:|----:|------|
+| 0x1334 | 0004 | 0000 | 0029 | 0000 | 0008 | line 1: red, Arial, centered |
+| 0x1371 | 0005 | 0000 | 001F | 0000 | 0006 | line 2: yellow, Tahoma |
+| 0x13A4 | 0006 | 0000 | 0273 | 0000 | 000B | line 3: green, Terminal |
+| 0x162B | 0007 | 0000 | 0070 | 0000 | 0003 | line 4: orange, Tahoma |
+| 0x16AF | 0008 | 0000 | 0366 | 0000 | 0005 | line 5: red again |
+| 0x1A29 | 0009 | 0000 | 0015 | 0000 | 0002 | table terminator |
+
+Later in the file the same entries repeat starting at offset `0x230C`.
+
+The single line variant holds a similar table:
+
+| Offset | F1 | F2 | F3 | F4 | F5 | Notes |
+|------:|----:|----:|----:|----:|----:|------|
+| 0x22CB | 0004 | 0000 | 001E | 0000 | 0006 | first style |
+| 0x22FD | 0005 | 0000 | 000A | 0000 | 0002 | second style |
+| 0x231B | 0006 | 0000 | 01FF | 0000 | 0009 | third style |
+| 0x252E | 0007 | 0000 | 0048 | 0000 | 0002 | fourth style |
+| 0x258A | 0008 | 0000 | 0366 | 0000 | 0005 | fifth style |
+| 0x2904 | 0009 | 0000 | 0013 | 0000 | 0002 | terminator |
+### Style ID to font mapping
+
+The table above lists the style indices for each line of the multi-style samples. Each index also appears near a style descriptor block that embeds the font name and size. A few offsets extracted from `Text_Multi_Line_Multi_Style.cst` illustrate this relationship:
+
+| Style ID | Descriptor offset | Font | Notes |
+|--------:|------------------:|------|------|
+| 0008 | 0x16A8 | Arial,12px | style used for first and last lines |
+| 0006 | 0x18C4 | Tahoma,9px | yellow line style |
+| 000B | 0x196E | Terminal,18px | green line style |
+| 0003 | 0x1A30 | Tahoma,9px | orange line style |
+| 0005 | 0x26A8 | Arial,12px | duplicate of style 0008 |
+
+### Per-style alignment and color bytes
+
+Each descriptor begins with a short binary header. The first two bytes mirror
+the style/flag pair used in single-style casts (offsets `0x0018`–`0x0019`).
+Immediately after this header the style ID appears as four ASCII digits followed
+by extra numbers. One of these numbers matches a color entry from the table that
+starts near `0x1110`.
+
+Example offsets from `Text_Multi_Line_Multi_Style.cst`:
+
+```
+0x16A8: 30 82 C1 03 ... "0008" ... "40," 'Arial'    ; centered red line
+0x18C4: 02 30 82 02 ... "0006" ... "40," 'Tahoma'   ; yellow left aligned
+0x196E: 30 30 30 38 ... "000B" ... "40," 'Terminal' ; green left aligned
+```
+
+The color table itself stores RGB hex pairs prefixed by `0x01`.  A fragment from
+the changed-color sample at `0x1354` reads:
+
+```
+00001354: 01 CC 00 01 FF 00 01 66 00 01 30 01 46 46 46 46
+```
+
+The final digits in each style block select one of these color entries.
+
+
+### Width byte comparison
+
+`Text_Wider_Width4.cst` stores a much larger 32‑bit value at offset `0x0018`
+(`7A 17 00 00` little endian) compared with `Text_Hallo.cst` which has
+`2C 00 00 00`. Converting from twips, this roughly equals four inches of
+field width.
 to map style indices to character positions.  In this example the bytes around
 `0x1700` reference two styles so that characters 0‑2 use *Arcade ***, the middle
 letters switch to *Trajan Pro*, and the last letter reverts back.

--- a/Z_Analysis/ProjectorRays.DotNet/CastMembers/CastMemberTextRead.cs
+++ b/Z_Analysis/ProjectorRays.DotNet/CastMembers/CastMemberTextRead.cs
@@ -2,6 +2,7 @@
 using ProjectorRays.Common;
 using ProjectorRays.Director;
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -94,6 +95,16 @@ namespace ProjectorRays.CastMembers
         public string HexBefore { get; set; } = string.Empty;
         public string HexAfter { get; set; } = string.Empty;
     }
+
+    public class StyleEntry
+    {
+        public int Offset { get; set; }
+        public int F1 { get; set; }
+        public int F2 { get; set; }
+        public int F3 { get; set; }
+        public int F4 { get; set; }
+        public int StyleId { get; set; }
+    }
     /*
     var hex = BitConverter.ToString(view.Data, view.Offset, Math.Min(64, view.Size));
             dir.Logger.LogInformation($"XMED raw start (64 bytes): {hex}");
@@ -123,6 +134,8 @@ namespace ProjectorRays.CastMembers
         public string RtfText { get; private set; }
         public string FontName { get; private set; }
         public List<string> FontNames { get; } = new();
+        public Dictionary<int, string> StyleFonts { get; } = new();
+        public List<StyleEntry> StyleEntries { get; } = new();
         public string? MemberName { get; private set; }
         public int SpacingBefore { get; private set; }
         public int SpacingAfter { get; private set; }
@@ -133,219 +146,214 @@ namespace ProjectorRays.CastMembers
         {
             var result = new CastMemberTextRead();
 
-            // Todo: Check Field or Text
-            if (true)
-                ReadText(view, dir);
-            else
-                ReadField(view, dir);
+            // Dump the raw payload for debugging. The format is still largely
+            // unknown so we treat it as opaque ASCII for now.
+            var ascii = Encoding.Latin1.GetString(view.Data, view.Offset, view.Size);
+            dir.Logger.LogInformation($"XMED all : {BitConverter.ToString(view.Data, view.Offset, view.Size)}");
 
-            
+            result.RtfText = ascii;
+
+            // Field casts use a little-endian length value at offset 0x4C
+            if (view.Size > 0x50)
+            {
+                var hdr = Encoding.ASCII.GetString(view.Data, view.Offset + 0x4C, 4);
+                if (hdr != "XFIR")
+                {
+                    result.FieldTextLength = BinaryPrimitives.ReadUInt32LittleEndian(view.Data.AsSpan(view.Offset + 0x4C, 4));
+                }
+            }
+
+            // Parse text runs manually. Runs are encoded as
+            //   0x00 <digits> ',' <text> 0x03
+            // where the digits represent the character count for the run.
+            int pos = 0;
+            while (pos < view.Size - 1)
+            {
+                if (view.Data[view.Offset + pos] == 0x00)
+                {
+                    int p = pos + 1;
+                    int lenVal = 0;
+                    while (p < view.Size && view.Data[view.Offset + p] >= (byte)'0' && view.Data[view.Offset + p] <= (byte)'9')
+                    {
+                        lenVal = lenVal * 10 + (view.Data[view.Offset + p] - (byte)'0');
+                        p++;
+                    }
+                    if (p < view.Size && view.Data[view.Offset + p] == (byte)',')
+                    {
+                        p++;
+                        int start = p;
+                        while (p < view.Size && view.Data[view.Offset + p] != 0x03)
+                            p++;
+                        if (p < view.Size)
+                        {
+                            string txt = Encoding.Latin1.GetString(view.Data, view.Offset + start, p - start);
+                            var run = new TextRun
+                            {
+                                Offset = pos,
+                                Length = lenVal,
+                                Text = txt,
+                                HexBefore = BitConverter.ToString(view.Data, Math.Max(0, view.Offset + pos - 8), Math.Min(8, pos)),
+                                HexAfter = BitConverter.ToString(view.Data, view.Offset + p + 1, Math.Min(16, view.Size - (p + 1)))
+                            };
+                            result.Runs.Add(run);
+                            result.TextLength += lenVal;
+                            pos = p + 1;
+                            continue;
+                        }
+                    }
+                }
+                pos++;
+            }
+
+            if (result.Runs.Count > 0)
+            {
+                result.Text = string.Join("\n", result.Runs.ConvertAll(r => r.Text));
+                result.TextLength = result.Text.Length;
+            }
+
+            // Extract style table entries like "00040000002900000008"
+            var styleMatch = Regex.Matches(ascii, "[0-9]{20}");
+            foreach (Match m in styleMatch)
+            {
+                string s = m.Value;
+                var entry = new StyleEntry
+                {
+                    Offset = m.Index,
+                    F1 = int.Parse(s.Substring(0, 4)),
+                    F2 = int.Parse(s.Substring(4, 4)),
+                    F3 = int.Parse(s.Substring(8, 4)),
+                    F4 = int.Parse(s.Substring(12, 4)),
+                    StyleId = int.Parse(s.Substring(16, 4))
+                };
+                result.StyleEntries.Add(entry);
+            }
+
+
+
+            // Try to capture font names. They appear after a "40," marker
+            // followed by a single control byte and a null terminator.
+            var idx = ascii.IndexOf("40,");
+            while (idx >= 0 && idx + 4 < ascii.Length)
+            {
+                byte len = view.Data[view.Offset + idx + 3];
+                if (len > 0 && idx + 4 + len <= view.Size)
+                {
+                    string font = Encoding.Latin1.GetString(view.Data, view.Offset + idx + 4, len);
+                    result.FontNames.Add(font);
+                    if (idx >= 4 && char.IsDigit(ascii[idx - 1]) && char.IsDigit(ascii[idx - 2]) && char.IsDigit(ascii[idx - 3]) && char.IsDigit(ascii[idx - 4]))
+                    {
+                        string digits = ascii.Substring(idx - 4, 4);
+                        if (int.TryParse(digits, out int styleId))
+                            result.StyleFonts[styleId] = font;
+                    }
+                }
+                idx = ascii.IndexOf("40,", idx + 3);
+            }
+            if (result.FontNames.Count > 0)
+            {
+                result.FontName = result.FontNames[^1];
+            }
+
+            // Try to detect the color table entry. Two formats have been seen:
+            //  1. an 8-digit hex string before the constant 000600040001
+            //  2. three groups like 01CC00 01FF00 016600 representing "CCFF66".
+            var colorMatch = Regex.Match(ascii, "([A-F0-9]{8})000600040001");
+            if (colorMatch.Success)
+            {
+                if (uint.TryParse(colorMatch.Groups[1].Value, System.Globalization.NumberStyles.HexNumber, null, out uint rgb))
+                {
+                    result.ForeColor = new LingoColor(rgb & 0xFFFFFF);
+                }
+            }
+            else
+            {
+                var tableMatch = Regex.Match(ascii, "\x01([0-9A-F]{4})\x01([0-9A-F]{4})\x01([0-9A-F]{4})");
+                if (tableMatch.Success)
+                {
+                    string col = tableMatch.Groups[1].Value.Substring(0,2) +
+                                 tableMatch.Groups[2].Value.Substring(0,2) +
+                                 tableMatch.Groups[3].Value.Substring(0,2);
+                    if (uint.TryParse(col, System.Globalization.NumberStyles.HexNumber, null, out uint rgb2))
+                        result.ForeColor = new LingoColor(rgb2);
+                }
+            }
+
+            // Attempt to detect an embedded member name string. In many casts
+            // the name appears as an ASCII sequence surrounded by null bytes or
+            // prefixed with a length byte.
+            var nameMatch = Regex.Match(ascii, "\x00([A-Za-z ]{3,20})\x00");
+            if (nameMatch.Success)
+            {
+                string candidate = nameMatch.Groups[1].Value;
+                if (!candidate.StartsWith("NoTexture") && !candidate.StartsWith("TestData"))
+                    result.MemberName = candidate;
+            }
+            else
+            {
+                // Fallback for variants like "My field" or "MyText" stored without nulls
+                var direct = Regex.Match(ascii, "(MyText|My field)");
+                if (direct.Success)
+                    result.MemberName = direct.Value;
+            }
+
+
+            // Alignment and style flags appear around offsets 0x18-0x19
+            if (view.Size > 0x19)
+            {
+                byte styleByte = view.Data[view.Offset + 0x18];
+                byte flagsByte = view.Data[view.Offset + 0x19];
+
+                result.Alignment = flagsByte switch
+                {
+                    0x1A when styleByte == 0xBE => TextAlignment.Left,
+                    0x15 when styleByte == 0xD0 => TextAlignment.Right,
+                    _ => TextAlignment.Center
+                };
+
+                result.Bold = !(styleByte == 0xB8 && flagsByte == 0x17);
+                result.Italic = styleByte == 0x30 && flagsByte == 0x1A;
+                result.Underline = styleByte == 0x9C && flagsByte == 0x16;
+                result.WordWrap = !(styleByte == 0xF4 && flagsByte == 0x19);
+            }
+
+            // Font size seems to be stored as a 32-bit little endian value at offset 0x40
+            if (view.Size > 0x44)
+            {
+                result.FontSize = (ushort)BinaryPrimitives.ReadUInt32LittleEndian(view.Data.AsSpan(view.Offset + 0x40, 4));
+            }
+
+            // Letter spacing byte at 0x18 changes with the letterSpace_6 variant
+            if (view.Size > 0x18)
+            {
+                result.LetterSpacing = view.Data[view.Offset + 0x18];
+            }
+
+            // Heuristically locate spacing values
+            static int FindBytes(ReadOnlySpan<byte> data, ReadOnlySpan<byte> pattern)
+            {
+                for (int i = 0; i <= data.Length - pattern.Length; i++)
+                {
+                    if (data.Slice(i, pattern.Length).SequenceEqual(pattern))
+                        return i;
+                }
+                return -1;
+            }
+
+            int sbIndex = FindBytes(view.Data.AsSpan(view.Offset, view.Size), new byte[] { 0x0D, 0x00, 0x00, 0x00 });
+            if (sbIndex >= 0)
+                result.SpacingBefore = 13;
+
+            int saIndex = FindBytes(view.Data.AsSpan(view.Offset, view.Size), new byte[] { 0x09, 0x00, 0x00, 0x00 });
+            if (saIndex >= 0)
+                result.SpacingAfter = 9;
+
+            if (view.Size > 0x4DE)
+                result.LeftMargin = BitConverter.ToSingle(view.Data, view.Offset + 0x4DA);
+
             return result;
         }
 
-        private static void ReadField(BufferView view, DirectorFile dir)
-        {
-
-            // try extracting common styles
-            // try extracting styles
-            // Try extracting Run texts
-            // try fiding text <> style mapping
-            // try inserting styles in run texts.
 
 
-
-
-
-
-
-
-            // OLD
-            //// Dump the raw payload for debugging. The format is still largely
-            //// unknown so we treat it as opaque ASCII for now.
-            //var ascii = Encoding.Latin1.GetString(view.Data, view.Offset, view.Size);
-            //dir.Logger.LogInformation($"XMED all : {BitConverter.ToString(view.Data, view.Offset, view.Size)}");
-
-            //result.RtfText = ascii;
-
-            //// Field casts use a little-endian length value at offset 0x4C
-            //if (view.Size > 0x50)
-            //{
-            //    var hdr = Encoding.ASCII.GetString(view.Data, view.Offset + 0x4C, 4);
-            //    if (hdr != "XFIR")
-            //    {
-            //        result.FieldTextLength = BinaryPrimitives.ReadUInt32LittleEndian(view.Data.AsSpan(view.Offset + 0x4C, 4));
-            //    }
-            //}
-
-            //// Parse text runs manually. Runs are encoded as
-            ////   0x00 <digits> ',' <text> 0x03
-            //// where the digits represent the character count for the run.
-            //int pos = 0;
-            //while (pos < view.Size - 1)
-            //{
-            //    if (view.Data[view.Offset + pos] == 0x00)
-            //    {
-            //        int p = pos + 1;
-            //        int lenVal = 0;
-            //        while (p < view.Size && view.Data[view.Offset + p] >= (byte)'0' && view.Data[view.Offset + p] <= (byte)'9')
-            //        {
-            //            lenVal = lenVal * 10 + (view.Data[view.Offset + p] - (byte)'0');
-            //            p++;
-            //        }
-            //        if (p < view.Size && view.Data[view.Offset + p] == (byte)',')
-            //        {
-            //            p++;
-            //            int start = p;
-            //            while (p < view.Size && view.Data[view.Offset + p] != 0x03)
-            //                p++;
-            //            if (p < view.Size)
-            //            {
-            //                string txt = Encoding.Latin1.GetString(view.Data, view.Offset + start, p - start);
-            //                var run = new TextRun
-            //                {
-            //                    Offset = pos,
-            //                    Length = lenVal,
-            //                    Text = txt,
-            //                    HexBefore = BitConverter.ToString(view.Data, Math.Max(0, view.Offset + pos - 8), Math.Min(8, pos)),
-            //                    HexAfter = BitConverter.ToString(view.Data, view.Offset + p + 1, Math.Min(16, view.Size - (p + 1)))
-            //                };
-            //                result.Runs.Add(run);
-            //                result.TextLength += lenVal;
-            //                pos = p + 1;
-            //                continue;
-            //            }
-            //        }
-            //    }
-            //    pos++;
-            //}
-
-            //if (result.Runs.Count > 0)
-            //{
-            //    result.Text = string.Join("\n", result.Runs.ConvertAll(r => r.Text));
-            //    result.TextLength = result.Text.Length;
-            //}
-
-
-
-            //// Try to capture font names. They appear after a "40," marker
-            //// followed by a single control byte and a null terminator.
-            //var idx = ascii.IndexOf("40,");
-            //while (idx >= 0 && idx + 4 < ascii.Length)
-            //{
-            //    byte len = view.Data[view.Offset + idx + 3];
-            //    if (len > 0 && idx + 4 + len <= view.Size)
-            //    {
-            //        string font = Encoding.Latin1.GetString(view.Data, view.Offset + idx + 4, len);
-            //        result.FontNames.Add(font);
-            //    }
-            //    idx = ascii.IndexOf("40,", idx + 3);
-            //}
-            //if (result.FontNames.Count > 0)
-            //{
-            //    result.FontName = result.FontNames[^1];
-            //}
-
-            //// Try to detect the color table entry. Two formats have been seen:
-            ////  1. an 8-digit hex string before the constant 000600040001
-            ////  2. three groups like 01CC00 01FF00 016600 representing "CCFF66".
-            //var colorMatch = Regex.Match(ascii, "([A-F0-9]{8})000600040001");
-            //if (colorMatch.Success)
-            //{
-            //    if (uint.TryParse(colorMatch.Groups[1].Value, System.Globalization.NumberStyles.HexNumber, null, out uint rgb))
-            //    {
-            //        result.ForeColor = new LingoColor(rgb & 0xFFFFFF);
-            //    }
-            //}
-            //else
-            //{
-            //    var tableMatch = Regex.Match(ascii, "\x01([0-9A-F]{4})\x01([0-9A-F]{4})\x01([0-9A-F]{4})");
-            //    if (tableMatch.Success)
-            //    {
-            //        string col = tableMatch.Groups[1].Value.Substring(0,2) +
-            //                     tableMatch.Groups[2].Value.Substring(0,2) +
-            //                     tableMatch.Groups[3].Value.Substring(0,2);
-            //        if (uint.TryParse(col, System.Globalization.NumberStyles.HexNumber, null, out uint rgb2))
-            //            result.ForeColor = new LingoColor(rgb2);
-            //    }
-            //}
-
-            //// Attempt to detect an embedded member name string. In many casts
-            //// the name appears as an ASCII sequence surrounded by null bytes or
-            //// prefixed with a length byte.
-            //var nameMatch = Regex.Match(ascii, "\x00([A-Za-z ]{3,20})\x00");
-            //if (nameMatch.Success)
-            //{
-            //    string candidate = nameMatch.Groups[1].Value;
-            //    if (!candidate.StartsWith("NoTexture") && !candidate.StartsWith("TestData"))
-            //        result.MemberName = candidate;
-            //}
-            //else
-            //{
-            //    // Fallback for variants like "My field" or "MyText" stored without nulls
-            //    var direct = Regex.Match(ascii, "(MyText|My field)");
-            //    if (direct.Success)
-            //        result.MemberName = direct.Value;
-            //}
-
-
-            //// Alignment and style flags appear around offsets 0x18-0x19
-            //if (view.Size > 0x19)
-            //{
-            //    byte styleByte = view.Data[view.Offset + 0x18];
-            //    byte flagsByte = view.Data[view.Offset + 0x19];
-
-            //    result.Alignment = flagsByte switch
-            //    {
-            //        0x1A when styleByte == 0xBE => TextAlignment.Left,
-            //        0x15 when styleByte == 0xD0 => TextAlignment.Right,
-            //        _ => TextAlignment.Center
-            //    };
-
-            //    result.Bold = !(styleByte == 0xB8 && flagsByte == 0x17);
-            //    result.Italic = styleByte == 0x30 && flagsByte == 0x1A;
-            //    result.Underline = styleByte == 0x9C && flagsByte == 0x16;
-            //    result.WordWrap = !(styleByte == 0xF4 && flagsByte == 0x19);
-            //}
-
-            //// Font size seems to be stored as a 32-bit little endian value at offset 0x40
-            //if (view.Size > 0x44)
-            //{
-            //    result.FontSize = (ushort)BinaryPrimitives.ReadUInt32LittleEndian(view.Data.AsSpan(view.Offset + 0x40, 4));
-            //}
-
-            //// Letter spacing byte at 0x18 changes with the letterSpace_6 variant
-            //if (view.Size > 0x18)
-            //{
-            //    result.LetterSpacing = view.Data[view.Offset + 0x18];
-            //}
-
-            //// Heuristically locate spacing values
-            //static int FindBytes(ReadOnlySpan<byte> data, ReadOnlySpan<byte> pattern)
-            //{
-            //    for (int i = 0; i <= data.Length - pattern.Length; i++)
-            //    {
-            //        if (data.Slice(i, pattern.Length).SequenceEqual(pattern))
-            //            return i;
-            //    }
-            //    return -1;
-            //}
-
-            //int sbIndex = FindBytes(view.Data.AsSpan(view.Offset, view.Size), new byte[] { 0x0D, 0x00, 0x00, 0x00 });
-            //if (sbIndex >= 0)
-            //    result.SpacingBefore = 13;
-
-            //int saIndex = FindBytes(view.Data.AsSpan(view.Offset, view.Size), new byte[] { 0x09, 0x00, 0x00, 0x00 });
-            //if (saIndex >= 0)
-            //    result.SpacingAfter = 9;
-
-            //if (view.Size > 0x4DE)
-            //    result.LeftMargin = BitConverter.ToSingle(view.Data, view.Offset + 0x4DA);
-
-        }
-
-        private static void ReadText(BufferView view, DirectorFile dir)
-        {
-            // todo
-        }
     }
 }


### PR DESCRIPTION
## Summary
- restore earlier XMED parser implementation
- map style IDs to font names and collect style table entries
- document subscript and superscript style bytes
- document wider width text file

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68525a433e648332b23b6a0164b43246