### PR TITLE
Fix picture regpoint origin and zoom

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Pictures/DirGodotPictureMemberEditorWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Pictures/DirGodotPictureMemberEditorWindow.cs
@@ -76,6 +76,8 @@ internal partial class DirGodotPictureMemberEditorWindow : BaseGodotWindow, IHas
         _centerContainer.OffsetTop = TitleBarHeight + IconBarHeight;
         _centerContainer.OffsetRight = 0;
         _centerContainer.OffsetBottom = -BottomBarHeight;
+        _centerContainer.PivotOffset = new Vector2(Size.X / 2f,
+            (Size.Y - (TitleBarHeight + IconBarHeight + BottomBarHeight)) / 2f);
 
         _imageRect.StretchMode = TextureRect.StretchModeEnum.Keep;
         _centerContainer.AddChild(_imageRect);
@@ -235,7 +237,7 @@ internal partial class DirGodotPictureMemberEditorWindow
             Vector2 offset = new((areaSize.X - texSize.X * factor) / 2f,
                                  (areaSize.Y - texSize.Y * factor) / 2f);
 
-            Vector2 pos = new Vector2(member.RegPoint.X, member.RegPoint.Y) * factor + offset;
+            Vector2 pos = new Vector2(texSize.X - member.RegPoint.X, member.RegPoint.Y) * factor + offset;
 
             DrawLine(new Vector2(pos.X, 0), new Vector2(pos.X, areaSize.Y), Colors.Red);
             DrawLine(new Vector2(0, pos.Y), new Vector2(areaSize.X, pos.Y), Colors.Red);

--- a/src/Director/LingoEngine.Director.LGodot/Pictures/DirGodotPictureMemberEditorWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Pictures/DirGodotPictureMemberEditorWindow.cs
@@ -237,7 +237,8 @@ internal partial class DirGodotPictureMemberEditorWindow
             Vector2 offset = new((areaSize.X - texSize.X * factor) / 2f,
                                  (areaSize.Y - texSize.Y * factor) / 2f);
 
-            Vector2 pos = new Vector2(member.RegPoint.X, member.RegPoint.Y) * factor + offset;
+            // Convert from top-right regPoint origin
+            Vector2 pos = new Vector2(member.Width - member.RegPoint.X, member.RegPoint.Y) * factor + offset;
 
             DrawLine(new Vector2(pos.X, 0), new Vector2(pos.X, areaSize.Y), Colors.Red);
             DrawLine(new Vector2(0, pos.Y), new Vector2(areaSize.X, pos.Y), Colors.Red);

--- a/src/Director/LingoEngine.Director.LGodot/Pictures/DirGodotPictureMemberEditorWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Pictures/DirGodotPictureMemberEditorWindow.cs
@@ -237,7 +237,7 @@ internal partial class DirGodotPictureMemberEditorWindow
             Vector2 offset = new((areaSize.X - texSize.X * factor) / 2f,
                                  (areaSize.Y - texSize.Y * factor) / 2f);
 
-            Vector2 pos = new Vector2(texSize.X - member.RegPoint.X, member.RegPoint.Y) * factor + offset;
+            Vector2 pos = new Vector2(member.RegPoint.X, member.RegPoint.Y) * factor + offset;
 
             DrawLine(new Vector2(pos.X, 0), new Vector2(pos.X, areaSize.Y), Colors.Red);
             DrawLine(new Vector2(0, pos.Y), new Vector2(areaSize.X, pos.Y), Colors.Red);

--- a/src/LingoEngine/Members/LingoMemberExtensions.cs
+++ b/src/LingoEngine/Members/LingoMemberExtensions.cs
@@ -13,8 +13,6 @@ public static class LingoMemberExtensions
     public static LingoPoint CenterOffsetFromRegPoint(this ILingoMember member)
     {
         var center = new LingoPoint(member.Width / 2f, member.Height / 2f);
-        var regTopLeft = new LingoPoint(member.Width - member.RegPoint.X,
-            member.Height - member.RegPoint.Y);
-        return regTopLeft - center;
+        return member.RegPoint - center;
     }
 }

--- a/src/LingoEngine/Members/LingoMemberExtensions.cs
+++ b/src/LingoEngine/Members/LingoMemberExtensions.cs
@@ -13,6 +13,8 @@ public static class LingoMemberExtensions
     public static LingoPoint CenterOffsetFromRegPoint(this ILingoMember member)
     {
         var center = new LingoPoint(member.Width / 2f, member.Height / 2f);
-        return member.RegPoint - center;
+        var regTopLeft = new LingoPoint(member.Width - member.RegPoint.X,
+            member.Height - member.RegPoint.Y);
+        return regTopLeft - center;
     }
 }

--- a/src/LingoEngine/Members/LingoMemberExtensions.cs
+++ b/src/LingoEngine/Members/LingoMemberExtensions.cs
@@ -13,6 +13,9 @@ public static class LingoMemberExtensions
     public static LingoPoint CenterOffsetFromRegPoint(this ILingoMember member)
     {
         var center = new LingoPoint(member.Width / 2f, member.Height / 2f);
-        return member.RegPoint - center;
+        // RegPoint coordinates originate from the picture's top-right corner
+        var regFromTopRight = new LingoPoint(member.Width - member.RegPoint.X,
+            member.RegPoint.Y);
+        return regFromTopRight - center;
     }
 }


### PR DESCRIPTION
## Summary
- center the zoom in the picture editor
- draw picture registration point using top-right origin
- adjust registration offset calculation for new origin

## Testing
- `bash scripts/install-dotnet.sh`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj` *(fails: BehaviorScriptGeneratesClass)*


------
https://chatgpt.com/codex/tasks/task_e_6855896cbd8483328b78cb787f243109