### PR TITLE
Implement double-click editing in cast window

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastView.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastView.cs
@@ -3,6 +3,7 @@ using LingoEngine.Casts;
 using LingoEngine.Director.Core.Casts;
 using LingoEngine.Director.LGodot;
 using LingoEngine.Members;
+using LingoEngine.Core;
 using System.Linq;
 
 namespace LingoEngine.Director.LGodot.Casts
@@ -14,10 +15,11 @@ namespace LingoEngine.Director.LGodot.Casts
         private readonly List<DirGodotCastItem> _elements = new List<DirGodotCastItem>();
         private readonly Action<DirGodotCastItem> _onSelectItem;
         private readonly DirectorStyle _style;
+        private readonly ILingoCommandManager _commandManager;
 
         public Node Node => _ScrollContainer;
 
-        public DirGodotCastView(Action<DirGodotCastItem> onSelect, DirectorStyle style)
+        public DirGodotCastView(Action<DirGodotCastItem> onSelect, DirectorStyle style, ILingoCommandManager commandManager)
         {
             _ScrollContainer = new ScrollContainer();
             _ScrollContainer.SizeFlagsVertical = Control.SizeFlags.ExpandFill;
@@ -29,6 +31,7 @@ namespace LingoEngine.Director.LGodot.Casts
             _ScrollContainer.AddChild(_elementsContainer);
             _onSelectItem = onSelect;
             _style = style;
+            _commandManager = commandManager;
         }
 
         public void Show(ILingoCast cast)
@@ -37,7 +40,7 @@ namespace LingoEngine.Director.LGodot.Casts
             var i = 0;
             foreach (var castItem in cast.GetAll())
             {
-                var dirCastItem = new DirGodotCastItem(castItem, i+1, _onSelectItem, _style.SelectedColor);
+                var dirCastItem = new DirGodotCastItem(castItem, i+1, _onSelectItem, _style.SelectedColor, _commandManager);
                 dirCastItem.Init();
                 _elements.Add(dirCastItem);
                 _elementsContainer.AddChild(dirCastItem);

--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastWindow.cs
@@ -8,6 +8,7 @@ using LingoEngine.Director.Core.Casts;
 using LingoEngine.Core;
 using LingoEngine.Director.LGodot;
 using LingoEngine.Director.LGodot.Gfx;
+using LingoEngine.Core;
 
 namespace LingoEngine.Director.LGodot.Casts
 {
@@ -21,16 +22,18 @@ namespace LingoEngine.Director.LGodot.Casts
         private readonly Dictionary<int, DirGodotCastView> _castViews = new();
         private DirGodotCastItem? _selectedItem;
         private ILingoPlayer _player;
+        private readonly ILingoCommandManager _commandManager;
 
         public ILingoCast? ActiveCastLib { get; private set; }
 
-        public DirGodotCastWindow(IDirectorEventMediator mediator, DirectorStyle style, DirectorCastWindow directorCastWindow, ILingoPlayer player, IDirGodotWindowManager windowManager)
+        public DirGodotCastWindow(IDirectorEventMediator mediator, DirectorStyle style, DirectorCastWindow directorCastWindow, ILingoPlayer player, IDirGodotWindowManager windowManager, ILingoCommandManager commandManager)
             : base(DirectorMenuCodes.CastWindow, "Cast", windowManager)
         {
             _mediator = mediator;
             _style = style;
             directorCastWindow.Init(this);
             _player = player;
+            _commandManager = commandManager;
             _player.ActiveMovieChanged += OnActiveMovieChanged;
             _mediator.Subscribe(this);
 
@@ -67,7 +70,7 @@ namespace LingoEngine.Director.LGodot.Casts
             if (lingoMovie == null) return;
             foreach (var cast in lingoMovie.CastLib.GetAll())
             {
-                var castLibViewer = new DirGodotCastView(OnSelectElement, _style);
+                var castLibViewer = new DirGodotCastView(OnSelectElement, _style, _commandManager);
                 castLibViewer.Show(cast);
                 _castViews.Add(cast.Number, castLibViewer);
                 var tabContent = new VBoxContainer


### PR DESCRIPTION
## Summary
- allow cast items to open an editor on double-click
- pass `ILingoCommandManager` through cast view and window classes
- invoke `OpenWindowCommand` for text or picture members

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685520143818833290fd4dc3dc216c52