### PR TITLE
Fix audio channel layout in score viewer

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -154,6 +154,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         if (!Visible) return;
         _channelBar.Position = new Vector2(0, -_masterScroller.ScrollVertical);
         _topStripContent.Position = new Vector2(-_masterScroller.ScrollHorizontal, _topStripContent.Position.Y);
+        _soundBar.ScrollX = _masterScroller.ScrollHorizontal;
     }
 
     private void UpdateScrollSize()

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotSoundBar.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotSoundBar.cs
@@ -1,135 +1,49 @@
 using Godot;
-using System.Collections.Generic;
 using LingoEngine.Movies;
-using LingoEngine.Members;
-using LingoEngine.Sounds;
 
 namespace LingoEngine.Director.LGodot.Scores;
 
+/// <summary>
+/// Container for the sound channel header and grid.
+/// </summary>
 internal partial class DirGodotSoundBar : Control
 {
-    private LingoMovie? _movie;
-    private readonly List<DirGodotScoreAudioClip> _clips = new();
-    private readonly DirGodotScoreGfxValues _gfxValues;
-    private bool _dirty = true;
-    private bool _collapsed;
-    private readonly bool[] _muted = new bool[4];
+    private readonly DirGodotSoundHeader _header;
+    private readonly DirGodotSoundGrid _grid;
 
     public DirGodotSoundBar(DirGodotScoreGfxValues gfxValues)
     {
-        _gfxValues = gfxValues;
+        _header = new DirGodotSoundHeader(gfxValues);
+        _grid = new DirGodotSoundGrid(gfxValues) { Position = new Vector2(gfxValues.ChannelInfoWidth, 0) };
+        AddChild(_header);
+        AddChild(_grid);
     }
-
-    public bool IsMuted(int channel) => _muted[channel];
 
     public bool Collapsed
     {
-        get => _collapsed;
+        get => _grid.Collapsed;
         set
         {
-            _collapsed = value;
-            QueueRedraw();
+            _header.Collapsed = value;
+            _grid.Collapsed = value;
         }
+    }
+
+    public float ScrollX
+    {
+        get => _grid.ScrollX;
+        set => _grid.ScrollX = value;
     }
 
     public void SetMovie(LingoMovie? movie)
     {
-        if (_movie != null)
-            _movie.AudioClipListChanged -= OnClipsChanged;
-        _movie = movie;
-        _clips.Clear();
-        if (_movie != null)
-        {
-            foreach (var clip in _movie.GetAudioClips())
-                _clips.Add(new DirGodotScoreAudioClip(clip));
-            _movie.AudioClipListChanged += OnClipsChanged;
-        }
-        QueueRedraw();
+        _header.SetMovie(movie);
+        _grid.SetMovie(movie);
     }
 
-    private void OnClipsChanged()
+    protected override void OnResized()
     {
-        _clips.Clear();
-        if (_movie != null)
-            foreach (var clip in _movie.GetAudioClips())
-                _clips.Add(new DirGodotScoreAudioClip(clip));
-        QueueRedraw();
-    }
-
-        public override bool _CanDropData(Vector2 atPosition, Variant data)
-        {
-            if (_movie == null || _collapsed) return false;
-
-            var obj = data.Obj as LingoMemberSound;
-            return obj != null;
-    }
-
-    public override void _DropData(Vector2 atPosition, Variant data)
-    {
-        if (_movie == null || _collapsed) return;
-
-        var sound = data.Obj as LingoMemberSound;
-        if (sound == null) return;
-
-        int channel = (int)(atPosition.Y / _gfxValues.ChannelHeight);
-        int frame = Mathf.Clamp(Mathf.RoundToInt((atPosition.X - _gfxValues.LeftMargin) / _gfxValues.FrameWidth) + 1, 1, _movie.FrameCount);
-        _movie.AddAudioClip(channel, frame, sound);
-    }
-
-
-    public override void _GuiInput(InputEvent @event)
-    {
-        if (@event is InputEventMouseButton mb && mb.Pressed && mb.ButtonIndex == MouseButton.Left)
-        {
-            if (!_collapsed)
-            {
-                int ch = (int)(mb.Position.Y / _gfxValues.ChannelHeight);
-                if (ch >= 0 && ch < 4 && mb.Position.X >= 12 && mb.Position.X <= 28)
-                {
-                    ToggleMute(ch);
-                }
-            }
-        }
-    }
-
-    public override void _Draw()
-    {
-        if (_movie == null) return;
-        int channels = _collapsed ? 0 : 4;
-        float height = channels * _gfxValues.ChannelHeight;
-        Size = new Vector2(_gfxValues.LeftMargin + _movie.FrameCount * _gfxValues.FrameWidth, height);
-        DrawRect(new Rect2(0,0,Size.X,Size.Y), new Color("#f0f0f0"));
-
-        var font = ThemeDB.FallbackFont;
-        if (_collapsed) return;
-
-        for (int c = 0; c < channels; c++)
-        {
-            float y = c * _gfxValues.ChannelHeight;
-            DrawLine(new Vector2(0, y), new Vector2(Size.X, y), Colors.DarkGray);
-            DrawRect(new Rect2(0, y, _gfxValues.ChannelInfoWidth, _gfxValues.ChannelHeight), new Color("#f0f0f0"));
-            string icon = _muted[c] ? "🔇" : "🔊";
-            DrawString(font, new Vector2(4, y + font.GetAscent() - 6), icon, HorizontalAlignment.Left, -1, 11, new Color("#a0a0a0"));
-            DrawString(font, new Vector2(_gfxValues.ChannelHeight + 2, y + font.GetAscent() - 6), $"{c + 1}", HorizontalAlignment.Left, -1, 11, new Color("#a0a0a0"));
-        }
-
-        foreach (var clip in _clips)
-        {
-            int ch = clip.Clip.Channel;
-            if (ch < 0 || ch >= channels) continue;
-            float x = _gfxValues.LeftMargin + (clip.Clip.BeginFrame -1) * _gfxValues.FrameWidth;
-            float width = (clip.Clip.EndFrame - clip.Clip.BeginFrame +1) * _gfxValues.FrameWidth;
-            float y = ch * _gfxValues.ChannelHeight;
-            clip.Draw(this, new Vector2(x,y), width, _gfxValues.ChannelHeight, font);
-        }
-    }
-
-    private void ToggleMute(int channel)
-    {
-        if (_movie == null) return;
-        _muted[channel] = !_muted[channel];
-        var chObj = _movie.GetEnvironment().Sound.Channel(channel + 1);
-        chObj.Volume = _muted[channel] ? 0 : 255;
-        QueueRedraw();
+        base.OnResized();
+        _grid.Position = new Vector2(_header.Size.X, 0);
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotSoundGrid.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotSoundGrid.cs
@@ -1,0 +1,165 @@
+using Godot;
+using System.Collections.Generic;
+using LingoEngine.Movies;
+using LingoEngine.Members;
+using LingoEngine.Sounds;
+
+namespace LingoEngine.Director.LGodot.Scores;
+
+/// <summary>
+/// Draws the scrollable area with audio clips and grid lines.
+/// </summary>
+internal partial class DirGodotSoundGrid : Control
+{
+    private LingoMovie? _movie;
+    private readonly List<DirGodotScoreAudioClip> _clips = new();
+    private readonly DirGodotScoreGfxValues _gfxValues;
+    private bool _collapsed;
+    private bool _clipDirty = true;
+    private float _scrollX;
+
+    private readonly ClipCanvas _canvas;
+
+    public DirGodotSoundGrid(DirGodotScoreGfxValues gfxValues)
+    {
+        _gfxValues = gfxValues;
+        _canvas = new ClipCanvas(this);
+        AddChild(_canvas);
+    }
+
+    public bool Collapsed
+    {
+        get => _collapsed;
+        set
+        {
+            _collapsed = value;
+            _clipDirty = true;
+            QueueRedraw();
+        }
+    }
+
+    public float ScrollX
+    {
+        get => _scrollX;
+        set
+        {
+            _scrollX = value;
+            _canvas.QueueRedraw();
+            QueueRedraw();
+        }
+    }
+
+    public void SetMovie(LingoMovie? movie)
+    {
+        if (_movie != null)
+            _movie.AudioClipListChanged -= OnClipsChanged;
+        _movie = movie;
+        _clips.Clear();
+        if (_movie != null)
+        {
+            foreach (var clip in _movie.GetAudioClips())
+                _clips.Add(new DirGodotScoreAudioClip(clip));
+            _movie.AudioClipListChanged += OnClipsChanged;
+        }
+        UpdateSize();
+        _clipDirty = true;
+        QueueRedraw();
+    }
+
+    private void OnClipsChanged()
+    {
+        _clips.Clear();
+        if (_movie != null)
+            foreach (var clip in _movie.GetAudioClips())
+                _clips.Add(new DirGodotScoreAudioClip(clip));
+        _clipDirty = true;
+        QueueRedraw();
+    }
+
+    public override bool _CanDropData(Vector2 atPosition, Variant data)
+    {
+        if (_movie == null || _collapsed) return false;
+
+        var obj = data.Obj as LingoMemberSound;
+        if (obj == null) return false;
+
+        int channel = (int)(atPosition.Y / _gfxValues.ChannelHeight);
+        if (channel < 0 || channel >= 4) return false;
+
+        float frameX = atPosition.X + _scrollX;
+        if (frameX < 0) return false;
+
+        return true;
+    }
+
+    public override void _DropData(Vector2 atPosition, Variant data)
+    {
+        if (_movie == null || _collapsed) return;
+
+        var sound = data.Obj as LingoMemberSound;
+        if (sound == null) return;
+
+        int channel = (int)(atPosition.Y / _gfxValues.ChannelHeight);
+        float frameX = atPosition.X + _scrollX;
+        int frame = Mathf.Clamp(Mathf.RoundToInt(frameX / _gfxValues.FrameWidth) + 1, 1, _movie.FrameCount);
+        _movie.AddAudioClip(channel, frame, sound);
+    }
+
+    public override void _Process(double delta)
+    {
+        if (_clipDirty)
+        {
+            _clipDirty = false;
+            _canvas.QueueRedraw();
+        }
+    }
+
+    public override void _Draw()
+    {
+        if (_movie == null || _collapsed) return;
+        int channels = 4;
+        float height = channels * _gfxValues.ChannelHeight;
+        float width = _movie.FrameCount * _gfxValues.FrameWidth + _gfxValues.ExtraMargin;
+        Size = new Vector2(width, height);
+        DrawRect(new Rect2(0,0,width,height), new Color("#f0f0f0"));
+        for (int c = 0; c <= channels; c++)
+        {
+            float y = c * _gfxValues.ChannelHeight;
+            DrawLine(new Vector2(0, y), new Vector2(width, y), Colors.DarkGray);
+        }
+        for (int f = 0; f <= _movie.FrameCount; f++)
+        {
+            float x = -_scrollX + f * _gfxValues.FrameWidth;
+            DrawLine(new Vector2(x, 0), new Vector2(x, height), Colors.DarkGray);
+        }
+    }
+
+    private void UpdateSize()
+    {
+        if (_movie == null) return;
+        float width = _movie.FrameCount * _gfxValues.FrameWidth + _gfxValues.ExtraMargin;
+        float height = (_collapsed ? 0 : 4 * _gfxValues.ChannelHeight);
+        CustomMinimumSize = new Vector2(width, height);
+        _canvas.CustomMinimumSize = CustomMinimumSize;
+    }
+
+    private partial class ClipCanvas : Control
+    {
+        private readonly DirGodotSoundGrid _owner;
+        public ClipCanvas(DirGodotSoundGrid owner) => _owner = owner;
+        public override void _Draw()
+        {
+            var movie = _owner._movie;
+            if (movie == null || _owner._collapsed) return;
+            var font = ThemeDB.FallbackFont;
+            foreach (var clip in _owner._clips)
+            {
+                int ch = clip.Clip.Channel;
+                float x = -_owner._scrollX + (clip.Clip.BeginFrame - 1) * _owner._gfxValues.FrameWidth;
+                float width = (clip.Clip.EndFrame - clip.Clip.BeginFrame + 1) * _owner._gfxValues.FrameWidth;
+                float y = ch * _owner._gfxValues.ChannelHeight;
+                clip.Draw(this, new Vector2(x, y), width, _owner._gfxValues.ChannelHeight, font);
+            }
+        }
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotSoundHeader.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotSoundHeader.cs
@@ -1,0 +1,73 @@
+using Godot;
+using LingoEngine.Movies;
+
+namespace LingoEngine.Director.LGodot.Scores;
+
+/// <summary>
+/// Fixed left area showing sound channel icons and numbers.
+/// </summary>
+internal partial class DirGodotSoundHeader : Control
+{
+    private LingoMovie? _movie;
+    private readonly DirGodotScoreGfxValues _gfxValues;
+    private readonly bool[] _muted = new bool[4];
+    private bool _collapsed;
+
+    public DirGodotSoundHeader(DirGodotScoreGfxValues gfxValues)
+    {
+        _gfxValues = gfxValues;
+    }
+
+    public bool Collapsed
+    {
+        get => _collapsed;
+        set { _collapsed = value; QueueRedraw(); }
+    }
+
+    public void SetMovie(LingoMovie? movie)
+    {
+        _movie = movie;
+        QueueRedraw();
+    }
+
+    public bool IsMuted(int channel) => _muted[channel];
+
+    public override void _GuiInput(InputEvent @event)
+    {
+        if (@event is InputEventMouseButton mb && mb.Pressed && mb.ButtonIndex == MouseButton.Left)
+        {
+            if (!_collapsed)
+            {
+                int ch = (int)(mb.Position.Y / _gfxValues.ChannelHeight);
+                if (ch >= 0 && ch < 4 && mb.Position.X >= 12 && mb.Position.X <= 28)
+                    ToggleMute(ch);
+            }
+        }
+    }
+
+    public override void _Draw()
+    {
+        if (_movie == null || _collapsed) return;
+        int channels = 4;
+        float height = channels * _gfxValues.ChannelHeight;
+        Size = new Vector2(_gfxValues.ChannelInfoWidth, height);
+        DrawRect(new Rect2(0,0,Size.X,Size.Y), new Color("#f0f0f0"));
+        var font = ThemeDB.FallbackFont;
+        for (int c = 0; c < channels; c++)
+        {
+            float y = c * _gfxValues.ChannelHeight;
+            string icon = _muted[c] ? "🔇" : "🔊";
+            DrawString(font, new Vector2(4, y + font.GetAscent() - 6), icon, HorizontalAlignment.Left, -1, 11, new Color("#a0a0a0"));
+            DrawString(font, new Vector2(_gfxValues.ChannelHeight + 2, y + font.GetAscent() - 6), $"{c + 1}", HorizontalAlignment.Left, -1, 11, new Color("#a0a0a0"));
+        }
+    }
+
+    private void ToggleMute(int channel)
+    {
+        if (_movie == null) return;
+        _muted[channel] = !_muted[channel];
+        var chObj = _movie.GetEnvironment().Sound.Channel(channel + 1);
+        chObj.Volume = _muted[channel] ? 0 : 255;
+        QueueRedraw();
+    }
+}


### PR DESCRIPTION
## Summary
- split sound bar into a fixed header and a scrollable grid
- added canvas-based drawing of audio clips with dirty flag
- keep audio grid synced with score horizontal scroll

## Testing
- ❌ `dotnet test` (failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68579a8095a48332a654da49840b0249