### PR TITLE
Add vector shape member support

### DIFF
--- a/src/Director/LingoEngine.Director.Core/FileSystems/IdeLauncher.cs
+++ b/src/Director/LingoEngine.Director.Core/FileSystems/IdeLauncher.cs
@@ -27,7 +27,11 @@ namespace LingoEngine.Director.Core.FileSystems
             switch (settings.PreferredIde)
             {
                 case IdeType.VisualStudio:
+#if USE_WINDOWS_FEATURES
                     OpenInVisualStudio(settings, filePath, line);
+#else
+                    OpenInVisualStudio(settings.VisualStudioPath, filePath, line);
+#endif
                     break;
 
                 case IdeType.VisualStudioCode:

--- a/src/LingoEngine.3D.Core/Members/LingoMember3D.cs
+++ b/src/LingoEngine.3D.Core/Members/LingoMember3D.cs
@@ -1,6 +1,8 @@
 using LingoEngine.Core;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Primitives;
+using LingoEngine.Casts;
+using LingoEngine.Members;
 
 namespace LingoEngine.Primitives3D;
 

--- a/src/LingoEngine.LGodot/GodotFactory.cs
+++ b/src/LingoEngine.LGodot/GodotFactory.cs
@@ -7,6 +7,7 @@ using LingoEngine.LGodot.Movies;
 using LingoEngine.LGodot.Pictures;
 using LingoEngine.LGodot.Sounds;
 using LingoEngine.LGodot.Texts;
+using LingoEngine.LGodot.Shapes;
 using LingoEngine.Inputs;
 using LingoEngine.Movies;
 using LingoEngine.Primitives;
@@ -17,6 +18,7 @@ using LingoEngine.Pictures;
 using LingoEngine.LGodot.Stages;
 using LingoEngine.Members;
 using LingoEngine.Casts;
+using LingoEngine.Shapes;
 
 namespace LingoEngine.LGodot
 {
@@ -66,6 +68,7 @@ namespace LingoEngine.LGodot
                 Type t when t == typeof(LingoMemberField) => (CreateMemberField(cast, numberInCast, name) as T)!,
                 Type t when t == typeof(LingoMemberSound) => (CreateMemberSound(cast, numberInCast, name) as T)!,
                 Type t when t == typeof(LingoMemberFilmLoop) => (CreateMemberFilmLoop(cast, numberInCast, name) as T)!,
+                Type t when t == typeof(LingoMemberShape) => (CreateMemberShape(cast, numberInCast, name) as T)!,
             };
         }
         public LingoMemberSound CreateMemberSound(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default)
@@ -81,6 +84,13 @@ namespace LingoEngine.LGodot
             var impl = new LingoGodotMemberFilmLoop();
             var member = new LingoMemberFilmLoop(impl, (LingoCast)cast, numberInCast, name, fileName ?? "", regPoint);
             impl.Init(member);
+            _disposables.Add(impl);
+            return member;
+        }
+        public LingoMemberShape CreateMemberShape(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default)
+        {
+            var impl = new LingoGodotMemberShape();
+            var member = new LingoMemberShape((LingoCast)cast, impl, numberInCast, name, fileName ?? "", regPoint);
             _disposables.Add(impl);
             return member;
         }

