### PR TITLE
Document multi-style offsets

### DIFF
--- a/docs/Text_Multi_Line_Multi_Style.md
+++ b/docs/Text_Multi_Line_Multi_Style.md
@@ -1,0 +1,63 @@
+# Text_Multi_Line_Multi_Style.cst
+
+This note collects known offsets for the `Text_Multi_Line_Multi_Style.cst` sample. The file contains two copies of the XMED data as explained in Anthony Kleine's memory-map documentation.  The second copy begins at `0x20E4` and is the one referenced by the memory map.
+
+## Byte blocks
+
+| Byte Address | Δ prev | Bytes Length | Bit | Description | Notes |
+|-------------:|-------:|-------------:|----|-------------|-------|
+| 0x110C | — | 4 | | DEMX header | obsolete copy |
+| 0x120A | 0x0FE | ~0x12A | | text string (first copy) | lines of styled text |
+| 0x1334 | 0x12A | 120 | | style map table | six entries |
+| 0x16A8 | 0x374 | 48 | | style descriptor 0008 | Arial red centered |
+| 0x18C4 | 0x21C | 48 | | style descriptor 0006 | yellow left Tahoma |
+| 0x196E | 0x0AA | 48 | | style descriptor 000B | Terminal green |
+| 0x1A30 | 0x0C2 | 48 | | style descriptor 0003 | orange left |
+| 0x21E1 | 0x8B1 | ~0x12A | | text string (second copy) | used version |
+| 0x230C | 0x12B | 120 | | style map table (repeat) | six entries |
+| 0x2680 | 0x374 | 48 | | style descriptor 0008 | duplicate of 0008 |
+| 0x26A8 | 0x28 | 48 | | style descriptor 0005 | duplicate Arial |
+| 0x289C | 0x1F4 | 48 | | style descriptor 0006 | duplicate Tahoma |
+| 0x2946 | 0x0AA | 48 | | style descriptor 000B | duplicate Terminal |
+
+## Block descriptions
+
+### DEMX header `0x110C`
+
+The four bytes at this offset read `44 45 4D 58` (`DEMX`), marking the start of the first XMED copy.
+
+### Text string copy 1 `0x120A`
+
+Around `0x120A` the visible text is stored for the first time. The bytes hold ASCII characters separated by carriage returns.
+
+### Style map table `0x1334`
+
+Six 20-digit ASCII rows list line lengths and style IDs. Each row links to one of the style descriptors below.
+
+### Descriptor blocks `0x16A8` etc
+
+Blocks beginning at `0x16A8`, `0x18C4`, `0x196E` and `0x1A30` store style properties. They include a style byte, flag byte, four-digit ID, a small `40,` token with the font size, the font name and finally a color index.
+
+### Text string copy 2 `0x21E1`
+
+The same text string appears again at this offset. Comparing the bytes shows both copies are identical except for numeric prefixes.
+
+### Repeated map table `0x230C`
+
+Another set of 20-digit rows mirrors the earlier style map. The later style descriptors starting at `0x2680` repeat the earlier blocks verbatim.
+
+## Style block details
+
+### Style 0008 (Arial)
+Offset `0x16A8` stores the first descriptor. The header bytes `30 82` encode bold and italic flags. The short `40,` token before the font name holds the size `12px`. The final byte `05` selects color index five.
+
+### Style 0006 (Tahoma)
+At `0x18C4` another block repeats the layout with the font `Tahoma` and color index `06`. The flag byte `02` denotes left alignment.
+
+### Style 000B (Terminal)
+The block at `0x196E` references `Terminal` with index `0B` and the same alignment bytes as the Tahoma style.
+
+### Style 0003 (Tahoma copy)
+Offset `0x1A30` mirrors the previous blocks but links to style ID `0003`. The alignment bytes match those of the yellow line.
+
+The later descriptors starting at `0x2680` repeat these structures verbatim. Their offsets correspond to the second XMED copy.

--- a/docs/XMED_Offsets.md
+++ b/docs/XMED_Offsets.md
@@ -51,12 +51,18 @@ Line spacing is stored at `0x003C`; font size at `0x0040`. Margins and indent by
 |0x0983|Font name string|
 |0x0CAE|Spacing before|
 |0x0EF7|Member name|
+|0x120A|Text string copy|
 |0x1354|Color table (multi-style)|
 |0x1970|Spacing after|
+|0x21E1|Text string copy|
 
 ### Style Blocks
 
 Multi-style casts contain descriptor blocks beginning at offsets such as `0x16A8`.
 Each block repeats the style and flag bytes, followed by an ASCII style ID,
