### PR TITLE
Add Import/Export window with wizard step

### DIFF
--- a/src/Director/LingoEngine.Director.Core/DirectorSetup.cs
+++ b/src/Director/LingoEngine.Director.Core/DirectorSetup.cs
@@ -42,6 +42,7 @@ namespace LingoEngine.Director.Core
                     .AddSingleton<DirectorStageWindow>()
                     .AddSingleton<DirectorTextEditWindow>()
                     .AddSingleton<DirectorPictureEditWindow>()
+                    .AddSingleton<DirectorImportExportWindow>()
                     );
             engineRegistration.AddBuildAction(
                 (serviceProvider) =>

--- a/src/Director/LingoEngine.Director.Core/Gfx/DirectorImportExportWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Gfx/DirectorImportExportWindow.cs
@@ -1,0 +1,8 @@
+using LingoEngine.Director.Core.Windows;
+
+namespace LingoEngine.Director.Core.Gfx
+{
+    public class DirectorImportExportWindow : DirectorWindow<IDirFrameworkImportExportWindow>
+    {
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Windows/DirectorMenuCodes.cs
+++ b/src/Director/LingoEngine.Director.Core/Windows/DirectorMenuCodes.cs
@@ -15,5 +15,6 @@ namespace LingoEngine.Director.LGodot.Gfx
         public const string BinaryViewerWindow = "BinaryViewerWindow";
         public const string TextEditWindow = "TextEditWindow";
         public const string PictureEditWindow = "PictureEditWindow";
+        public const string ImportExportWindow = "ImportExportWindow";
     }
 }

--- a/src/Director/LingoEngine.Director.Core/Windows/DirectorWindowRegistrator.cs
+++ b/src/Director/LingoEngine.Director.Core/Windows/DirectorWindowRegistrator.cs
@@ -27,6 +27,7 @@ namespace LingoEngine.Director.Core.Windows
                 .Register<DirectorStageWindow>(DirectorMenuCodes.StageWindow, shortCutManager.CreateShortCut(DirectorMenuCodes.StageWindow, "Ctrl+1", sc => new ExecuteShortCutCommand(sc)))
                 .Register<DirectorTextEditWindow>(DirectorMenuCodes.TextEditWindow, shortCutManager.CreateShortCut(DirectorMenuCodes.TextEditWindow, "Ctrl+T", sc => new ExecuteShortCutCommand(sc)))
                 .Register<DirectorPictureEditWindow>(DirectorMenuCodes.PictureEditWindow, shortCutManager.CreateShortCut(DirectorMenuCodes.PictureEditWindow, "Ctrl+5", sc => new ExecuteShortCutCommand(sc)))
+                .Register<DirectorImportExportWindow>(DirectorMenuCodes.ImportExportWindow)
                 ;
 
             return serviceProvider;

--- a/src/Director/LingoEngine.Director.Core/Windows/IDirFrameworkWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Windows/IDirFrameworkWindow.cs
@@ -24,4 +24,5 @@ namespace LingoEngine.Director.Core.Windows
     public interface IDirFrameworkPropertyInspectorWindow : IDirFrameworkWindow { }
     public interface IDirFrameworkTextEditWindow : IDirFrameworkWindow { }
     public interface IDirFrameworkPictureEditWindow : IDirFrameworkWindow { }
+    public interface IDirFrameworkImportExportWindow : IDirFrameworkWindow { }
 }

--- a/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
@@ -34,6 +34,7 @@ namespace LingoEngine.Director.LGodot
                 s.AddSingleton<DirGodotScoreWindow>();
                 s.AddSingleton<DirGodotStageWindow>();
                 s.AddSingleton<DirGodotBinaryViewerWindow>();
+                s.AddSingleton<DirGodotImportExportWindow>();
                 s.AddSingleton<DirGodotPropertyInspector>();
                 s.AddSingleton<DirGodotTextableMemberWindow>();
                 s.AddSingleton<DirGodotPictureMemberEditorWindow>();
@@ -50,6 +51,7 @@ namespace LingoEngine.Director.LGodot
                 s.AddTransient<IDirFrameworkBinaryViewerWindow>(p => p.GetRequiredService<DirGodotBinaryViewerWindow>());
                 s.AddTransient<IDirFrameworkPropertyInspectorWindow>(p => p.GetRequiredService<DirGodotPropertyInspector>());
                 s.AddTransient<IDirFrameworkPictureEditWindow>(p => p.GetRequiredService<DirGodotPictureMemberEditorWindow>());
