### PR TITLE
Fix sprite bounding box offset

### DIFF
--- a/src/LingoEngine.SDL2/SdlSprite.cs
+++ b/src/LingoEngine.SDL2/SdlSprite.cs
@@ -97,8 +97,8 @@ public class SdlSprite : ILingoFrameworkSprite, IDisposable
 
         SDL.SDL_Rect dst = new SDL.SDL_Rect
         {
-            x = (int)(X + offset.X),
-            y = (int)(Y + offset.Y),
+            x = (int)(X - offset.X),
+            y = (int)(Y - offset.Y),
             w = (int)Width,
             h = (int)Height
         };

--- a/src/LingoEngine/Movies/LingoSprite.cs
+++ b/src/LingoEngine/Movies/LingoSprite.cs
@@ -106,8 +106,8 @@ namespace LingoEngine.Movies
             get
             {
                 var offset = GetRegPointOffset();
-                float left = LocH + offset.X;
-                float top = LocV + offset.Y;
+                float left = LocH - offset.X;
+                float top = LocV - offset.Y;
                 return new LingoRect(left, top, left + Width, top + Height);
             }
         }


### PR DESCRIPTION
## Summary
- fix bounding box calculation to match regpoint offset
- align SDL sprite rendering with bounding box logic

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68566a11a7308332a0622f4d03996e36