### PR TITLE
Add viewport layers and editable labels

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
@@ -61,7 +61,7 @@ namespace LingoEngine.Director.LGodot.Gfx
 
             _dirGodotMainMenu = new DirGodotMainMenu(_mediator, lingoMovie);
             _castViewer = new DirGodotCastWindow(_mediator, lingoMovie, style);
-            _scoreWindow = new DirGodotScoreWindow(_mediator);
+            _scoreWindow = new DirGodotScoreWindow(_mediator, commandManager);
             _inspector = new DirGodotObjectInspector(_mediator);
             _toolsWindow = new DirGodotToolsWindow(_mediator) { Visible = true};
             _binaryViewer = new DirGodotBinaryViewerWindow(_mediator) { Visible = false };

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotFrameScriptsBar.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotFrameScriptsBar.cs
@@ -8,9 +8,44 @@ internal partial class DirGodotFrameScriptsBar : Control
     private LingoMovie? _movie;
     private readonly List<DirGodotScoreSprite> _sprites = new();
     private readonly DirGodotScoreGfxValues _gfxValues;
+
+    private readonly SubViewport _gridViewport = new();
+    private readonly SubViewport _spriteViewport = new();
+    private readonly TextureRect _gridTexture = new();
+    private readonly TextureRect _spriteTexture = new();
+    private readonly GridCanvas _gridCanvas;
+    private readonly SpriteCanvas _spriteCanvas;
+    private bool _spriteDirty = true;
+    private int _lastFrame = -1;
+
     public DirGodotFrameScriptsBar(DirGodotScoreGfxValues gfxValues)
     {
         _gfxValues = gfxValues;
+
+        _gridViewport.SetDisable3D(true);
+        _gridViewport.TransparentBg = true;
+        _gridViewport.SetUpdateMode(SubViewport.UpdateMode.Always);
+        _gridCanvas = new GridCanvas(this);
+        _gridViewport.AddChild(_gridCanvas);
+
+        _spriteViewport.SetDisable3D(true);
+        _spriteViewport.TransparentBg = true;
+        _spriteViewport.SetUpdateMode(SubViewport.UpdateMode.Always);
+        _spriteCanvas = new SpriteCanvas(this);
+        _spriteViewport.AddChild(_spriteCanvas);
+
+        _gridTexture.Texture = _gridViewport.GetTexture();
+        _gridTexture.ZIndex = -20;
+        _gridTexture.MouseFilter = MouseFilterEnum.Ignore;
+
+        _spriteTexture.Texture = _spriteViewport.GetTexture();
+        _spriteTexture.ZIndex = -10;
+        _spriteTexture.MouseFilter = MouseFilterEnum.Ignore;
+
+        AddChild(_gridViewport);
+        AddChild(_spriteViewport);
+        AddChild(_gridTexture);
+        AddChild(_spriteTexture);
     }
 
     public void SetMovie(LingoMovie? movie)
@@ -20,40 +55,82 @@ internal partial class DirGodotFrameScriptsBar : Control
         if (_movie == null) return;
         foreach (var kv in _movie.GetFrameSpriteBehaviors())
             _sprites.Add(new DirGodotScoreSprite(kv.Value, false, true));
-        Size = new Vector2(_gfxValues.LeftMargin + ((_movie?.FrameCount )?? 0) * _gfxValues.FrameWidth, 20);
+        UpdateViewportSize();
+        _spriteDirty = true;
     }
 
