### PR TITLE
Add direct import load and refactor DTO conversion

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Import/DirectorRaysDtoExtensions.cs
+++ b/src/Director/LingoEngine.Director.Core/Import/DirectorRaysDtoExtensions.cs
@@ -1,0 +1,194 @@
+using System;
+using ProjectorRays.Director;
+using ProjectorRays.director.Chunks;
+using LingoEngine.IO.Data.DTO;
+
+namespace LingoEngine.Director.Core.Import;
+
+internal static class DirectorRaysDtoExtensions
+{
+    public static LingoMovieDTO ToDto(this DirectorFile dir, string movieName, DirFilesContainerDTO resources)
+    {
+        var movie = new LingoMovieDTO
+        {
+            Name = movieName,
+            Number = 0,
+            Tempo = 0,
+            FrameCount = dir.Score?.Frames.Count ?? 0
+        };
+
+        int castNum = 1;
+        foreach (var cast in dir.Casts)
+            movie.Casts.Add(cast.ToDto(castNum++, resources));
+
+        if (dir.Score != null)
+        {
+            foreach (var f in dir.Score.Frames)
+                movie.Sprites.Add(f.ToDto());
+        }
+
+        return movie;
+    }
+
+    public static LingoCastDTO ToDto(this CastChunk cast, int number, DirFilesContainerDTO resources)
+    {
+        var castDto = new LingoCastDTO
+        {
+            Name = cast.Name,
+            Number = number,
+            FileName = string.Empty,
+            PreLoadMode = PreLoadModeTypeDTO.WhenNeeded
+        };
+
+        foreach (var mem in cast.Members.Values)
+            castDto.Members.Add(mem.ToDto(castDto, resources));
+
+        return castDto;
+    }
+
+    public static LingoMemberDTO ToDto(this CastMemberChunk mem, LingoCastDTO cast, DirFilesContainerDTO resources)
+    {
+        var baseDto = CreateBaseDto(mem, cast);
+
+        return mem.Type switch
+        {
+            MemberType.FieldMember or MemberType.TextMember => mem.ToTextDto(baseDto),
+            MemberType.BitmapMember or MemberType.PictureMember => mem.ToPictureDto(baseDto, cast, resources),
+            MemberType.SoundMember => mem.ToSoundDto(baseDto, cast, resources),
+            _ => baseDto
+        };
+    }
+
+    private static LingoMemberDTO CreateBaseDto(CastMemberChunk mem, LingoCastDTO cast)
+        => new LingoMemberDTO
+        {
+            Name = mem.GetName(),
+            Number = mem.Id,
+            CastLibNum = cast.Number,
+            NumberInCast = mem.Id,
+            Type = MapMemberType(mem.Type),
+            RegPoint = new LingoPointDTO(),
+            Width = 0,
+            Height = 0,
+            Size = mem.SpecificData.Size,
+            Comments = string.Empty,
+            FileName = string.Empty,
+            PurgePriority = 0
+        };
+
+    private static LingoMemberTextDTO ToTextDto(this CastMemberChunk mem, LingoMemberDTO baseDto)
+        => new LingoMemberTextDTO
+        {
+            Name = baseDto.Name,
+            Number = baseDto.Number,
+            CastLibNum = baseDto.CastLibNum,
+            NumberInCast = baseDto.NumberInCast,
+            Type = baseDto.Type,
+            RegPoint = baseDto.RegPoint,
+            Width = baseDto.Width,
+            Height = baseDto.Height,
+            Size = baseDto.Size,
+            Comments = baseDto.Comments,
+            FileName = baseDto.FileName,
+            PurgePriority = baseDto.PurgePriority,
+            Text = mem.GetText()
+        };
+
+    private static LingoMemberPictureDTO ToPictureDto(this CastMemberChunk mem, LingoMemberDTO baseDto, LingoCastDTO cast, DirFilesContainerDTO resources)
+    {
+        var file = $"{cast.Number}_{mem.Id}.img";
+        var dto = new LingoMemberPictureDTO
+        {
+            Name = baseDto.Name,
+            Number = baseDto.Number,
+            CastLibNum = baseDto.CastLibNum,
+            NumberInCast = baseDto.NumberInCast,
+            Type = baseDto.Type,
+            RegPoint = baseDto.RegPoint,
+            Width = baseDto.Width,
+            Height = baseDto.Height,
+            Size = baseDto.Size,
+            Comments = baseDto.Comments,
+            FileName = baseDto.FileName,
+            PurgePriority = baseDto.PurgePriority,
+            ImageFile = file
+        };
+        var bytes = mem.SpecificData.Data.AsSpan(mem.SpecificData.Offset, mem.SpecificData.Size).ToArray();
+        resources.Files.Add(new DirFileResourceDTO
+        {
+            CastName = cast.Name,
+            FileName = file,
+            Bytes = bytes
+        });
+        return dto;
+    }
+
+    private static LingoMemberSoundDTO ToSoundDto(this CastMemberChunk mem, LingoMemberDTO baseDto, LingoCastDTO cast, DirFilesContainerDTO resources)
+    {
+        var file = $"{cast.Number}_{mem.Id}.snd";
+        var dto = new LingoMemberSoundDTO
+        {
+            Name = baseDto.Name,
+            Number = baseDto.Number,
+            CastLibNum = baseDto.CastLibNum,
+            NumberInCast = baseDto.NumberInCast,
+            Type = baseDto.Type,
+            RegPoint = baseDto.RegPoint,
+            Width = baseDto.Width,
+            Height = baseDto.Height,
+            Size = baseDto.Size,
+            Comments = baseDto.Comments,
+            FileName = baseDto.FileName,
+            PurgePriority = baseDto.PurgePriority,
+            SoundFile = file
+        };
+        var bytes = mem.SpecificData.Data.AsSpan(mem.SpecificData.Offset, mem.SpecificData.Size).ToArray();
+        resources.Files.Add(new DirFileResourceDTO
+        {
+            CastName = cast.Name,
+            FileName = file,
+            Bytes = bytes
+        });
+        return dto;
+    }
+
+    public static LingoSpriteDTO ToDto(this ScoreChunk.FrameDescriptor f)
+        => new LingoSpriteDTO
+        {
+            Name = $"Sprite{f.SpriteNumber}",
+            SpriteNum = f.SpriteNumber,
+            MemberNum = f.SpriteNumber,
+            Puppet = false,
+            Lock = false,
+            Visibility = true,
+            LocH = 0,
+            LocV = 0,
+            LocZ = f.Channel,
+            Rotation = 0,
+            Skew = 0,
+            RegPoint = new LingoPointDTO(),
+            Width = 0,
+            Height = 0,
+            BeginFrame = f.StartFrame,
+            EndFrame = f.EndFrame
+        };
+
+    private static LingoMemberTypeDTO MapMemberType(MemberType t)
+        => t switch
+        {
+            MemberType.BitmapMember => LingoMemberTypeDTO.Bitmap,
+            MemberType.FilmLoopMember => LingoMemberTypeDTO.FilmLoop,
+            MemberType.TextMember => LingoMemberTypeDTO.Text,
+            MemberType.PaletteMember => LingoMemberTypeDTO.Palette,
+            MemberType.PictureMember => LingoMemberTypeDTO.Picture,
+            MemberType.SoundMember => LingoMemberTypeDTO.Sound,
+            MemberType.ButtonMember => LingoMemberTypeDTO.Button,
+            MemberType.ShapeMember => LingoMemberTypeDTO.Shape,
+            MemberType.MovieMember => LingoMemberTypeDTO.Movie,
+            MemberType.DigitalVideoMember => LingoMemberTypeDTO.DigitalVideo,
+            MemberType.ScriptMember => LingoMemberTypeDTO.Script,
+            MemberType.FieldMember => LingoMemberTypeDTO.Field,
+            MemberType.FontMember => LingoMemberTypeDTO.Font,
+            _ => LingoMemberTypeDTO.Unknown
+        };
+}

