### PR TITLE
Fix score grid multi-selection

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.SpriteCanvas.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.SpriteCanvas.cs
@@ -31,6 +31,7 @@ internal partial class DirGodotScoreGrid
                 float x = _owner._gfxValues.LeftMargin + (sp.Sprite.BeginFrame - 1) * _owner._gfxValues.FrameWidth;
                 float width = (sp.Sprite.EndFrame - sp.Sprite.BeginFrame + 1) * _owner._gfxValues.FrameWidth;
                 float y = ch * _owner._gfxValues.ChannelHeight;
+                sp.Selected = _owner.IsSpriteSelected(sp);
                 sp.Draw(this, new Vector2(x, y), width, _owner._gfxValues.ChannelHeight, font);
             }
 

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
@@ -179,6 +179,7 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
         if (shift && _lastSelectedCell.HasValue)
         {
             SelectRange(_lastSelectedCell.Value, cell);
+            _lastSelectedCell = cell;
         }
         else if (ctrl)
         {
@@ -207,7 +208,22 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
             for (int x = minX; x <= maxX; x++)
                 _selectedCells.Add(new Vector2I(x, y));
     }
+
     public bool IsCellSelected(Vector2I cell) => _selectedCells.Contains(cell);
+
+    public bool IsSpriteSelected(DirGodotScoreSprite sprite)
+    {
+        if (_selectedCells.Count == 0)
+            return _selected == sprite;
+
+        int row = sprite.Sprite.SpriteNum - 1;
+        for (int frame = sprite.Sprite.BeginFrame; frame <= sprite.Sprite.EndFrame; frame++)
+        {
+            if (_selectedCells.Contains(new Vector2I(frame - 1, row)))
+                return true;
+        }
+        return false;
+    }
 
     public void ClearSelection()
     {


### PR DESCRIPTION
## Summary
- fix multi-selection range tracking
- determine selection state per sprite
- highlight selected sprites in the score grid

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a2a2bb1ec833290932d0a7bbb678b