### PR TITLE
Fix window opening position

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastWindow.cs
@@ -6,6 +6,7 @@ using LingoEngine.Members;
 using LingoEngine.Casts;
 using LingoEngine.Director.Core.Casts;
 using LingoEngine.Core;
+using LingoEngine.Director.LGodot;
 
 namespace LingoEngine.Director.LGodot.Casts
 {
@@ -22,8 +23,8 @@ namespace LingoEngine.Director.LGodot.Casts
 
         public ILingoCast? ActiveCastLib { get; private set; }
 
-        public DirGodotCastWindow(IDirectorEventMediator mediator, DirectorStyle style, DirectorCastWindow directorCastWindow, ILingoPlayer player)
-            : base("Cast")
+        public DirGodotCastWindow(IDirectorEventMediator mediator, DirectorStyle style, DirectorCastWindow directorCastWindow, ILingoPlayer player, GodotWindowManager windowManager)
+            : base("Cast", windowManager)
         {
             _mediator = mediator;
             _style = style;

--- a/src/Director/LingoEngine.Director.LGodot/Casts/TextableMemberWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/TextableMemberWindow.cs
@@ -4,6 +4,7 @@ using LingoEngine.Director.Core.Windows;
 using LingoEngine.Texts;
 using LingoEngine.Members;
 using LingoEngine.Director.Core.Casts;
+using LingoEngine.Director.LGodot;
 
 namespace LingoEngine.Director.LGodot.Casts;
 
@@ -17,7 +18,7 @@ internal partial class DirGodotTextableMemberWindow : BaseGodotWindow, IHasMembe
 
     private ILingoMemberTextBase? _member;
 
-    public DirGodotTextableMemberWindow(IDirectorEventMediator mediator, DirectorTextEditWindow directorTextEditWindow) : base("Edit Text")
+    public DirGodotTextableMemberWindow(IDirectorEventMediator mediator, DirectorTextEditWindow directorTextEditWindow, GodotWindowManager windowManager) : base("Edit Text", windowManager)
     {
         mediator.Subscribe(this);
         directorTextEditWindow.Init(this);

--- a/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
@@ -25,6 +25,7 @@ namespace LingoEngine.Director.LGodot
             engineRegistration.Services(s =>
             {
                 s.AddSingleton<DirectorStyle>();
+                s.AddSingleton<GodotWindowManager>();
                 s.AddSingleton<DirGodotProjectSettingsWindow>();
                 s.AddSingleton<DirGodotToolsWindow>();
                 s.AddSingleton<DirGodotCastWindow>();

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotBinaryViewerWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotBinaryViewerWindow.cs
@@ -3,6 +3,7 @@ using LingoEngine.Director.Core.Events;
 using LingoEngine.Director.LGodot.TestData;
 using LingoEngine.Director.Core.Windows;
 using LingoEngine.Director.Core.Gfx;
+using LingoEngine.Director.LGodot;
 
 namespace LingoEngine.Director.LGodot.Gfx
 {
@@ -23,7 +24,7 @@ namespace LingoEngine.Director.LGodot.Gfx
         private SubViewport _viewport;
         private TextureRect _textureRect;
 
-        public DirGodotBinaryViewerWindow(IDirectorEventMediator mediator, DirectorBinaryViewerWindow directorBinaryViewerWindow) : base("Binary Viewer")
+        public DirGodotBinaryViewerWindow(IDirectorEventMediator mediator, DirectorBinaryViewerWindow directorBinaryViewerWindow, GodotWindowManager windowManager) : base("Binary Viewer", windowManager)
         {
             _mediator = mediator;
             directorBinaryViewerWindow.Init(this);

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotProjectSettingsWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotProjectSettingsWindow.cs
@@ -2,6 +2,7 @@ using Godot;
 using LingoEngine.Director.Core;
 using LingoEngine.Director.Core.Windows;
 using LingoEngine;
+using LingoEngine.Director.LGodot;
 
 namespace LingoEngine.Director.LGodot.Gfx;
 
@@ -11,8 +12,8 @@ internal partial class DirGodotProjectSettingsWindow : BaseGodotWindow, IDirFram
     private readonly LineEdit _nameEdit = new LineEdit();
     private readonly LineEdit _folderEdit = new LineEdit();
 
-    public DirGodotProjectSettingsWindow(ProjectSettings settings)
-        : base("Project Settings")
+    public DirGodotProjectSettingsWindow(ProjectSettings settings, GodotWindowManager windowManager)
+        : base("Project Settings", windowManager)
     {
         _settings = settings;
 

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotToolsWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotToolsWindow.cs
@@ -1,6 +1,7 @@
 using Godot;
 using LingoEngine.Director.Core.Gfx;
 using LingoEngine.Director.Core.Windows;
+using LingoEngine.Director.LGodot;
 
 namespace LingoEngine.Director.LGodot.Gfx;
 
@@ -11,7 +12,7 @@ internal partial class DirGodotToolsWindow : BaseGodotWindow, IDirFrameworkTools
 
     public event Action<int>? IconPressed;
 
-    public DirGodotToolsWindow(DirectorToolsWindow directorToolsWindow) : base("Tools")
+    public DirGodotToolsWindow(DirectorToolsWindow directorToolsWindow, GodotWindowManager windowManager) : base("Tools", windowManager)
     {
         directorToolsWindow.Init(this);
 

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/GodotWindowManager.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/GodotWindowManager.cs
@@ -1,0 +1,21 @@
+using Godot;
+
+namespace LingoEngine.Director.LGodot;
+
+internal class GodotWindowManager
+{
+    public BaseGodotWindow? ActiveWindow { get; private set; }
+
+    public void SetActiveWindow(BaseGodotWindow window)
+    {
+        if (ActiveWindow == window)
+            return;
+
+        ActiveWindow = window;
+        var parent = window.GetParent();
+        if (parent != null)
+        {
+            parent.MoveChild(window, parent.GetChildCount() - 1);
+        }
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
@@ -6,6 +6,7 @@ using LingoEngine.Pictures;
 using LingoEngine.Members;
 using LingoEngine.Director.Core.Windows;
 using LingoEngine.Director.Core.Inspector;
+using LingoEngine.Director.LGodot;
 
 namespace LingoEngine.Director.LGodot.Inspector;
 
@@ -15,7 +16,7 @@ public partial class DirGodotPropertyInspector : BaseGodotWindow, IHasSpriteSele
     private readonly ScrollContainer _vScroller = new ScrollContainer();
     private readonly TabContainer _tabs = new TabContainer();
 
-    public DirGodotPropertyInspector(IDirectorEventMediator mediator, DirectorPropertyInspectorWindow inspectorWindow) : base("Inspector")
+    public DirGodotPropertyInspector(IDirectorEventMediator mediator, DirectorPropertyInspectorWindow inspectorWindow, GodotWindowManager windowManager) : base("Inspector", windowManager)
     {
         _mediator = mediator;
         inspectorWindow.Init(this);

--- a/src/Director/LingoEngine.Director.LGodot/Pictures/DirGodotPictureMemberEditorWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Pictures/DirGodotPictureMemberEditorWindow.cs
@@ -2,6 +2,7 @@ using Godot;
 using LingoEngine.Pictures;
 using LingoEngine.LGodot.Pictures;
 using LingoEngine.Director.LGodot.Gfx;
+using LingoEngine.Director.LGodot;
 
 namespace LingoEngine.Director.LGodot.Pictures;
 
@@ -20,7 +21,7 @@ internal partial class DirGodotPictureMemberEditorWindow : BaseGodotWindow
 
     private float _scale = 1f;
 
-    public DirGodotPictureMemberEditorWindow() : base("Picture Editor")
+    public DirGodotPictureMemberEditorWindow(GodotWindowManager windowManager) : base("Picture Editor", windowManager)
     {
         Size = new Vector2(400, 300);
         CustomMinimumSize = Size;

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -4,6 +4,7 @@ using LingoEngine.Director.Core.Events;
 using LingoEngine.Core;
 using LingoEngine.Director.Core.Windows;
 using LingoEngine.Director.Core.Scores;
+using LingoEngine.Director.LGodot;
 
 namespace LingoEngine.Director.LGodot.Scores;
 
@@ -36,8 +37,8 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
     private readonly ILingoCommandManager _commandManager;
 
 
-    public DirGodotScoreWindow(IDirectorEventMediator directorMediator, ILingoCommandManager commandManager, DirectorScoreWindow directorScoreWindow, ILingoPlayer player)
-        : base("Score")
+    public DirGodotScoreWindow(IDirectorEventMediator directorMediator, ILingoCommandManager commandManager, DirectorScoreWindow directorScoreWindow, ILingoPlayer player, GodotWindowManager windowManager)
+        : base("Score", windowManager)
     {
         _mediator = directorMediator;
         _commandManager = commandManager;

--- a/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
@@ -8,6 +8,7 @@ using LingoEngine.Director.LGodot.Gfx;
 using LingoEngine.Core;
 using LingoEngine.Commands;
 using LingoEngine.Director.Core.Stages;
+using LingoEngine.Director.LGodot;
 
 namespace LingoEngine.Director.LGodot.Movies;
 
@@ -35,8 +36,8 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
     private ILingoFrameworkStage? _stage;
     private LingoSprite? _selectedSprite;
 
-    public DirGodotStageWindow(ILingoFrameworkStageContainer stageContainer, IDirectorEventMediator directorEventMediator, ILingoCommandManager commandManager, ILingoPlayer player, DirectorStageWindow directorStageWindow)
-        : base("Stage")
+    public DirGodotStageWindow(ILingoFrameworkStageContainer stageContainer, IDirectorEventMediator directorEventMediator, ILingoCommandManager commandManager, ILingoPlayer player, DirectorStageWindow directorStageWindow, GodotWindowManager windowManager)
+        : base("Stage", windowManager)
     {
         _stageContainer = (LingoGodotStageContainer)stageContainer;
         _mediator = directorEventMediator;


### PR DESCRIPTION
## Summary
- ensure all Godot windows stay within the viewport when opened
- track the active window so the clicked window moves to the top

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855134a8f388332afddd1eb07671e84