### PR TITLE
Add audio channels to score

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreAudioClip.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreAudioClip.cs
@@ -1,0 +1,20 @@
+using Godot;
+using LingoEngine.Movies;
+
+namespace LingoEngine.Director.LGodot.Scores;
+
+internal class DirGodotScoreAudioClip
+{
+    internal readonly LingoAudioClip Clip;
+    internal DirGodotScoreAudioClip(LingoAudioClip clip)
+    {
+        Clip = clip;
+    }
+
+    internal void Draw(CanvasItem canvas, Vector2 position, float width, float height, Font font)
+    {
+        canvas.DrawRect(new Rect2(position.X, position.Y, width, height), new Color("#ccffcc"));
+        canvas.DrawString(font, new Vector2(position.X + 4, position.Y + font.GetAscent() - 6),
+            Clip.Sound.Name ?? string.Empty, HorizontalAlignment.Left, width - 4, 9, Colors.Black);
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGfxValues.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGfxValues.cs
@@ -10,7 +10,7 @@ namespace LingoEngine.Director.LGodot.Scores
         public int ChannelLabelWidth { get; set; } = 54;
         public int ChannelInfoWidth { get; set; } 
         public int ExtraMargin { get; set; }  = 20;
-        public int TopStripHeight { get; set; } = 80;
+        public int TopStripHeight { get; set; } = 140;
 
         public Color ColLineLight = new Color("#f9f9f9");
         public Color ColLineDark = new Color("#d0d0d0");

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -31,6 +31,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
     private readonly DirGodotScoreGrid _grid;
     private readonly DirGodotFrameHeader _header;
     private readonly DirGodotFrameScriptsBar _frameScripts;
+    private readonly DirGodotSoundBar _soundBar;
     private readonly DirGodotScoreLabelsBar _labelBar;
     private readonly DirGodotScoreChannelBar _channelBar;
 
@@ -61,6 +62,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         _mediator.Subscribe(_grid);
         _header = new DirGodotFrameHeader(_gfxValues);
         _frameScripts = new DirGodotFrameScriptsBar(_gfxValues);
+        _soundBar = new DirGodotSoundBar(_gfxValues);
         _labelBar = new DirGodotScoreLabelsBar(_gfxValues, commandManager);
         
 
@@ -94,6 +96,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         _hClipper.AddChild(_topStripContent);
         AddChild(_hClipper);
         _topStripContent.AddChild(_labelBar);
+        _topStripContent.AddChild(_soundBar);
         _topStripContent.AddChild(_frameScripts);
         _topStripContent.AddChild(_header);
 
@@ -114,8 +117,9 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
 
        
         _labelBar.Position = new Vector2(0, 0);
-        _frameScripts.Position = new Vector2(0, 20);
-        _header.Position = new Vector2(0, 40);
+        _soundBar.Position = new Vector2(0, 20);
+        _frameScripts.Position = new Vector2(0, 20 + _gfxValues.ChannelHeight * 4 + 10);
+        _header.Position = new Vector2(0, _frameScripts.Position.Y + 20);
         
 
 
@@ -161,6 +165,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         _grid.SetMovie(movie);
         _header.SetMovie(movie);
         _frameScripts.SetMovie(movie);
+        _soundBar.SetMovie(movie);
         _channelBar.SetMovie(movie);
         _labelBar.SetMovie(movie);
 
@@ -175,6 +180,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         _grid.Dispose();
         _labelBar.Dispose();
         _frameScripts.Dispose();
+        _soundBar.Dispose();
         _masterScroller.Dispose();
         //_hScroller.Dispose();
         _channelBar.Dispose();
@@ -219,7 +225,8 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
             DrawRect(new Rect2(0, 0, Size.X, Size.Y), new Color("#f0f0f0"));
             DrawTextWithLine(0,20, "Labels");
             DrawTextWithLine(20,20, "Scripts");
-            DrawTextWithLine(37,23, "Member", false);
+            DrawTextWithLine(37,64, "Audio");
+            DrawTextWithLine(102,23, "Member", false);
         }
         private void DrawTextWithLine(int top, int height, string text, bool withTopLines = false)
         {

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotSoundBar.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotSoundBar.cs
@@ -1,0 +1,104 @@
+using Godot;
+using System.Collections.Generic;
+using LingoEngine.Movies;
+using LingoEngine.Members;
+
+namespace LingoEngine.Director.LGodot.Scores;
+
+internal partial class DirGodotSoundBar : Control
+{
+    private LingoMovie? _movie;
+    private readonly List<DirGodotScoreAudioClip> _clips = new();
+    private readonly DirGodotScoreGfxValues _gfxValues;
+    private bool _dirty = true;
+    private bool _collapsed;
+
+    public DirGodotSoundBar(DirGodotScoreGfxValues gfxValues)
+    {
+        _gfxValues = gfxValues;
+    }
+
+    public void SetMovie(LingoMovie? movie)
+    {
+        if (_movie != null)
+            _movie.AudioClipListChanged -= OnClipsChanged;
+        _movie = movie;
+        _clips.Clear();
+        if (_movie != null)
+        {
+            foreach (var clip in _movie.GetAudioClips())
+                _clips.Add(new DirGodotScoreAudioClip(clip));
+            _movie.AudioClipListChanged += OnClipsChanged;
+        }
+        QueueRedraw();
+    }
+
+    private void OnClipsChanged()
+    {
+        _clips.Clear();
+        if (_movie != null)
+            foreach (var clip in _movie.GetAudioClips())
+                _clips.Add(new DirGodotScoreAudioClip(clip));
+        QueueRedraw();
+    }
+
+    public override bool _CanDropData(Vector2 atPosition, Variant data)
+    {
+        if (_movie == null || _collapsed) return false;
+        if (data.Obj is not GodotObject obj) return false;
+        if (obj is not LingoMemberSound) return false;
+        return true;
+    }
+
+    public override void _DropData(Vector2 atPosition, Variant data)
+    {
+        if (_movie == null || _collapsed) return;
+        if (data.Obj is not GodotObject obj) return;
+        if (obj is not LingoMemberSound sound) return;
+        int channel = (int)(atPosition.Y / _gfxValues.ChannelHeight);
+        int frame = Mathf.Clamp(Mathf.RoundToInt((atPosition.X - _gfxValues.LeftMargin) / _gfxValues.FrameWidth) + 1, 1, _movie.FrameCount);
+        _movie.AddAudioClip(channel, frame, sound);
+    }
+
+    public override void _GuiInput(InputEvent @event)
+    {
+        if (@event is InputEventMouseButton mb && mb.Pressed && mb.ButtonIndex == MouseButton.Left)
+        {
+            if (mb.Position.Y < 10 && mb.Position.X < 10)
+            {
+                _collapsed = !_collapsed;
+                QueueRedraw();
+            }
+        }
+    }
+
+    public override void _Draw()
+    {
+        if (_movie == null) return;
+        int channels = _collapsed ? 0 : 4;
+        float height = channels * _gfxValues.ChannelHeight + (_collapsed ? 0 : 0);
+        Size = new Vector2(_gfxValues.LeftMargin + _movie.FrameCount * _gfxValues.FrameWidth, height + 10);
+        DrawRect(new Rect2(0,0,Size.X,Size.Y), new Color("#f0f0f0"));
+
+        var font = ThemeDB.FallbackFont;
+        DrawString(font, new Vector2(2, font.GetAscent()-2), (_collapsed ? "▶" : "▼"));
+        if (_collapsed) return;
+
+        for (int c = 0; c < channels; c++)
+        {
+            float y = c * _gfxValues.ChannelHeight + 10;
+            DrawLine(new Vector2(0,y), new Vector2(Size.X,y), Colors.DarkGray);
+            DrawString(font, new Vector2(12, y + font.GetAscent()-4), $"🔊{c+1}");
+        }
+
+        foreach (var clip in _clips)
+        {
+            int ch = clip.Clip.Channel;
+            if (ch < 0 || ch >= channels) continue;
+            float x = _gfxValues.LeftMargin + (clip.Clip.BeginFrame -1) * _gfxValues.FrameWidth;
+            float width = (clip.Clip.EndFrame - clip.Clip.BeginFrame +1) * _gfxValues.FrameWidth;
+            float y = ch * _gfxValues.ChannelHeight + 10;
+            clip.Draw(this, new Vector2(x,y), width, _gfxValues.ChannelHeight, font);
+        }
+    }
+}

--- a/src/LingoEngine/Movies/ILingoMovie.cs
+++ b/src/LingoEngine/Movies/ILingoMovie.cs
@@ -219,5 +219,11 @@ namespace LingoEngine.Movies
         int GetNextLabelFrame(int frame);
         int GetNextSpriteStart(int channel, int frame);
         int GetPrevSpriteEnd(int channel, int frame);
+
+        // Audio clips support
+        event Action? AudioClipListChanged;
+        IReadOnlyList<LingoAudioClip> GetAudioClips();
+        LingoAudioClip AddAudioClip(int channel, int frame, LingoMemberSound sound);
+        void MoveAudioClip(LingoAudioClip clip, int newFrame);
     }
 }

--- a/src/LingoEngine/Movies/LingoAudioClip.cs
+++ b/src/LingoEngine/Movies/LingoAudioClip.cs
@@ -1,0 +1,19 @@
+using LingoEngine.Members;
+
+namespace LingoEngine.Movies;
+
+public class LingoAudioClip
+{
+    public int Channel { get; set; }
+    public int BeginFrame { get; set; }
+    public int EndFrame { get; set; }
+    public LingoMemberSound Sound { get; }
+
+    public LingoAudioClip(int channel, int beginFrame, int endFrame, LingoMemberSound sound)
+    {
+        Channel = channel;
+        BeginFrame = beginFrame;
+        EndFrame = endFrame;
+        Sound = sound;
+    }
+}


### PR DESCRIPTION
## Summary
- support audio clips in `LingoMovie`
- expose audio clip functions via `ILingoMovie`
- draw sound tracks with new `DirGodotSoundBar`
- update score window layout to include sound tracks
- adjust graphics constants for new top strip height

## Testing
- `dotnet` was not available so build/tests were skipped

------
https://chatgpt.com/codex/tasks/task_e_68570814a080833296a49c7db053a7da