### PR TITLE
Fix registration point bounding boxes

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Pictures/DirGodotPictureMemberEditorWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Pictures/DirGodotPictureMemberEditorWindow.cs
@@ -329,9 +329,10 @@ internal partial class DirGodotPictureMemberEditorWindow
             if (member == null || _owner._imageRect.Texture == null) return;
 
             Vector2 areaSize = Size;
+            var scale = _owner._centerContainer.Scale;
 
             // RegPoint origin is the texture's top-left corner
-            Vector2 pos = new Vector2(member.RegPoint.X, member.RegPoint.Y);
+            Vector2 pos = new Vector2(member.RegPoint.X * scale.X, member.RegPoint.Y * scale.Y);
 
             DrawLine(new Vector2(pos.X, 0), new Vector2(pos.X, areaSize.Y), Colors.Red);
             DrawLine(new Vector2(0, pos.Y), new Vector2(areaSize.X, pos.Y), Colors.Red);

--- a/src/LingoEngine/Movies/LingoSprite.cs
+++ b/src/LingoEngine/Movies/LingoSprite.cs
@@ -106,8 +106,8 @@ namespace LingoEngine.Movies
             get
             {
                 var offset = GetRegPointOffset();
-                float left = LocH - offset.X;
-                float top = LocV - offset.Y;
+                float left = LocH - offset.X - Width / 2f;
+                float top = LocV - offset.Y - Height / 2f;
                 return new LingoRect(left, top, left + Width, top + Height);
             }
         }


### PR DESCRIPTION
## Summary
- ensure bounding boxes use sprite registration point correctly
- scale registration point overlay in picture editor

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68567096ee7c83328ddfeacbce6c7c23