-    public override void _Draw()
+    public override void _Process(double delta)
+    {
+        if (!Visible) return;
+        int cur = _movie?.CurrentFrame ?? -1;
+        if (_spriteDirty || cur != _lastFrame)
+        {
+            _spriteDirty = false;
+            _lastFrame = cur;
+            _spriteCanvas.QueueRedraw();
+        }
+    }
+
+    private void UpdateViewportSize()
     {
         if (_movie == null) return;
-        int frameCount = _movie.FrameCount;
-        var font = ThemeDB.FallbackFont;
-        Size = new Vector2(_gfxValues.LeftMargin + frameCount * _gfxValues.FrameWidth, 20);
-        DrawRect(new Rect2(0, 0, Size.X, 20), new Color("#f0f0f0"));
-        for (int f = 0; f < frameCount; f++)
-        {
-            float x = _gfxValues.LeftMargin + f * _gfxValues.FrameWidth;
-            if (f % 5 == 0)
-                DrawRect(new Rect2(x, 0, _gfxValues.FrameWidth, _gfxValues.ChannelHeight), Colors.DarkGray);
-        }
-        for (int f = 0; f <= frameCount; f++)
-        {
-            float x = _gfxValues.LeftMargin + f * _gfxValues.FrameWidth;
-            DrawLine(new Vector2(x, 0), new Vector2(x, _gfxValues.ChannelHeight), Colors.DarkGray);
-        }
-        DrawLine(new Vector2(0, 0), new Vector2(_gfxValues.LeftMargin + frameCount * _gfxValues.FrameWidth, 0), Colors.DarkGray);
-        DrawLine(new Vector2(0, _gfxValues.ChannelHeight), new Vector2(_gfxValues.LeftMargin + frameCount * _gfxValues.FrameWidth, _gfxValues.ChannelHeight), Colors.DarkGray);
+        float width = _gfxValues.LeftMargin + _movie.FrameCount * _gfxValues.FrameWidth;
+        Size = new Vector2(width, 20);
+        CustomMinimumSize = Size;
+        _gridViewport.SetSize(new Vector2I((int)width, 20));
+        _spriteViewport.SetSize(new Vector2I((int)width, 20));
+        _gridTexture.CustomMinimumSize = new Vector2(width, 20);
+        _spriteTexture.CustomMinimumSize = new Vector2(width, 20);
+        _gridCanvas.QueueRedraw();
+        _spriteCanvas.QueueRedraw();
+    }
 
-        foreach (var sp in _sprites)
+    private partial class GridCanvas : Control
+    {
+        private readonly DirGodotFrameScriptsBar _owner;
+        public GridCanvas(DirGodotFrameScriptsBar owner) => _owner = owner;
+        public override void _Draw()
         {
-            float x = _gfxValues.LeftMargin + (sp.Sprite.BeginFrame - 1) * _gfxValues.FrameWidth;
-            float width = (sp.Sprite.EndFrame - sp.Sprite.BeginFrame + 1) * _gfxValues.FrameWidth;
-            sp.Draw(this, new Vector2(x, 0), width, _gfxValues.ChannelHeight, font);
+            var movie = _owner._movie;
+            if (movie == null) return;
+            int frameCount = movie.FrameCount;
+            DrawRect(new Rect2(0, 0, _owner.Size.X, 20), new Color("#f0f0f0"));
+            for (int f = 0; f < frameCount; f++)
+            {
+                float x = _owner._gfxValues.LeftMargin + f * _owner._gfxValues.FrameWidth;
+                if (f % 5 == 0)
+                    DrawRect(new Rect2(x, 0, _owner._gfxValues.FrameWidth, _owner._gfxValues.ChannelHeight), Colors.DarkGray);
+            }
+            for (int f = 0; f <= frameCount; f++)
+            {
+                float x = _owner._gfxValues.LeftMargin + f * _owner._gfxValues.FrameWidth;
+                DrawLine(new Vector2(x, 0), new Vector2(x, _owner._gfxValues.ChannelHeight), Colors.DarkGray);
+            }
+            DrawLine(new Vector2(0, 0), new Vector2(_owner._gfxValues.LeftMargin + frameCount * _owner._gfxValues.FrameWidth, 0), Colors.DarkGray);
+            DrawLine(new Vector2(0, _owner._gfxValues.ChannelHeight), new Vector2(_owner._gfxValues.LeftMargin + frameCount * _owner._gfxValues.FrameWidth, _owner._gfxValues.ChannelHeight), Colors.DarkGray);
         }
+    }
 