--- a/src/Director/LingoEngine.Director.Core/Import/DirectorRaysImporter.cs
+++ b/src/Director/LingoEngine.Director.Core/Import/DirectorRaysImporter.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProjectorRays.Director;
+using ProjectorRays.IO;
+using ProjectorRays.Common;
+using LingoEngine.IO.Data.DTO;
+
+namespace LingoEngine.Director.Core.Import;
+
+/// <summary>
+/// Utility to convert Director files using the ProjectorRays library into
+/// LingoEngine data transfer objects.
+/// The conversion is minimal and only extracts data required to load a movie.
+/// </summary>
+public static class DirectorRaysImporter
+{
+    public static (LingoMovieDTO Movie, DirFilesContainerDTO Resources) ImportMovie(string filePath)
+    {
+        byte[] data = File.ReadAllBytes(filePath);
+        var stream = new ReadStream(data, data.Length, Endianness.BigEndian);
+        var dir = new DirectorFile(NullLogger.Instance);
+        if (!dir.Read(stream))
+            throw new Exception($"Failed to read Director file '{filePath}'");
+
+        var resources = new DirFilesContainerDTO();
+        var movie = dir.ToDto(Path.GetFileNameWithoutExtension(filePath), resources);
+        return (movie, resources);
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotImportExportWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/DirGodotImportExportWindow.cs
@@ -1,6 +1,7 @@
 using Godot;
 using LingoEngine.Director.Core.Gfx;
 using LingoEngine.Director.Core.Windows;
+using LingoEngine.Core;
 
 namespace LingoEngine.Director.LGodot.Gfx;
 
@@ -13,7 +14,7 @@ internal partial class DirGodotImportExportWindow : BaseGodotWindow, IDirFramewo
     private readonly Button _dirButton = new();
     private readonly Button _exportButton = new();
 
-    public DirGodotImportExportWindow(ProjectSettings settings, DirectorImportExportWindow directorWindow, IDirGodotWindowManager windowManager)
+    public DirGodotImportExportWindow(ProjectSettings settings, LingoPlayer player, DirectorImportExportWindow directorWindow, IDirGodotWindowManager windowManager)
         : base(DirectorMenuCodes.ImportExportWindow, "Import / Export", windowManager)
     {
         directorWindow.Init(this);
@@ -36,11 +37,21 @@ internal partial class DirGodotImportExportWindow : BaseGodotWindow, IDirFramewo
         _exportButton.Text = "Export/Optimize code through AI";
         _home.AddChild(_exportButton);
 
-        _importLingoStep = new ImportLingoFilesStep(settings);
+        _importLingoStep = new ImportLingoFilesStep(settings)
+        {
+            Position = new Vector2(5, TitleBarHeight + 5),
+            SizeFlagsHorizontal = SizeFlags.ExpandFill,
+            SizeFlagsVertical = SizeFlags.ExpandFill
+        };
         _importLingoStep.Back += ShowHome;
         AddChild(_importLingoStep);
 
-        _importDirStep = new ImportDirCstFilesStep();
+        _importDirStep = new ImportDirCstFilesStep(player)
+        {
+            Position = new Vector2(5, TitleBarHeight + 5),
+            SizeFlagsHorizontal = SizeFlags.ExpandFill,
+            SizeFlagsVertical = SizeFlags.ExpandFill
+        };
         _importDirStep.Back += ShowHome;
         AddChild(_importDirStep);
 

--- a/src/LingoEngine.IO.Data/DTO/DirFileResourceDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/DirFileResourceDTO.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace LingoEngine.IO.Data.DTO;
+
+public class DirFileResourceDTO
+{
+    public string CastName { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
+    public byte[] Bytes { get; set; } = Array.Empty<byte>();
+}

--- a/src/LingoEngine.IO.Data/DTO/DirFilesContainerDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/DirFilesContainerDTO.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace LingoEngine.IO.Data.DTO;
+
+public class DirFilesContainerDTO
+{
+    public List<DirFileResourceDTO> Files { get; set; } = new();
+}

--- a/src/LingoEngine.IO/JsonStateRepository.cs
+++ b/src/LingoEngine.IO/JsonStateRepository.cs
@@ -36,6 +36,19 @@ public class JsonStateRepository
         var json = File.ReadAllText(filePath);
         var dto = JsonSerializer.Deserialize<LingoMovieDTO>(json) ?? throw new Exception("Invalid movie file");
 
+        return Load(dto, player, dir);
+    }
+
+    public LingoMovie Load(LingoMovieDTO dto, LingoPlayer player, string resourceDir)
+    {
+        if (string.IsNullOrEmpty(resourceDir))
+            resourceDir = Directory.GetCurrentDirectory();
+
+        return BuildMovieFromDto(dto, player, resourceDir);
+    }
+
+    private static LingoMovie BuildMovieFromDto(LingoMovieDTO dto, LingoPlayer player, string dir)
+    {
         var movie = (LingoMovie)player.NewMovie(dto.Name);
         movie.Tempo = dto.Tempo;
 


### PR DESCRIPTION
## Summary
- refactor DirectorRays DTO conversion into smaller helpers
- support loading a movie DTO directly with `JsonStateRepository`
- simplify import step to use new load overload

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: missing test data)*

------
https://chatgpt.com/codex/tasks/task_e_6858c79092648332b9c002849641a9c1