--- a/src/LingoEngine.LGodot/Shapes/LingoGodotMemberShape.cs
+++ b/src/LingoEngine.LGodot/Shapes/LingoGodotMemberShape.cs
@@ -1,0 +1,28 @@
+using System;
+using Godot;
+using LingoEngine.Primitives;
+using LingoEngine.Shapes;
+
+namespace LingoEngine.LGodot.Shapes
+{
+    public class LingoGodotMemberShape : ILingoFrameworkMemberShape, IDisposable
+    {
+        public bool IsLoaded { get; private set; }
+        public LingoList<LingoPoint> VertexList { get; } = new();
+        public LingoShapeType ShapeType { get; set; } = LingoShapeType.Rectangle;
+        public LingoColor FillColor { get; set; } = LingoColor.FromRGB(255, 255, 255);
+        public LingoColor EndColor { get; set; } = LingoColor.FromRGB(255, 255, 255);
+        public LingoColor StrokeColor { get; set; } = LingoColor.FromRGB(0, 0, 0);
+        public int StrokeWidth { get; set; } = 1;
+        public bool Closed { get; set; } = true;
+        public bool AntiAlias { get; set; } = true;
+
+        public void CopyToClipboard() { }
+        public void Erase() { VertexList.Clear(); }
+        public void ImportFileInto() { }
+        public void PasteClipboardInto() { }
+        public void Preload() { IsLoaded = true; }
+        public void Unload() { IsLoaded = false; }
+        public void Dispose() { }
+    }
+}

--- a/src/LingoEngine.SDL2/SdlFactory.cs
+++ b/src/LingoEngine.SDL2/SdlFactory.cs
@@ -12,7 +12,9 @@ using LingoEngine.SDL2.Movies;
 using LingoEngine.SDL2.Pictures;
 using LingoEngine.SDL2.Sounds;
 using LingoEngine.SDL2.Texts;
+using LingoEngine.SDL2.Shapes;
 using LingoEngine.Sounds;
+using LingoEngine.Shapes;
 using LingoEngine.Texts;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -79,6 +81,13 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
         var impl = new SdlMemberFilmLoop();
         var member = new LingoMemberFilmLoop(impl, (LingoCast)cast, numberInCast, name, fileName ?? "", regPoint);
         impl.Init(member);
+        _disposables.Add(impl);
+        return member;
+    }
+    public LingoMemberShape CreateMemberShape(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default)
+    {
+        var impl = new SdlMemberShape();
+        var member = new LingoMemberShape((LingoCast)cast, impl, numberInCast, name, fileName ?? "", regPoint);
         _disposables.Add(impl);
         return member;
     }

--- a/src/LingoEngine.SDL2/Shapes/SdlMemberShape.cs
+++ b/src/LingoEngine.SDL2/Shapes/SdlMemberShape.cs
@@ -1,0 +1,27 @@
+using System;
+using LingoEngine.Primitives;
+using LingoEngine.Shapes;
+
+namespace LingoEngine.SDL2.Shapes
+{
+    public class SdlMemberShape : ILingoFrameworkMemberShape, IDisposable
+    {
+        public bool IsLoaded { get; private set; }
+        public LingoList<LingoPoint> VertexList { get; } = new();
+        public LingoShapeType ShapeType { get; set; } = LingoShapeType.Rectangle;
+        public LingoColor FillColor { get; set; } = LingoColor.FromRGB(255, 255, 255);
+        public LingoColor EndColor { get; set; } = LingoColor.FromRGB(255, 255, 255);
+        public LingoColor StrokeColor { get; set; } = LingoColor.FromRGB(0, 0, 0);
+        public int StrokeWidth { get; set; } = 1;
+        public bool Closed { get; set; } = true;
+        public bool AntiAlias { get; set; } = true;
+
+        public void CopyToClipboard() { }
+        public void Erase() { VertexList.Clear(); }
+        public void ImportFileInto() { }
+        public void PasteClipboardInto() { }
+        public void Preload() { IsLoaded = true; }
+        public void Unload() { IsLoaded = false; }
+        public void Dispose() { }
+    }
+}

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
@@ -6,6 +6,7 @@ using LingoEngine.Movies;
 using LingoEngine.Pictures;
 using LingoEngine.Primitives;
 using LingoEngine.Sounds;
+using LingoEngine.Shapes;
 using LingoEngine.Texts;
 
 namespace LingoEngine.FrameworkCommunication
