### PR TITLE
Fix score layout and unify sound grid painter

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotGridPainter.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotGridPainter.cs
@@ -8,6 +8,7 @@ internal partial class DirGodotGridPainter : Control
     public int FrameCount { get; set; }
     public int ChannelCount { get; set; }
     public bool DrawBackground { get; set; } = true;
+    public float ScrollX { get; set; }
 
     public DirGodotGridPainter(DirGodotScoreGfxValues gfxValues)
     {
@@ -20,19 +21,19 @@ internal partial class DirGodotGridPainter : Control
         float height = ChannelCount * _gfxValues.ChannelHeight;
         Size = new Vector2(width, height);
         if (DrawBackground)
-            DrawRect(new Rect2(0, 0, width, height), Colors.White);
+            DrawRect(new Rect2(-ScrollX, 0, width, height), Colors.White);
         for (int f = 0; f < FrameCount; f++)
         {
-            float x = _gfxValues.LeftMargin + f * _gfxValues.FrameWidth;
+            float x = -ScrollX + _gfxValues.LeftMargin + f * _gfxValues.FrameWidth;
             if (f % 5 == 0)
                 DrawRect(new Rect2(x, 0, _gfxValues.FrameWidth, height), Colors.DarkGray);
         }
         for (int f = 0; f <= FrameCount; f++)
         {
-            float x = _gfxValues.LeftMargin + f * _gfxValues.FrameWidth;
+            float x = -ScrollX + _gfxValues.LeftMargin + f * _gfxValues.FrameWidth;
             DrawLine(new Vector2(x, 0), new Vector2(x, height), Colors.DarkGray);
         }
-        DrawLine(new Vector2(0, 0), new Vector2(width, 0), Colors.DarkGray);
-        DrawLine(new Vector2(0, height), new Vector2(width, height), Colors.DarkGray);
+        DrawLine(new Vector2(-ScrollX, 0), new Vector2(width - ScrollX, 0), Colors.DarkGray);
+        DrawLine(new Vector2(-ScrollX, height), new Vector2(width - ScrollX, height), Colors.DarkGray);
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -123,7 +123,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
 
        
         _labelBar.Position = new Vector2(0, 0);
-        _soundBar.Position = new Vector2(0, 20);
+        _soundBar.Position = new Vector2(0, 40);
         RepositionBars();
         
 
@@ -145,8 +145,8 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         _header.Position = new Vector2(0, _frameScripts.Position.Y + 20);
 
         float topHeight = _header.Position.Y + 20;
-        _masterScroller.Position = new Vector2(_gfxValues.ChannelInfoWidth, topHeight);
-        _vClipper.Position = new Vector2(0, topHeight);
+        _masterScroller.Position = new Vector2(_gfxValues.ChannelInfoWidth, topHeight + 20);
+        _vClipper.Position = new Vector2(0, topHeight + 20);
         _collapseButton.Position = new Vector2(_hClipper.Size.X - 16, 4);
         UpdateScrollSize();
     }
@@ -169,11 +169,11 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
 
         _channelBar.CustomMinimumSize = new Vector2(_gfxValues.ChannelInfoWidth, gridHeight - _footerMargin);
         _scrollContent.CustomMinimumSize = new Vector2(gridWidth, gridHeight - _footerMargin);
-        _topStripContent.CustomMinimumSize = new Vector2(gridWidth, topHeight);
+        _topStripContent.CustomMinimumSize = new Vector2(gridWidth, topHeight + 20);
 
-        _vClipper.Size = new Vector2(_gfxValues.ChannelInfoWidth, Size.Y - topHeight - _footerMargin);
-        _hClipper.Size = new Vector2(Size.X - _gfxValues.ChannelInfoWidth, topHeight);
-        _masterScroller.Size = new Vector2(Size.X - _gfxValues.ChannelInfoWidth, Size.Y - topHeight - _footerMargin);
+        _vClipper.Size = new Vector2(_gfxValues.ChannelInfoWidth, Size.Y - topHeight - 20 - _footerMargin);
+        _hClipper.Size = new Vector2(Size.X - _gfxValues.ChannelInfoWidth, topHeight + 20);
+        _masterScroller.Size = new Vector2(Size.X - _gfxValues.ChannelInfoWidth, Size.Y - topHeight - 20 - _footerMargin);
     }
 
 

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotSoundBar.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotSoundBar.cs
@@ -41,9 +41,15 @@ internal partial class DirGodotSoundBar : Control
         _grid.SetMovie(movie);
     }
 