-        int cur = _movie.CurrentFrame - 1;
-        if (cur < 0) cur = 0;
-        float barX = _gfxValues.LeftMargin + cur * _gfxValues.FrameWidth + _gfxValues.FrameWidth / 2f;
-        DrawLine(new Vector2(barX, 0), new Vector2(barX, _gfxValues.ChannelHeight), Colors.Red, 2);
+    private partial class SpriteCanvas : Control
+    {
+        private readonly DirGodotFrameScriptsBar _owner;
+        public SpriteCanvas(DirGodotFrameScriptsBar owner) => _owner = owner;
+        public override void _Draw()
+        {
+            var movie = _owner._movie;
+            if (movie == null) return;
+            var font = ThemeDB.FallbackFont;
+            foreach (var sp in _owner._sprites)
+            {
+                float x = _owner._gfxValues.LeftMargin + (sp.Sprite.BeginFrame - 1) * _owner._gfxValues.FrameWidth;
+                float width = (sp.Sprite.EndFrame - sp.Sprite.BeginFrame + 1) * _owner._gfxValues.FrameWidth;
+                sp.Draw(this, new Vector2(x, 0), width, _owner._gfxValues.ChannelHeight, font);
+            }
+
+            int cur = movie.CurrentFrame - 1;
+            if (cur < 0) cur = 0;
+            float barX = _owner._gfxValues.LeftMargin + cur * _owner._gfxValues.FrameWidth + _owner._gfxValues.FrameWidth / 2f;
+            DrawLine(new Vector2(barX, 0), new Vector2(barX, _owner._gfxValues.ChannelHeight), Colors.Red, 2);
+        }
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
@@ -8,7 +8,7 @@ namespace LingoEngine.Director.LGodot.Scores;
 internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
 {
     private LingoMovie? _movie;
-   
+
     private ILingoSprite? _dragSprite;
     private bool _dragBegin;
     private bool _dragEnd;
@@ -18,25 +18,64 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
     private readonly PopupMenu _contextMenu = new();
     private DirGodotScoreSprite? _contextSprite;
     private readonly DirGodotScoreGfxValues _gfxValues;
+
+    private readonly SubViewport _gridViewport = new();
+    private readonly SubViewport _spriteViewport = new();
+    private readonly TextureRect _gridTexture = new();
+    private readonly TextureRect _spriteTexture = new();
+    private readonly GridCanvas _gridCanvas;
+    private readonly SpriteCanvas _spriteCanvas;
+    private bool _spriteDirty = true;
+    private int _lastFrame = -1;
     public DirGodotScoreGrid(IDirectorEventMediator mediator, DirGodotScoreGfxValues gfxValues)
     {
         _gfxValues = gfxValues;
         _mediator = mediator;
         AddChild(_contextMenu);
         _contextMenu.IdPressed += OnContextMenuItem;
+
+        _gridViewport.SetDisable3D(true);
+        _gridViewport.TransparentBg = true;
+        _gridViewport.SetUpdateMode(SubViewport.UpdateMode.Always);
+        _gridCanvas = new GridCanvas(this);
+        _gridViewport.AddChild(_gridCanvas);
+
+        _spriteViewport.SetDisable3D(true);
+        _spriteViewport.TransparentBg = true;
+        _spriteViewport.SetUpdateMode(SubViewport.UpdateMode.Always);
+        _spriteCanvas = new SpriteCanvas(this);
+        _spriteViewport.AddChild(_spriteCanvas);
+
+        _gridTexture.Texture = _gridViewport.GetTexture();
+        _gridTexture.Position = Vector2.Zero;
+        _gridTexture.ZIndex = -20;
+        _gridTexture.MouseFilter = MouseFilterEnum.Ignore;
+        _spriteTexture.Texture = _spriteViewport.GetTexture();
+        _spriteTexture.Position = Vector2.Zero;
+        _spriteTexture.ZIndex = -10;
+        _spriteTexture.MouseFilter = MouseFilterEnum.Ignore;
+
+        AddChild(_gridViewport);
+        AddChild(_spriteViewport);
+        AddChild(_gridTexture);
+        AddChild(_spriteTexture);
     }
 
     public void SetMovie(LingoMovie? movie)
     {
         _movie = movie;
         _sprites.Clear();
-        if (_movie == null) return;
-        int idx = 1;
-        while (_movie.TryGetAllTimeSprite(idx, out var sp))
+        if (_movie != null)
         {
-            _sprites.Add(new DirGodotScoreSprite((LingoSprite)sp));
-            idx++;
+            int idx = 1;
+            while (_movie.TryGetAllTimeSprite(idx, out var sp))
+            {
+                _sprites.Add(new DirGodotScoreSprite((LingoSprite)sp));
+                idx++;
+            }
         }
+        UpdateViewportSize();
+        _spriteDirty = true;
     }
 
     private void SelectSprite(DirGodotScoreSprite? sprite, bool raiseEvent = true)
@@ -50,7 +89,7 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
             if (raiseEvent)
                 _mediator.RaiseSpriteSelected(_selected.Sprite);
         }
-        QueueRedraw();
+        _spriteDirty = true;
     }
 
     public override void _Input(InputEvent @event)
