### PR TITLE
Fix locked sprite selection

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
@@ -362,7 +362,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         {
             Vector2 localPos = _stageContainer.Container.ToLocal(mb.Position);
 
-            var sprite = _movie.GetSpriteAtPoint(localPos.X, localPos.Y) as LingoSprite;
+            var sprite = _movie.GetSpriteAtPoint(localPos.X, localPos.Y, skipLockedSprites: true) as LingoSprite;
             if (mb.Pressed)
             {
                 if (sprite != null)


### PR DESCRIPTION
## Summary
- ignore locked sprites in the stage window when the movie is stopped

## Testing
- `dotnet test` *(fails: Attempting to cancel the build)*

------
https://chatgpt.com/codex/tasks/task_e_6857ad1684d88332a274f61ce3b9f12c