### PR TITLE
Fix score grid sprite rebuild

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
@@ -26,6 +26,7 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
     private readonly GridCanvas _gridCanvas;
     private readonly SpriteCanvas _spriteCanvas;
     private bool _spriteDirty = true;
+    private bool _spriteListDirty;
     private int _lastFrame = -1;
     public DirGodotScoreGrid(IDirectorEventMediator mediator, DirGodotScoreGfxValues gfxValues)
     {
@@ -64,7 +65,27 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
 
     public void SetMovie(LingoMovie? movie)
     {
+        if (_movie != null)
+            _movie.SpriteListChanged -= OnSpritesChanged;
+
         _movie = movie;
+        BuildSpriteList();
+        _spriteListDirty = false;
+        if (_movie != null)
+            _movie.SpriteListChanged += OnSpritesChanged;
+
+        UpdateViewportSize();
+        _spriteDirty = true;
+    }
+
+    private void OnSpritesChanged()
+    {
+        _spriteListDirty = true;
+        _spriteDirty = true;
+    }
+
+    private void BuildSpriteList()
+    {
         _sprites.Clear();
         if (_movie != null)
         {
@@ -75,8 +96,6 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
                 idx++;
             }
         }
-        UpdateViewportSize();
-        _spriteDirty = true;
     }
 
     private void SelectSprite(DirGodotScoreSprite? sprite, bool raiseEvent = true)
@@ -179,6 +198,13 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
     public override void _Process(double delta)
     {
         if (!Visible) return;
+        if (_spriteListDirty)
+        {
+            BuildSpriteList();
+            UpdateViewportSize();
+            _spriteListDirty = false;
+            _spriteDirty = true;
+        }
         int cur = _movie?.CurrentFrame ?? -1;
         if (_spriteDirty || cur != _lastFrame)
         {

--- a/src/LingoEngine/Movies/ILingoMovie.cs
+++ b/src/LingoEngine/Movies/ILingoMovie.cs
@@ -168,6 +168,11 @@ namespace LingoEngine.Movies
         void SetSpriteMember(int number, int memberNumber);
 
         /// <summary>
+        /// Raised whenever sprites are added or removed from the movie.
+        /// </summary>
+        event Action? SpriteListChanged;
+
+        /// <summary>
         /// Gets the total number of sprite channels in the Score.
         /// Lingo: the spriteCount
         /// </summary>

--- a/src/LingoEngine/Movies/LingoMovie.cs
+++ b/src/LingoEngine/Movies/LingoMovie.cs
@@ -38,6 +38,10 @@ namespace LingoEngine.Movies
         private readonly List<LingoSprite> _enteredSprites = new();
         private readonly List<LingoSprite> _exitedSprites = new();
         private bool _IsManualUpdateStage;
+        public event Action? SpriteListChanged;
+
+        private void RaiseSpriteListChanged()
+            => SpriteListChanged?.Invoke();
         private LingoSprite? _currentFrameSprite;
 
         // Movie Script subscriptions
@@ -163,7 +167,8 @@ namespace LingoEngine.Movies
             var sprite = _environment.Factory.CreateSprite<LingoSprite>(this, s =>
             {
                 // On remove method
-                var index = _frameSpriteBehaviors.Remove(frameNumber);
+                _frameSpriteBehaviors.Remove(frameNumber);
+                RaiseSpriteListChanged();
             });
             sprite.Init(0, "FrameSprite_"+frameNumber);
             if (_frameSpriteBehaviors.ContainsKey(frameNumber))
@@ -176,6 +181,7 @@ namespace LingoEngine.Movies
             var behaviour = sprite.SetBehavior<TBehaviour>();
             if (configureBehaviour != null) configureBehaviour(behaviour);
             if (configure != null) configure(sprite);
+            RaiseSpriteListChanged();
             return sprite;
         }
           
@@ -198,6 +204,7 @@ namespace LingoEngine.Movies
                 var index = _allTimeSprites.IndexOf(s);
                 _allTimeSprites.RemoveAt(index);
                 _spritesByName.Remove(name);
+                RaiseSpriteListChanged();
             });
             sprite.Init(num, name);
             //var sprite = new LingoSprite(_environment, this, name, num);
@@ -208,6 +215,7 @@ namespace LingoEngine.Movies
                 _maxSpriteNum = num;
             if (configure != null)
                 configure(sprite);
+            RaiseSpriteListChanged();
             return sprite;
         }
         public bool RemoveSprite(string name)


### PR DESCRIPTION
## Summary
- make DirGodotScoreGrid rebuild its sprite list lazily
- use a dirty flag instead of rebuilding on every sprite add/remove
- rename movie sprite event to `SpriteListChanged`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685515d371a4833287f6337f8a61f501