@@ -76,13 +115,16 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
                                 float ex = _gfxValues.LeftMargin + sp.Sprite.EndFrame * _gfxValues.FrameWidth;
                                 if (pos.X >= sx && pos.X <= ex)
                                 {
-                                    if (Math.Abs(pos.X - sx) < 3)
+                                    float firstFrameRight = sx + _gfxValues.FrameWidth;
+                                    float lastFrameLeft = ex - _gfxValues.FrameWidth;
+
+                                    if (pos.X <= firstFrameRight)
                                     {
                                         _dragSprite = sp.Sprite;
                                         _dragBegin = true;
                                         _dragEnd = false;
                                     }
-                                    else if (Math.Abs(pos.X - ex) < 3)
+                                    else if (pos.X >= lastFrameLeft)
                                     {
                                         _dragSprite = sp.Sprite;
                                         _dragBegin = false;
@@ -102,6 +144,7 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
                 {
                     _dragSprite = null;
                     _dragBegin = _dragEnd = false;
+                    _spriteDirty = true;
                 }
             }
             else if (mb.ButtonIndex == MouseButton.Right && mb.Pressed)
@@ -128,14 +171,20 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
                 _dragSprite.BeginFrame = Math.Min(newFrame, _dragSprite.EndFrame);
             else if (_dragEnd)
                 _dragSprite.EndFrame = Math.Max(newFrame, _dragSprite.BeginFrame);
-            QueueRedraw();
+            _spriteDirty = true;
         }
     }
 
     public override void _Process(double delta)
     {
-        if (Visible)
-            QueueRedraw();
+        if (!Visible) return;
+        int cur = _movie?.CurrentFrame ?? -1;
+        if (_spriteDirty || cur != _lastFrame)
+        {
+            _spriteDirty = false;
+            _lastFrame = cur;
+            _spriteCanvas.QueueRedraw();
+        }
     }
 
     public void SpriteSelected(ILingoSprite sprite)
@@ -168,50 +217,83 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
         }
         _contextSprite = null;
     }
-    
 
-    public override void _Draw()
+    private void UpdateViewportSize()
     {
-        if (!Visible || _movie == null) return;
-        int channelCount = _movie.MaxSpriteChannelCount;
-        int frameCount = _movie.FrameCount;
-        var font = ThemeDB.FallbackFont;
+        if (_movie == null) return;
 
-        const int ExtraMargin = 20;
+        float width = _gfxValues.LeftMargin + _movie.FrameCount * _gfxValues.FrameWidth + _gfxValues.ExtraMargin;
+        float height = _movie.MaxSpriteChannelCount * _gfxValues.ChannelHeight + _gfxValues.ExtraMargin;
 
-        Size = new Vector2(_gfxValues.LeftMargin + frameCount * _gfxValues.FrameWidth + ExtraMargin,
-            channelCount * _gfxValues.ChannelHeight + ExtraMargin);
+        Size = new Vector2(width, height);
         CustomMinimumSize = Size;
 
-        DrawRect(new Rect2(0, 0, Size.X, Size.Y), Colors.White);
+        _gridViewport.SetSize(new Vector2I((int)width, (int)height));
+        _spriteViewport.SetSize(new Vector2I((int)width, (int)height));
+        _gridTexture.CustomMinimumSize = new Vector2(width, height);
+        _spriteTexture.CustomMinimumSize = new Vector2(width, height);
 
-        for (int f = 0; f < frameCount; f++)
-        {
-            float x = _gfxValues.LeftMargin + f * _gfxValues.FrameWidth;
-            if (f % 5 == 0)
-                DrawRect(new Rect2(x, 0, _gfxValues.FrameWidth, channelCount * _gfxValues.ChannelHeight), Colors.DarkGray);
-        }
-
-        for (int f = 0; f <= frameCount; f++)
-        {
-            float x = _gfxValues.LeftMargin + f * _gfxValues.FrameWidth;
-            DrawLine(new Vector2(x, 0), new Vector2(x, channelCount * _gfxValues.ChannelHeight), Colors.DarkGray);
-        }
-
-        // Draw sprites
-        foreach (var sp in _sprites)
-        {
-            int ch = sp.Sprite.SpriteNum - 1;
-            if (ch < 0 || ch >= channelCount) continue;
-            float x = _gfxValues.LeftMargin + (sp.Sprite.BeginFrame - 1) * _gfxValues.FrameWidth;
-            float width = (sp.Sprite.EndFrame - sp.Sprite.BeginFrame + 1) * _gfxValues.FrameWidth;
-            float y = ch * _gfxValues.ChannelHeight;
-            sp.Draw(this, new Vector2(x, y), width, _gfxValues.ChannelHeight, font);
-        }
-
-        int cur = _movie.CurrentFrame - 1;
-        if (cur < 0) cur = 0;
-        float barX = _gfxValues.LeftMargin + cur * _gfxValues.FrameWidth + _gfxValues.FrameWidth / 2f;
-        DrawLine(new Vector2(barX, 0), new Vector2(barX, channelCount * _gfxValues.ChannelHeight), Colors.Red, 2);
+        _gridCanvas.QueueRedraw();
+        _spriteCanvas.QueueRedraw();
     }
