### PR TITLE
Add DocFX docs generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Need to install the SDK?
 - [XMED Offsets](docs/XMED_Offsets.md)
 - [Text Styling Example](docs/Text_Multi_Line_Multi_Style.md)
 
+### API Reference
+
+Documentation generated from the source code is available using [DocFX](https://github.com/dotnet/docfx). Run `scripts/build-docs.sh` to produce the site in `docs/docfx/_site`. The pages include "View Source" links back to the repository.
+
 ### Component READMEs
 
 - [Core Runtime Readme](src/LingoEngine/README.md)

--- a/docs/docfx/docfx.json
+++ b/docs/docfx/docfx.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/docfx/main/schemas/docfx.schema.json",
+  "metadata": [
+    {
+      "src": [
+        {
+          "src": "../src",
+          "files": [
+            "**/*.csproj"
+          ]
+        }
+      ],
+      "dest": "api"
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "**/*.{md,yml}"
+        ],
+        "exclude": [
+          "_site/**"
+        ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+          "images/**"
+        ]
+      }
+    ],
+    "output": "_site",
+    "template": [
+      "default",
+      "modern"
+    ],
+    "globalMetadata": {
+      "_appName": "LingoEngine API",
+      "_appTitle": "LingoEngine API",
+      "_enableSearch": true,
+      "pdf": true
+    }
+  },
+  "repository": {
+    "url": "https://github.com/EmmanuelTheCreator/LingoEngine",
+    "branch": "main"
+  }
+}
+

--- a/docs/docfx/index.md
+++ b/docs/docfx/index.md
@@ -1,0 +1,3 @@
+# LingoEngine Documentation
+
+Generated API reference and guides live here. Run `scripts/build-docs.sh` to rebuild this site.

--- a/docs/docfx/toc.yml
+++ b/docs/docfx/toc.yml
@@ -1,0 +1,2 @@
+- name: API Reference
+  href: api/index.md

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+export PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$PATH"
+export DOTNET_ROOT="$HOME/.dotnet"
+
+docfx docs/docfx/docfx.json


### PR DESCRIPTION
## Summary
- add DocFX project under `docs/docfx`
- provide script `build-docs.sh`
- document how to generate API docs in README

## Testing
- `bash scripts/build-docs.sh`
- `dotnet test` *(fails: could not find test data)*

------
https://chatgpt.com/codex/tasks/task_e_6856d703c6548332a6bca03958ab6232