### PR TITLE
Use WindowManager in director windows

### DIFF
--- a/src/Director/LingoEngine.Director.Core/DirectorProjectManager.cs
+++ b/src/Director/LingoEngine.Director.Core/DirectorProjectManager.cs
@@ -1,61 +1,55 @@
 using LingoEngine.Core;
-using LingoEngine.Director.Core.Events;
 using LingoEngine.IO;
 using LingoEngine.Director.LGodot.Gfx;
 using LingoEngine.Movies;
+using LingoEngine.Director.Core.Windows;
 
 namespace LingoEngine.Director.Core;
 
 /// <summary>
 /// Handles project level operations such as saving and loading movies.
-/// Subscribes to menu events from <see cref="IDirectorEventMediator"/>.
 /// </summary>
 public class DirectorProjectManager
 {
     private readonly ProjectSettings _settings;
     private readonly LingoPlayer _player;
-    private readonly IDirectorEventMediator _mediator;
     private readonly JsonStateRepository _repo = new();
+    private readonly IDirectorWindowManager _windowManager;
 
-    public DirectorProjectManager(ProjectSettings settings, LingoPlayer player, IDirectorEventMediator mediator)
+    public DirectorProjectManager(ProjectSettings settings, LingoPlayer player, IDirectorWindowManager windowManager)
     {
         _settings = settings;
         _player = player;
-        _mediator = mediator;
-
-        _mediator.SubscribeToMenu(DirectorMenuCodes.FileSave, SaveMovie);
-        _mediator.SubscribeToMenu(DirectorMenuCodes.FileLoad, LoadMovie);
+        _windowManager = windowManager;
     }
 
-    private bool SaveMovie()
+    public void SaveMovie()
     {
         if (!_settings.HasValidSettings)
         {
-            _mediator.RaiseMenuSelected(DirectorMenuCodes.ProjectSettingsWindow);
-            return true;
+            _windowManager.OpenWindow(DirectorMenuCodes.ProjectSettingsWindow);
+            return;
         }
         if (_player.ActiveMovie is not LingoMovie movie)
-            return true;
+            return;
 
         Directory.CreateDirectory(_settings.ProjectFolder);
         var path = _settings.GetMoviePath(_settings.ProjectName);
         _repo.Save(path, movie);
-        return true;
     }
 
-    private bool LoadMovie()
+    public void LoadMovie()
     {
         if (!_settings.HasValidSettings)
         {
-            _mediator.RaiseMenuSelected(DirectorMenuCodes.ProjectSettingsWindow);
-            return true;
+            _windowManager.OpenWindow(DirectorMenuCodes.ProjectSettingsWindow);
+            return;
         }
         var path = _settings.GetMoviePath(_settings.ProjectName);
         if (!File.Exists(path))
-            return true;
+            return;
 
         var movie = _repo.Load(path, _player);
         _player.SetActiveMovie(movie);
-        return true;
     }
 }

--- a/src/Director/LingoEngine.Director.Core/Events/DirectorEventMediator.cs
+++ b/src/Director/LingoEngine.Director.Core/Events/DirectorEventMediator.cs
@@ -10,27 +10,19 @@ namespace LingoEngine.Director.Core.Events
         void RaiseSpriteSelected(ILingoSprite sprite);
         void RaiseMemberSelected(ILingoMember member);
         void RaiseFindMember(ILingoMember member);
-        void RaiseMenuSelected(string menuCode);
-        IDirecorEventSubscription SubscribeToMenu(string menuCode, Func<bool> value);
-    }
-    public interface IDirecorEventSubscription
-    {
-        void Release();
     }
     internal class DirectorEventMediator : IDirectorEventMediator
     {
         private readonly List<IHasSpriteSelectedEvent> _spriteSelected = new();
         private readonly List<IHasMemberSelectedEvent> _membersSelected = new();
         private readonly List<IHasFindMemberEvent> _findMemberEvents = new();
-        private readonly List<IHasMenuItemSelectedEvent> _menuItemsSelected = new();
-        private readonly Dictionary<string,List<EventSubscription>> _menuItemsSelectedSubscriptions = new();
 
         public void Subscribe(object listener)
         {
             if (listener is IHasSpriteSelectedEvent spriteSelected) _spriteSelected.Add(spriteSelected);
             if (listener is IHasMemberSelectedEvent memberSelected) _membersSelected.Add(memberSelected);
-            if (listener is IHasFindMemberEvent findMember) _findMemberEvents.Add(findMember);
-            if (listener is IHasMenuItemSelectedEvent menuItemSelected) _menuItemsSelected.Add(menuItemSelected);
+            if (listener is IHasFindMemberEvent findMember)
+                _findMemberEvents.Add(findMember);
         }
 
         public void Unsubscribe(object listener)
@@ -41,8 +33,6 @@ namespace LingoEngine.Director.Core.Events
                 _membersSelected.Remove(memberSelected);
             if (listener is IHasFindMemberEvent findMember)
                 _findMemberEvents.Remove(findMember);
-            if (listener is IHasMenuItemSelectedEvent menuItemSelected)
-                _menuItemsSelected.Remove(menuItemSelected);
         }
 
         public void RaiseSpriteSelected(ILingoSprite sprite)
@@ -54,41 +44,27 @@ namespace LingoEngine.Director.Core.Events
         public void RaiseFindMember(ILingoMember member)
             => _findMemberEvents.ForEach(x => x.FindMember(member));
 
