### PR TITLE
Fix stage command handler placement

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Commands/SetStageScaleCommandHandler.cs
+++ b/src/Director/LingoEngine.Director.Core/Commands/SetStageScaleCommandHandler.cs
@@ -1,0 +1,30 @@
+using LingoEngine.Commands;
+using LingoEngine.FrameworkCommunication;
+
+namespace LingoEngine.Director.Core.Commands;
+
+/// <summary>
+/// Adjusts the current stage scale via the framework stage implementation.
+/// </summary>
+public sealed class SetStageScaleCommandHandler : ICommandHandler<SetStageScaleCommand>
+{
+    private ILingoFrameworkStage? _stage;
+
+    public void SetStage(ILingoFrameworkStage stage) => _stage = stage;
+
+    public bool CanExecute(SetStageScaleCommand command) => _stage != null;
+
+    public void Handle(SetStageScaleCommand command)
+    {
+        if (_stage == null) return;
+
+        var prop = _stage.GetType().GetProperty("Scale");
+        if (prop == null) return;
+        var vectorType = prop.PropertyType;
+        var ctor = vectorType.GetConstructor(new[] { typeof(float), typeof(float) });
+        if (ctor == null) return;
+        var vector = ctor.Invoke(new object[] { command.Scale, command.Scale });
+        prop.SetValue(_stage, vector);
+    }
+}
+

--- a/src/Director/LingoEngine.Director.Core/DirectorSetup.cs
+++ b/src/Director/LingoEngine.Director.Core/DirectorSetup.cs
@@ -1,5 +1,6 @@
 using LingoEngine.Director.Core.Events;
 using LingoEngine;
+using LingoEngine.Director.Core.Commands;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LingoEngine.Director.Core
@@ -14,6 +15,7 @@ namespace LingoEngine.Director.Core
                 IServiceCollection serviceCollection = s
                     .AddSingleton<IDirectorEventMediator, DirectorEventMediator>()
                     .AddSingleton<DirectorProjectManager>()
+                    .AddSingleton<SetStageScaleCommandHandler>()
                     ;
 
             });

--- a/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
@@ -3,6 +3,7 @@ using LingoEngine.Director.Core;
 using LingoEngine.LGodot;
 using Microsoft.Extensions.DependencyInjection;
 using LingoEngine.Director.LGodot.Gfx;
