### PR TITLE
Fix type icon position in cast view

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
@@ -13,7 +13,7 @@ using LingoEngine.Director.LGodot.Gfx;
 
 namespace LingoEngine.Director.LGodot.Casts
 {
-    internal partial class DirGodotCastItem : VBoxContainer
+    internal partial class DirGodotCastItem : Control
     {
         private readonly ColorRect _bg;
         private readonly ColorRect _selectionBg;
@@ -117,8 +117,14 @@ namespace LingoEngine.Director.LGodot.Casts
             _typeLabel.AddThemeStyleboxOverride("normal", typeStyle);
             _typeLabel.AddThemeColorOverride("font_color", Colors.Black);
             AddChild(_typeLabel);
-            _typeLabel.Position = new Vector2(Width - _typeLabel.CustomMinimumSize.X - 2,
-                Height - LabelHeight - _typeLabel.CustomMinimumSize.Y - 2);
+            _typeLabel.AnchorLeft = 1;
+            _typeLabel.AnchorRight = 1;
+            _typeLabel.AnchorTop = 1;
+            _typeLabel.AnchorBottom = 1;
+            _typeLabel.OffsetRight = -2;
+            _typeLabel.OffsetBottom = -LabelHeight - 2;
+            _typeLabel.OffsetLeft = -_typeLabel.CustomMinimumSize.X - 2;
+            _typeLabel.OffsetTop = -LabelHeight - _typeLabel.CustomMinimumSize.Y - 2;
 
             // Bottom label
             _caption = new Label
@@ -130,11 +136,19 @@ namespace LingoEngine.Director.LGodot.Casts
                 FontSize = 8,
             };
             AddChild(_caption);
-            _caption.Text = !string.IsNullOrWhiteSpace(element.Name)? element.NumberInCast+"."+ element.Name: number.ToString();
+            _caption.Text = !string.IsNullOrWhiteSpace(element.Name) ? element.NumberInCast + "." + element.Name : number.ToString();
             _caption.AddThemeColorOverride("font_color", Colors.Black);
             // Apply background style to the label using the "normal" stylebox
             _caption.AddThemeStyleboxOverride("normal", _normalLabelStyle);
             _caption.MouseFilter = MouseFilterEnum.Ignore;
+            _caption.AnchorLeft = 0;
+            _caption.AnchorRight = 1;
+            _caption.AnchorTop = 1;
+            _caption.AnchorBottom = 1;
+            _caption.OffsetLeft = 0;
+            _caption.OffsetRight = 0;
+            _caption.OffsetBottom = 0;
+            _caption.OffsetTop = -LabelHeight;
             
         }
         public void SetPosition(int x, int y)


### PR DESCRIPTION
## Summary
- keep custom position for type icon
- anchor caption at bottom
- switch cast item container to `Control`

## Testing
- `scripts/install-dotnet.sh` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_685788b3b71c8332a4d83084cd85582f