+
+    private partial class GridCanvas : Control
+    {
+        private readonly DirGodotScoreGrid _owner;
+        public GridCanvas(DirGodotScoreGrid owner) => _owner = owner;
+        public override void _Draw()
+        {
+            var movie = _owner._movie;
+            if (movie == null) return;
+            int channelCount = movie.MaxSpriteChannelCount;
+            int frameCount = movie.FrameCount;
+
+            DrawRect(new Rect2(0, 0, _owner.Size.X, _owner.Size.Y), Colors.White);
+
+            for (int f = 0; f < frameCount; f++)
+            {
+                float x = _owner._gfxValues.LeftMargin + f * _owner._gfxValues.FrameWidth;
+                if (f % 5 == 0)
+                    DrawRect(new Rect2(x, 0, _owner._gfxValues.FrameWidth, channelCount * _owner._gfxValues.ChannelHeight), Colors.DarkGray);
+            }
+
+            for (int f = 0; f <= frameCount; f++)
+            {
+                float x = _owner._gfxValues.LeftMargin + f * _owner._gfxValues.FrameWidth;
+                DrawLine(new Vector2(x, 0), new Vector2(x, channelCount * _owner._gfxValues.ChannelHeight), Colors.DarkGray);
+            }
+        }
+    }
+
+    private partial class SpriteCanvas : Control
+    {
+        private readonly DirGodotScoreGrid _owner;
+        public SpriteCanvas(DirGodotScoreGrid owner) => _owner = owner;
+        public override void _Draw()
+        {
+            var movie = _owner._movie;
+            if (movie == null) return;
+
+            int channelCount = movie.MaxSpriteChannelCount;
+            var font = ThemeDB.FallbackFont;
+
+            foreach (var sp in _owner._sprites)
+            {
+                int ch = sp.Sprite.SpriteNum - 1;
+                if (ch < 0 || ch >= channelCount) continue;
+                float x = _owner._gfxValues.LeftMargin + (sp.Sprite.BeginFrame - 1) * _owner._gfxValues.FrameWidth;
+                float width = (sp.Sprite.EndFrame - sp.Sprite.BeginFrame + 1) * _owner._gfxValues.FrameWidth;
+                float y = ch * _owner._gfxValues.ChannelHeight;
+                sp.Draw(this, new Vector2(x, y), width, _owner._gfxValues.ChannelHeight, font);
+            }
+
+            int cur = movie.CurrentFrame - 1;
+            if (cur < 0) cur = 0;
+            float barX = _owner._gfxValues.LeftMargin + cur * _owner._gfxValues.FrameWidth + _owner._gfxValues.FrameWidth / 2f;
+            DrawLine(new Vector2(barX, 0), new Vector2(barX, channelCount * _owner._gfxValues.ChannelHeight), Colors.Red, 2);
+        }
+    }
+    
+
+    // drawing handled by SubViewports
 }

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreLabelsBar.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreLabelsBar.cs
@@ -1,5 +1,7 @@
 ﻿using Godot;
 using LingoEngine.Movies;
+using LingoEngine.Core;
+using LingoEngine.Commands;
 
 namespace LingoEngine.Director.LGodot.Scores;
 
@@ -8,15 +10,29 @@ internal partial class DirGodotScoreLabelsBar : Control
     private LingoMovie? _movie;
 
     private readonly DirGodotScoreGfxValues _gfxValues;
