### PR TITLE
Conditionally add Director lib for TetriGrounds

### DIFF
--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/LingoEngine.Demo.TetriGrounds.Godot.csproj
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/LingoEngine.Demo.TetriGrounds.Godot.csproj
@@ -405,8 +405,10 @@
 	  <None Include="project.godot" />
 	  <None Include="Scenes\root_node_tetri_grounds.tscn" />
 	</ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
     <ProjectReference Include="..\..\..\src\Director\LingoEngine.Director.LGodot\LingoEngine.Director.LGodot.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\..\src\LingoEngine.LGodot\LingoEngine.LGodot.csproj" />
     <ProjectReference Include="..\LingoEngine.Demo.TetriGrounds.Core\LingoEngine.Demo.TetriGrounds.Core.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- only reference the Director library when building the TetriGrounds Godot demo in Debug mode

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a3b7d35bc8332aecc07ffd7317273