-color index and font name. Single-style files use the same layout with just one block.
+a **one‑byte color index** and the font name.  The color index selects one of
+the values from the table near the start of the file.
+Single-style files use the same layout with just one block.
+
+Mapping tables reference these descriptors via 20‑digit entries. These hold a line length and up to three style IDs. The final ID picks the descriptor that overrides the parent style values.
 

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/HexDrawControl.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/HexDrawControl.cs
@@ -1,65 +1,39 @@
-﻿using Godot;
+using Godot;
 using System;
 using System.Collections.Generic;
 
 namespace LingoEngine.Director.LGodot.Gfx
 {
-    public partial class HexDrawControl : Control
+    internal partial class HexDrawControl : Control
     {
         private readonly byte[] _data;
-        private readonly Dictionary<int, string> _knownOffsets;
-        private readonly Dictionary<int, Color> _colors;
-        private readonly HashSet<int> _styleBlocks;
+        private readonly IReadOnlyList<XmedBlock> _blocks;
+        private readonly Dictionary<int, Color> _blockColors;
+        private readonly Dictionary<int, int> _blockIndexByOffset = new();
+        private readonly HashSet<int> _styleOffsets = new();
 
         private const int BytesPerRow = 32;
         private const int ByteSpacing = 24;
         private const int GroupGap = 8;
-        private const int RowHeight = 22; // taller to fit label
+        private const int RowHeight = 22;
         private const int LeftMargin = 10;
         private const int AsciiOffsetX = 900;
 
-        private readonly Dictionary<int, int> _groupMap = new();
-
         public HexDrawControl(
             byte[] data,
-            Dictionary<int, string> knownOffsets,
-            Dictionary<int, Color> colors,
-            HashSet<int> styleBlocks)
+            IReadOnlyList<XmedBlock> blocks,
+            Dictionary<int, Color> blockColors,
+            Dictionary<int, int> blockIndexByOffset,
+            HashSet<int> styleOffsets)
         {
             _data = data;
-            _knownOffsets = knownOffsets;
-            _colors = colors;
-            _styleBlocks = styleBlocks;
+            _blocks = blocks;
+            _blockColors = blockColors;
 
-            // Build group map from style blocks
-            int groupId = 0;
-            var sortedOffsets = new List<int>(_styleBlocks);
-            foreach (var kv in _knownOffsets)
-                sortedOffsets.Add(kv.Key);
-
-            sortedOffsets.Sort();
-
-
-            for (int i = 0; i < sortedOffsets.Count;)
-            {
-                int start = sortedOffsets[i];
-                int end = start;
-
-                // Walk contiguous block
-                while (i + 1 < sortedOffsets.Count && sortedOffsets[i + 1] == end + 1)
-                {
-                    i++;
-                    end = sortedOffsets[i];
-                }
-
-                // Assign groupId to all offsets in [start, end]
-                for (int off = start; off <= end; off++)
-                    _groupMap[off] = groupId;
-
-                groupId++;
-                i++;
-            }
-
+            foreach (var kv in blockIndexByOffset)
+                _blockIndexByOffset[kv.Key] = kv.Value;
+            foreach (var s in styleOffsets)
+                _styleOffsets.Add(s);
 
             int totalRows = (int)Math.Ceiling(data.Length / (float)BytesPerRow);
             CustomMinimumSize = new Vector2(AsciiOffsetX + 300, totalRows * RowHeight);
@@ -75,62 +49,46 @@ namespace LingoEngine.Director.LGodot.Gfx
                 return;
             }
 
-            int colorIndex = 0;
-
             for (int i = 0; i < _data.Length; i += BytesPerRow)
             {
                 float y = (i / BytesPerRow) * RowHeight;
-                string ascii = "";
+                string ascii = string.Empty;
 
                 for (int j = 0; j < BytesPerRow && i + j < _data.Length; j++)
                 {
                     int offset = i + j;
                     byte b = _data[offset];
 
-                    // Column position with group spacing
                     int group = j / GroupGap;
                     float hexX = LeftMargin + (j + group) * ByteSpacing;
 
-                    // Background highlight
-                    string tag = "";
+                    string tag = string.Empty;
                     Color? bg = null;
 
-                    if (_groupMap.TryGetValue(offset, out int groupId))
+                    if (_blockIndexByOffset.TryGetValue(offset, out int blockId))
                     {
-                        if (!_colors.ContainsKey(groupId))
-                        {
-                            float hue = (groupId * 0.1f) % 1f;
-                            _colors[groupId] = Color.FromHsv(hue, 0.3f, 1f);
-                        }
+                        if (_blockColors.TryGetValue(blockId, out var c))
+                            bg = c;
 
-                        bg = _colors[groupId];
-                    }
-
-                    if (_knownOffsets.TryGetValue(offset, out var desc))
-                    {
-                        tag = desc.Length > 6 ? desc.Substring(0, 6) : desc;
+                        var block = _blocks[blockId];
+                        if (offset == block.Start)
+                            tag = block.Description.Length > 6 ? block.Description.Substring(0, 6) : block.Description;
                     }
 
                     if (bg != null)
                     {
                         DrawRect(new Rect2(hexX, y, ByteSpacing - 2, RowHeight), bg.Value, true);
-                        if (_styleBlocks.Contains(offset))
+                        if (_styleOffsets.Contains(offset))
                             DrawRect(new Rect2(hexX, y, ByteSpacing - 2, RowHeight), Colors.Black, false, 1.0f);
                     }
 
-
-                    // Hex byte (top)
                     DrawString(font, new Vector2(hexX, y + 12), $"{b:X2}", HorizontalAlignment.Center, -1, 12, Colors.Black);
-
-                    // Tag label (bottom)
                     if (!string.IsNullOrEmpty(tag))
-                        DrawString(font, new Vector2(hexX, y + 20), tag,HorizontalAlignment.Left,-1,8, Colors.Black);
+                        DrawString(font, new Vector2(hexX, y + 20), tag, HorizontalAlignment.Left, -1, 8, Colors.Black);
 
-                    // Build ASCII string
                     ascii += (b >= 32 && b <= 126) ? (char)b : '.';
                 }
 
-                // ASCII column
                 DrawString(font, new Vector2(AsciiOffsetX, y + 16), ascii, HorizontalAlignment.Left, -1, 12, Colors.Black);
             }
         }

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/XmedInterpreter.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/XmedInterpreter.cs
@@ -1,17 +1,151 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace LingoEngine.Director.LGodot.Gfx
 {
+    internal abstract class XmedBlock
+    {
+        public int Start { get; }
+        public int Length { get; }
+
+        public virtual bool IsStyle => false;
+
+        protected XmedBlock(int start, int length)
+        {
+            Start = start;
+            Length = length;
+        }
+
+        public abstract string Description { get; }
+
+        public virtual string Detail => Description;
+    }
+
+    internal sealed class SimpleBlock : XmedBlock
+    {
+        private readonly string _name;
+        private readonly bool _style;
+        public override bool IsStyle => _style;
+        public override string Description => _name;
+
+        public SimpleBlock(int start, int length, string name, bool style = false)
+            : base(start, length)
+        {
+            _name = name;
+            _style = style;
+        }
+    }
+
+    internal sealed class TextBlock : XmedBlock
+    {
+        public string Text { get; }
+        public override string Description => "text";
+        public override string Detail => $"text: \"{Text}\"";
+
+        public TextBlock(int start, int length, string text)
+            : base(start, length)
+        {
+            Text = text;
+        }
+    }
+
+    internal sealed class StyleMapEntryBlock : XmedBlock
+    {
+        public ushort Field1 { get; }
+        public ushort Field2 { get; }
+        public ushort Field3 { get; }
+        public ushort Field4 { get; }
+        public string StyleId { get; }
+
+        public override bool IsStyle => true;
+        public override string Description => $"map {StyleId}";
+        public override string Detail => $"map {StyleId} len {Field3}";
+
+        public StyleMapEntryBlock(int start, ushort f1, ushort f2, ushort f3, ushort f4, string styleId)
+            : base(start, 20)
+        {
+            Field1 = f1;
+            Field2 = f2;
+            Field3 = f3;
+            Field4 = f4;
+            StyleId = styleId;
+        }
+    }
+
+    internal sealed class StyleDescriptorBlock : XmedBlock
+    {
+        public string StyleId { get; }
+        public byte ColorIndex { get; }
+        public string FontName { get; }
+        public string Alignment { get; }
+        public XmedStyle StyleFlags { get; }
+        public XmedFlags ExtraFlags { get; }
+
+        public override bool IsStyle => true;
+        public override string Description => $"style {StyleId}";
+        public override string Detail => $"{FontName} color {ColorIndex} {Alignment} {StyleFlags} {ExtraFlags}".Trim();
+
+        public StyleDescriptorBlock(
+            int start,
+            int length,
+            string styleId,
+            byte colorIndex,
+            string fontName,
+            string alignment,
+            XmedStyle styleFlags,
+            XmedFlags extraFlags)
+            : base(start, length)
+        {
+            StyleId = styleId;
+            ColorIndex = colorIndex;
+            FontName = fontName;
+            Alignment = alignment;
+            StyleFlags = styleFlags;
+            ExtraFlags = extraFlags;
+        }
+    }
+
+    internal sealed class XmedRelation
+    {
+        public int ByteOffset { get; }
+        public XmedBlock Source { get; }
+        public XmedBlock Target { get; }
+        public string Type { get; }
+
+        public XmedRelation(int byteOffset, XmedBlock source, XmedBlock target, string type)
+        {
+            ByteOffset = byteOffset;
+            Source = source;
+            Target = target;
+            Type = type;
+        }
+    }
+
     internal sealed class XmedInterpretation
     {
-        public Dictionary<int,string> Offsets { get; }
-        public HashSet<int> StyleBlocks { get; }
+        public IReadOnlyList<XmedBlock> Blocks { get; }
+        public IReadOnlyList<XmedRelation> Relations { get; }
 
-        public XmedInterpretation(Dictionary<int,string> offsets, HashSet<int> blocks)
+        public Dictionary<int,string> Offsets { get; } = new();
+        public HashSet<int> StyleBlocks { get; } = new();
+
+        public XmedInterpretation(List<XmedBlock> blocks, List<XmedRelation> relations)
         {
-            Offsets = offsets;
-            StyleBlocks = blocks;
+            Blocks = blocks;
+            Relations = relations;
+
+            foreach (var b in blocks)
+            {
+                for (int i = 0; i < b.Length; i++)
+                {
+                    int off = b.Start + i;
+                    if (!Offsets.ContainsKey(off))
+                        Offsets[off] = b.Description;
+                    if (b.IsStyle)
+                        StyleBlocks.Add(off);
+                }
+            }
         }
     }
 
@@ -39,51 +173,142 @@ namespace LingoEngine.Director.LGodot.Gfx
 
     internal static class XmedInterpreter
     {
-        public static XmedInterpretation Interpret(byte[] data, Dictionary<int,string>? manualOffsets = null, HashSet<int>? manualBlocks = null)
+        public static int FindXmedStart(byte[] data)
         {
-            var offsets = manualOffsets != null ? new Dictionary<int,string>(manualOffsets) : new Dictionary<int,string>();
-            var blocks = manualBlocks != null ? new HashSet<int>(manualBlocks) : new HashSet<int>();
-
-            void AddOffset(int off, string desc)
+            for (int i = 0; i <= data.Length - 4; i++)
             {
-                if (off < data.Length && !offsets.ContainsKey(off))
-                    offsets[off] = desc;
+                if (data[i] == 0x58 && data[i + 1] == 0x4D && data[i + 2] == 0x45 && data[i + 3] == 0x44)
+                    return i; // XMED
+                if (data[i] == 0x44 && data[i + 1] == 0x45 && data[i + 2] == 0x4D && data[i + 3] == 0x58)
+                    return i; // DEMX
+            }
+            return 0;
+        }
+
+        public static XmedInterpretation Interpret(byte[] data, IEnumerable<XmedBlock>? manualBlocks = null)
+        {
+            var blocks = manualBlocks != null ? new List<XmedBlock>(manualBlocks) : new List<XmedBlock>();
+            var relations = new List<XmedRelation>();
+
+            SimpleBlock? AddBlock(int start, int length, string desc, bool isStyle = false)
+            {
+                if (start >= data.Length || length <= 0)
+                    return null;
+
+                int len = Math.Min(length, data.Length - start);
+                foreach (var b in blocks)
+                {
+                    int end = start + len - 1;
+                    int bEnd = b.Start + b.Length - 1;
+                    if (start <= bEnd && end >= b.Start)
+                        return null; // overlap
+                }
+                var nb = new SimpleBlock(start, len, desc, isStyle);
+                blocks.Add(nb);
+                return nb;
             }
 
+            bool TryAdd(XmedBlock block)
+            {
+                if (block.Start >= data.Length || block.Start + block.Length > data.Length)
+                    return false;
+                foreach (var b in blocks)
+                {
+                    int end = block.Start + block.Length - 1;
+                    int bEnd = b.Start + b.Length - 1;
+                    if (block.Start <= bEnd && end >= b.Start)
+                        return false;
+                }
+                blocks.Add(block);
+                return true;
+            }
+
+            AddBlock(0x04, 2, "header bytes");
             if (data.Length > 0x18)
             {
-                AddOffset(0x18, "width value");
+                AddBlock(0x18, 4, "width value");
             }
             if (data.Length > 0x1C)
             {
-                AddOffset(0x1C, $"style byte ({DescribeStyle(data[0x1C])})");
+                AddBlock(0x1C, 1, $"style byte ({ParseStyleEnum(data[0x1C])})");
             }
             if (data.Length > 0x1D)
             {
-                AddOffset(0x1D, $"flags byte ({DescribeFlags(data[0x1D])})");
+                var (al, fl) = ParseFlagEnum(data[0x1D]);
+                AddBlock(0x1D, 1, $"flags byte ({al} {fl})");
             }
-            AddOffset(0x3C, "line spacing");
-            AddOffset(0x40, "font size");
-            AddOffset(0x4C, "text len");
-            AddOffset(0x4DA, "left margin");
-            AddOffset(0x4DE, "right margin");
-            AddOffset(0x4E2, "first indent");
-            AddOffset(0x0622, "color table");
-            AddOffset(0x0983, "font name");
-            AddOffset(0x0CAE, "spacing before");
-            AddOffset(0x0EF7, "member name");
-            AddOffset(0x1354, "color table");
-            AddOffset(0x1970, "spacing after");
+            AddBlock(0x2C, 4, "header bytes");
+            AddBlock(0x3C, 4, "line spacing");
+            AddBlock(0x40, 4, "font size");
+            AddBlock(0x4C, 4, "text length");
+            AddBlock(0x50, 2, "header bytes");
+            AddBlock(0x4DA, 4, "left margin");
+            AddBlock(0x4DE, 4, "right margin");
+            AddBlock(0x4E2, 4, "first indent");
+            AddBlock(0x0622, 1, "color table");
+            AddBlock(0x0983, 1, "font name");
+            AddBlock(0x0CAE, 1, "spacing before");
+            AddBlock(0x0EF7, 1, "member name");
+            AddBlock(0x1354, 1, "color table");
+            AddBlock(0x1970, 1, "spacing after");
 
             for (int i = 0; i <= data.Length - 4; i++)
             {
                 if (data[i] == 0x58 && data[i + 1] == 0x46 && data[i + 2] == 0x49 && data[i + 3] == 0x52)
                 {
-                    AddOffset(i, "XFIR");
+                    AddBlock(i, 4, "XFIR");
                 }
             }
 
-            // Look for color table ASCII header
+            // Detect style descriptor blocks based on "40," font markers
+            for (int i = 0; i < data.Length - 4; i++)
+            {
+                if (data[i] == 0x34 && data[i + 1] == 0x30 && data[i + 2] == 0x2C)
+                {
+                    // search backward for a four digit style id
+                    int idEnd = i;
+                    int idStart = idEnd - 4;
+                    while (idStart > 1 && IsDigit(data[idStart - 1]))
+                        idStart--;
+
+                    if (idStart - 2 >= 0 && IsDigit(data[idStart]) && IsDigit(data[idStart + 1]) &&
+                        IsDigit(data[idStart + 2]) && IsDigit(data[idStart + 3]))
+                    {
+                        int start = idStart - 2; // include style and flag bytes
+                        string id = Encoding.ASCII.GetString(data, idStart, 4);
+
+                        int j = i + 3;
+                        while (j < data.Length && IsPrintable(data[j]))
+                            j++;
+                        if (j < data.Length && data[j] == 0x00)
+                            j++;
+
+                        int end = j;
+                        while (end < data.Length && data[end] == 0x00)
+                            end++;
+                        // grab some extra trailing numbers that belong to this descriptor
+                        int extra = 0;
+                        while (end + extra < data.Length && extra < 16 && !IsPrintable(data[end + extra]))
+                            extra++;
+
+                        TryAdd(new SimpleBlock(start, end + extra - start, $"style {id}", true));
+                        i = end + extra - 1;
+                    }
+                }
+            }
+
+            // Build lookup of style blocks by ID
+            var styleBlocksById = new Dictionary<string, XmedBlock>();
+            foreach (var b in blocks)
+            {
+                if (b.Description.StartsWith("style "))
+                {
+                    var id = b.Description.Substring(6).Trim();
+                    styleBlocksById[id] = b;
+                }
+            }
+
+            // Look for color table ASCII header followed by color entries
             var colorHeader = System.Text.Encoding.ASCII.GetBytes("FFFF0000000600040001");
             for (int i = 0; i <= data.Length - colorHeader.Length; i++)
             {
@@ -98,14 +323,158 @@ namespace LingoEngine.Director.LGodot.Gfx
                 }
                 if (match)
                 {
-                    AddOffset(i, "color table");
+                    var hdr = AddBlock(i, colorHeader.Length, "color table");
+                    int pos = i + colorHeader.Length;
+                    // parse 0x01XXXX sequences
+                    while (pos + 5 <= data.Length && data[pos] == 0x01 &&
+                           IsHexDigit(data[pos + 1]) && IsHexDigit(data[pos + 2]) &&
+                           IsHexDigit(data[pos + 3]) && IsHexDigit(data[pos + 4]))
+                    {
+                        string hex = Encoding.ASCII.GetString(data, pos + 1, 4);
+                        TryAdd(new SimpleBlock(pos, 5, $"color {hex}"));
+                        pos += 5;
+                    }
                 }
             }
 
-            return new XmedInterpretation(offsets, blocks);
+            // Detect sequences of digits that form the style mapping table
+            for (int i = 0; i < data.Length;)
+            {
+                int start = i;
+                if (data[i] == 0x03 && i + 21 <= data.Length && IsDigit(data[i + 1]))
+                {
+                    start = i + 1;
+                }
+
+                if (IsDigit(data[start]))
+                {
+                    int j = start;
+                    while (j < data.Length && IsDigit(data[j]))
+                        j++;
+                    int len = j - start;
+                    if (len >= 20)
+                    {
+                        string digits = System.Text.Encoding.ASCII.GetString(data, start, len);
+                        for (int off = 0; off + 20 <= len; off += 20)
+                        {
+                            string entry = digits.Substring(off, 20);
+                            ushort f1 = Convert.ToUInt16(entry.Substring(0, 4));
+                            ushort f2 = Convert.ToUInt16(entry.Substring(4, 4));
+                            ushort f3 = Convert.ToUInt16(entry.Substring(8, 4));
+                            ushort f4 = Convert.ToUInt16(entry.Substring(12, 4));
+                            string id = entry.Substring(16, 4);
+                            var map = new StyleMapEntryBlock(start + off, f1, f2, f3, f4, id);
+                            if (TryAdd(map) && styleBlocksById.TryGetValue(id, out var sb))
+                            {
+                                relations.Add(new XmedRelation(start + off + 16, map, sb, "styleId"));
+                            }
+                        }
+                        i = j;
+                        continue;
+                    }
+                }
+                i++;
+            }
+
+            // Legacy font entry detection removed in favour of style descriptors
+
+            // Detect printable ASCII sequences (text content)
+            for (int i = 0; i < data.Length;)
+            {
+                if (IsPrintable(data[i]))
+                {
+                    int start = i;
+                    bool digitsOnly = true;
+                    while (i < data.Length && IsPrintable(data[i]))
+                    {
+                        if (!IsDigit(data[i]))
+                            digitsOnly = false;
+                        i++;
+                    }
+                    int len = i - start;
+                    if (len >= 4 && !digitsOnly)
+                    {
+                        var tb = new TextBlock(start, len, Encoding.ASCII.GetString(data, start, len));
+                        TryAdd(tb);
+                        continue;
+                    }
+                }
+                i++;
+            }
+
+            // Enhance descriptions for style blocks
+            var enhanced = new List<XmedBlock>();
+            foreach (var b in blocks)
+            {
+                if (b.IsStyle && b.Description.StartsWith("style"))
+                {
+                    enhanced.Add(ParseStyleBlock(data, b));
+                }
+                else
+                {
+                    enhanced.Add(b);
+                }
+            }
+
+            return new XmedInterpretation(enhanced, relations);
         }
 
-        private static string DescribeStyle(byte b)
+        private static bool IsPrintable(byte b) => b >= 32 && b <= 126;
+
+        private static bool IsDigit(byte b) => b >= (byte)'0' && b <= (byte)'9';
+
+        private static bool IsHexDigit(byte b)
+        {
+            return (b >= (byte)'0' && b <= (byte)'9') ||
+                   (b >= (byte)'A' && b <= (byte)'F') ||
+                   (b >= (byte)'a' && b <= (byte)'f');
+        }
+
+        private static XmedBlock ParseStyleBlock(byte[] data, XmedBlock block)
+        {
+            int start = block.Start;
+            int end = start + block.Length;
+            byte styleByte = data.Length > start ? data[start] : (byte)0;
+            byte flagByte = data.Length > start + 1 ? data[start + 1] : (byte)0;
+
+            string id = block.Description.Length > 6 ? block.Description.Substring(6) : block.Description;
+            for (int i = start; i <= end - 4; i++)
+            {
+                if (IsDigit(data[i]) && IsDigit(data[i + 1]) && IsDigit(data[i + 2]) && IsDigit(data[i + 3]))
+                {
+                    id = System.Text.Encoding.ASCII.GetString(data, i, 4);
+                    break;
+                }
+            }
+
+            int fontIndex = -1;
+            for (int i = start; i <= end - 3; i++)
+            {
+                if (data[i] == 0x34 && data[i + 1] == 0x30 && data[i + 2] == 0x2C)
+                {
+                    fontIndex = i;
+                    break;
+                }
+            }
+
+            byte color = 0;
+            string font = string.Empty;
+            if (fontIndex >= 0 && fontIndex + 4 < data.Length)
+            {
+                color = data[fontIndex + 3];
+                int j = fontIndex + 4;
+                while (j < end && IsPrintable(data[j]))
+                    j++;
+                font = System.Text.Encoding.ASCII.GetString(data, fontIndex + 4, Math.Max(0, j - (fontIndex + 4)));
+            }
+
+            var styleFlags = ParseStyleEnum(styleByte);
+            var (align, extraFlags) = ParseFlagEnum(flagByte);
+
+            return new StyleDescriptorBlock(block.Start, block.Length, id, color, font, align, styleFlags, extraFlags);
+        }
+
+        private static XmedStyle ParseStyleEnum(byte b)
         {
             XmedStyle flags = XmedStyle.None;
             if ((b & 0x01) != 0) flags |= XmedStyle.Bold;
@@ -116,10 +485,10 @@ namespace LingoEngine.Director.LGodot.Gfx
             if ((b & 0x20) != 0) flags |= XmedStyle.Superscript;
             if ((b & 0x40) != 0) flags |= XmedStyle.Tabbed;
             if ((b & 0x80) != 0) flags |= XmedStyle.Editable;
-            return flags == XmedStyle.None ? "0x" + b.ToString("X2") : flags.ToString();
+            return flags;
         }
 
-        private static string DescribeFlags(byte b)
+        private static (string align, XmedFlags flags) ParseFlagEnum(byte b)
         {
             string align = b switch
             {
@@ -132,7 +501,7 @@ namespace LingoEngine.Director.LGodot.Gfx
             if ((b & 0x10) != 0) flags |= XmedFlags.Tabs;
             if (b == 0x19) flags |= XmedFlags.WrapOff;
 
-            return flags == XmedFlags.None ? align : $"{align} {flags}";
+            return (align, flags);
         }
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/TestData/HalloTempOffsets.cs
+++ b/src/Director/LingoEngine.Director.LGodot/TestData/HalloTempOffsets.cs
@@ -1,0 +1,16 @@
+using LingoEngine.Director.LGodot.Gfx;
+
+namespace LingoEngine.Director.LGodot.TestData;
+
+internal sealed class HalloTempOffsets : XmedFileHints
+{
+    public HalloTempOffsets()
+    {
+        StartOffset = 0x061A;
+        AddBlock(0x0622, 1, "color table");
+        AddBlock(0x0983, 1, "font name");
+        AddBlock(0x0CAE, 1, "spacing before");
+        AddBlock(0x0EF7, 1, "member name");
+        AddBlock(0x1970, 1, "spacing after");
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/TestData/MultiMultiTempOffsets.cs
+++ b/src/Director/LingoEngine.Director.LGodot/TestData/MultiMultiTempOffsets.cs
@@ -1,0 +1,22 @@
+using LingoEngine.Director.LGodot.Gfx;
+
+namespace LingoEngine.Director.LGodot.TestData;
+
+internal sealed class MultiMultiTempOffsets : XmedFileHints
+{
+    public MultiMultiTempOffsets()
+    {
+        StartOffset = 0x20E4;
+        // style descriptor blocks after the text
+        // offsets from docs/XMED_FileComparisons.md
+        AddBlock(0x120A, 0x12A, "text copy 1");
+        AddBlock(0x1334, 120, "style map table");
+        AddStyleBlock(0x16A8, 48, "style 0008");
+        AddStyleBlock(0x18C4, 48, "style 0006");
+        AddStyleBlock(0x196E, 48, "style 000B");
+        AddStyleBlock(0x1A30, 48, "style 0003");
+        AddBlock(0x21E1, 0x12A, "text copy 2");
+        AddBlock(0x230C, 120, "style map table");
+        AddStyleBlock(0x26A8, 48, "style 0005");
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/TestData/MultiSingleTempOffsets.cs
+++ b/src/Director/LingoEngine.Director.LGodot/TestData/MultiSingleTempOffsets.cs
@@ -1,0 +1,14 @@
+using LingoEngine.Director.LGodot.Gfx;
+
+namespace LingoEngine.Director.LGodot.TestData;
+
+internal sealed class MultiSingleTempOffsets : XmedFileHints
+{
+    public MultiSingleTempOffsets()
+    {
+        StartOffset = 0x110C;
+        AddBlock(0x1354, 1, "color table");
+        AddBlock(0x22CB, 0x639, "style map and descriptors");
+        AddStyleBlock(0x22CB, 0x639, "style region");
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/TestData/XmedTestHints.cs
+++ b/src/Director/LingoEngine.Director.LGodot/TestData/XmedTestHints.cs
@@ -1,52 +1,39 @@
 using System.Collections.Generic;
+using LingoEngine.Director.LGodot.Gfx;
 
 namespace LingoEngine.Director.LGodot.TestData
 {
     internal class XmedFileHints
     {
-        public Dictionary<int,string> Offsets = new();
-        public HashSet<int> StyleBlocks = new();
+        public List<XmedBlock> Blocks = new();
+        public int? StartOffset { get; set; }
 
-        public void AddStyleBlock(int start, int length)
+        public void AddBlock(int start, int length, string desc, bool style = false)
         {
-            for (int i = 0; i < length; i++)
-                StyleBlocks.Add(start + i);
+            int adjusted = StartOffset.HasValue ? start - StartOffset.Value : start;
+            Blocks.Add(new SimpleBlock(adjusted, length, desc, style));
+        }
+
+        public void AddStyleBlock(int start, int length, string desc)
+        {
+            AddBlock(start, length, desc, true);
         }
     }
 
     internal static class XmedTestHints
     {
-        public static readonly XmedFileHints HalloDefault;
-        public static readonly XmedFileHints MultiStyleMultiLine;
-        public static readonly XmedFileHints MultiStyleSingleLine;
+        public static readonly HalloTempOffsets HalloDefault;
+        public static readonly MultiMultiTempOffsets MultiStyleMultiLine;
+        public static readonly MultiSingleTempOffsets MultiStyleSingleLine;
         public static readonly XmedFileHints WiderWidth4;
 
         static XmedTestHints()
         {
-            HalloDefault = new XmedFileHints();
-            HalloDefault.Offsets[0x0622] = "color table";
-            HalloDefault.Offsets[0x0983] = "font name";
-            HalloDefault.Offsets[0x0CAE] = "spacing before";
-            HalloDefault.Offsets[0x0EF7] = "member name";
-            HalloDefault.Offsets[0x1970] = "spacing after";
-
-            MultiStyleMultiLine = new XmedFileHints();
-            MultiStyleMultiLine.Offsets[0x16A8] = "style 0008";
-            MultiStyleMultiLine.AddStyleBlock(0x16A8, 32);
-            MultiStyleMultiLine.Offsets[0x18C4] = "style 0006";
-            MultiStyleMultiLine.AddStyleBlock(0x18C4, 32);
-            MultiStyleMultiLine.Offsets[0x196E] = "style 000B";
-            MultiStyleMultiLine.AddStyleBlock(0x196E, 32);
-            MultiStyleMultiLine.Offsets[0x1A30] = "style 0003";
-            MultiStyleMultiLine.AddStyleBlock(0x1A30, 32);
-            MultiStyleMultiLine.Offsets[0x26A8] = "style 0005";
-            MultiStyleMultiLine.AddStyleBlock(0x26A8, 32);
-            MultiStyleMultiLine.Offsets[0x1354] = "color table";
-
-            MultiStyleSingleLine = new XmedFileHints();
-            MultiStyleSingleLine.Offsets[0x1354] = "color table";
+            HalloDefault = new HalloTempOffsets();
+            MultiStyleMultiLine = new MultiMultiTempOffsets();
+            MultiStyleSingleLine = new MultiSingleTempOffsets();
             WiderWidth4 = new XmedFileHints();
-            WiderWidth4.Offsets[0x0018] = "width 4in";
+            WiderWidth4.AddBlock(0x0018, 1, "width 4in");
         }
     }
 }


### PR DESCRIPTION
## Summary
- merge the duplicate descriptor rows into the style ID mapping table
- add a file dedicated to `Text_Multi_Line_Multi_Style.cst`
- broaden known byte ranges and highlight text and style map sections

## Testing
- `dotnet build LingoEngine.sln -v minimal` *(fails: command not found)*
- `dotnet test LingoEngine.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b41af2d48332a6ef10268a485b3c