-        public void RaiseMenuSelected(string menuCode)
+        private class EventSubscription : IDirectorEventSubscription
         {
-            GetForMenu(menuCode).ForEach(x => x.Do());
-            _menuItemsSelected.ForEach(x => x.MenuItemSelected(menuCode));
-        }
-
-        public IDirecorEventSubscription SubscribeToMenu(string menuCode, Func<bool> action)
-        {
-            var subscription = new EventSubscription(menuCode, action, o => _menuItemsSelectedSubscriptions[menuCode].Remove(o));
-            GetForMenu(menuCode).Add(subscription);
-            return subscription;
-        }
-        private List<EventSubscription> GetForMenu(string menuCode)
-        {
-            if (_menuItemsSelectedSubscriptions.TryGetValue(menuCode, out var subscriptions)) return subscriptions;
-            var subscriptions2 = new List<EventSubscription>();
-            _menuItemsSelectedSubscriptions.Add(menuCode, subscriptions2);
-            return subscriptions2;
-        }
-
-        private class EventSubscription : IDirecorEventSubscription
-        {
-            private readonly Func<bool> _action;
             private readonly Action<EventSubscription> _onRelease;
-            public string MenuCode { get; }
+            private readonly Func<bool> _action;
 
-            public EventSubscription(string menuCode,Func<bool> action, Action<EventSubscription> onRelease)
+            public string Code { get; }
+
+            public EventSubscription(string code, Func<bool> action, Action<EventSubscription> onRelease)
             {
-                MenuCode = menuCode;
+                Code = code;
                 _action = action;
                 _onRelease = onRelease;
             }
-            public void Do() => _action();
 
+            public void Do() => _action();
             public void Release() => _onRelease(this);
         }
+    }
+
+    public interface IDirectorEventSubscription
+    {
+        void Release();
     }
 }

--- a/src/Director/LingoEngine.Director.Core/Projects/IDirectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Projects/IDirectorWindow.cs
@@ -1,10 +1,15 @@
 ﻿namespace LingoEngine.Director.Core.Projects
 {
+    using LingoEngine.Director.Core.Windows;
+
     public interface IDirectorWindow
     {
         bool IsOpen { get; }
         void OpenWindow();
         void CloseWindow();
         void MoveWindow(int x, int y);
+
+        IDirFrameworkWindow FrameworkObj { get; }
+        T Framework<T>() where T : class, IDirFrameworkWindow;
     }
 }

