### PR TITLE
Fix behavior list visibility in property inspector

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
@@ -148,7 +148,12 @@ public partial class DirGodotPropertyInspector : BaseGodotWindow, IHasSpriteSele
         {
             var behLabel = new Label { Text = "Behaviors" };
             container.AddChild(behLabel);
-            var list = new ItemList();
+            var list = new ItemList
+            {
+                SizeFlagsVertical = Control.SizeFlags.ExpandFill,
+                SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+                CustomMinimumSize = new Vector2(0, 80)
+            };
             foreach (var b in sprite.Behaviors)
                 list.AddItem(b.GetType().Name);
             list.ItemActivated += idx => ShowBehavior(sprite.Behaviors[(int)idx]);


### PR DESCRIPTION
## Summary
- adjust the ItemList inside the property inspector to expand vertically

## Testing
- `dotnet test` *(fails: `dotnet` not found or blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685666a5f97c8332bc42e62f10bdb3a9