### PR TITLE
Fix cast drag to score

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
@@ -236,8 +236,7 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
         _showPreview = false;
         if (_movie == null) return false;
 
-        if (data.Obj is not GodotObject obj) return false;
-        if (obj is not ILingoMember member) return false;
+        if (data.Obj is not ILingoMember member) return false;
 
         if (member.Type == LingoMemberType.Sound) return false;
 
@@ -274,6 +273,7 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
         {
             s.SetMember(_previewMember);
         });
+        _previewMember = null;
         _spriteListDirty = true;
     }
 


### PR DESCRIPTION
## Summary
- fix _CanDropData so CastItem drag is recognized
- reset preview member after drop

## Testing
- `dotnet restore Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj --no-restore --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6857ad72c9dc83328052a5a04819586a