### PR TITLE
Fix sprite lock grid color

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreSprite.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreSprite.cs
@@ -20,6 +20,8 @@ internal class DirGodotScoreSprite
     internal void Draw(CanvasItem canvas, Vector2 position, float width, float height, Font font)
     {
         var baseColor = new Color("#ccccff");
+        if (Sprite.Lock)
+            baseColor = baseColor.Lightened(0.3f);
         if (Selected)
             baseColor = baseColor.Darkened(0.25f);
         canvas.DrawRect(new Rect2(position.X, position.Y, width, height), baseColor);

--- a/src/LingoEngine/Movies/LingoSprite.cs
+++ b/src/LingoEngine/Movies/LingoSprite.cs
@@ -27,9 +27,6 @@ namespace LingoEngine.Movies
         private bool isDragging = false;
         private bool isDraggable = false;  // A flag to control dragging behavior
         private bool _lock = false;
-        private LingoColor? _origColor;
-        private LingoColor? _origBackColor;
-        private LingoColor? _origForeColor;
         private LingoMember? _Member;
         private Action<LingoSprite>? _onRemoveMe;
         private bool _isFocus = false;
@@ -94,26 +91,7 @@ namespace LingoEngine.Movies
         public bool Lock
         {
             get => _lock;
-            set
-            {
-                if (_lock == value) return;
-                _lock = value;
-                if (value)
-                {
-                    _origColor = Color;
-                    _origForeColor = ForeColor;
-                    _origBackColor = BackColor;
-                    Color = Color.Lighten(0.3f);
-                    ForeColor = ForeColor.Lighten(0.3f);
-                    BackColor = BackColor.Lighten(0.3f);
-                }
-                else
-                {
-                    if (_origColor.HasValue) Color = _origColor.Value;
-                    if (_origForeColor.HasValue) ForeColor = _origForeColor.Value;
-                    if (_origBackColor.HasValue) BackColor = _origBackColor.Value;
-                }
-            }
+            set => _lock = value;
         }
         public bool IsDraggable
         {


### PR DESCRIPTION
## Summary
- revert sprite color modification when locking
- lighten grid sprite display when locked

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856743e04a883328a62d30b249b507e