### PR TITLE
Ensure sprite lists refresh when hidden

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
@@ -89,6 +89,7 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
     {
         _spriteListDirty = true;
         _spriteDirty = true;
+        RefreshSprites();
     }
 
     private void BuildSpriteList()
@@ -102,6 +103,17 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
                 _sprites.Add(new DirGodotScoreSprite((LingoSprite)sp));
                 idx++;
             }
+        }
+    }
+
+    private void RefreshSprites()
+    {
+        if (_spriteListDirty)
+        {
+            BuildSpriteList();
+            UpdateViewportSize();
+            _spriteListDirty = false;
+            _spriteDirty = true;
         }
     }
 
@@ -260,14 +272,9 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
 
     public override void _Process(double delta)
     {
+        if (Visible)
+            RefreshSprites();
         if (!Visible) return;
-        if (_spriteListDirty)
-        {
-            BuildSpriteList();
-            UpdateViewportSize();
-            _spriteListDirty = false;
-            _spriteDirty = true;
-        }
         int cur = _movie?.CurrentFrame ?? -1;
         if (_spriteDirty || cur != _lastFrame)
         {


### PR DESCRIPTION
## Summary
- refactor sprite list rebuild logic into `RefreshSprites`
- call `RefreshSprites` from `_Process` and `OnSpritesChanged` so hidden nodes still update

## Testing
- `./scripts/install-dotnet.sh`
- `dotnet test` *(fails: Could not find file '/workspace/LingoEngine/Test/TestData/TextCast.cst')*

------
https://chatgpt.com/codex/tasks/task_e_685670c9b3e08332a5bb91be6eef7e45