### PR TITLE
Add automatic registration of movie scripts

### DIFF
--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/TetriGroundsSetup.cs
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/TetriGroundsSetup.cs
@@ -30,39 +30,7 @@ namespace LingoEngine.Demo.TetriGrounds.Core
                         .ForMovie(TetriGroundsGame.MovieName, s => s
                             //.AddMovieScript<StartMoviesScript>()
                             //.AddMovieScript<StarMovieScript>()
-                            // Globals
-                            .AddBehavior<MouseDownNavigateBehavior>()
-                            .AddBehavior<MouseDownNavigateWithStayBehavior>()
-                            .AddBehavior<PauseBehaviour>()
-                            .AddBehavior<StartGameBehavior>()
-                            .AddBehavior<StayOnFrameFrameScript>()
-                            .AddBehavior<WaiterFrameScript>()
-                            // Beh
-                            .AddBehavior<AnimationScriptBehavior>()
-                            .AddBehavior<AppliBgBehavior>()
-                            .AddBehavior<BgScriptBehavior>()
-                            .AddBehavior<ExecuteBehavior>()
-                            .AddBehavior<FontRollOverBehavior>()
-                            .AddBehavior<GameStopBehavior>()
-                            .AddBehavior<NewGameBehavior>()
-                            .AddBehavior<StartBehavior>()
-                            .AddBehavior<StopMenuBehavior>()
-                            .AddBehavior<TextCounterBehavior>()
-
-                            //.AddParentScript<BlockParentScript>()
-                            //.AddParentScript<BlocksParentScript>()
-                            //.AddParentScript<GfxParentScript>()
-                            //.AddParentScript<InterestingEncryptoParentScript>()
-                            //.AddParentScript<MousePointer>()
-                            //.AddParentScript<OverScreenTextParentScript>()
-                            //.AddParentScript<PlayerBlockParentScript>()
-                            //.AddParentScript<ScoreManagerParentScript>()
-                            //.AddParentScript<SpriteManagerParentScript>()
-                            //.AddParentScript<ScoreGetParentScript>()
-                            //.AddParentScript<ScoreSaveParentScript>()
-                            //.AddParentScript<ClassSubscribeParentScript>()
-                            //.AddParentScript<StartDataGetParentScript>()
-                            //.AddParentScript<StartDataSaveParentScript>()
+                            .AddScriptsFromAssembly()
                             // Other
                         );
                     registration(config);

--- a/src/LingoEngine/MovieRegistrationExtensions.cs
+++ b/src/LingoEngine/MovieRegistrationExtensions.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace LingoEngine
+{
+    public static class MovieRegistrationExtensions
+    {
+        public static IMovieRegistration AddScriptsFromAssembly(this IMovieRegistration registration, Assembly? assembly = null)
+        {
+            assembly ??= Assembly.GetCallingAssembly();
+
+            var addBehavior = registration.GetType().GetMethod(nameof(IMovieRegistration.AddBehavior));
+            var addParentScript = registration.GetType().GetMethod(nameof(IMovieRegistration.AddParentScript));
+            var addMovieScript = registration.GetType().GetMethod(nameof(IMovieRegistration.AddMovieScript));
+            if (addBehavior == null || addParentScript == null || addMovieScript == null)
+                throw new InvalidOperationException("Registration implementation missing required methods");
+
+            foreach (var type in assembly.GetTypes())
+            {
+                if (type.IsAbstract || type.IsInterface) continue;
+
+                if (typeof(Movies.LingoSpriteBehavior).IsAssignableFrom(type))
+                {
+                    addBehavior.MakeGenericMethod(type).Invoke(registration, null);
+                }
+                else if (typeof(Core.LingoParentScript).IsAssignableFrom(type))
+                {
+                    addParentScript.MakeGenericMethod(type).Invoke(registration, null);
+                }
+                else if (typeof(Movies.LingoMovieScript).IsAssignableFrom(type))
+                {
+                    addMovieScript.MakeGenericMethod(type).Invoke(registration, null);
+                }
+            }
+            return registration;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `AddScriptsFromAssembly` extension to register Lingo behaviours, parent and movie scripts via reflection
- simplify TetriGrounds setup by using the automatic registration

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68567177086c83328d493d399a6d1f98