### PR TITLE
Fix TextEditWindow menu integration

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Menus/DirectorMenuCodes.cs
+++ b/src/Director/LingoEngine.Director.Core/Menus/DirectorMenuCodes.cs
@@ -9,6 +9,7 @@
         public const string CastWindow = "CastWindow";
         public const string ScoreWindow = "ScoreWindow";
         public const string ProjectSettingsWindow = "ProjectSettingsWindow";
+        public const string TextEditWindow = "TextEditWindow";
         public const string FileSave = "FileSave";
         public const string FileLoad = "FileLoad";
     }

--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
@@ -13,6 +13,7 @@ namespace LingoEngine.Director.LGodot.Casts
         private readonly Sprite2D _Sprite2D;
         private readonly ILingoMember _lingoMember;
         private readonly Action<DirGodotCastItem> _onSelect;
+        private readonly Action<DirGodotCastItem>? _onDoubleClick;
         private readonly Label _caption;
         public int LabelHeight { get; set; } = 18;
         public int Width { get; set; } = 50;
@@ -22,10 +23,11 @@ namespace LingoEngine.Director.LGodot.Casts
         {
             _selectionBg.Visible = selected;
         }
-        public DirGodotCastItem(ILingoMember element, int number, Action<DirGodotCastItem> onSelect, Color selectedColor)
+        public DirGodotCastItem(ILingoMember element, int number, Action<DirGodotCastItem> onSelect, Color selectedColor, Action<DirGodotCastItem>? onDoubleClick = null)
         {
             _lingoMember = element;
             _onSelect = onSelect;
+            _onDoubleClick = onDoubleClick;
             CustomMinimumSize = new Vector2(50, 50);
 
             // Selection background - slightly larger than the item itself
@@ -78,22 +80,25 @@ namespace LingoEngine.Director.LGodot.Casts
         {
             if (@event is InputEventMouseButton mouseEvent && mouseEvent.ButtonIndex == MouseButton.Left)
             {
+                if (mouseEvent.DoubleClick)
+                {
+                    _onDoubleClick?.Invoke(this);
+                    return;
+                }
+
                 if (!wasClicked && mouseEvent.Pressed)
                 {
                     Vector2 mousePos = GetGlobalMousePosition();
-
                     Rect2 bounds = new Rect2(GlobalPosition - CustomMinimumSize * 0.5f, CustomMinimumSize);
-
                     if (bounds.HasPoint(mousePos))
                     {
                         _onSelect(this);
                         wasClicked = true;
                     }
                     return;
-                } 
+                }
                 else if (wasClicked && !mouseEvent.Pressed)
                 {
-                    _onSelect(this);
                     wasClicked = false;
                 }
             }

--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastView.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastView.cs
@@ -11,11 +11,12 @@ namespace LingoEngine.Director.LGodot.Casts
         private readonly ScrollContainer _ScrollContainer;
         private readonly List<DirGodotCastItem> _elements = new List<DirGodotCastItem>();
         private readonly Action<DirGodotCastItem> _onSelectItem;
+        private readonly Action<DirGodotCastItem>? _onDoubleClickItem;
         private readonly DirectorStyle _style;
 
         public Node Node => _ScrollContainer;
 
-        public DirGodotCastView(Action<DirGodotCastItem> onSelect, DirectorStyle style)
+        public DirGodotCastView(Action<DirGodotCastItem> onSelect, Action<DirGodotCastItem>? onDoubleClick, DirectorStyle style)
         {
             _ScrollContainer = new ScrollContainer();
             _ScrollContainer.SizeFlagsVertical = Control.SizeFlags.ExpandFill;
@@ -26,6 +27,7 @@ namespace LingoEngine.Director.LGodot.Casts
             _elementsContainer.SizeFlagsHorizontal = Control.SizeFlags.ExpandFill;
             _ScrollContainer.AddChild(_elementsContainer);
             _onSelectItem = onSelect;
+            _onDoubleClickItem = onDoubleClick;
             _style = style;
         }
 
@@ -35,7 +37,7 @@ namespace LingoEngine.Director.LGodot.Casts
             var i = 0;
             foreach (var castItem in cast.GetAll())
             {
-                var dirCastItem = new DirGodotCastItem(castItem, i+1, _onSelectItem, _style.SelectedColor);
+                var dirCastItem = new DirGodotCastItem(castItem, i + 1, _onSelectItem, _style.SelectedColor, _onDoubleClickItem);
                 dirCastItem.Init();
                 _elements.Add(dirCastItem);
                 _elementsContainer.AddChild(dirCastItem);

--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastWindow.cs
@@ -4,6 +4,7 @@ using LingoEngine.Director.Core.Events;
 using LingoEngine.Director.LGodot.Gfx;
 using LingoEngine.Director.LGodot;
 using LingoEngine.Movies;
+using LingoEngine.Texts;
 
 namespace LingoEngine.Director.LGodot.Casts
 {
@@ -39,7 +40,7 @@ namespace LingoEngine.Director.LGodot.Casts
 
             foreach (var cast in lingoMovie.CastLib.GetAll())
             {
-                var castLibViewer = new DirGodotCastView(OnSelectElement, _style);
+                var castLibViewer = new DirGodotCastView(OnSelectElement, OnItemDoubleClick, _style);
                 castLibViewer.Show(cast);
                 var tabContent = new VBoxContainer
                 {
@@ -82,6 +83,15 @@ namespace LingoEngine.Director.LGodot.Casts
             _selectedItem = castItem;
             _mediator.RaiseMemberSelected(castItem.LingoMember);
 
+        }
+
+        private void OnItemDoubleClick(DirGodotCastItem castItem)
+        {
+            if (castItem.LingoMember is ILingoMemberTextBase textMember)
+            {
+                _mediator.RaiseMemberSelected(textMember);
+                _mediator.RaiseMenuSelected(DirectorMenuCodes.TextEditWindow);
+            }
         }
         public void Activate(int castlibNum)
         {

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
@@ -30,6 +30,7 @@ namespace LingoEngine.Director.LGodot.Gfx
         private readonly LingoPlayer _player;
         private readonly DirGodotProjectSettingsWindow _projectSettingsWindow;
         private readonly DirectorProjectManager _projectManager;
+        private readonly TextableMemberWindow _textEditWindow;
 
 
         public LingoGodotDirectorRoot(ILingoMovie lingoMovie, LingoPlayer player, IServiceProvider serviceProvider)
@@ -57,11 +58,13 @@ namespace LingoEngine.Director.LGodot.Gfx
             _castViewer = new DirGodotCastWindow(_mediator, lingoMovie, style);
             _scoreWindow = new DirGodotScoreWindow(_mediator);
             _inspector = new DirGodotObjectInspector(_mediator);
+            _textEditWindow = new TextableMemberWindow(_mediator);
             _scoreWindow.SetMovie((LingoMovie)lingoMovie);
             _directorParent.AddChild(_dirGodotMainMenu);
             _directorParent.AddChild(_projectSettingsWindow);
             _directorParent.AddChild(_castViewer);
             _directorParent.AddChild(_scoreWindow);
+            _directorParent.AddChild(_textEditWindow);
 
 
             //var hContainer = new HBoxContainer
@@ -81,6 +84,7 @@ namespace LingoEngine.Director.LGodot.Gfx
             _castViewer.Position = new Vector2(830, 25);
             _scoreWindow.Position = new Vector2(20, 540);
             _inspector.Position = new Vector2(1330, 25);
+            _textEditWindow.Position = new Vector2(900, 500);
 
         }
 
@@ -92,6 +96,7 @@ namespace LingoEngine.Director.LGodot.Gfx
             _scoreWindow.Dispose();
             _castViewer.Dispose();
             _inspector.Dispose();
+            _textEditWindow.Dispose();
         }
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotObjectInspector.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotObjectInspector.cs
@@ -6,6 +6,7 @@ using System;
 using System.Reflection;
 using LingoEngine.Pictures;
 using LingoEngine.Director.LGodot.Gfx;
+using LingoEngine.Texts;
 
 namespace LingoEngine.Director.LGodot.Inspector;
 
@@ -93,6 +94,16 @@ public partial class DirGodotObjectInspector : BaseGodotWindow, IHasSpriteSelect
         _tabs.AddChild(vScroller);
         var container = new VBoxContainer();
         BuildProperties(container, obj);
+        if (obj is ILingoMemberTextBase textMember)
+        {
+            var edit = new Button { Text = "Edit" };
+            edit.Pressed += () =>
+            {
+                _mediator.RaiseMemberSelected(textMember);
+                _mediator.RaiseMenuSelected(DirectorMenuCodes.TextEditWindow);
+            };
+            container.AddChild(edit);
+        }
         vScroller.AddChild(container);
     }
 

--- a/src/Director/LingoEngine.Director.LGodot/Inspector/TextableMemberWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Inspector/TextableMemberWindow.cs
@@ -1,0 +1,92 @@
+using Godot;
+using LingoEngine.Director.Core.Events;
+using LingoEngine.Director.LGodot.Gfx;
+using LingoEngine.Texts;
+using LingoEngine.Core;
+
+namespace LingoEngine.Director.LGodot.Inspector;
+
+internal partial class TextableMemberWindow : BaseGodotWindow, IHasMemberSelectedEvent
+{
+    private readonly TextEdit _textEdit = new TextEdit();
+    private readonly Button _alignLeft = new Button();
+    private readonly Button _alignCenter = new Button();
+    private readonly Button _alignRight = new Button();
+    private readonly SpinBox _fontSize = new SpinBox();
+
+    private ILingoMemberTextBase? _member;
+
+    public TextableMemberWindow(IDirectorEventMediator mediator) : base("Edit Text")
+    {
+        mediator.Subscribe(this);
+        mediator.SubscribeToMenu(DirectorMenuCodes.TextEditWindow, ToggleVisible);
+
+        Size = new Vector2(300, 200);
+        CustomMinimumSize = Size;
+
+        var bar = new HBoxContainer();
+        bar.Position = new Vector2(0, TitleBarHeight);
+        AddChild(bar);
+
+        _alignLeft.Text = "L";
+        _alignLeft.CustomMinimumSize = new Vector2(20, 16);
+        _alignLeft.Pressed += () => SetAlignment(LingoTextAlignment.Left);
+        bar.AddChild(_alignLeft);
+
+        _alignCenter.Text = "C";
+        _alignCenter.CustomMinimumSize = new Vector2(20, 16);
+        _alignCenter.Pressed += () => SetAlignment(LingoTextAlignment.Center);
+        bar.AddChild(_alignCenter);
+
+        _alignRight.Text = "R";
+        _alignRight.CustomMinimumSize = new Vector2(20, 16);
+        _alignRight.Pressed += () => SetAlignment(LingoTextAlignment.Right);
+        bar.AddChild(_alignRight);
+
+        _fontSize.MinValue = 1;
+        _fontSize.MaxValue = 200;
+        _fontSize.CustomMinimumSize = new Vector2(50, 16);
+        _fontSize.ValueChanged += v => { if (_member != null) _member.FontSize = (int)v; };
+        bar.AddChild(_fontSize);
+
+        _textEdit.Position = new Vector2(0, TitleBarHeight + 20);
+        _textEdit.Size = new Vector2(Size.X - 10, Size.Y - (TitleBarHeight + 25));
+        _textEdit.SizeFlagsHorizontal = SizeFlags.ExpandFill;
+        _textEdit.SizeFlagsVertical = SizeFlags.ExpandFill;
+        _textEdit.TextChanged += () =>
+        {
+            if (_member != null)
+                _member.Text = _textEdit.Text;
+        };
+        AddChild(_textEdit);
+    }
+
+    public void MemberSelected(ILingoMember member)
+    {
+        if (member is ILingoMemberTextBase text)
+        {
+            _member = text;
+            _textEdit.Text = text.Text;
+            _fontSize.Value = text.FontSize;
+        }
+    }
+
+    private bool ToggleVisible()
+    {
+        Visible = !Visible;
+        return true;
+    }
+
+    protected override void OnResizing(Vector2 size)
+    {
+        base.OnResizing(size);
+        _textEdit.Size = new Vector2(size.X - 10, size.Y - (TitleBarHeight + 25));
+    }
+
+    private void SetAlignment(LingoTextAlignment alignment)
+    {
+        if (_member != null)
+            _member.Alignment = alignment;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add TextEditWindow menucode constant
- wire object inspector and cast window to show the text editor via menu events
- fix TextableMemberWindow event handlers

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: missing test assets)*

------
https://chatgpt.com/codex/tasks/task_e_6852c52f1e1c8332ae4a72e2973c104b