### PR TITLE
Fix scrollbars always visible in Godot score view

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -44,6 +44,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
         AddChild(_hScroller);
         _hScroller.VerticalScrollMode = ScrollContainer.ScrollMode.Disabled;
         _hScroller.HorizontalScrollMode = ScrollContainer.ScrollMode.ShowAlways;
+        _hScroller.ZIndex = 100;
         _hScroller.Size = new Vector2(Size.X- 10, Size.Y-20);
         _hScroller.Position = new Vector2(0, 20);
         _hScroller.AddChild(_scrollContent);
@@ -56,6 +57,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
 
         _vScroller.VerticalScrollMode = ScrollContainer.ScrollMode.ShowAlways;
         _vScroller.HorizontalScrollMode = ScrollContainer.ScrollMode.Disabled;
+        _vScroller.ZIndex = 100;
 
         _vScroller.AddChild(_grid);
         _grid.Resized += UpdateScrollSize;


### PR DESCRIPTION
## Summary
- ensure score scrollbars render above other controls by raising Z-index

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e84a44fc8332b6fa7c0aae3724dc