@@ -38,6 +39,8 @@ namespace LingoEngine.FrameworkCommunication
         LingoMemberSound CreateMemberSound(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default);
         /// <summary>Creates a film loop member.</summary>
         LingoMemberFilmLoop CreateMemberFilmLoop(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default);
+        /// <summary>Creates a vector shape member.</summary>
+        LingoMemberShape CreateMemberShape(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default);
         /// <summary>Creates a field member.</summary>
         LingoMemberField CreateMemberField(ILingoCast cast, int numberInCast, string name = "", string? fileName = null,
             LingoPoint regPoint = default);

--- a/src/LingoEngine/Members/LingoMemberFactory.cs
+++ b/src/LingoEngine/Members/LingoMemberFactory.cs
@@ -2,6 +2,7 @@
 using LingoEngine.Movies;
 using LingoEngine.Pictures;
 using LingoEngine.Sounds;
+using LingoEngine.Shapes;
 using LingoEngine.Texts;
 
 namespace LingoEngine.Members
@@ -12,6 +13,7 @@ namespace LingoEngine.Members
         LingoMemberPicture Picture(int numberInCast = 0, string name = "");
         LingoMemberSound Sound(int numberInCast = 0, string name = "");
         LingoMemberFilmLoop FilmLoop(int numberInCast = 0, string name = "");
+        LingoMemberShape Shape(int numberInCast = 0, string name = "");
         LingoMemberText Text(int numberInCast = 0, string name = "");
     }
 
