### PR TITLE
Fix stuck window drag in Godot

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Gfx/BaseGodotWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Gfx/BaseGodotWindow.cs
@@ -121,7 +121,15 @@ namespace LingoEngine.Director.LGodot
 
         public override void _UnhandledInput(InputEvent @event)
         {
-            if (@event is InputEventMouseMotion)
+            if (@event is InputEventMouseButton mb)
+            {
+                if (mb.ButtonIndex == MouseButton.Left && !mb.Pressed)
+                {
+                    _dragging = false;
+                    _resizing = false;
+                }
+            }
+            else if (@event is InputEventMouseMotion)
             {
                 if (_dragging)
                 {


### PR DESCRIPTION
## Summary
- fix `BaseGodotWindow` so releasing the mouse outside of the window ends dragging

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a29b9a204833286eedf15c5016727