### PR TITLE
Fix Score editor UI behavior

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotFrameScriptsBar.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotFrameScriptsBar.cs
@@ -35,11 +35,12 @@ internal partial class DirGodotFrameScriptsBar : Control
         _spriteViewport.AddChild(_spriteCanvas);
 
         _gridTexture.Texture = _gridViewport.GetTexture();
-        _gridTexture.ZIndex = -20;
+        // Draw textures above the window background
+        _gridTexture.ZIndex = 0;
         _gridTexture.MouseFilter = MouseFilterEnum.Ignore;
 
         _spriteTexture.Texture = _spriteViewport.GetTexture();
-        _spriteTexture.ZIndex = -10;
+        _spriteTexture.ZIndex = 1;
         _spriteTexture.MouseFilter = MouseFilterEnum.Ignore;
 
         AddChild(_gridViewport);

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
@@ -48,11 +48,12 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
 
         _gridTexture.Texture = _gridViewport.GetTexture();
         _gridTexture.Position = Vector2.Zero;
-        _gridTexture.ZIndex = -20;
+        // Ensure textures draw above the window background
+        _gridTexture.ZIndex = 0;
         _gridTexture.MouseFilter = MouseFilterEnum.Ignore;
         _spriteTexture.Texture = _spriteViewport.GetTexture();
         _spriteTexture.Position = Vector2.Zero;
-        _spriteTexture.ZIndex = -10;
+        _spriteTexture.ZIndex = 1;
         _spriteTexture.MouseFilter = MouseFilterEnum.Ignore;
 
         AddChild(_gridViewport);

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreLabelsBar.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreLabelsBar.cs
@@ -25,7 +25,6 @@ internal partial class DirGodotScoreLabelsBar : Control
         _editField.Visible = false;
         _editField.Size = new Vector2(60, 16);
         _editField.TextSubmitted += _ => CommitEdit();
-        _editField.FocusExited += () => CommitEdit();
     }
 
     public void SetMovie(LingoMovie? movie)
@@ -71,11 +70,20 @@ internal partial class DirGodotScoreLabelsBar : Control
                         _activeLabel = kv.Key;
                         _activeFrame = kv.Value;
                         _startFrame = kv.Value;
-                        _dragging = true;
-                        _editField.Text = kv.Key;
-                        UpdateEditFieldPosition();
-                        _editField.Visible = true;
-                        _editField.GrabFocus();
+                        if (mb.DoubleClick)
+                        {
+                            // Open the edit field on double click
+                            _dragging = false;
+                            _editField.Text = kv.Key;
+                            UpdateEditFieldPosition();
+                            _editField.Visible = true;
+                            _editField.GrabFocus();
+                        }
+                        else
+                        {
+                            // Start dragging to reposition the label
+                            _dragging = true;
+                        }
                         break;
                     }
                 }


### PR DESCRIPTION
## Summary
- fix texture ZIndex so score grid and scripts appear over window
- keep frame label edit field open on double click and close on Enter

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6854d1d6777c83329912dfad502bfca9