-    protected override void OnResized()
+    public override void _Ready()
     {
-        base.OnResized();
+        base._Ready();
+        UpdateGridPosition();
+        Resized += UpdateGridPosition;
+    }
+
+    private void UpdateGridPosition()
+    {
         _grid.Position = new Vector2(_header.Size.X, 0);
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotSoundGrid.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotSoundGrid.cs
@@ -18,12 +18,15 @@ internal partial class DirGodotSoundGrid : Control
     private bool _clipDirty = true;
     private float _scrollX;
 
+    private readonly DirGodotGridPainter _gridCanvas;
     private readonly ClipCanvas _canvas;
 
     public DirGodotSoundGrid(DirGodotScoreGfxValues gfxValues)
     {
         _gfxValues = gfxValues;
+        _gridCanvas = new DirGodotGridPainter(gfxValues);
         _canvas = new ClipCanvas(this);
+        AddChild(_gridCanvas);
         AddChild(_canvas);
     }
 
@@ -45,6 +48,8 @@ internal partial class DirGodotSoundGrid : Control
         {
             _scrollX = value;
             _canvas.QueueRedraw();
+            _gridCanvas.ScrollX = _scrollX;
+            _gridCanvas.QueueRedraw();
             QueueRedraw();
         }
     }
@@ -60,6 +65,8 @@ internal partial class DirGodotSoundGrid : Control
             foreach (var clip in _movie.GetAudioClips())
                 _clips.Add(new DirGodotScoreAudioClip(clip));
             _movie.AudioClipListChanged += OnClipsChanged;
+            _gridCanvas.FrameCount = _movie.FrameCount;
+            _gridCanvas.ChannelCount = 4;
         }
         UpdateSize();
         _clipDirty = true;
@@ -117,21 +124,7 @@ internal partial class DirGodotSoundGrid : Control
     public override void _Draw()
     {
         if (_movie == null || _collapsed) return;
-        int channels = 4;
-        float height = channels * _gfxValues.ChannelHeight;
-        float width = _movie.FrameCount * _gfxValues.FrameWidth + _gfxValues.ExtraMargin;
-        Size = new Vector2(width, height);
-        DrawRect(new Rect2(0,0,width,height), new Color("#f0f0f0"));
-        for (int c = 0; c <= channels; c++)
-        {
-            float y = c * _gfxValues.ChannelHeight;
-            DrawLine(new Vector2(0, y), new Vector2(width, y), Colors.DarkGray);
-        }
-        for (int f = 0; f <= _movie.FrameCount; f++)
-        {
-            float x = -_scrollX + f * _gfxValues.FrameWidth;
-            DrawLine(new Vector2(x, 0), new Vector2(x, height), Colors.DarkGray);
-        }
+        Size = CustomMinimumSize;
     }
 
     private void UpdateSize()
@@ -141,6 +134,9 @@ internal partial class DirGodotSoundGrid : Control
         float height = (_collapsed ? 0 : 4 * _gfxValues.ChannelHeight);
         CustomMinimumSize = new Vector2(width, height);
         _canvas.CustomMinimumSize = CustomMinimumSize;
+        _gridCanvas.CustomMinimumSize = CustomMinimumSize;
+        _gridCanvas.FrameCount = _movie.FrameCount;
+        _gridCanvas.ChannelCount = 4;
     }
 
     private partial class ClipCanvas : Control


### PR DESCRIPTION
## Summary
- fix sound bar position and grid top offset
- share grid painter for sound channels
- use Ready handler for SoundBar resize

## Testing
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ac392184833298b351994dcae086