### PR TITLE
Add class generation support to converter

### DIFF
--- a/Test/LingoEngine.Lingo.Core.Tests/ClassGenerationTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/ClassGenerationTests.cs
@@ -1,0 +1,71 @@
+using LingoEngine.Lingo.Core;
+using Xunit;
+
+namespace LingoEngine.Lingo.Core.Tests;
+
+public class ClassGenerationTests
+{
+    [Fact]
+    public void BehaviorScriptGeneratesClass()
+    {
+        var file = new LingoScriptFile
+        {
+            Name = "MyBehavior",
+            Source = "",
+            Type = LingoScriptType.Behavior
+        };
+        var result = LingoToCSharpConverter.ConvertClass(file).Trim();
+        var expected = string.Join('\n',
+            "public class MyBehaviorBehavior : LingoSpriteBehavior",
+            "{",
+            "    public MyBehaviorBehavior(ILingoMovieEnvironment env) : base(env) { }",
+            "}");
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ParentScriptGeneratesClass()
+    {
+        var file = new LingoScriptFile
+        {
+            Name = "MyParent",
+            Source = "",
+            Type = LingoScriptType.Parent
+        };
+        var result = LingoToCSharpConverter.ConvertClass(file).Trim();
+        var expected = string.Join('\n',
+            "public class MyParentParentScript : LingoParentScript",
+            "{",
+            "    private readonly GlobalVars _global;",
+            "",
+            "    public MyParentParentScript(ILingoMovieEnvironment env, GlobalVars global) : base(env)",
+            "    {",
+            "        _global = global;",
+            "    }",
+            "}");
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void MovieScriptGeneratesClass()
+    {
+        var file = new LingoScriptFile
+        {
+            Name = "MyMovie",
+            Source = "",
+            Type = LingoScriptType.Movie
+        };
+        var result = LingoToCSharpConverter.ConvertClass(file).Trim();
+        var expected = string.Join('\n',
+            "public class MyMovieMovieScript : LingoMovieScript",
+            "{",
+            "    private readonly GlobalVars _global;",
+            "",
+            "    public MyMovieMovieScript(ILingoMovieEnvironment env, GlobalVars global) : base(env)",
+            "    {",
+            "        _global = global;",
+            "    }",
+            "}");
+        Assert.Equal(expected, result);
+    }
+}


### PR DESCRIPTION
## Summary
- generate C# classes with IoC constructor and `GlobalVars` support
- add unit tests for movie, parent and behavior class generation

## Testing
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855334c90148332b147b8327f3528ff