@@ -30,6 +32,7 @@ namespace LingoEngine.Members
         public LingoMemberPicture Picture(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberPicture(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
         public LingoMemberSound Sound(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberSound(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
         public LingoMemberFilmLoop FilmLoop(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberFilmLoop(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
+        public LingoMemberShape Shape(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberShape(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
         public LingoMemberText Text(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberText(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
     }
 }

--- a/src/LingoEngine/Movies/LingoStage.cs
+++ b/src/LingoEngine/Movies/LingoStage.cs
@@ -30,7 +30,7 @@ namespace LingoEngine.Movies
             _lingoFrameworkMovieStage = godotInstance;
         }
 
-        internal void AddKeyFrame(LingoSprite sprite)
+        public void AddKeyFrame(LingoSprite sprite)
         {
             if (!RecordKeyframes || ActiveMovie == null)
                 return;
@@ -38,7 +38,7 @@ namespace LingoEngine.Movies
             sprite.AddKeyframes((frame, sprite.LocH, sprite.LocV, sprite.Rotation, sprite.Skew));
         }
 
-        internal void UpdateKeyFrame(LingoSprite sprite)
+        public void UpdateKeyFrame(LingoSprite sprite)
         {
             if (!RecordKeyframes || ActiveMovie == null)
                 return;
@@ -46,7 +46,7 @@ namespace LingoEngine.Movies
             sprite.UpdateKeyframe(frame, sprite.LocH, sprite.LocV, sprite.Rotation, sprite.Skew);
         }
 
-        internal void SetSpriteTweenOptions(LingoSprite sprite, bool positionEnabled, bool rotationEnabled,
+        public void SetSpriteTweenOptions(LingoSprite sprite, bool positionEnabled, bool rotationEnabled,
             bool skewEnabled, bool foregroundColorEnabled, bool backgroundColorEnabled, bool blendEnabled,
             float curvature, bool continuousAtEnds, bool speedSmooth, float easeIn, float easeOut)
         {
@@ -66,7 +66,7 @@ namespace LingoEngine.Movies
         }
 
      
-        internal LingoSprite? GetSpriteUnderMouse()
+        public LingoSprite? GetSpriteUnderMouse()
         {
             if (ActiveMovie == null)
                 return null;

--- a/src/LingoEngine/Primitives/LingoInkType.cs
+++ b/src/LingoEngine/Primitives/LingoInkType.cs
@@ -1,0 +1,24 @@
+namespace LingoEngine.Primitives
+{
+    public enum LingoInkType
+    {
+        Copy = 0,
+        Transparent,
+        Reverse,
+        Ghost,
+        NotCopy,
+        NotTransparent,
+        NotReverse,
+        NotGhost,
+        Matte,
+        Mask,
+        Blend = 32,
+        AddPin,
+        Add,
+        SubPin,
+        BackgndTrans,
+        Light,
+        Sub,
+        Dark
+    }
+}

--- a/src/LingoEngine/Shapes/ILingoFrameworkMemberShape.cs
+++ b/src/LingoEngine/Shapes/ILingoFrameworkMemberShape.cs
@@ -1,0 +1,17 @@
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.Shapes
+{
+    public interface ILingoFrameworkMemberShape : ILingoFrameworkMember
+    {
+        LingoList<LingoPoint> VertexList { get; }
+        LingoShapeType ShapeType { get; set; }
+        LingoColor FillColor { get; set; }
+        LingoColor EndColor { get; set; }
+        LingoColor StrokeColor { get; set; }
+        int StrokeWidth { get; set; }
+        bool Closed { get; set; }
+        bool AntiAlias { get; set; }
+    }
+}

--- a/src/LingoEngine/Shapes/LingoMemberShape.cs
+++ b/src/LingoEngine/Shapes/LingoMemberShape.cs
@@ -1,0 +1,36 @@
+using LingoEngine.Casts;
+using LingoEngine.Members;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.Shapes
+{
+    /// <summary>
+    /// Represents a vector shape cast member.
+    /// </summary>
+    public class LingoMemberShape : LingoMember
+    {
+        private readonly ILingoFrameworkMemberShape _framework;
+
+        public LingoList<LingoPoint> VertexList => _framework.VertexList;
+        public LingoShapeType ShapeType { get => _framework.ShapeType; set => _framework.ShapeType = value; }
+        public LingoColor FillColor { get => _framework.FillColor; set => _framework.FillColor = value; }
+        public LingoColor EndColor { get => _framework.EndColor; set => _framework.EndColor = value; }
+        public LingoColor StrokeColor { get => _framework.StrokeColor; set => _framework.StrokeColor = value; }
+        public int StrokeWidth { get => _framework.StrokeWidth; set => _framework.StrokeWidth = value; }
+        public bool Closed { get => _framework.Closed; set => _framework.Closed = value; }
+        public bool AntiAlias { get => _framework.AntiAlias; set => _framework.AntiAlias = value; }
+
+        public T Framework<T>() where T : ILingoFrameworkMemberShape => (T)_framework;
+
+        public LingoMemberShape(LingoCast cast, ILingoFrameworkMemberShape framework, int numberInCast, string name = "", string fileName = "", LingoPoint regPoint = default)
+            : base(framework, LingoMemberType.VectorShape, cast, numberInCast, name, fileName, regPoint)
+        {
+            _framework = framework;
+        }
+
+        protected override LingoMember OnDuplicate(int newNumber)
+        {
+            throw new NotImplementedException("_framework has to be retrieved from the factory");
+        }
+    }
+}

--- a/src/LingoEngine/Shapes/LingoShapeType.cs
+++ b/src/LingoEngine/Shapes/LingoShapeType.cs
@@ -1,0 +1,10 @@
+namespace LingoEngine.Shapes
+{
+    public enum LingoShapeType
+    {
+        Rectangle = 1,
+        RoundRect = 2,
+        Oval = 3,
+        Line = 4
+    }
+}


### PR DESCRIPTION
## Summary
- add `LingoShapeType` and `LingoInkType` enums
- add `ILingoFrameworkMemberShape` and `LingoMemberShape`
- implement Godot and SDL backends for vector shapes
- extend factories to create shape members
- fix minor compile issues in 3D member and IDE launcher
- make stage keyframe helpers public and move ink type to primitives

## Testing
- `dotnet restore`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_685705ff1cc4833299d63b9fd4ffdbe6