### PR TITLE
Fix layering of frame scripts without ZIndex

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotFrameScriptsBar.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotFrameScriptsBar.cs
@@ -35,9 +35,11 @@ internal partial class DirGodotFrameScriptsBar : Control
         _spriteViewport.AddChild(_spriteCanvas);
 
         _gridTexture.Texture = _gridViewport.GetTexture();
+        _gridTexture.Position = Vector2.Zero;
         _gridTexture.MouseFilter = MouseFilterEnum.Ignore;
 
         _spriteTexture.Texture = _spriteViewport.GetTexture();
+        _spriteTexture.Position = Vector2.Zero;
         _spriteTexture.MouseFilter = MouseFilterEnum.Ignore;
 
         AddChild(_gridViewport);


### PR DESCRIPTION
## Summary
- avoid ZIndex usage in frame scripts bar textures
- match layering behavior of the score grid

## Testing
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856651f5d548332a7909c8be8283aa2