### PR TITLE
Implement basic drag & drop in Score grid

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
@@ -219,6 +219,17 @@ namespace LingoEngine.Director.LGodot.Casts
             _Sprite2D.Scale = new Vector2(scaleFactorW, scaleFactorH);
         }
 
+        public override Variant? _GetDragData(Vector2 atPosition)
+        {
+            var preview = new ColorRect
+            {
+                Color = new Color(1f, 1f, 1f, 0.5f),
+                Size = CustomMinimumSize
+            };
+            SetDragPreview(preview);
+            return Variant.From(_lingoMember);
+        }
+
 
 
         private static string GetPreviewText(ILingoMemberTextBase text)

--- a/src/LingoEngine/Movies/LingoMovie.cs
+++ b/src/LingoEngine/Movies/LingoMovie.cs
@@ -5,6 +5,7 @@ using LingoEngine.Events;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Inputs;
 using LingoEngine.Members;
+using System.Linq;
 
 namespace LingoEngine.Movies
 {
@@ -604,6 +605,39 @@ namespace LingoEngine.Movies
 
         public IReadOnlyDictionary<string, int> GetScoreLabels() => _scoreLabels;
         public IReadOnlyDictionary<int, LingoSprite> GetFrameSpriteBehaviors() => _frameSpriteBehaviors;
+
+        internal int GetNextLabelFrame(int frame)
+        {
+            var next = _scoreLabels.Values
+                .Where(v => v > frame)
+                .DefaultIfEmpty(int.MaxValue)
+                .Min();
+            if (next == int.MaxValue)
+                return frame + 10;
+            return next;
+        }
+
+        internal int GetNextSpriteStart(int channel, int frame)
+        {
+            int next = int.MaxValue;
+            foreach (var sp in _allTimeSprites)
+            {
+                if (sp.SpriteNum - 1 == channel && sp.BeginFrame > frame)
+                    next = Math.Min(next, sp.BeginFrame);
+            }
+            return next == int.MaxValue ? -1 : next;
+        }
+
+        internal int GetPrevSpriteEnd(int channel, int frame)
+        {
+            int prev = -1;
+            foreach (var sp in _allTimeSprites)
+            {
+                if (sp.SpriteNum - 1 == channel && sp.EndFrame < frame)
+                    prev = Math.Max(prev, sp.EndFrame);
+            }
+            return prev;
+        }
 
         public int GetMaxLocZ() => _activeSprites.Values.Max(x => x.LocZ);
 


### PR DESCRIPTION
## Summary
- allow cast items to start drag operations
- show preview rectangles while dragging over the score grid
- add drop handling to create new sprites without overlap
- clamp sprite resize to avoid collisions
- move drag helper methods into `LingoMovie`
- rename drag-drop callbacks following style guidelines

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6856683dff6483328f5afc7e4f6e2420