### PR TITLE
Fix score window sound bar layout

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -138,7 +138,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
 
     private void RepositionBars()
     {
-        float soundHeight = (_soundBar.Collapsed ? 0 : _gfxValues.ChannelHeight * 4) + 10;
+        float soundHeight = (_soundBar.Collapsed ? 0 : _gfxValues.ChannelHeight * 4);
         _frameScripts.Position = new Vector2(0, 20 + soundHeight);
         _header.Position = new Vector2(0, _frameScripts.Position.Y + 20);
 
@@ -241,16 +241,22 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         public DirGodotCastLeftTopLabels(DirGodotScoreGfxValues gfxValues)
         {
             _gfxValues = gfxValues;
-            Size = new Vector2(gfxValues.ChannelLabelWidth + gfxValues.ChannelHeight, gfxValues.TopStripHeight - 20);
+            int soundHeight = _gfxValues.ChannelHeight * 4;
+            int totalHeight = soundHeight + 40; // labels + scripts + header
+            Size = new Vector2(gfxValues.ChannelLabelWidth + gfxValues.ChannelHeight, totalHeight);
             Position = new Vector2(0, 20);
         }
         public override void _Draw()
         {
-            
+
             DrawRect(new Rect2(0, 0, Size.X, Size.Y), new Color("#f0f0f0"));
-            DrawTextWithLine(0,20, "Labels");
-            DrawTextWithLine(74,20, "Scripts");
-            DrawTextWithLine(102,23, "Member", false);
+            int labelHeight = 20;
+            int soundHeight = _gfxValues.ChannelHeight * 4;
+            int scriptTop = labelHeight + soundHeight;
+            int memberTop = scriptTop + labelHeight;
+            DrawTextWithLine(0, labelHeight, "Labels");
+            DrawTextWithLine(scriptTop, labelHeight, "Scripts");
+            DrawTextWithLine(memberTop, labelHeight, "Member", false);
         }
         private void DrawTextWithLine(int top, int height, string text, bool withTopLines = false)
         {

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotSoundBar.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotSoundBar.cs
@@ -56,12 +56,12 @@ internal partial class DirGodotSoundBar : Control
         QueueRedraw();
     }
 
-    public override bool _CanDropData(Vector2 atPosition, Variant data)
-    {
-        if (_movie == null || _collapsed) return false;
+        public override bool _CanDropData(Vector2 atPosition, Variant data)
+        {
+            if (_movie == null || _collapsed) return false;
 
-        var obj = data.Obj as LingoMemberSound;
-        return obj != null;
+            var obj = data.Obj as LingoMemberSound;
+            return obj != null;
     }
 
     public override void _DropData(Vector2 atPosition, Variant data)
@@ -81,9 +81,9 @@ internal partial class DirGodotSoundBar : Control
     {
         if (@event is InputEventMouseButton mb && mb.Pressed && mb.ButtonIndex == MouseButton.Left)
         {
-            if (!_collapsed && mb.Position.Y >= 10)
+            if (!_collapsed)
             {
-                int ch = (int)((mb.Position.Y - 10) / _gfxValues.ChannelHeight);
+                int ch = (int)(mb.Position.Y / _gfxValues.ChannelHeight);
                 if (ch >= 0 && ch < 4 && mb.Position.X >= 12 && mb.Position.X <= 28)
                 {
                     ToggleMute(ch);
@@ -96,8 +96,8 @@ internal partial class DirGodotSoundBar : Control
     {
         if (_movie == null) return;
         int channels = _collapsed ? 0 : 4;
-        float height = channels * _gfxValues.ChannelHeight + (_collapsed ? 0 : 0);
-        Size = new Vector2(_gfxValues.LeftMargin + _movie.FrameCount * _gfxValues.FrameWidth, height + 10);
+        float height = channels * _gfxValues.ChannelHeight;
+        Size = new Vector2(_gfxValues.LeftMargin + _movie.FrameCount * _gfxValues.FrameWidth, height);
         DrawRect(new Rect2(0,0,Size.X,Size.Y), new Color("#f0f0f0"));
 
         var font = ThemeDB.FallbackFont;
@@ -105,7 +105,7 @@ internal partial class DirGodotSoundBar : Control
 
         for (int c = 0; c < channels; c++)
         {
-            float y = c * _gfxValues.ChannelHeight + 10;
+            float y = c * _gfxValues.ChannelHeight;
             DrawLine(new Vector2(0, y), new Vector2(Size.X, y), Colors.DarkGray);
             DrawRect(new Rect2(0, y, _gfxValues.ChannelInfoWidth, _gfxValues.ChannelHeight), new Color("#f0f0f0"));
             string icon = _muted[c] ? "🔇" : "🔊";
@@ -119,7 +119,7 @@ internal partial class DirGodotSoundBar : Control
             if (ch < 0 || ch >= channels) continue;
             float x = _gfxValues.LeftMargin + (clip.Clip.BeginFrame -1) * _gfxValues.FrameWidth;
             float width = (clip.Clip.EndFrame - clip.Clip.BeginFrame +1) * _gfxValues.FrameWidth;
-            float y = ch * _gfxValues.ChannelHeight + 10;
+            float y = ch * _gfxValues.ChannelHeight;
             clip.Draw(this, new Vector2(x,y), width, _gfxValues.ChannelHeight, font);
         }
     }


### PR DESCRIPTION
## Summary
- align sound icons with sprite channel visibility buttons
- recalc top bar height without magic numbers
- sync Labels/Scripts/Member markers with new layout

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685793b389a88332b068461cdf04eae1