--- a/src/Director/LingoEngine.Director.Core/Windows/Casts/DirectorCastWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Windows/Casts/DirectorCastWindow.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.Director.Core.Windows
+{
+    public class DirectorCastWindow : DirectorWindow<IDirFrameworkCastWindow>
+    {
+        public DirectorCastWindow(IDirFrameworkCastWindow framework) : base(framework) { }
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Windows/Casts/DirectorTextEditWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Windows/Casts/DirectorTextEditWindow.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.Director.Core.Windows
+{
+    public class DirectorTextEditWindow : DirectorWindow<IDirFrameworkTextEditWindow>
+    {
+        public DirectorTextEditWindow(IDirFrameworkTextEditWindow framework) : base(framework) { }
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Windows/DirectorMenuCodes.cs
+++ b/src/Director/LingoEngine.Director.Core/Windows/DirectorMenuCodes.cs
@@ -5,7 +5,7 @@ namespace LingoEngine.Director.LGodot.Gfx
         public const string ScriptWindow = "ScriptWindow";
         public const string StageWindow = "StageWindow";
         public const string ControlPanel = "ControlPanel";
-        public const string ObjectInspector = "ObjectInspector";
+        public const string PropertyInspector = "PropertyInspector";
         public const string CastWindow = "CastWindow";
         public const string ScoreWindow = "ScoreWindow";
         public const string ProjectSettingsWindow = "ProjectSettingsWindow";

--- a/src/Director/LingoEngine.Director.Core/Windows/DirectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Windows/DirectorWindow.cs
@@ -1,0 +1,22 @@
+using LingoEngine.Director.Core.Projects;
+
+namespace LingoEngine.Director.Core.Windows
+{
+    public class DirectorWindow<TFrameworkWindow> : IDirectorWindow
+        where TFrameworkWindow : IDirFrameworkWindow
+    {
+        protected readonly TFrameworkWindow _frameworkWindow;
+        public DirectorWindow(TFrameworkWindow frameworkWindow)
+        {
+            _frameworkWindow = frameworkWindow;
+        }
+
+        public bool IsOpen => _frameworkWindow.IsOpen;
+        public void OpenWindow() => _frameworkWindow.OpenWindow();
+        public void CloseWindow() => _frameworkWindow.CloseWindow();
+        public void MoveWindow(int x, int y) => _frameworkWindow.MoveWindow(x, y);
+
+        public IDirFrameworkWindow FrameworkObj => _frameworkWindow;
+        public T Framework<T>() where T : class, IDirFrameworkWindow => (T)_frameworkWindow;
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Windows/DirectorWindowRegistrator.cs
+++ b/src/Director/LingoEngine.Director.Core/Windows/DirectorWindowRegistrator.cs
@@ -1,5 +1,6 @@
 ﻿using LingoEngine.Director.Core.Menus;
 using Microsoft.Extensions.DependencyInjection;
+using LingoEngine.Commands;
 
 namespace LingoEngine.Director.Core.Windows
 {
@@ -8,9 +9,38 @@ namespace LingoEngine.Director.Core.Windows
         internal static IServiceProvider RegisterDirectorWindows(this IServiceProvider serviceProvider)
         {
             var windowManager = serviceProvider.GetRequiredService<IDirectorWindowManager>();
-            //windowManager.Register<DirectorMainMenu>("MainMenu", (sp) => new DirectorMainMenu(sp));
-            //windowManager.Register<DirectorProjectSettingsWindow>("ProjectSettings", (sp) => new DirectorProjectSettingsWindow(sp));
-            //windowManager.Register<DirectorShortCutWindow>("ShortCuts", (sp) => new DirectorShortCutWindow(sp));
+            var shortCutManager = serviceProvider.GetRequiredService<IDirectorShortCutManager>();
+
+            windowManager.Register<DirectorProjectSettingsWindow>(DirectorMenuCodes.ProjectSettingsWindow,
+                sp => new DirectorProjectSettingsWindow(sp.GetRequiredService<IDirFrameworkProjectSettingsWindow>()));
+
+            windowManager.Register<DirectorToolsWindow>(DirectorMenuCodes.ToolsWindow,
+                sp => new DirectorToolsWindow(sp.GetRequiredService<IDirFrameworkToolsWindow>()),
+                shortCutManager.CreateShortCut(DirectorMenuCodes.ToolsWindow, "Ctrl+7", sc => new ExecuteShortCutCommand(sc)));
+
+            windowManager.Register<DirectorCastWindow>(DirectorMenuCodes.CastWindow,
+                sp => new DirectorCastWindow(sp.GetRequiredService<IDirFrameworkCastWindow>()),
+                shortCutManager.CreateShortCut(DirectorMenuCodes.CastWindow, "Ctrl+3", sc => new ExecuteShortCutCommand(sc)));
+
+            windowManager.Register<DirectorScoreWindow>(DirectorMenuCodes.ScoreWindow,
+                sp => new DirectorScoreWindow(sp.GetRequiredService<IDirFrameworkScoreWindow>()),
+                shortCutManager.CreateShortCut(DirectorMenuCodes.ScoreWindow, "Ctrl+4", sc => new ExecuteShortCutCommand(sc)));
+
+            windowManager.Register<DirectorPropertyInspectorWindow>(DirectorMenuCodes.PropertyInspector,
+                sp => new DirectorPropertyInspectorWindow(sp.GetRequiredService<IDirFrameworkPropertyInspectorWindow>()),
+                shortCutManager.CreateShortCut(DirectorMenuCodes.PropertyInspector, "Ctrl+Alt+S", sc => new ExecuteShortCutCommand(sc)));
+
+            windowManager.Register<DirectorBinaryViewerWindow>(DirectorMenuCodes.BinaryViewerWindow,
+                sp => new DirectorBinaryViewerWindow(sp.GetRequiredService<IDirFrameworkBinaryViewerWindow>()));
+
+            windowManager.Register<DirectorStageWindow>(DirectorMenuCodes.StageWindow,
+                sp => new DirectorStageWindow(sp.GetRequiredService<IDirFrameworkStageWindow>()),
+                shortCutManager.CreateShortCut(DirectorMenuCodes.StageWindow, "Ctrl+1", sc => new ExecuteShortCutCommand(sc)));
+
+            windowManager.Register<DirectorTextEditWindow>(DirectorMenuCodes.TextEditWindow,
+                sp => new DirectorTextEditWindow(sp.GetRequiredService<IDirFrameworkTextEditWindow>()),
+                shortCutManager.CreateShortCut(DirectorMenuCodes.TextEditWindow, "Ctrl+T", sc => new ExecuteShortCutCommand(sc)));
+
             return serviceProvider;
         }
 

--- a/src/Director/LingoEngine.Director.Core/Windows/Gfx/DirectorBinaryViewerWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Windows/Gfx/DirectorBinaryViewerWindow.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.Director.Core.Windows
+{
+    public class DirectorBinaryViewerWindow : DirectorWindow<IDirFrameworkBinaryViewerWindow>
+    {
+        public DirectorBinaryViewerWindow(IDirFrameworkBinaryViewerWindow framework) : base(framework) { }
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Windows/Gfx/DirectorProjectSettingsWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Windows/Gfx/DirectorProjectSettingsWindow.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.Director.Core.Windows
+{
+    public class DirectorProjectSettingsWindow : DirectorWindow<IDirFrameworkProjectSettingsWindow>
+    {
+        public DirectorProjectSettingsWindow(IDirFrameworkProjectSettingsWindow framework) : base(framework) { }
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Windows/Gfx/DirectorToolsWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Windows/Gfx/DirectorToolsWindow.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.Director.Core.Windows
+{
+    public class DirectorToolsWindow : DirectorWindow<IDirFrameworkToolsWindow>
+    {
+        public DirectorToolsWindow(IDirFrameworkToolsWindow framework) : base(framework) { }
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Windows/IDirFrameworkWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Windows/IDirFrameworkWindow.cs
@@ -1,0 +1,19 @@
+namespace LingoEngine.Director.Core.Windows
+{
+    public interface IDirFrameworkWindow
+    {
+        bool IsOpen { get; }
+        void OpenWindow();
+        void CloseWindow();
+        void MoveWindow(int x, int y);
+    }
+
+    public interface IDirFrameworkCastWindow : IDirFrameworkWindow { }
+    public interface IDirFrameworkScoreWindow : IDirFrameworkWindow { }
+    public interface IDirFrameworkStageWindow : IDirFrameworkWindow { }
+    public interface IDirFrameworkToolsWindow : IDirFrameworkWindow { }
+    public interface IDirFrameworkBinaryViewerWindow : IDirFrameworkWindow { }
+    public interface IDirFrameworkProjectSettingsWindow : IDirFrameworkWindow { }
+    public interface IDirFrameworkPropertyInspectorWindow : IDirFrameworkWindow { }
+    public interface IDirFrameworkTextEditWindow : IDirFrameworkWindow { }
+}

--- a/src/Director/LingoEngine.Director.Core/Windows/Inspector/DirectorPropertyInspectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Windows/Inspector/DirectorPropertyInspectorWindow.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.Director.Core.Windows
+{
+    public class DirectorPropertyInspectorWindow : DirectorWindow<IDirFrameworkPropertyInspectorWindow>
+    {
+        public DirectorPropertyInspectorWindow(IDirFrameworkPropertyInspectorWindow framework) : base(framework) { }
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Windows/Scores/DirectorScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Windows/Scores/DirectorScoreWindow.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.Director.Core.Windows
+{
+    public class DirectorScoreWindow : DirectorWindow<IDirFrameworkScoreWindow>
+    {
+        public DirectorScoreWindow(IDirFrameworkScoreWindow framework) : base(framework) { }
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Windows/Stages/DirectorStageWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Windows/Stages/DirectorStageWindow.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.Director.Core.Windows
+{
+    public class DirectorStageWindow : DirectorWindow<IDirFrameworkStageWindow>
+    {
+        public DirectorStageWindow(IDirFrameworkStageWindow framework) : base(framework) { }
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastWindow.cs
@@ -2,13 +2,14 @@
 using LingoEngine.Director.Core.Events;
 using LingoEngine.Director.LGodot.Gfx;
 using LingoEngine.Director.LGodot;
+using LingoEngine.Director.Core.Windows;
 using LingoEngine.Movies;
 using LingoEngine.Members;
 using LingoEngine.Casts;
 
 namespace LingoEngine.Director.LGodot.Casts
 {
-    internal partial class DirGodotCastWindow : BaseGodotWindow, IDisposable, IHasFindMemberEvent
+    internal partial class DirGodotCastWindow : BaseGodotWindow, IDisposable, IHasFindMemberEvent, IDirFrameworkCastWindow
     {
         private readonly TabContainer _tabs;
         
@@ -27,7 +28,6 @@ namespace LingoEngine.Director.LGodot.Casts
             _lingoMovie = lingoMovie;
             _mediator = mediator;
             _style = style;
-            _mediator.SubscribeToMenu(DirectorMenuCodes.CastWindow, () => Visible = !Visible);
             _mediator.Subscribe(this);
 
             Size = new Vector2(360, 620);
@@ -109,5 +109,10 @@ namespace LingoEngine.Director.LGodot.Casts
         {
             _mediator.Unsubscribe(this);
         }
+
+        public bool IsOpen => Visible;
+        public void OpenWindow() => Visible = true;
+        public void CloseWindow() => Visible = false;
+        public void MoveWindow(int x, int y) => Position = new Vector2(x, y);
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/Casts/TextableMemberWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/TextableMemberWindow.cs
@@ -1,12 +1,13 @@
 ﻿using Godot;
 using LingoEngine.Director.Core.Events;
 using LingoEngine.Director.LGodot.Gfx;
+using LingoEngine.Director.Core.Windows;
 using LingoEngine.Texts;
 using LingoEngine.Members;
 
 namespace LingoEngine.Director.LGodot.Casts;
 
-internal partial class TextableMemberWindow : BaseGodotWindow, IHasMemberSelectedEvent
+internal partial class TextableMemberWindow : BaseGodotWindow, IHasMemberSelectedEvent, IDirFrameworkTextEditWindow
 {
     private readonly TextEdit _textEdit = new TextEdit();
     private readonly Button _alignLeft = new Button();
@@ -19,7 +20,6 @@ internal partial class TextableMemberWindow : BaseGodotWindow, IHasMemberSelecte
     public TextableMemberWindow(IDirectorEventMediator mediator) : base("Edit Text")
     {
         mediator.Subscribe(this);
-        mediator.SubscribeToMenu(DirectorMenuCodes.TextEditWindow, ToggleVisible);
 
         Size = new Vector2(300, 200);
         CustomMinimumSize = Size;
@@ -71,12 +71,6 @@ internal partial class TextableMemberWindow : BaseGodotWindow, IHasMemberSelecte
         }
     }
 
-    private bool ToggleVisible()
-    {
-        Visible = !Visible;
-        return true;
-    }
-
     protected override void OnResizing(Vector2 size)
     {
         base.OnResizing(size);
@@ -88,4 +82,9 @@ internal partial class TextableMemberWindow : BaseGodotWindow, IHasMemberSelecte
         if (_member != null)
             _member.Alignment = alignment;
     }
+
+    public bool IsOpen => Visible;
+    public void OpenWindow() => Visible = true;
+    public void CloseWindow() => Visible = false;
+    public void MoveWindow(int x, int y) => Position = new Vector2(x, y);
 }

--- a/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
@@ -3,6 +3,11 @@ using LingoEngine.Director.Core;
 using LingoEngine.LGodot;
 using Microsoft.Extensions.DependencyInjection;
 using LingoEngine.Director.LGodot.Gfx;
+using LingoEngine.Director.LGodot.Casts;
+using LingoEngine.Director.LGodot.Scores;
+using LingoEngine.Director.LGodot.Stages;
+using LingoEngine.Director.LGodot.Inspector;
+using LingoEngine.Director.Core.Windows;
 
 namespace LingoEngine.Director.LGodot
 {
@@ -19,6 +24,21 @@ namespace LingoEngine.Director.LGodot
                 s.AddSingleton<DirectorStyle>();
                 s.AddSingleton<DirGodotProjectSettingsWindow>();
                 s.AddSingleton<DirGodotToolsWindow>();
+                s.AddSingleton<DirGodotCastWindow>();
+                s.AddSingleton<DirGodotScoreWindow>();
+                s.AddSingleton<DirGodotStageWindow>();
+                s.AddSingleton<DirGodotBinaryViewerWindow>();
+                s.AddSingleton<DirGodotPropertyInspector>();
+                s.AddSingleton<TextableMemberWindow>();
+
+                s.AddSingleton<IDirFrameworkProjectSettingsWindow>(p => p.GetRequiredService<DirGodotProjectSettingsWindow>());
+                s.AddSingleton<IDirFrameworkToolsWindow>(p => p.GetRequiredService<DirGodotToolsWindow>());
+                s.AddSingleton<IDirFrameworkCastWindow>(p => p.GetRequiredService<DirGodotCastWindow>());
+                s.AddSingleton<IDirFrameworkScoreWindow>(p => p.GetRequiredService<DirGodotScoreWindow>());
+                s.AddSingleton<IDirFrameworkStageWindow>(p => p.GetRequiredService<DirGodotStageWindow>());
+                s.AddSingleton<IDirFrameworkBinaryViewerWindow>(p => p.GetRequiredService<DirGodotBinaryViewerWindow>());
+                s.AddSingleton<IDirFrameworkPropertyInspectorWindow>(p => p.GetRequiredService<DirGodotPropertyInspector>());
+                s.AddSingleton<IDirFrameworkTextEditWindow>(p => p.GetRequiredService<TextableMemberWindow>());
             
                 //IServiceCollection serviceCollection = s
                   //  .AddSingleton<ILingoFrameworkStageWindow>(p => new DirGodotStageWindow(rootNode))
@@ -31,7 +51,7 @@ namespace LingoEngine.Director.LGodot
                   //  .AddSingleton(p =>
                   //  {
 
-                //      var inspector = new Inspector.DirGodotObjectInspector(p.GetRequiredService<IDirectorEventMediator>()) { Visible = false };
+                //      var inspector = new Inspector.DirGodotPropertyInspector(p.GetRequiredService<IDirectorEventMediator>()) { Visible = false };
                 //      rootNode.AddChild(inspector);
                 //      return inspector;
                 //  })

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotBinaryViewerWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotBinaryViewerWindow.cs
@@ -5,11 +5,12 @@ using System.IO;
 using LingoEngine.Director.Core.Events;
 using LingoEngine.Director.LGodot.TestData;
 using LingoEngine.Director.LGodot.Gfx;
+using LingoEngine.Director.Core.Windows;
 using System.Diagnostics;
 
 namespace LingoEngine.Director.LGodot.Gfx
 {
-    internal partial class DirGodotBinaryViewerWindow : BaseGodotWindow, IHasMenuItemSelectedEvent
+    internal partial class DirGodotBinaryViewerWindow : BaseGodotWindow, IDirFrameworkBinaryViewerWindow
     {
         private readonly IDirectorEventMediator _mediator;
         private readonly LineEdit _pathEdit = new LineEdit();
@@ -29,7 +30,6 @@ namespace LingoEngine.Director.LGodot.Gfx
         public DirGodotBinaryViewerWindow(IDirectorEventMediator mediator) : base("Binary Viewer")
         {
             _mediator = mediator;
-            _mediator.SubscribeToMenu(DirectorMenuCodes.BinaryViewerWindow, () => Visible = !Visible);
             Size = new Vector2(1400, 600);
             CustomMinimumSize = Size;
 
@@ -267,8 +267,6 @@ namespace LingoEngine.Director.LGodot.Gfx
             }
         }
 
-        public void MenuItemSelected(string code) {}
-
         private void ClearChildren(Container container)
         {
             foreach (var child in container.GetChildren().ToArray())
@@ -277,5 +275,10 @@ namespace LingoEngine.Director.LGodot.Gfx
                     node.QueueFree();
             }
         }
+
+        public bool IsOpen => Visible;
+        public void OpenWindow() => Visible = true;
+        public void CloseWindow() => Visible = false;
+        public void MoveWindow(int x, int y) => Position = new Vector2(x, y);
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotMainMenu.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotMainMenu.cs
@@ -1,7 +1,9 @@
 using Godot;
 using LingoEngine.Director.Core.Events;
+using LingoEngine.Director.Core.Windows;
 using LingoEngine.Director.LGodot.Gfx;
 using LingoEngine.Movies;
+using LingoEngine.Director.Core;
 
 namespace LingoEngine.Director.LGodot;
 
@@ -15,21 +17,23 @@ internal partial class DirGodotMainMenu : Control
     private readonly MenuButton _editMenu = new MenuButton() { Text = "Edit" };
     private readonly MenuButton _WindowMenu = new MenuButton() { Text = "Window" };
     private readonly HBoxContainer _iconBar = new HBoxContainer();
-    private IDirectorEventMediator _mediator;
+    private readonly IDirectorWindowManager _windowManager;
+    private readonly DirectorProjectManager _projectManager;
     private readonly Button _rewindButton;
     private readonly Button _playButton;
     private readonly ILingoMovie _lingoMovie;
 
-    public DirGodotMainMenu(IDirectorEventMediator mediator, ILingoMovie lingoMovie)
+    public DirGodotMainMenu(IDirectorWindowManager windowManager, DirectorProjectManager projectManager, ILingoMovie lingoMovie)
     {
-        _mediator = mediator;
+        _windowManager = windowManager;
+        _projectManager = projectManager;
         _lingoMovie = lingoMovie;
         _lingoMovie.PlayStateChanged += OnPlayStateChanged;
 
         AddChild(_menuBar);
         _menuBar.SizeFlagsHorizontal = SizeFlags.ExpandFill;
 
-        ComposeMenu(mediator);
+        ComposeMenu();
 
         AddChild(_iconBar);
         _iconBar.Position = new Vector2(300, 0);
@@ -50,7 +54,7 @@ internal partial class DirGodotMainMenu : Control
         UpdatePlayButton();
     }
 
-    private void ComposeMenu(IDirectorEventMediator mediator)
+    private void ComposeMenu()
     {
         // FileMenu
         _menuBar.AddChild(_fileMenu);
@@ -62,8 +66,8 @@ internal partial class DirGodotMainMenu : Control
         {
             switch (id)
             {
-                case 1: mediator.RaiseMenuSelected(DirectorMenuCodes.FileLoad); break;
-                case 2: mediator.RaiseMenuSelected(DirectorMenuCodes.FileSave); break;
+                case 1: _projectManager.LoadMovie(); break;
+                case 2: _projectManager.SaveMovie(); break;
                 case 3:
                     // TODO: check project for unsaved changes before quitting
                     GetTree().Quit();
@@ -76,32 +80,32 @@ internal partial class DirGodotMainMenu : Control
         popupEdit.AddItem("Project Settings", 20);
         popupEdit.IdPressed += id =>
         {
-            if (id == 20) mediator.RaiseMenuSelected(DirectorMenuCodes.ProjectSettingsWindow);
+            if (id == 20) _windowManager.OpenWindow(DirectorMenuCodes.ProjectSettingsWindow);
         };
 
         // Window Menu
         _menuBar.AddChild(_WindowMenu);
         var popupWindow = _WindowMenu.GetPopup();
         //popupWindow.AddItem("Script", 5);
-        popupWindow.AddItem("Stage", 6);
-        //popupWindow.AddItem("Control Panel", 7);
-        popupWindow.AddItem("Cast", 8);
-        popupWindow.AddItem("Score", 9);
-        popupWindow.AddItem("Object Inspector", 15);
-        popupWindow.AddItem("Tools", 16);
+        popupWindow.AddItem("Stage\tCtrl+1", 6);
+        //popupWindow.AddItem("Control Panel\tCtrl+2", 7);
+        popupWindow.AddItem("Cast\tCtrl+3", 8);
+        popupWindow.AddItem("Score\tCtrl+4", 9);
+        popupWindow.AddItem("Property Inspector\tCtrl+Alt+S", 15);
+        popupWindow.AddItem("Tools\tCtrl+7", 16);
         popupWindow.AddItem("Binary Viewer", 17);
         popupWindow.IdPressed += id =>
         {
             switch (id)
             {
-                case 5: mediator.RaiseMenuSelected(DirectorMenuCodes.ScriptWindow); break;
-                case 6: mediator.RaiseMenuSelected(DirectorMenuCodes.StageWindow); break;
-                case 7: mediator.RaiseMenuSelected(DirectorMenuCodes.ControlPanel); break;
-                case 8: mediator.RaiseMenuSelected(DirectorMenuCodes.CastWindow); break;
-                case 9: mediator.RaiseMenuSelected(DirectorMenuCodes.ScoreWindow); break;
-                case 15: mediator.RaiseMenuSelected(DirectorMenuCodes.ObjectInspector); break;
-                case 16: mediator.RaiseMenuSelected(DirectorMenuCodes.ToolsWindow); break;
-                case 17: mediator.RaiseMenuSelected(DirectorMenuCodes.BinaryViewerWindow); break;
+                case 5: _windowManager.OpenWindow(DirectorMenuCodes.ScriptWindow); break;
+                case 6: _windowManager.OpenWindow(DirectorMenuCodes.StageWindow); break;
+                case 7: _windowManager.OpenWindow(DirectorMenuCodes.ControlPanel); break;
+                case 8: _windowManager.OpenWindow(DirectorMenuCodes.CastWindow); break;
+                case 9: _windowManager.OpenWindow(DirectorMenuCodes.ScoreWindow); break;
+                case 15: _windowManager.OpenWindow(DirectorMenuCodes.PropertyInspector); break;
+                case 16: _windowManager.OpenWindow(DirectorMenuCodes.ToolsWindow); break;
+                case 17: _windowManager.OpenWindow(DirectorMenuCodes.BinaryViewerWindow); break;
                 default:
                     break;
             }

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotProjectSettingsWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotProjectSettingsWindow.cs
@@ -1,21 +1,20 @@
 using Godot;
 using LingoEngine.Director.Core;
-using LingoEngine.Director.Core.Events;
+using LingoEngine.Director.Core.Windows;
 using LingoEngine;
 
 namespace LingoEngine.Director.LGodot.Gfx;
 
-internal partial class DirGodotProjectSettingsWindow : BaseGodotWindow
+internal partial class DirGodotProjectSettingsWindow : BaseGodotWindow, IDirFrameworkProjectSettingsWindow
 {
     private readonly ProjectSettings _settings;
     private readonly LineEdit _nameEdit = new LineEdit();
     private readonly LineEdit _folderEdit = new LineEdit();
 
-    public DirGodotProjectSettingsWindow(IDirectorEventMediator mediator, ProjectSettings settings)
+    public DirGodotProjectSettingsWindow(ProjectSettings settings)
         : base("Project Settings")
     {
         _settings = settings;
-        mediator.SubscribeToMenu(DirectorMenuCodes.ProjectSettingsWindow, () => Visible = !Visible);
 
         Size = new Vector2(300, 120);
         CustomMinimumSize = Size;
@@ -47,4 +46,9 @@ internal partial class DirGodotProjectSettingsWindow : BaseGodotWindow
         _settings.ProjectFolder = _folderEdit.Text.Trim();
         Visible = false;
     }
+
+    public bool IsOpen => Visible;
+    public void OpenWindow() => Visible = true;
+    public void CloseWindow() => Visible = false;
+    public void MoveWindow(int x, int y) => Position = new Vector2(x, y);
 }

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotToolsWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotToolsWindow.cs
@@ -1,19 +1,18 @@
 using Godot;
 using LingoEngine.Director.Core.Events;
+using LingoEngine.Director.Core.Windows;
 
 namespace LingoEngine.Director.LGodot.Gfx;
 
-internal partial class DirGodotToolsWindow : BaseGodotWindow
+internal partial class DirGodotToolsWindow : BaseGodotWindow, IDirFrameworkToolsWindow
 {
     private readonly GridContainer _grid = new GridContainer();
     private readonly DirGodotIconManager _iconManager = new DirGodotIconManager();
 
     public event Action<int>? IconPressed;
 
-    public DirGodotToolsWindow(IDirectorEventMediator mediator) : base("Tools")
+    public DirGodotToolsWindow() : base("Tools")
     {
-        mediator.SubscribeToMenu(DirectorMenuCodes.ToolsWindow, () => Visible = !Visible);
-
         Size = new Vector2(80, 200);
         CustomMinimumSize = Size;
 
@@ -38,4 +37,9 @@ internal partial class DirGodotToolsWindow : BaseGodotWindow
             }
         }
     }
+
+    public bool IsOpen => Visible;
+    public void OpenWindow() => Visible = true;
+    public void CloseWindow() => Visible = false;
+    public void MoveWindow(int x, int y) => Position = new Vector2(x, y);
 }

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
@@ -13,6 +13,7 @@ using LingoEngine.Director.LGodot.Inspector;
 using LingoEngine.Director.LGodot.Movies;
 using LingoEngine.Director.LGodot;
 using LingoEngine.Director.Core;
+using LingoEngine.Director.Core.Windows;
 
 namespace LingoEngine.Director.LGodot.Gfx
 {
@@ -22,7 +23,7 @@ namespace LingoEngine.Director.LGodot.Gfx
         private readonly Control _directorParent = new();
         private readonly DirGodotCastWindow _castViewer;
         private readonly DirGodotScoreWindow _scoreWindow;
-        private readonly DirGodotObjectInspector _inspector;
+        private readonly DirGodotPropertyInspector _propertyInspector;
         private readonly DirGodotToolsWindow _toolsWindow;
         private readonly IDirectorEventMediator _mediator;
         private readonly DirGodotStageWindow _stageWindow;
@@ -59,11 +60,12 @@ namespace LingoEngine.Director.LGodot.Gfx
             _projectSettingsWindow.Visible = false;
             _projectSettingsWindow.Position = new Vector2(100, 100);
 
-            _dirGodotMainMenu = new DirGodotMainMenu(_mediator, lingoMovie);
+            var windowManager = serviceProvider.GetRequiredService<IDirectorWindowManager>();
+            _dirGodotMainMenu = new DirGodotMainMenu(windowManager, _projectManager, lingoMovie);
             _castViewer = new DirGodotCastWindow(_mediator, lingoMovie, style);
             _scoreWindow = new DirGodotScoreWindow(_mediator);
-            _inspector = new DirGodotObjectInspector(_mediator);
-            _toolsWindow = new DirGodotToolsWindow(_mediator) { Visible = true};
+            _propertyInspector = new DirGodotPropertyInspector(_mediator);
+            _toolsWindow = new DirGodotToolsWindow() { Visible = true};
             _binaryViewer = new DirGodotBinaryViewerWindow(_mediator) { Visible = false };
 
             _scoreWindow.SetMovie((LingoMovie)lingoMovie);
@@ -75,23 +77,25 @@ namespace LingoEngine.Director.LGodot.Gfx
             _directorParent.AddChild(_binaryViewer);
 
 
+
+
             //var hContainer = new HBoxContainer
             //{
             //    SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
             //};
             ////var spacer = new Control { SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
             ////hContainer.AddChild(spacer);
-            ////hContainer.AddChild(_inspector);
+            ////hContainer.AddChild(_propertyInspector);
             ////_directorParent.AddChild(hContainer);
-            ////_inspector.AnchorLeft = 1.0f;
-            //_inspector.AnchorRight = 1.0f;
-            //_inspector.OffsetLeft = -150; // Adjust to control width
-            //_inspector.OffsetRight = 0;
-            _directorParent.AddChild(_inspector);
+            ////_propertyInspector.AnchorLeft = 1.0f;
+            //_propertyInspector.AnchorRight = 1.0f;
+            //_propertyInspector.OffsetLeft = -150; // Adjust to control width
+            //_propertyInspector.OffsetRight = 0;
+            _directorParent.AddChild(_propertyInspector);
             _stageWindow.Position = new Vector2(100, 25);
             _castViewer.Position = new Vector2(830, 25);
             _scoreWindow.Position = new Vector2(20, 560);
-            _inspector.Position = new Vector2(1330, 25);
+            _propertyInspector.Position = new Vector2(1330, 25);
             _toolsWindow.Position = new Vector2(10, 25);
             _binaryViewer.Position = new Vector2(20, 120);
 
@@ -104,7 +108,7 @@ namespace LingoEngine.Director.LGodot.Gfx
             _stageWindow.Dispose();
             _scoreWindow.Dispose();
             _castViewer.Dispose();
-            _inspector.Dispose();
+            _propertyInspector.Dispose();
             _toolsWindow.Dispose();
             _binaryViewer.Dispose();
         }

--- a/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
@@ -6,19 +6,19 @@ using System.Reflection;
 using LingoEngine.Pictures;
 using LingoEngine.Director.LGodot.Gfx;
 using LingoEngine.Members;
+using LingoEngine.Director.Core.Windows;
 
 namespace LingoEngine.Director.LGodot.Inspector;
 
-public partial class DirGodotObjectInspector : BaseGodotWindow, IHasSpriteSelectedEvent, IHasMemberSelectedEvent 
+public partial class DirGodotPropertyInspector : BaseGodotWindow, IHasSpriteSelectedEvent, IHasMemberSelectedEvent, IDirFrameworkPropertyInspectorWindow
 {
     private readonly IDirectorEventMediator _mediator;
     private readonly ScrollContainer _vScroller = new ScrollContainer();
     private readonly TabContainer _tabs = new TabContainer();
 
-    public DirGodotObjectInspector(IDirectorEventMediator mediator) : base("Inspector")
+    public DirGodotPropertyInspector(IDirectorEventMediator mediator) : base("Inspector")
     {
         _mediator = mediator;
-        _mediator.SubscribeToMenu(DirectorMenuCodes.ObjectInspector, () => Visible = !Visible);
         
         //Position = new Vector2(500, 20);
         Size = new Vector2(260, 400);
@@ -165,6 +165,12 @@ public partial class DirGodotObjectInspector : BaseGodotWindow, IHasSpriteSelect
         if (t.IsEnum) return Enum.Parse(t, text);
         return Convert.ChangeType(text, t);
     }
+
+    public bool IsOpen => Visible;
+    public void OpenWindow() => Visible = true;
+    public void CloseWindow() => Visible = false;
+    public void MoveWindow(int x, int y) => Position = new Vector2(x, y);
+
 
    
 }

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -2,6 +2,7 @@ using Godot;
 using LingoEngine.Movies;
 using LingoEngine.Director.Core.Events;
 using LingoEngine.Director.LGodot.Gfx;
+using LingoEngine.Director.Core.Windows;
 using static System.Net.Mime.MediaTypeNames;
 
 namespace LingoEngine.Director.LGodot.Scores;
@@ -10,7 +11,7 @@ namespace LingoEngine.Director.LGodot.Scores;
 /// Simple timeline overlay showing the Score channels and frames.
 /// Toggled with F2.
 /// </summary>
-public partial class DirGodotScoreWindow : BaseGodotWindow
+public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWindow
 {
    
     
@@ -38,7 +39,6 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
         : base("Score")
     {
         _mediator = directorMediator;
-        _mediator.SubscribeToMenu(DirectorMenuCodes.ScoreWindow, () => Visible = !Visible);
         var height = 400;
         var width = 800;
 
@@ -213,5 +213,10 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
             DrawLine(new Vector2(0, top), new Vector2(Size.X, top), _gfxValues.ColLineDark);
             DrawLine(new Vector2(0, top + 1), new Vector2(Size.X, top + 1), _gfxValues.ColLineLight);
         }
+
+        public bool IsOpen => Visible;
+        public void OpenWindow() => Visible = true;
+        public void CloseWindow() => Visible = false;
+        public void MoveWindow(int x, int y) => Position = new Vector2(x, y);
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
@@ -3,13 +3,14 @@ using LingoEngine.Movies;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.LGodot.Stages;
 using LingoEngine.Director.Core.Events;
+using LingoEngine.Director.Core.Windows;
 using LingoEngine.Director.LGodot.Gfx;
 using LingoEngine.Core;
 using LingoEngine.Commands;
 
 namespace LingoEngine.Director.LGodot.Movies;
 
-internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelectedEvent
+internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelectedEvent, IDirFrameworkStageWindow
 {
     private const int IconBarHeight = 12;
     private readonly LingoGodotStageContainer _stageContainer;
@@ -136,8 +137,6 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         _iconBar.AddChild(_colorPicker);
 
         UpdatePlayButton();
-
-        directorEventMediator.SubscribeToMenu(DirectorMenuCodes.StageWindow, () => Visible = !Visible);
     }
     protected override void OnResizing(Vector2 size)
     {
@@ -258,4 +257,8 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
             DrawRect(_rect, Colors.Yellow, false, 1);
         }
     }
+    public bool IsOpen => Visible;
+    public void OpenWindow() => Visible = true;
+    public void CloseWindow() => Visible = false;
+    public void MoveWindow(int x, int y) => Position = new Vector2(x, y);
 }


### PR DESCRIPTION
## Summary
- organize core window classes in subfolders
- rename object inspector menu entry and show shortcuts
- use tabs to display keyboard shortcuts in the window menu
- keep `EventSubscription` private

## Testing
- `dotnet build LingoEngine.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ba193c208332bb08454d6cd72ba0