-    public DirGodotScoreLabelsBar(DirGodotScoreGfxValues gfxValues)
+    private readonly ILingoCommandManager _commandManager;
+    private readonly LineEdit _editField = new();
+    private string? _activeLabel;
+    private int _activeFrame;
+    private int _startFrame;
+    private bool _dragging;
+
+    public DirGodotScoreLabelsBar(DirGodotScoreGfxValues gfxValues, ILingoCommandManager commandManager)
     {
         _gfxValues = gfxValues;
+        _commandManager = commandManager;
+        AddChild(_editField);
+        _editField.Visible = false;
+        _editField.Size = new Vector2(60, 16);
+        _editField.TextSubmitted += _ => CommitEdit();
+        _editField.FocusExited += () => CommitEdit();
     }
 
     public void SetMovie(LingoMovie? movie)
     {
         _movie = movie;
         Size = new Vector2(_gfxValues.LeftMargin + (_movie?.FrameCount ?? 0) * _gfxValues.FrameWidth, 20);
+        _editField.Visible = false;
     }
 
     public override void _Draw()
@@ -34,5 +50,63 @@ internal partial class DirGodotScoreLabelsBar : Control
             DrawString(font, new Vector2(x + 12, font.GetAscent() - 5), kv.Key,
                 HorizontalAlignment.Left, -1, 10, Colors.Black);
         }
