### PR TITLE
Fix sprite selection when movie stopped

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
@@ -232,7 +232,8 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         if (!Visible || _movie == null || _movie.IsPlaying) return;
         if (@event is InputEventMouseButton mb && mb.ButtonIndex == MouseButton.Left && mb.Pressed)
         {
-            var sprite = _movie.GetSpriteUnderMouse();
+            Vector2 localPos = _stageContainer.Container.ToLocal(mb.Position);
+            var sprite = _movie.GetSpriteAtPoint(localPos.X, localPos.Y);
             if (sprite != null)
                 _mediator.RaiseSpriteSelected(sprite);
         }

--- a/src/LingoEngine/Movies/LingoMovie.cs
+++ b/src/LingoEngine/Movies/LingoMovie.cs
@@ -294,6 +294,16 @@ namespace LingoEngine.Movies
             }
             return null; // Return null if no sprite is under the mouse
         }
+
+        public LingoSprite? GetSpriteAtPoint(float x, float y)
+        {
+            foreach (var sprite in _activeSprites.Values)
+            {
+                if (sprite.IsPointInsideBoundingBox(x, y))
+                    return sprite;
+            }
+            return null;
+        }
         private void CallActiveSprites(Action<LingoSprite> actionOnAllActiveSprites)
         {
             foreach (var sprite in _activeSprites.Values)

--- a/src/LingoEngine/Movies/LingoSprite.cs
+++ b/src/LingoEngine/Movies/LingoSprite.cs
@@ -512,6 +512,12 @@ When a movie stops, events occur in the following order:
         public bool IsMouseInsideBoundingBox(LingoMouse mouse)
             => Rect.Contains((mouse.MouseH, mouse.MouseV));
 
+        /// <summary>
+        /// Check if the given point is inside the bounding box of the sprite
+        /// </summary>
+        public bool IsPointInsideBoundingBox(float x, float y)
+            => Rect.Contains((x, y));
+
         internal void CallBehavior<T>(Action<T> actionOnSpriteBehaviour) where T : LingoSpriteBehavior
         {
             var behavior = _behaviors.FirstOrDefault(x => x is T) as T;


### PR DESCRIPTION
## Summary
- map mouse clicks on the stage window to stage-local coordinates
- allow LingoMovie to find sprites using explicit coordinates
- expose point-based bounding box check on LingoSprite

## Testing
- `dotnet test --verbosity minimal Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj` *(fails: BehaviorScriptGeneratesClass)*

------
https://chatgpt.com/codex/tasks/task_e_6856658a5fa08332a847d281dbe88ad5