### PR TITLE
Fix cast item click area in Godot UI

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
@@ -120,7 +120,7 @@ namespace LingoEngine.Director.LGodot.Casts
             {
                 Vector2 mousePos = GetGlobalMousePosition();
 
-                Rect2 bounds = new Rect2(GlobalPosition - CustomMinimumSize * 0.5f, CustomMinimumSize);
+                Rect2 bounds = new Rect2(GlobalPosition, CustomMinimumSize);
 
                 if (mouseEvent.Pressed && mouseEvent.DoubleClick && !_openingEditor && bounds.HasPoint(mousePos))
                 {


### PR DESCRIPTION
## Summary
- fix input bounds for cast items in Godot director UI

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68566602b8f48332a8179f587cd3f537