### PR TITLE
Fix frame scripts bar layering

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotFrameScriptsBar.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotFrameScriptsBar.cs
@@ -35,12 +35,9 @@ internal partial class DirGodotFrameScriptsBar : Control
         _spriteViewport.AddChild(_spriteCanvas);
 
         _gridTexture.Texture = _gridViewport.GetTexture();
-        // Draw textures above the window background
-        _gridTexture.ZIndex = 0;
         _gridTexture.MouseFilter = MouseFilterEnum.Ignore;
 
         _spriteTexture.Texture = _spriteViewport.GetTexture();
-        _spriteTexture.ZIndex = 1;
         _spriteTexture.MouseFilter = MouseFilterEnum.Ignore;
 
         AddChild(_gridViewport);


### PR DESCRIPTION
## Summary
- fix layering in `DirGodotFrameScriptsBar`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558a4c9d6c83329791040186f73d4e