### PR TITLE
Fix picture editor centering and editor top bars

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Casts/TextableMemberWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/TextableMemberWindow.cs
@@ -16,6 +16,7 @@ internal partial class DirGodotTextableMemberWindow : BaseGodotWindow, IHasMembe
     private readonly Button _alignCenter = new Button();
     private readonly Button _alignRight = new Button();
     private readonly SpinBox _fontSize = new SpinBox();
+    private readonly HBoxContainer _topBar = new HBoxContainer();
 
     private ILingoMemberTextBase? _member;
 
@@ -28,30 +29,31 @@ internal partial class DirGodotTextableMemberWindow : BaseGodotWindow, IHasMembe
         Size = new Vector2(300, 200);
         CustomMinimumSize = Size;
 
-        var bar = new HBoxContainer();
-        bar.Position = new Vector2(0, TitleBarHeight);
-        AddChild(bar);
+        _topBar.Position = new Vector2(0, TitleBarHeight);
+        _topBar.CustomMinimumSize = new Vector2(Size.X, 20);
+        _topBar.SizeFlagsHorizontal = SizeFlags.ExpandFill;
+        AddChild(_topBar);
 
         _alignLeft.Text = "L";
         _alignLeft.CustomMinimumSize = new Vector2(20, 16);
         _alignLeft.Pressed += () => SetAlignment(LingoTextAlignment.Left);
-        bar.AddChild(_alignLeft);
+        _topBar.AddChild(_alignLeft);
 
         _alignCenter.Text = "C";
         _alignCenter.CustomMinimumSize = new Vector2(20, 16);
         _alignCenter.Pressed += () => SetAlignment(LingoTextAlignment.Center);
-        bar.AddChild(_alignCenter);
+        _topBar.AddChild(_alignCenter);
 
         _alignRight.Text = "R";
         _alignRight.CustomMinimumSize = new Vector2(20, 16);
         _alignRight.Pressed += () => SetAlignment(LingoTextAlignment.Right);
-        bar.AddChild(_alignRight);
+        _topBar.AddChild(_alignRight);
 
         _fontSize.MinValue = 1;
         _fontSize.MaxValue = 200;
         _fontSize.CustomMinimumSize = new Vector2(50, 16);
         _fontSize.ValueChanged += v => { if (_member != null) _member.FontSize = (int)v; };
-        bar.AddChild(_fontSize);
+        _topBar.AddChild(_fontSize);
 
         _textEdit.Position = new Vector2(0, TitleBarHeight + 20);
         _textEdit.Size = new Vector2(Size.X - 10, Size.Y - (TitleBarHeight + 25));
@@ -78,6 +80,7 @@ internal partial class DirGodotTextableMemberWindow : BaseGodotWindow, IHasMembe
     protected override void OnResizing(Vector2 size)
     {
         base.OnResizing(size);
+        _topBar.CustomMinimumSize = new Vector2(size.X, 20);
         _textEdit.Size = new Vector2(size.X - 10, size.Y - (TitleBarHeight + 25));
     }
 

--- a/src/Director/LingoEngine.Director.LGodot/Pictures/DirGodotPictureMemberEditorWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Pictures/DirGodotPictureMemberEditorWindow.cs
@@ -230,11 +230,28 @@ internal partial class DirGodotPictureMemberEditorWindow : BaseGodotWindow, IHas
         Vector2 view = _scrollContainer.Size;
         if (view == Vector2.Zero)
             view = new Vector2(Size.X, Size.Y - (TitleBarHeight + IconBarHeight + BottomBarHeight));
-        Vector2 img = _centerContainer.CustomMinimumSize * _scale;
-        int h = (int)Mathf.Max(0, (img.X - view.X) / 2f);
-        int v = (int)Mathf.Max(0, (img.Y - view.Y) / 2f);
-        _scrollContainer.ScrollHorizontal = h;
-        _scrollContainer.ScrollVertical = v;
+
+        if (_member == null)
+            return;
+
+        // Calculate the scaled work area size
+        Vector2 canvasSize = _centerContainer.CustomMinimumSize * _scale;
+
+        // Determine the position of the registration point within the canvas
+        Vector2 canvasHalf = _centerContainer.CustomMinimumSize / 2f;
+        Vector2 imageHalf = _imageRect.CustomMinimumSize / 2f;
+        Vector2 regOffset = canvasHalf - imageHalf + new Vector2(_member.RegPoint.X, _member.RegPoint.Y);
+        Vector2 regPos = regOffset * _scale;
+
+        // Desired scroll positions so the reg point is centered in view
+        float desiredH = regPos.X - view.X / 2f;
+        float desiredV = regPos.Y - view.Y / 2f;
+
+        int maxH = (int)Mathf.Max(0, canvasSize.X - view.X);
+        int maxV = (int)Mathf.Max(0, canvasSize.Y - view.Y);
+
+        _scrollContainer.ScrollHorizontal = (int)Mathf.Clamp(desiredH, 0, maxH);
+        _scrollContainer.ScrollVertical = (int)Mathf.Clamp(desiredV, 0, maxV);
     }
 
     private void UpdateRegPointCanvasSize()


### PR DESCRIPTION
## Summary
- center picture editor on the registration point when selecting a member
- ensure text editor top bar is visible and resizes with the window

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68578556cc2c83329cdef5830148ae3a