### PR TITLE
Add multi-selection bounding boxes

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
@@ -12,6 +12,7 @@ using LingoEngine.Director.LGodot;
 using System.Linq;
 using System.Collections.Generic;
 using LingoEngine.LGodot.Primitives;
+using LingoEngine.Texts;
 
 
 namespace LingoEngine.Director.LGodot.Movies;
@@ -39,6 +40,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
     private readonly ColorPickerButton _colorPicker = new ColorPickerButton();
     private readonly ScrollContainer _scrollContainer = new ScrollContainer();
     private readonly SelectionBox _selectionBox = new SelectionBox();
+    private readonly BoundingBoxesOverlay _boundingBoxes = new BoundingBoxesOverlay();
 
     private LingoMovie? _movie;
     private ILingoFrameworkStage? _stage;
@@ -90,7 +92,10 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         _stageBgRect.SizeFlagsVertical = SizeFlags.ExpandFill;
         _scrollContainer.AddChild(_stageBgRect);
         _scrollContainer.AddChild(_stageContainer.Container);
+        _stageContainer.Container.AddChild(_boundingBoxes);
         _stageContainer.Container.AddChild(_selectionBox);
+        _boundingBoxes.ZIndex = 500;
+        _boundingBoxes.InputPickable = false; // ensure mouse clicks pass through
         _selectionBox.Visible = false;
         _selectionBox.ZIndex = 1000;
         AddChild(_scrollContainer);
@@ -198,7 +203,10 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
     public void SetActiveMovie(LingoMovie? movie)
     {
         if (_movie != null)
+        {
             _movie.PlayStateChanged -= OnPlayStateChanged;
+            _movie.SpriteListChanged -= UpdateBoundingBoxes;
+        }
 
         _stage?.SetActiveMovie(movie);
         _movie = movie;
@@ -207,9 +215,13 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         _selectionBox.Visible = false;
 
         if (_movie != null)
+        {
             _movie.PlayStateChanged += OnPlayStateChanged;
+            _movie.SpriteListChanged += UpdateBoundingBoxes;
+        }
 
         UpdatePlayButton();
+        UpdateBoundingBoxes();
     }
 
     private void OnActiveMovieChanged(ILingoMovie? movie)
@@ -220,6 +232,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
     private void OnPlayStateChanged(bool isPlaying)
     {
         UpdatePlayButton();
+        UpdateBoundingBoxes();
         if (isPlaying)
             _selectionBox.Visible = false;
         else if (_selectedSprites.Count > 0)
@@ -287,6 +300,35 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         var rect = new Rect2(left, top, right - left, bottom - top);
         _selectionBox.UpdateRect(rect);
         _selectionBox.Visible = true;
+    }
+
+    private void UpdateBoundingBoxes()
+    {
+        if (_movie == null || _movie.IsPlaying)
+        {
+            _boundingBoxes.Visible = false;
+            return;
+        }
+
+        var rects = new List<Rect2>();
+        foreach (var sprite in _selectedSprites)
+        {
+            if (sprite.Member is LingoMemberText || sprite.Member is LingoMemberField)
+            {
+                var r = sprite.Rect;
+                rects.Add(new Rect2(r.Left, r.Top, r.Right - r.Left, r.Bottom - r.Top));
+            }
+        }
+
+        if (rects.Count > 0)
+        {
+            _boundingBoxes.SetRects(rects);
+            _boundingBoxes.Visible = true;
+        }
+        else
+        {
+            _boundingBoxes.Visible = false;
+        }
     }
 
     public override void _Input(InputEvent @event)
@@ -374,6 +416,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
                         else
                             _selectedSprites.Add(sprite);
                         UpdateSelectionBox();
+                        UpdateBoundingBoxes();
                     }
                     else
                     {
@@ -381,6 +424,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
                         _selectedSprites.Add(sprite);
                         _mediator.RaiseSpriteSelected(sprite);
                         UpdateSelectionBox();
+                        UpdateBoundingBoxes();
                     }
                 }
             }
@@ -425,6 +469,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
                     lp.Stage.UpdateKeyFrame(s);
             }
             UpdateSelectionBox();
+            UpdateBoundingBoxes();
         }
     }
 
@@ -469,6 +514,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
                     lp.Stage.UpdateKeyFrame(s);
             }
             UpdateSelectionBox();
+            UpdateBoundingBoxes();
         }
     }
 
@@ -492,6 +538,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         }
         _historyManager.Push(command.ToUndo(UpdateSelectionBox));
         UpdateSelectionBox();
+        UpdateBoundingBoxes();
         return true;
     }
 
@@ -502,13 +549,17 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
             kv.Key.Rotation = kv.Value;
         _historyManager.Push(command.ToUndo(UpdateSelectionBox));
         UpdateSelectionBox();
+        UpdateBoundingBoxes();
         return true;
     }
 
     protected override void Dispose(bool disposing)
     {
         if (_movie != null)
+        {
             _movie.PlayStateChanged -= OnPlayStateChanged;
+            _movie.SpriteListChanged -= UpdateBoundingBoxes;
+        }
         _player.ActiveMovieChanged -= OnActiveMovieChanged;
         _toolManager.ToolChanged -= OnToolChanged;
         _mediator.Unsubscribe(this);
@@ -527,6 +578,23 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         public override void _Draw()
         {
             DrawRect(_rect, Colors.Yellow, false, 1);
+        }
+    }
+
+    private class BoundingBoxesOverlay : Node2D
+    {
+        private readonly List<Rect2> _rects = new();
+        public void SetRects(IEnumerable<Rect2> rects)
+        {
+            _rects.Clear();
+            _rects.AddRange(rects);
+            QueueRedraw();
+        }
+
+        public override void _Draw()
+        {
+            foreach (var rect in _rects)
+                DrawRect(rect, Colors.Yellow, false, 1);
         }
     }
     

--- a/src/LingoEngine.LGodot/Texts/LingoGodotMemberTextBase.cs
+++ b/src/LingoEngine.LGodot/Texts/LingoGodotMemberTextBase.cs
@@ -137,7 +137,7 @@ namespace LingoEngine.LGodot.Texts
 
 #pragma warning disable CS8618
         public LingoGodotMemberTextBase(ILingoFontManager lingoFontManager)
-#pragma warning restore CS8618 
+#pragma warning restore CS8618
         {
             _fontManager = lingoFontManager;
             _parentNode = new CenterContainer();


### PR DESCRIPTION
## Summary
- support multiple bounding boxes in the director stage window
- show bounding boxes for each selected text/field sprite
- retain group selection rectangle via selection box overlay

## Testing
- `dotnet test LingoEngine.sln --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857b74beef083328dc4b64dda05b5fa