+    }
+
+    public override void _GuiInput(InputEvent @event)
+    {
+        if (_movie == null) return;
+
+        if (@event is InputEventMouseButton mb && mb.ButtonIndex == MouseButton.Left)
+        {
+            if (mb.Pressed)
+            {
+                Vector2 pos = GetLocalMousePosition();
+                foreach (var kv in _movie.GetScoreLabels())
+                {
+                    var font = ThemeDB.FallbackFont;
+                    float x = _gfxValues.LeftMargin + (kv.Value - 1) * _gfxValues.FrameWidth;
+                    float width = font.GetStringSize(kv.Key).X + 20;
+                    if (pos.X >= x && pos.X <= x + width)
+                    {
+                        _activeLabel = kv.Key;
+                        _activeFrame = kv.Value;
+                        _startFrame = kv.Value;
+                        _dragging = true;
+                        _editField.Text = kv.Key;
+                        UpdateEditFieldPosition();
+                        _editField.Visible = true;
+                        _editField.GrabFocus();
+                        break;
+                    }
+                }
+            }
+            else if (_dragging)
+            {
+                CommitEdit();
+                _dragging = false;
+            }
+        }
+        else if (@event is InputEventMouseMotion && _dragging)
+        {
+            float frameF = (GetLocalMousePosition().X - _gfxValues.LeftMargin) / _gfxValues.FrameWidth;
+            _activeFrame = Math.Clamp(Mathf.RoundToInt(frameF) + 1, 1, _movie.FrameCount);
+            UpdateEditFieldPosition();
+        }
+    }
+
+    private void UpdateEditFieldPosition()
+    {
+        float x = _gfxValues.LeftMargin + (_activeFrame - 1) * _gfxValues.FrameWidth + 12;
+        _editField.Position = new Vector2(x, 2);
+    }
+
+    private void CommitEdit()
+    {
+        if (_activeLabel == null || _movie == null) return;
+        if (_activeFrame != _startFrame || _editField.Text != _activeLabel)
+            _commandManager.Handle(new UpdateFrameLabelCommand(_startFrame, _activeFrame, _editField.Text));
+        _activeLabel = null;
+        _editField.Visible = false;
+        QueueRedraw();
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -2,6 +2,7 @@ using Godot;
 using LingoEngine.Movies;
 using LingoEngine.Director.Core.Events;
 using LingoEngine.Director.LGodot.Gfx;
+using LingoEngine.Core;
 using static System.Net.Mime.MediaTypeNames;
 
 namespace LingoEngine.Director.LGodot.Scores;
@@ -30,14 +31,16 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
     private readonly DirGodotFrameScriptsBar _frameScripts;
     private readonly DirGodotScoreLabelsBar _labelBar;
     private readonly DirGodotScoreChannelBar _channelBar;
-    
+
     private readonly IDirectorEventMediator _mediator;
+    private readonly ILingoCommandManager _commandManager;
 
 
-    public DirGodotScoreWindow(IDirectorEventMediator directorMediator)
+    public DirGodotScoreWindow(IDirectorEventMediator directorMediator, ILingoCommandManager commandManager)
         : base("Score")
     {
         _mediator = directorMediator;
+        _commandManager = commandManager;
         _mediator.SubscribeToMenu(DirectorMenuCodes.ScoreWindow, () => Visible = !Visible);
         var height = 400;
         var width = 800;
@@ -52,7 +55,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow
         _mediator.Subscribe(_grid);
         _header = new DirGodotFrameHeader(_gfxValues);
         _frameScripts = new DirGodotFrameScriptsBar(_gfxValues);
-        _labelBar = new DirGodotScoreLabelsBar(_gfxValues);
+        _labelBar = new DirGodotScoreLabelsBar(_gfxValues, commandManager);
         
 
         // The grid inside master scoller

--- a/src/LingoEngine/Commands/AddFrameLabelCommand.cs
+++ b/src/LingoEngine/Commands/AddFrameLabelCommand.cs
@@ -1,0 +1,3 @@
+namespace LingoEngine.Commands;
+
+public sealed record AddFrameLabelCommand(int FrameNumber, string Name) : ILingoCommand;

--- a/src/LingoEngine/Commands/SetScoreLabelCommand.cs
+++ b/src/LingoEngine/Commands/SetScoreLabelCommand.cs
@@ -1,0 +1,3 @@
+namespace LingoEngine.Commands;
+
+public sealed record SetScoreLabelCommand(int FrameNumber, string? Name) : ILingoCommand;

--- a/src/LingoEngine/Commands/UpdateFrameLabelCommand.cs
+++ b/src/LingoEngine/Commands/UpdateFrameLabelCommand.cs
@@ -1,0 +1,3 @@
+namespace LingoEngine.Commands;
+
+public sealed record UpdateFrameLabelCommand(int PreviousFrame, int NewFrame, string Name) : ILingoCommand;

--- a/src/LingoEngine/Core/LingoPlayer.cs
+++ b/src/LingoEngine/Core/LingoPlayer.cs
@@ -12,10 +12,13 @@ namespace LingoEngine.Core
 {
 
 
-    public class LingoPlayer : ILingoPlayer, 
+    public class LingoPlayer : ILingoPlayer,
         ICommandHandler<RewindMovieCommand>,
          ICommandHandler<PlayMovieCommand>,
-        ICommandHandler<StepFrameCommand>
+        ICommandHandler<StepFrameCommand>,
+        ICommandHandler<SetScoreLabelCommand>,
+        ICommandHandler<AddFrameLabelCommand>,
+        ICommandHandler<UpdateFrameLabelCommand>
     {
         private Lazy<CsvImporter> _csvImporter = new Lazy<CsvImporter>(() => new CsvImporter());
         private readonly LingoCastLibsContainer _castLibsContainer;
@@ -252,6 +255,36 @@ namespace LingoEngine.Core
                 movie.Halt();
             else
                 movie.Play();
+            return true;
+        }
+
+        public bool CanExecute(SetScoreLabelCommand command) => ActiveMovie is LingoMovie;
+
+        public bool Handle(SetScoreLabelCommand command)
+        {
+            if (ActiveMovie is LingoMovie movie)
+                movie.SetScoreLabel(command.FrameNumber, command.Name);
+            return true;
+        }
+
+        public bool CanExecute(AddFrameLabelCommand command) => ActiveMovie is LingoMovie;
+
+        public bool Handle(AddFrameLabelCommand command)
+        {
+            if (ActiveMovie is LingoMovie movie)
+                movie.SetScoreLabel(command.FrameNumber, command.Name);
+            return true;
+        }
+
+        public bool CanExecute(UpdateFrameLabelCommand command) => ActiveMovie is LingoMovie;
+
+        public bool Handle(UpdateFrameLabelCommand command)
+        {
+            if (ActiveMovie is LingoMovie movie)
+            {
+                movie.SetScoreLabel(command.PreviousFrame, null);
+                movie.SetScoreLabel(command.NewFrame, command.Name);
+            }
             return true;
         }
         #endregion


### PR DESCRIPTION
## Summary
- keep grid viewport transparent
- render frame scripts through viewports
- allow editing and dragging score labels via command
- wire command manager into score window and player
- add explicit frame label update command

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c238c5b48332b5e0c74afc3ab34c