+                s.AddTransient<IDirFrameworkImportExportWindow>(p => p.GetRequiredService<DirGodotImportExportWindow>());
                 s.AddTransient<IDirGodotWindowManager>(p => p.GetRequiredService<DirGodotWindowManager>());
 
 

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotImportExportWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotImportExportWindow.cs
@@ -1,0 +1,55 @@
+using Godot;
+using LingoEngine.Director.Core.Gfx;
+using LingoEngine.Director.Core.Windows;
+
+namespace LingoEngine.Director.LGodot.Gfx;
+
+internal partial class DirGodotImportExportWindow : BaseGodotWindow, IDirFrameworkImportExportWindow
+{
+    private readonly VBoxContainer _home = new();
+    private readonly ImportLingoFilesStep _importLingoStep;
+    private readonly Button _scriptsButton = new();
+    private readonly Button _dirButton = new();
+    private readonly Button _exportButton = new();
+
+    public DirGodotImportExportWindow(ProjectSettings settings, DirectorImportExportWindow directorWindow, IDirGodotWindowManager windowManager)
+        : base(DirectorMenuCodes.ImportExportWindow, "Import / Export", windowManager)
+    {
+        directorWindow.Init(this);
+        Size = new Vector2(400, 300);
+        CustomMinimumSize = Size;
+
+        _home.Position = new Vector2(5, TitleBarHeight + 5);
+        _home.SizeFlagsHorizontal = SizeFlags.ExpandFill;
+        _home.SizeFlagsVertical = SizeFlags.ExpandFill;
+        AddChild(_home);
+
+        _scriptsButton.Text = "Import Lingo scripts";
+        _scriptsButton.Pressed += () => ShowStep(_importLingoStep);
+        _home.AddChild(_scriptsButton);
+
+        _dirButton.Text = "Import dir/cst file";
+        _home.AddChild(_dirButton);
+
+        _exportButton.Text = "Export/Optimize code through AI";
+        _home.AddChild(_exportButton);
+
+        _importLingoStep = new ImportLingoFilesStep(settings);
+        _importLingoStep.Back += ShowHome;
+        AddChild(_importLingoStep);
+
+        ShowHome();
+    }
+
+    private void ShowHome()
+    {
+        _home.Visible = true;
+        _importLingoStep.Visible = false;
+    }
+
+    private void ShowStep(Control step)
+    {
+        _home.Visible = false;
+        step.Visible = true;
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotMainMenu.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotMainMenu.cs
@@ -84,6 +84,7 @@ internal partial class DirGodotMainMenu : Control, IDirFrameworkMainMenuWindow
         var popupFile = _fileMenu.GetPopup();
         popupFile.AddItem("Load", 1);
         popupFile.AddItem("Save", 2);
+        popupFile.AddItem("Import/Export", 4);
         popupFile.AddItem("Quit", 3);
         popupFile.IdPressed += id =>
         {
@@ -91,6 +92,7 @@ internal partial class DirGodotMainMenu : Control, IDirFrameworkMainMenuWindow
             {
                 case 1: _projectManager.LoadMovie(); break;
                 case 2: _projectManager.SaveMovie(); break;
+                case 4: _windowManager.OpenWindow(DirectorMenuCodes.ImportExportWindow); break;
                 case 3:
                     // TODO: check project for unsaved changes before quitting
                     GetTree().Quit();

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/ImportLingoFilesStep.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/ImportLingoFilesStep.cs
@@ -1,0 +1,213 @@
+using Godot;
+using LingoEngine.Director.Core.Windows;
+using LingoEngine.Lingo.Core;
+using LingoEngine;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace LingoEngine.Director.LGodot.Gfx;
+
+internal partial class ImportLingoFilesStep : VBoxContainer
+{
+    private readonly ProjectSettings _settings;
+    private readonly VBoxContainer _fileList = new();
+    private readonly List<HBoxContainer> _rows = new();
+    private readonly HashSet<HBoxContainer> _selectedRows = new();
+    private readonly StyleBoxFlat _normalStyle = new();
+    private readonly StyleBoxFlat _selectedStyle = new() { BgColor = Colors.SkyBlue };
+    private readonly FileDialog _folderDialog = new();
+    private readonly Button _importButton = new();
+    private readonly OptionButton _bulkType = new();
+    private readonly Button _backButton = new();
+    private string _folderPath = string.Empty;
+
+    public event Action? Back;
+
+    public ImportLingoFilesStep(ProjectSettings settings)
+    {
+        _settings = settings;
+        Visible = false;
+
+        var selectBtn = new Button { Text = "Select Folder" };
+        selectBtn.Pressed += () => _folderDialog.PopupCentered();
+        AddChild(selectBtn);
+
+        _backButton.Text = "Back";
+        _backButton.Pressed += () => Back?.Invoke();
+        AddChild(_backButton);
+
+        _folderDialog.Access = FileDialog.AccessEnum.Filesystem;
+        _folderDialog.Mode = FileDialog.FileModeEnum.OpenDir;
+        _folderDialog.DirSelected += dir => LoadFolder(dir);
+        AddChild(_folderDialog);
+
+        var scroll = new ScrollContainer();
+        scroll.SizeFlagsHorizontal = SizeFlags.ExpandFill;
+        scroll.SizeFlagsVertical = SizeFlags.ExpandFill;
+        scroll.AddChild(_fileList);
+        AddChild(scroll);
+
+        var bulkRow = new HBoxContainer();
+        bulkRow.AddChild(new Label { Text = "Set type for selected" });
+        _bulkType.AddItem("Parent", (int)LingoScriptType.Parent);
+        _bulkType.AddItem("Movie", (int)LingoScriptType.Movie);
+        _bulkType.AddItem("Behavior", (int)LingoScriptType.Behavior);
+        _bulkType.Selected = 2;
+        _bulkType.ItemSelected += idx => ApplyBulkType((int)idx);
+        bulkRow.AddChild(_bulkType);
+        AddChild(bulkRow);
+
+        _importButton.Text = "Import";
+        _importButton.Pressed += OnImportPressed;
+        AddChild(_importButton);
+    }
+
+    private void LoadFolder(string path)
+    {
+        _folderPath = path;
+        foreach (var child in _fileList.GetChildren())
+        {
+            if (child is Node n)
+            {
+                _fileList.RemoveChild(n);
+                n.QueueFree();
+            }
+        }
+        _rows.Clear();
+        _selectedRows.Clear();
+        _lastClickedIndex = -1;
+
+        foreach (var file in Directory.GetFiles(path, "*.ls"))
+        {
+            var row = new HBoxContainer();
+            row.SetMeta("path", file);
+
+            var label = new Label { Text = Path.GetFileName(file), CustomMinimumSize = new Vector2(200, 16) };
+            row.AddChild(label);
+
+            var opt = new OptionButton();
+            opt.AddItem("Parent", (int)LingoScriptType.Parent);
+            opt.AddItem("Movie", (int)LingoScriptType.Movie);
+            opt.AddItem("Behavior", (int)LingoScriptType.Behavior);
+            opt.Selected = 2;
+            row.AddChild(opt);
+            row.SetMeta("opt", opt);
+
+            row.AddThemeStyleboxOverride("panel", _normalStyle);
+            row.MouseFilter = MouseFilterEnum.Stop;
+            row.GuiInput += (InputEvent e) => OnRowGuiInput(row, e);
+
+            _fileList.AddChild(row);
+            _rows.Add(row);
+        }
+    }
+
+    private int _lastClickedIndex = -1;
+
+    private void OnRowGuiInput(HBoxContainer row, InputEvent @event)
+    {
+        if (@event is InputEventMouseButton mb && mb.ButtonIndex == MouseButton.Left && mb.Pressed)
+        {
+            int index = _rows.IndexOf(row);
+            bool shift = Input.IsKeyPressed(Key.Shift);
+            bool ctrl = Input.IsKeyPressed(Key.Ctrl);
+
+            if (shift && _lastClickedIndex >= 0)
+            {
+                if (!ctrl)
+                    ClearSelection();
+                int start = Mathf.Min(_lastClickedIndex, index);
+                int end = Mathf.Max(_lastClickedIndex, index);
+                for (int i = start; i <= end; i++)
+                    SelectRow(_rows[i], true);
+            }
+            else if (ctrl)
+            {
+                if (_selectedRows.Contains(row))
+                    SelectRow(row, false);
+                else
+                    SelectRow(row, true);
+                _lastClickedIndex = index;
+            }
+            else
+            {
+                ClearSelection();
+                SelectRow(row, true);
+                _lastClickedIndex = index;
+            }
+        }
+    }
+
+    private void ApplyBulkType(int id)
+    {
+        foreach (var row in _selectedRows)
+        {
+            if (row.GetMeta("opt") is OptionButton opt)
+                opt.Selected = id;
+        }
+    }
+
+    private void ClearSelection()
+    {
+        foreach (var row in _selectedRows.ToList())
+            SelectRow(row, false);
+    }
+
+    private void SelectRow(HBoxContainer row, bool select)
+    {
+        if (select)
+        {
+            if (_selectedRows.Add(row))
+                row.AddThemeStyleboxOverride("panel", _selectedStyle);
+        }
+        else
+        {
+            if (_selectedRows.Remove(row))
+                row.AddThemeStyleboxOverride("panel", _normalStyle);
+        }
+    }
+
+    private void OnImportPressed()
+    {
+        if (string.IsNullOrEmpty(_folderPath) || !_settings.HasValidSettings)
+            return;
+
+        var scripts = new List<LingoScriptFile>();
+        foreach (var child in _fileList.GetChildren())
+        {
+            if (child is HBoxContainer row)
+            {
+                string path = (string)row.GetMeta("path");
+                var opt = (OptionButton)row.GetMeta("opt");
+                var type = (LingoScriptType)opt.GetSelectedId();
+                scripts.Add(new LingoScriptFile
+                {
+                    Name = Path.GetFileNameWithoutExtension(path),
+                    Source = File.ReadAllText(path),
+                    Type = type
+                });
+            }
+        }
+
+        if (scripts.Count == 0)
+            return;
+
+        var result = LingoToCSharpConverter.Convert(scripts);
+        foreach (var script in scripts)
+        {
+            if (!result.ConvertedScripts.TryGetValue(script.Name, out var code))
+                continue;
+            string folder = script.Type switch
+            {
+                LingoScriptType.Movie => Path.Combine(_settings.ProjectFolder, "MovieScripts"),
+                LingoScriptType.Parent => Path.Combine(_settings.ProjectFolder, "ParentScripts"),
+                LingoScriptType.Behavior => Path.Combine(_settings.ProjectFolder, "Sprites", "Behaviors"),
+                _ => _settings.ProjectFolder
+            };
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(Path.Combine(folder, script.Name + ".cs"), code);
+        }
+        Back?.Invoke();
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/LingoGodotDirectorRoot.cs
@@ -22,6 +22,7 @@ namespace LingoEngine.Director.LGodot.Gfx
         private readonly DirGodotMainMenu _dirGodotMainMenu;
         private readonly DirGodotProjectSettingsWindow _projectSettingsWindow;
         private readonly DirGodotBinaryViewerWindow _binaryViewer;
+        private readonly DirGodotImportExportWindow _importExportWindow;
         private readonly DirGodotTextableMemberWindow _textWindow;
         private readonly DirGodotPictureMemberEditorWindow _picture;
 
@@ -45,6 +46,7 @@ namespace LingoEngine.Director.LGodot.Gfx
             _propertyInspector = serviceProvider.GetRequiredService<DirGodotPropertyInspector>();
             _toolsWindow = serviceProvider.GetRequiredService<DirGodotToolsWindow>();
             _binaryViewer = serviceProvider.GetRequiredService<DirGodotBinaryViewerWindow>();
+            _importExportWindow = serviceProvider.GetRequiredService<DirGodotImportExportWindow>();
             _textWindow = serviceProvider.GetRequiredService<DirGodotTextableMemberWindow>();
             _picture = serviceProvider.GetRequiredService<DirGodotPictureMemberEditorWindow>();
 
@@ -55,6 +57,7 @@ namespace LingoEngine.Director.LGodot.Gfx
             _directorParent.AddChild(_castViewer);
             _directorParent.AddChild(_scoreWindow);
             _directorParent.AddChild(_toolsWindow);
+            _directorParent.AddChild(_importExportWindow);
             _directorParent.AddChild(_textWindow);
             _directorParent.AddChild(_propertyInspector);
             _directorParent.AddChild(_binaryViewer);
@@ -65,6 +68,7 @@ namespace LingoEngine.Director.LGodot.Gfx
             // close some windows
             _projectSettingsWindow.CloseWindow();
             _binaryViewer.CloseWindow();
+            _importExportWindow.CloseWindow();
             _textWindow.CloseWindow();
             _picture.CloseWindow();
 
@@ -78,6 +82,7 @@ namespace LingoEngine.Director.LGodot.Gfx
             _propertyInspector.Position = new Vector2(1330, 25);
             _toolsWindow.Position = new Vector2(10, 25);
             _binaryViewer.Position = new Vector2(20, 120);
+            _importExportWindow.Position = new Vector2(120, 120);
             _projectSettingsWindow.Position = new Vector2(100, 100);
             _textWindow.Position = new Vector2(20, 120);
             _picture.Position = new Vector2(20, 120);
@@ -93,6 +98,7 @@ namespace LingoEngine.Director.LGodot.Gfx
             _propertyInspector.Dispose();
             _toolsWindow.Dispose();
             _binaryViewer.Dispose();
+            _importExportWindow.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Summary
- rename script importer to Import/Export window and update menu codes
- implement ImportLingoFilesStep wizard for Lingo script conversion
- add Godot Import/Export window with a homepage to launch steps
- wire new window into setup, root, and main menu
- enable multiselect editing for Lingo script import step

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570a45cec483328f559e9722cad091