### PR TITLE
Fix sprite selection order

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
@@ -233,7 +233,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         if (@event is InputEventMouseButton mb && mb.ButtonIndex == MouseButton.Left && mb.Pressed)
         {
             Vector2 localPos = _stageContainer.Container.ToLocal(mb.Position);
-            var sprite = _movie.GetSpriteAtPoint(localPos.X, localPos.Y);
+            var sprite = _movie.GetSpriteAtPoint(localPos.X, localPos.Y, true);
             if (sprite != null)
                 _mediator.RaiseSpriteSelected(sprite);
         }

--- a/src/LingoEngine/Core/LingoScriptBase.cs
+++ b/src/LingoEngine/Core/LingoScriptBase.cs
@@ -150,6 +150,9 @@ namespace LingoEngine.Core
         protected void SendSprite<T>(int spriteNumber, Action<T> actionOnSprite) where T : LingoSpriteBehavior => _Movie.SendSprite(spriteNumber, actionOnSprite);
         protected TResult? SendSprite<T, TResult>(int spriteNumber, Func<T, TResult> actionOnSprite) where T : LingoSpriteBehavior => _Movie.SendSprite(spriteNumber, actionOnSprite);
 
+        protected LingoList<ILingoSpriteChannel> SpritesUnderPoint(LingoPoint point)
+            => new LingoList<ILingoSpriteChannel>(_Movie.GetSpritesAtPoint(point.X, point.Y).Select(s => (ILingoSpriteChannel)s));
+
         protected void UpdateStage() => _Movie.UpdateStage();
         protected void StartTimer() => _env.Movie.StartTimer();
         protected int Timer => _env.Movie.Timer; 

--- a/src/LingoEngine/Movies/ILingoMovie.cs
+++ b/src/LingoEngine/Movies/ILingoMovie.cs
@@ -182,6 +182,9 @@ namespace LingoEngine.Movies
         /// </summary>
         bool RollOver(int spriteNumber);
 
+        IEnumerable<LingoSprite> GetSpritesAtPoint(float x, float y, bool skipLockedSprites = false);
+        LingoSprite? GetSpriteAtPoint(float x, float y, bool skipLockedSprites = false);
+
 
         void SendSprite(string name, Action<ILingoSpriteChannel> actionOnSprite);
         void SendSprite(int number, Action<ILingoSpriteChannel> actionOnSprite);

--- a/src/LingoEngine/Movies/LingoMovie.cs
+++ b/src/LingoEngine/Movies/LingoMovie.cs
@@ -283,28 +283,27 @@ namespace LingoEngine.Movies
             return sprite.IsMouseInsideBoundingBox(_lingoMouse);
         }
 
-        public LingoSprite? GetSpriteUnderMouse()
+        public LingoSprite? GetSpriteUnderMouse(bool skipLockedSprites = false)
+            => GetSpritesAtPoint(_lingoMouse.MouseH, _lingoMouse.MouseV, skipLockedSprites).FirstOrDefault();
+
+        public IEnumerable<LingoSprite> GetSpritesAtPoint(float x, float y, bool skipLockedSprites = false)
         {
-            // Loop through all sprites and check if the mouse is inside the bounding box of the sprite
+            var matches = new List<LingoSprite>();
             foreach (var sprite in _activeSprites.Values)
             {
-                if (sprite.IsMouseInsideBoundingBox(_lingoMouse))
-                {
-                    return sprite; // Return the sprite the mouse is over
-                }
+                if (skipLockedSprites && sprite.Lock) continue;
+                if (sprite.SpriteChannel != null && !sprite.SpriteChannel.Visibility) continue;
+                if (sprite.IsPointInsideBoundingBox(x, y))
+                    matches.Add(sprite);
             }
-            return null; // Return null if no sprite is under the mouse
+
+            return matches
+                .OrderByDescending(s => s.LocH)
+                .ThenByDescending(s => s.SpriteNum);
         }
 
-        public LingoSprite? GetSpriteAtPoint(float x, float y)
-        {
-            foreach (var sprite in _activeSprites.Values)
-            {
-                if (sprite.IsPointInsideBoundingBox(x, y))
-                    return sprite;
-            }
-            return null;
-        }
+        public LingoSprite? GetSpriteAtPoint(float x, float y, bool skipLockedSprites = false)
+            => GetSpritesAtPoint(x, y, skipLockedSprites).FirstOrDefault();
         private void CallActiveSprites(Action<LingoSprite> actionOnAllActiveSprites)
         {
             foreach (var sprite in _activeSprites.Values)

--- a/src/LingoEngine/Movies/LingoStage.cs
+++ b/src/LingoEngine/Movies/LingoStage.cs
@@ -68,8 +68,11 @@ namespace LingoEngine.Movies
      
         internal LingoSprite? GetSpriteUnderMouse()
         {
-            if (ActiveMovie == null) return null;
-            return ActiveMovie.GetSpriteUnderMouse();
+            if (ActiveMovie == null)
+                return null;
+
+            bool skipLockedSprites = !ActiveMovie.IsPlaying;
+            return ActiveMovie.GetSpriteUnderMouse(skipLockedSprites);
         }
 
         public Animations.LingoSpriteMotionPath? GetSpriteMotionPath(LingoSprite sprite)


### PR DESCRIPTION
## Summary
- select sprites by LocH then spriteNum when multiple overlap
- expose enumerable lookup for sprites at a point
- add `SpritesUnderPoint()` helper on base script

## Testing
- `dotnet test` *(fails: missing test data)*

------
https://chatgpt.com/codex/tasks/task_e_6856782d630c8332990ade14ec02dcc2