### PR TITLE
Lighten sprite colors when locked

### DIFF
--- a/src/LingoEngine/Movies/LingoSprite.cs
+++ b/src/LingoEngine/Movies/LingoSprite.cs
@@ -27,6 +27,9 @@ namespace LingoEngine.Movies
         private bool isDragging = false;
         private bool isDraggable = false;  // A flag to control dragging behavior
         private bool _lock = false;
+        private LingoColor? _origColor;
+        private LingoColor? _origBackColor;
+        private LingoColor? _origForeColor;
         private LingoMember? _Member;
         private Action<LingoSprite>? _onRemoveMe;
         private bool _isFocus = false;
@@ -91,7 +94,26 @@ namespace LingoEngine.Movies
         public bool Lock
         {
             get => _lock;
-            set => _lock = value;
+            set
+            {
+                if (_lock == value) return;
+                _lock = value;
+                if (value)
+                {
+                    _origColor = Color;
+                    _origForeColor = ForeColor;
+                    _origBackColor = BackColor;
+                    Color = Color.Lighten(0.3f);
+                    ForeColor = ForeColor.Lighten(0.3f);
+                    BackColor = BackColor.Lighten(0.3f);
+                }
+                else
+                {
+                    if (_origColor.HasValue) Color = _origColor.Value;
+                    if (_origForeColor.HasValue) ForeColor = _origForeColor.Value;
+                    if (_origBackColor.HasValue) BackColor = _origBackColor.Value;
+                }
+            }
         }
         public bool IsDraggable
         {

--- a/src/LingoEngine/Primitives/LingoColor.cs
+++ b/src/LingoEngine/Primitives/LingoColor.cs
@@ -31,6 +31,19 @@
         }
 
         /// <summary>
+        /// Creates a lighter version of the color by blending towards white.
+        /// Factor should be between 0 (no change) and 1 (white).
+        /// </summary>
+        public LingoColor Lighten(float factor)
+        {
+            factor = Math.Clamp(factor, 0f, 1f);
+            byte r = (byte)(R + (255 - R) * factor);
+            byte g = (byte)(G + (255 - G) * factor);
+            byte b = (byte)(B + (255 - B) * factor);
+            return new LingoColor(Code, r, g, b, Name);
+        }
+
+        /// <summary>
         /// Converts the RGB color to a hex string, e.g., "#FF0000".
         /// </summary>
         public string ToHex() => $"#{R:X2}{G:X2}{B:X2}";


### PR DESCRIPTION
## Summary
- add Lighten helper to `LingoColor`
- adjust `LingoSprite.Lock` setter to brighten colors when locked and restore them when unlocked

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685671f0e68c83328fb9ca76d468b4b5