### PR TITLE
Update property inspector behavior list order

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
@@ -144,8 +144,6 @@ public partial class DirGodotPropertyInspector : BaseGodotWindow, IHasSpriteSele
             container.AddChild(editBtn);
         }
 
-        BuildProperties(container, obj);
-
         if (obj is LingoSprite sprite)
         {
             var behLabel = new Label { Text = "Behaviors" };
@@ -156,6 +154,8 @@ public partial class DirGodotPropertyInspector : BaseGodotWindow, IHasSpriteSele
             list.ItemActivated += idx => ShowBehavior(sprite.Behaviors[idx]);
             container.AddChild(list);
         }
+
+        BuildProperties(container, obj);
 
         vScroller.AddChild(container);
     }


### PR DESCRIPTION
## Summary
- show sprite behavior list before editable properties in the property inspector

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a653fe208332a182cd14c31abdbd