### PR TITLE
Add VS Code run tasks

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-dotnettools.csharp",
+        "geequlim.godot-tools"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Requires Godot 4 with the C# tools. Ensure `godot` is in PATH
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Demo SDL2",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.SDL2/bin/Debug/net8.0/LingoEngine.Demo.TetriGrounds.SDL2.dll",
+            "cwd": "${workspaceFolder}/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.SDL2",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Launch Demo Godot",
+            "type": "godot",
+            "request": "launch",
+            "project": "${workspaceFolder}/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot",
+            "preLaunchTask": "build"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "${workspaceFolder}/LingoEngine.sln"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,38 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "${workspaceFolder}/LingoEngine.sln"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "run SDL2",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "run",
+                "--project",
+                "${workspaceFolder}/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.SDL2/LingoEngine.Demo.TetriGrounds.SDL2.csproj"
+            ],
+            "problemMatcher": "$msCompile",
+            "dependsOn": "build"
+        },
+        {
+            "label": "run Godot",
+            "type": "shell",
+            "command": "godot",
+            "args": [
+                "--path",
+                "${workspaceFolder}/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot"
+            ],
+            "problemMatcher": [],
+            "dependsOn": "build"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@
 - [Godot Setup](docs/GodotSetup.md)
 - [SDL2 Setup](docs/SDLSetup.md)
 
+### VS Code Setup
+
+1. Install the [.NET SDK](https://learn.microsoft.com/dotnet/core/install/) and [Godot 4](https://godotengine.org/) with C# support.
+2. Open the repository folder in VS Code and accept the recommended extensions.
+3. Press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> to build the solution.
+4. From the Run and Debug panel choose **Launch Demo SDL2** or **Launch Demo Godot**.
+
+
 ---
 
 ## 🎮 Running the Demo


### PR DESCRIPTION
## Summary
- expand `.vscode` with tasks for running SDL2 and Godot demos
- add Godot debug configuration
- recommend the `godot-tools` extension
- document VS Code usage in the README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6cf55ff08332a550f7d72f163dac