### PR TITLE
Use icon manager for member thumbnails

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
@@ -25,6 +25,7 @@ namespace LingoEngine.Director.LGodot.Casts
         private readonly StyleBoxFlat _normalLabelStyle = new();
         //private readonly CenterContainer _spriteContainer;
         private readonly DirGodotMemberThumbnail _thumb;
+        private readonly IDirGodotIconManager _iconManager;
         private readonly ILingoMember _lingoMember;
         private readonly ColorRect _separator;
         private readonly Action<DirGodotCastItem> _onSelect;
@@ -43,11 +44,12 @@ namespace LingoEngine.Director.LGodot.Casts
             // Labels use the "normal" stylebox for their background, not "panel"
             _caption.AddThemeStyleboxOverride("normal", selected ? _selectedLabelStyle : _normalLabelStyle);
         }
-        public DirGodotCastItem(ILingoMember element, int number, Action<DirGodotCastItem> onSelect, Color selectedColor, ILingoCommandManager commandManager)
+        public DirGodotCastItem(ILingoMember element, int number, Action<DirGodotCastItem> onSelect, Color selectedColor, ILingoCommandManager commandManager, IDirGodotIconManager iconManager)
         {
             _lingoMember = element;
             _onSelect = onSelect;
             _commandManager = commandManager;
+            _iconManager = iconManager;
             _selectedColor = selectedColor;
             CustomMinimumSize = new Vector2(50, 50);
             MouseFilter = MouseFilterEnum.Stop;
@@ -86,7 +88,7 @@ namespace LingoEngine.Director.LGodot.Casts
             AddChild(_bg);
 
 
-            _thumb = new DirGodotMemberThumbnail(Width - 1, Height - LabelHeight);
+            _thumb = new DirGodotMemberThumbnail(Width - 1, Height - LabelHeight, _iconManager);
             AddChild(_thumb);
 
             // separator line above the caption

--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastView.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastView.cs
@@ -16,10 +16,11 @@ namespace LingoEngine.Director.LGodot.Casts
         private readonly Action<DirGodotCastItem> _onSelectItem;
         private readonly DirectorStyle _style;
         private readonly ILingoCommandManager _commandManager;
+        private readonly IDirGodotIconManager _iconManager;
 
         public Node Node => _ScrollContainer;
 
-        public DirGodotCastView(Action<DirGodotCastItem> onSelect, DirectorStyle style, ILingoCommandManager commandManager)
+        public DirGodotCastView(Action<DirGodotCastItem> onSelect, DirectorStyle style, ILingoCommandManager commandManager, IDirGodotIconManager iconManager)
         {
             _ScrollContainer = new ScrollContainer();
             _ScrollContainer.SizeFlagsVertical = Control.SizeFlags.ExpandFill;
@@ -32,6 +33,7 @@ namespace LingoEngine.Director.LGodot.Casts
             _onSelectItem = onSelect;
             _style = style;
             _commandManager = commandManager;
+            _iconManager = iconManager;
         }
 
         public void Show(ILingoCast cast)
@@ -40,7 +42,7 @@ namespace LingoEngine.Director.LGodot.Casts
             var i = 0;
             foreach (var castItem in cast.GetAll())
             {
-                var dirCastItem = new DirGodotCastItem(castItem, i+1, _onSelectItem, _style.SelectedColor, _commandManager);
+                var dirCastItem = new DirGodotCastItem(castItem, i+1, _onSelectItem, _style.SelectedColor, _commandManager, _iconManager);
                 dirCastItem.Init();
                 _elements.Add(dirCastItem);
                 _elementsContainer.AddChild(dirCastItem);

--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastWindow.cs
@@ -24,10 +24,11 @@ namespace LingoEngine.Director.LGodot.Casts
         private DirGodotCastItem? _selectedItem;
         private ILingoPlayer _player;
         private readonly ILingoCommandManager _commandManager;
+        private readonly IDirGodotIconManager _iconManager;
 
         public ILingoCast? ActiveCastLib { get; private set; }
 
-        public DirGodotCastWindow(IDirectorEventMediator mediator, DirectorStyle style, DirectorCastWindow directorCastWindow, ILingoPlayer player, IDirGodotWindowManager windowManager, ILingoCommandManager commandManager)
+        public DirGodotCastWindow(IDirectorEventMediator mediator, DirectorStyle style, DirectorCastWindow directorCastWindow, ILingoPlayer player, IDirGodotWindowManager windowManager, ILingoCommandManager commandManager, IDirGodotIconManager iconManager)
             : base(DirectorMenuCodes.CastWindow, "Cast", windowManager)
         {
             _mediator = mediator;
@@ -35,6 +36,7 @@ namespace LingoEngine.Director.LGodot.Casts
             directorCastWindow.Init(this);
             _player = player;
             _commandManager = commandManager;
+            _iconManager = iconManager;
             _player.ActiveMovieChanged += OnActiveMovieChanged;
             _mediator.Subscribe(this);
 
@@ -76,7 +78,7 @@ namespace LingoEngine.Director.LGodot.Casts
             int index = 0;
             foreach (var cast in lingoMovie.CastLib.GetAll())
             {
-                var castLibViewer = new DirGodotCastView(OnSelectElement, _style, _commandManager);
+                var castLibViewer = new DirGodotCastView(OnSelectElement, _style, _commandManager, _iconManager);
                 castLibViewer.Show(cast);
                 _castViews.Add(cast.Number, castLibViewer);
                 _castTabIndices.Add(cast.Number, index);

--- a/src/Director/LingoEngine.Director.LGodot/Casts/TextableMemberWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/TextableMemberWindow.cs
@@ -25,19 +25,21 @@ internal partial class DirGodotTextableMemberWindow : BaseGodotWindow, IHasMembe
     private readonly HBoxContainer _topBar = new HBoxContainer();
 
     private readonly ILingoPlayer _player;
+    private readonly IDirGodotIconManager _iconManager;
     private ILingoMemberTextBase? _member;
 
-    public DirGodotTextableMemberWindow(IDirectorEventMediator mediator, ILingoPlayer player, DirectorTextEditWindow directorTextEditWindow, IDirGodotWindowManager windowManager)
+    public DirGodotTextableMemberWindow(IDirectorEventMediator mediator, ILingoPlayer player, DirectorTextEditWindow directorTextEditWindow, IDirGodotWindowManager windowManager, IDirGodotIconManager iconManager)
         : base(DirectorMenuCodes.TextEditWindow, "Edit Text", windowManager)
     {
         _player = player;
+        _iconManager = iconManager;
         mediator.Subscribe(this);
         directorTextEditWindow.Init(this);
 
         Size = new Vector2(450, 200);
         CustomMinimumSize = Size;
 
-        _navBar = new MemberNavigationBar<ILingoMemberTextBase>(mediator, player, NavigationBarHeight);
+        _navBar = new MemberNavigationBar<ILingoMemberTextBase>(mediator, player, _iconManager, NavigationBarHeight);
         AddChild(_navBar);
         _navBar.Position = new Vector2(0, TitleBarHeight);
         _navBar.CustomMinimumSize = new Vector2(Size.X, NavigationBarHeight);

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotMemberThumbnail.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotMemberThumbnail.cs
@@ -11,19 +11,22 @@ namespace LingoEngine.Director.LGodot.Gfx;
 internal partial class DirGodotMemberThumbnail : Control
 {
     private readonly TextureRect _sprite;
-    private readonly Label _typeLabel;
+    private readonly PanelContainer _iconPanel;
+    private readonly TextureRect _iconTexture;
     private readonly Label _textLabel = new();
     private SubViewport _textViewport;
+    private readonly IDirGodotIconManager _iconManager;
 
     public float ThumbWidth { get; }
     public float ThumbHeight { get; }
 
     private const float LabelHeight = 15;
 
-    public DirGodotMemberThumbnail(float width, float height)
+    public DirGodotMemberThumbnail(float width, float height, IDirGodotIconManager iconManager)
     {
         ThumbWidth = width;
         ThumbHeight = height;
+        _iconManager = iconManager;
         CustomMinimumSize = new Vector2(width, height);
         MouseFilter = MouseFilterEnum.Ignore;
 
@@ -46,14 +49,11 @@ internal partial class DirGodotMemberThumbnail : Control
         spriteContainer.AddChild(_sprite);
         AddChild(spriteContainer);
 
-        // Type label overlay
-        _typeLabel = new Label
+        // Type icon overlay
+        _iconPanel = new PanelContainer
         {
-            LabelSettings = new LabelSettings { FontSize = 8 },
             MouseFilter = MouseFilterEnum.Ignore,
-            HorizontalAlignment = HorizontalAlignment.Center,
-            VerticalAlignment = VerticalAlignment.Center,
-            CustomMinimumSize = new Vector2(10, 10)
+            CustomMinimumSize = new Vector2(16, 16)
         };
         var typeStyle = new StyleBoxFlat
         {
@@ -64,18 +64,25 @@ internal partial class DirGodotMemberThumbnail : Control
             BorderWidthLeft = 1,
             BorderWidthRight = 1
         };
-        _typeLabel.AddThemeStyleboxOverride("normal", typeStyle);
-        _typeLabel.AddThemeColorOverride("font_color", Colors.Black);
-        AddChild(_typeLabel);
+        _iconPanel.AddThemeStyleboxOverride("panel", typeStyle);
+        _iconTexture = new TextureRect
+        {
+            StretchMode = TextureRect.StretchModeEnum.KeepAspectCentered,
+            MouseFilter = MouseFilterEnum.Ignore,
+            SizeFlagsHorizontal = SizeFlags.ExpandFill,
+            SizeFlagsVertical = SizeFlags.ExpandFill
+        };
+        _iconPanel.AddChild(_iconTexture);
+        AddChild(_iconPanel);
 
-        _typeLabel.AnchorLeft = 1;
-        _typeLabel.AnchorRight = 1;
-        _typeLabel.AnchorTop = 1;
-        _typeLabel.AnchorBottom = 1;
-        _typeLabel.OffsetRight = -2;
-        _typeLabel.OffsetBottom = -2;
-        _typeLabel.OffsetLeft = -_typeLabel.CustomMinimumSize.X - 2;
-        _typeLabel.OffsetTop = -_typeLabel.CustomMinimumSize.Y - 2;
+        _iconPanel.AnchorLeft = 1;
+        _iconPanel.AnchorRight = 1;
+        _iconPanel.AnchorTop = 1;
+        _iconPanel.AnchorBottom = 1;
+        _iconPanel.OffsetRight = -2;
+        _iconPanel.OffsetBottom = -2;
+        _iconPanel.OffsetLeft = -_iconPanel.CustomMinimumSize.X - 2;
+        _iconPanel.OffsetTop = -_iconPanel.CustomMinimumSize.Y - 2;
 
         //_textViewport = new SubViewport
         //{
@@ -90,7 +97,8 @@ internal partial class DirGodotMemberThumbnail : Control
 
     public void SetMember(ILingoMember member)
     {
-        _typeLabel.Text = LingoMemberTypeIcons.GetIcon(member);
+        var icon = LingoMemberTypeIcons.GetIcon(member);
+        _iconTexture.Texture = icon.HasValue ? _iconManager.Get(icon.Value) : null;
 
         
 

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/LingoMemberTypeIcons.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/LingoMemberTypeIcons.cs
@@ -3,20 +3,21 @@ using LingoEngine.Pictures;
 using LingoEngine.Sounds;
 using LingoEngine.Texts;
 
+
 namespace LingoEngine.Director.LGodot.Gfx
 {
     internal static class LingoMemberTypeIcons
     {
-        public static string GetIcon(ILingoMember member)
+        public static DirGodotEditorIcon? GetIcon(ILingoMember member)
         {
             return member switch
             {
-                LingoMemberPicture => "🖌",
-                LingoMemberSound => "🔊",
-                LingoMemberField => "F",
-                ILingoMemberTextBase => "T",
-                _ when member.Type == LingoMemberType.Shape || member.Type == LingoMemberType.VectorShape => "📐",
-                _ => string.Empty
+                LingoMemberPicture => DirGodotEditorIcon.MemberTypeBitmap,
+                LingoMemberSound => DirGodotEditorIcon.MemberTypSound,
+                LingoMemberField => DirGodotEditorIcon.MemberTypeField,
+                ILingoMemberTextBase => DirGodotEditorIcon.MemberTypeText,
+                _ when member.Type == LingoMemberType.Shape || member.Type == LingoMemberType.VectorShape => DirGodotEditorIcon.MemberTypeShape,
+                _ => null
             };
         }
     }

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/MemberNavigationBar.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/MemberNavigationBar.cs
@@ -12,10 +12,12 @@ internal partial class MemberNavigationBar<T> : HBoxContainer where T : class, I
 {
     private readonly IDirectorEventMediator _mediator;
     private readonly ILingoPlayer _player;
+    private readonly IDirGodotIconManager _iconManager;
 
     private readonly Button _prevButton = new Button();
     private readonly Button _nextButton = new Button();
-    private readonly Label _typeLabel = new Label();
+    private readonly PanelContainer _typePanel = new();
+    private readonly TextureRect _typeIcon = new();
     private readonly LineEdit _nameEdit = new LineEdit();
     private readonly Label _numberLabel = new Label();
     private readonly Button _infoButton = new Button();
@@ -23,10 +25,11 @@ internal partial class MemberNavigationBar<T> : HBoxContainer where T : class, I
 
     private T? _member;
 
-    public MemberNavigationBar(IDirectorEventMediator mediator, ILingoPlayer player, int barHeight = 20)
+    public MemberNavigationBar(IDirectorEventMediator mediator, ILingoPlayer player, IDirGodotIconManager iconManager, int barHeight = 20)
     {
         _mediator = mediator;
         _player = player;
+        _iconManager = iconManager;
 
         CustomMinimumSize = new Vector2(0, barHeight);
 
@@ -40,9 +43,22 @@ internal partial class MemberNavigationBar<T> : HBoxContainer where T : class, I
         _nextButton.Pressed += () => Navigate(1);
         AddChild(_nextButton);
 
-        _typeLabel.CustomMinimumSize = new Vector2(20, barHeight);
-        _typeLabel.AddThemeColorOverride("font_color", Colors.Black);
-        AddChild(_typeLabel);
+        _typePanel.CustomMinimumSize = new Vector2(20, barHeight);
+        var typeStyle = new StyleBoxFlat
+        {
+            BgColor = Colors.White,
+            BorderColor = Colors.Black,
+            BorderWidthBottom = 1,
+            BorderWidthTop = 1,
+            BorderWidthLeft = 1,
+            BorderWidthRight = 1
+        };
+        _typePanel.AddThemeStyleboxOverride("panel", typeStyle);
+        _typeIcon.StretchMode = TextureRect.StretchModeEnum.KeepAspectCentered;
+        _typeIcon.SizeFlagsHorizontal = SizeFlags.ExpandFill;
+        _typeIcon.SizeFlagsVertical = SizeFlags.ExpandFill;
+        _typePanel.AddChild(_typeIcon);
+        AddChild(_typePanel);
 
         _nameEdit.CustomMinimumSize = new Vector2(100, barHeight);
         _nameEdit.SizeFlagsHorizontal = SizeFlags.ExpandFill;
@@ -70,7 +86,8 @@ internal partial class MemberNavigationBar<T> : HBoxContainer where T : class, I
         _nameEdit.Text = member.Name;
         _numberLabel.Text = member.NumberInCast.ToString();
         _castLibLabel.Text = GetCastName(member);
-        _typeLabel.Text = LingoMemberTypeIcons.GetIcon(member);
+        var icon = LingoMemberTypeIcons.GetIcon(member);
+        _typeIcon.Texture = icon.HasValue ? _iconManager.Get(icon.Value) : null;
     }
 
     private string GetCastName(ILingoMember m)

--- a/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
@@ -31,26 +31,29 @@ public partial class DirGodotPropertyInspector : BaseGodotWindow, IHasSpriteSele
     private readonly VBoxContainer _behaviorBox = new VBoxContainer();
     private readonly Button _behaviorClose = new Button();
     private readonly ILingoPlayer _player;
+    private readonly IDirGodotIconManager _iconManager;
     private readonly HBoxContainer _header = new HBoxContainer();
-    private readonly DirGodotMemberThumbnail _thumb = new DirGodotMemberThumbnail(36,36);
+    private readonly DirGodotMemberThumbnail _thumb;
     private readonly VBoxContainer _headerText = new VBoxContainer();
     private readonly Label _spriteInfo = new Label();
     private readonly Label _memberInfo = new Label();
     private readonly Label _castInfo = new Label();
     private const int HeaderHeight = 44;
 
-    public DirGodotPropertyInspector(IDirectorEventMediator mediator, ILingoCommandManager commandManager, DirectorPropertyInspectorWindow inspectorWindow, ILingoPlayer player, IDirGodotWindowManager windowManager)
+    public DirGodotPropertyInspector(IDirectorEventMediator mediator, ILingoCommandManager commandManager, DirectorPropertyInspectorWindow inspectorWindow, ILingoPlayer player, IDirGodotWindowManager windowManager, IDirGodotIconManager iconManager)
         : base(DirectorMenuCodes.PropertyInspector, "Property Inspector", windowManager)
     {
         _mediator = mediator;
         _commandManager = commandManager;
         _player = player;
+        _iconManager = iconManager;
         inspectorWindow.Init(this);
 
         //Position = new Vector2(500, 20);
         Size = new Vector2(260, 400);
         CustomMinimumSize = Size;
 
+        _thumb = new DirGodotMemberThumbnail(36, 36, _iconManager);
         CreateHeader();
 
         _tabs.Position = new Vector2(0, TitleBarHeight + HeaderHeight);

--- a/src/Director/LingoEngine.Director.LGodot/Pictures/DirGodotPictureMemberEditorWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Pictures/DirGodotPictureMemberEditorWindow.cs
@@ -62,7 +62,7 @@ internal partial class DirGodotPictureMemberEditorWindow : BaseGodotWindow, IHas
         directorPictureEditWindow.Init(this);
         CustomMinimumSize = Size;
 
-        _navBar = new MemberNavigationBar<LingoMemberPicture>(_mediator, _player, NavigationBarHeight);
+        _navBar = new MemberNavigationBar<LingoMemberPicture>(_mediator, _player, _iconManager, NavigationBarHeight);
         AddChild(_navBar);
         _navBar.Position = new Vector2(0, TitleBarHeight);
         _navBar.CustomMinimumSize = new Vector2(Size.X, NavigationBarHeight);


### PR DESCRIPTION
## Summary
- show image icons for member types via DirGodotIconManager
- paint icon background directly onto member thumbnail
- pass icon manager to cast views and editor windows

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c4ecb49483328fb8c5b78cdfacef