### PR TITLE
Fix cast tab selection input

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
@@ -98,6 +98,8 @@ namespace LingoEngine.Director.LGodot.Casts
         private static object _lock = new object();
         public override void _Input(InputEvent @event)
         {
+            if (!IsVisibleInTree()) return;
+
             if (@event is InputEventMouseButton mouseEvent && mouseEvent.ButtonIndex == MouseButton.Left)
             {
                 Vector2 mousePos = GetGlobalMousePosition();


### PR DESCRIPTION
## Summary
- ignore input events for cast items when their tab is not visible

## Testing
- `dotnet test` *(fails: command not found)*
- `./scripts/install-dotnet.sh` *(fails due to network access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6855a49f56d483329126a2764bddf0ac