+using LingoEngine.Director.Core.Commands;
 
 namespace LingoEngine.Director.LGodot
 {

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
@@ -13,6 +13,8 @@ using LingoEngine.Director.LGodot.Inspector;
 using LingoEngine.Director.LGodot.Movies;
 using LingoEngine.Director.LGodot;
 using LingoEngine.Director.Core;
+using LingoEngine.Director.Core.Commands;
+using LingoEngine.Commands;
 using System.Reflection.Emit;
 
 namespace LingoEngine.Director.LGodot.Gfx
@@ -50,7 +52,9 @@ namespace LingoEngine.Director.LGodot.Gfx
 
             // Setup stage
             var stageContainer = (LingoGodotStageContainer)serviceProvider.GetRequiredService<ILingoFrameworkStageContainer>();
-            _stageWindow = new DirGodotStageWindow(_directorParent, stageContainer,_mediator, player);
+            var commandManager = serviceProvider.GetRequiredService<ICommandManager>();
+            var scaleHandler = serviceProvider.GetRequiredService<SetStageScaleCommandHandler>();
+            _stageWindow = new DirGodotStageWindow(_directorParent, stageContainer,_mediator, commandManager, scaleHandler, player);
 
 
             _dirGodotMainMenu = new DirGodotMainMenu(_mediator, lingoMovie);

--- a/src/LingoEngine/Commands/CommandManager.cs
+++ b/src/LingoEngine/Commands/CommandManager.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LingoEngine.Commands;
+
+internal sealed class CommandManager : ICommandManager
+{
+    private readonly IServiceProvider _provider;
+    private readonly Dictionary<Type, Type> _handlers = new();
+
+    public CommandManager(IServiceProvider provider) => _provider = provider;
+
+    public void Subscribe(Type handlerType)
+    {
+        foreach (var iface in handlerType.GetInterfaces()
+                     .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ICommandHandler<>)))
+        {
+            var cmdType = iface.GetGenericArguments()[0];
+            _handlers[cmdType] = handlerType;
+        }
+    }
+
+    public bool Handle(ILingoCommand command)
+    {
+        var type = command.GetType();
+        if (_handlers.TryGetValue(type, out var handlerType))
+        {
+            var handlerObj = _provider.GetService(handlerType) ?? ActivatorUtilities.CreateInstance(_provider, handlerType);
+            dynamic h = handlerObj;
+            dynamic c = command;
+            if (h.CanExecute(c))
+            {
+                h.Handle(c);
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/LingoEngine/Commands/CommandManagerExtensions.cs
+++ b/src/LingoEngine/Commands/CommandManagerExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LingoEngine.Commands;
+
+internal static class CommandManagerExtensions
+{
+    public static void DiscoverAndSubscribe(this ICommandManager manager, IServiceProvider provider)
+    {
+        var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+        foreach (var type in assemblies.SelectMany(a =>
+        {
+            try { return a.GetTypes(); } catch { return Array.Empty<Type>(); }
+        }))
+        {
+            if (type.IsAbstract || type.IsInterface) continue;
+            if (type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ICommandHandler<>)))
+            {
+                manager.Subscribe(type);
+            }
+        }
+    }
+}

--- a/src/LingoEngine/Commands/Handlers/PlayMovieCommandHandler.cs
+++ b/src/LingoEngine/Commands/Handlers/PlayMovieCommandHandler.cs
@@ -1,0 +1,23 @@
+using LingoEngine.Core;
+using LingoEngine.Movies;
+
+namespace LingoEngine.Commands.Handlers;
+
+internal sealed class PlayMovieCommandHandler : ICommandHandler<PlayMovieCommand>
+{
+    private readonly ILingoPlayer _player;
+    public PlayMovieCommandHandler(ILingoPlayer player) => _player = player;
+
+    public bool CanExecute(PlayMovieCommand command) => _player.ActiveMovie is LingoMovie;
+
+    public void Handle(PlayMovieCommand command)
+    {
+        if (_player.ActiveMovie is not LingoMovie movie) return;
+        if (command.Frame.HasValue)
+            movie.GoTo(command.Frame.Value);
+        if (movie.IsPlaying)
+            movie.Halt();
+        else
+            movie.Play();
+    }
+}

--- a/src/LingoEngine/Commands/Handlers/RewindMovieCommandHandler.cs
+++ b/src/LingoEngine/Commands/Handlers/RewindMovieCommandHandler.cs
@@ -1,0 +1,18 @@
+using LingoEngine.Core;
+using LingoEngine.Movies;
+
+namespace LingoEngine.Commands.Handlers;
+
+internal sealed class RewindMovieCommandHandler : ICommandHandler<RewindMovieCommand>
+{
+    private readonly ILingoPlayer _player;
+    public RewindMovieCommandHandler(ILingoPlayer player) => _player = player;
+
+    public bool CanExecute(RewindMovieCommand command) => _player.ActiveMovie is LingoMovie;
+
+    public void Handle(RewindMovieCommand command)
+    {
+        if (_player.ActiveMovie is LingoMovie movie)
+            movie.GoTo(1);
+    }
+}

--- a/src/LingoEngine/Commands/Handlers/StepFrameCommandHandler.cs
+++ b/src/LingoEngine/Commands/Handlers/StepFrameCommandHandler.cs
@@ -1,0 +1,33 @@
+using System;
+using LingoEngine.Core;
+using LingoEngine.Movies;
+
+namespace LingoEngine.Commands.Handlers;
+
+internal sealed class StepFrameCommandHandler : ICommandHandler<StepFrameCommand>
+{
+    private readonly ILingoPlayer _player;
+    public StepFrameCommandHandler(ILingoPlayer player) => _player = player;
+
+    public bool CanExecute(StepFrameCommand command) => _player.ActiveMovie is LingoMovie;
+
+    public void Handle(StepFrameCommand command)
+    {
+        if (_player.ActiveMovie is not LingoMovie movie) return;
+        int offset = command.Offset;
+        if (movie.IsPlaying)
+        {
+            var steps = Math.Abs(offset);
+            for (int i = 0; i < steps; i++)
+            {
+                if (offset > 0) movie.NextFrame();
+                else movie.PrevFrame();
+            }
+        }
+        else
+        {
+            var target = Math.Clamp(movie.Frame + offset, 1, movie.FrameCount);
+            movie.GoToAndStop(target);
+        }
+    }
+}

--- a/src/LingoEngine/Commands/ICommandHandler.cs
+++ b/src/LingoEngine/Commands/ICommandHandler.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.Commands;
+
+public interface ICommandHandler<TCommand> where TCommand : ILingoCommand
+{
+    bool CanExecute(TCommand command) => true;
+    void Handle(TCommand command);
+}

--- a/src/LingoEngine/Commands/ICommandManager.cs
+++ b/src/LingoEngine/Commands/ICommandManager.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.Commands;
+
+public interface ICommandManager
+{
+    void Subscribe(Type handlerType);
+    bool Handle(ILingoCommand command);
+}

--- a/src/LingoEngine/Commands/ILingoCommand.cs
+++ b/src/LingoEngine/Commands/ILingoCommand.cs
@@ -1,0 +1,3 @@
+namespace LingoEngine.Commands;
+
+public interface ILingoCommand { }

--- a/src/LingoEngine/Commands/PlayMovieCommand.cs
+++ b/src/LingoEngine/Commands/PlayMovieCommand.cs
@@ -1,0 +1,3 @@
+namespace LingoEngine.Commands;
+
+public sealed record PlayMovieCommand(int? Frame = null) : ILingoCommand;

--- a/src/LingoEngine/Commands/RewindMovieCommand.cs
+++ b/src/LingoEngine/Commands/RewindMovieCommand.cs
@@ -1,0 +1,3 @@
+namespace LingoEngine.Commands;
+
+public sealed record RewindMovieCommand() : ILingoCommand;

--- a/src/LingoEngine/Commands/SetStageScaleCommand.cs
+++ b/src/LingoEngine/Commands/SetStageScaleCommand.cs
@@ -1,0 +1,3 @@
+namespace LingoEngine.Commands;
+
+public sealed record SetStageScaleCommand(float Scale) : ILingoCommand;

--- a/src/LingoEngine/Commands/StepFrameCommand.cs
+++ b/src/LingoEngine/Commands/StepFrameCommand.cs
@@ -1,0 +1,3 @@
+namespace LingoEngine.Commands;
+
+public sealed record StepFrameCommand(int Offset) : ILingoCommand;

--- a/src/LingoEngine/LingoEngineRegistration.cs
+++ b/src/LingoEngine/LingoEngineRegistration.cs
@@ -3,6 +3,7 @@ using LingoEngine.Events;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Movies;
 using LingoEngine.Xtras.BuddyApi;
+using LingoEngine.Commands;
 using Microsoft.Extensions.DependencyInjection;
 namespace LingoEngine
 {
@@ -78,6 +79,8 @@ namespace LingoEngine
             player.SetActionOnNewMovie(ActionOnNewMovie);
             if (_FrameworkFactorySetup != null)
                 _FrameworkFactorySetup(serviceProvider.GetRequiredService<ILingoFrameworkFactory>());
+            serviceProvider.GetRequiredService<ICommandManager>()
+                .DiscoverAndSubscribe(serviceProvider);
             return player;
         }
 

--- a/src/LingoEngine/LingoEngineSetup.cs
+++ b/src/LingoEngine/LingoEngineSetup.cs
@@ -1,6 +1,7 @@
 ﻿using LingoEngine.Core;
 using LingoEngine.Events;
 using LingoEngine.Movies;
+using LingoEngine.Commands;
 using LingoEngine.Xtras.BuddyApi;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -22,6 +23,7 @@ namespace LingoEngine
                    .AddScoped<ILingoEventMediator, LingoEventMediator>()
                    // Xtras
                    .AddScoped<IBuddyAPI, BuddyAPI>()
+                   .AddSingleton<ICommandManager, CommandManager>()
                    ;
 
             return services;


### PR DESCRIPTION
## Summary
- move `SetStageScaleCommandHandler` into Director.Core
- use ILingoFrameworkStage for stage scaling
- revise `CommandManager` to register handler types and instantiate via DI
- support frame offsets in `StepFrameCommand`
- hook up new command behavior in stage window and director setup

## Testing
- `dotnet build LingoEngine.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68529b816460833287416e5b6b30247b