### PR TITLE
Enable undo for drag-and-drop from Cast to Score

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Stages/AddSpriteCommand.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/AddSpriteCommand.cs
@@ -8,6 +8,7 @@ namespace LingoEngine.Director.Core.Stages;
 public sealed record AddSpriteCommand(
     LingoMovie Movie,
     ILingoMember Member,
+    // Channel number is 1-based to match LingoMovie
     int Channel,
     int BeginFrame,
     int EndFrame) : ILingoCommand

--- a/src/Director/LingoEngine.Director.Core/Stages/AddSpriteCommand.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/AddSpriteCommand.cs
@@ -1,0 +1,23 @@
+using LingoEngine.Members;
+using LingoEngine.Movies;
+using LingoEngine.Commands;
+using System;
+
+namespace LingoEngine.Director.Core.Stages;
+
+public sealed record AddSpriteCommand(
+    LingoMovie Movie,
+    ILingoMember Member,
+    int Channel,
+    int BeginFrame,
+    int EndFrame) : ILingoCommand
+{
+    public Action ToUndo(LingoSprite sprite, Action refresh)
+    {
+        return () =>
+        {
+            sprite.RemoveMe();
+            refresh();
+        };
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Stages/ChangeSpriteRangeCommand.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/ChangeSpriteRangeCommand.cs
@@ -1,0 +1,33 @@
+using LingoEngine.Movies;
+using LingoEngine.Commands;
+using System;
+
+namespace LingoEngine.Director.Core.Stages;
+
+public sealed record ChangeSpriteRangeCommand(
+    LingoMovie Movie,
+    LingoSprite Sprite,
+    int StartChannel,
+    int StartBegin,
+    int StartEnd,
+    int EndChannel,
+    int EndBegin,
+    int EndEnd) : ILingoCommand
+{
+    public Action ToUndo(Action refresh)
+    {
+        var sprite = Sprite;
+        var movie = Movie;
+        int channel = StartChannel;
+        int begin = StartBegin;
+        int end = StartEnd;
+        return () =>
+        {
+            if (sprite.SpriteNum - 1 != channel)
+                movie.ChangeSpriteChannel(sprite, channel);
+            sprite.BeginFrame = begin;
+            sprite.EndFrame = end;
+            refresh();
+        };
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreDragHandler.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreDragHandler.cs
@@ -191,7 +191,8 @@ namespace LingoEngine.Director.LGodot.Scores
                 0,
                 out int channel, out int begin, out int end, out var member))
             {
-                _commandManager.Handle(new AddSpriteCommand(_movie!, member!, channel, begin, end));
+                // Convert channel from zero-based to one-based when creating the command
+                _commandManager.Handle(new AddSpriteCommand(_movie!, member!, channel + 1, begin, end));
             }
 
             DirDragDropHolder.EndDrag();

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
@@ -165,8 +165,6 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
             _dragHandler.HandleMouseButton(mb);
         else if (@event is InputEventMouseMotion)
             _dragHandler.HandleMouseMotion();
-        else if (@event is InputEventKey key && key.Pressed && key.Keycode == Key.Z && key.CtrlPressed)
-            _historyManager.Undo();
     }
     internal void SpriteCanvasQueueRedraw() => _spriteCanvas.QueueRedraw();
     internal void MarkSpriteDirty()

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -269,7 +269,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
     public bool CanExecute(AddSpriteCommand command) => true;
     public bool Handle(AddSpriteCommand command)
     {
-        var sprite = command.Movie.AddSprite(command.Channel + 1, command.BeginFrame, command.EndFrame, 0, 0,
+        var sprite = command.Movie.AddSprite(command.Channel, command.BeginFrame, command.EndFrame, 0, 0,
             s => s.SetMember(command.Member));
         _historyManager.Push(command.ToUndo(sprite, RefreshGrid));
         RefreshGrid();

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -6,6 +6,7 @@ using LingoEngine.Director.Core.Windows;
 using LingoEngine.Director.Core.Scores;
 using LingoEngine.Director.LGodot;
 using LingoEngine.Director.LGodot.Gfx;
+using LingoEngine.Director.Core.Stages;
 
 namespace LingoEngine.Director.LGodot.Scores;
 
@@ -13,7 +14,9 @@ namespace LingoEngine.Director.LGodot.Scores;
 /// Simple timeline overlay showing the Score channels and frames.
 /// Toggled with F2.
 /// </summary>
-public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWindow
+public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWindow,
+    ICommandHandler<ChangeSpriteRangeCommand>,
+    ICommandHandler<AddSpriteCommand>
 {
    
     
@@ -40,13 +43,15 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
 
     private readonly IDirectorEventMediator _mediator;
     private readonly ILingoCommandManager _commandManager;
+    private readonly IHistoryManager _historyManager;
 
 
-    public DirGodotScoreWindow(IDirectorEventMediator directorMediator, ILingoCommandManager commandManager, DirectorScoreWindow directorScoreWindow, ILingoPlayer player, IDirGodotWindowManager windowManager)
+    public DirGodotScoreWindow(IDirectorEventMediator directorMediator, ILingoCommandManager commandManager, IHistoryManager historyManager, DirectorScoreWindow directorScoreWindow, ILingoPlayer player, IDirGodotWindowManager windowManager)
         : base(DirectorMenuCodes.ScoreWindow, "Score", windowManager)
     {
         _mediator = directorMediator;
         _commandManager = commandManager;
+        _historyManager = historyManager;
         directorScoreWindow.Init(this);
         _player = player;
         _player.ActiveMovieChanged += OnActiveMovieChanged;
@@ -66,7 +71,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         _soundBar = new DirGodotSoundBar(_gfxValues);
         _soundBar.Collapsed = true;
         _channelBar = new DirGodotScoreChannelBar(_gfxValues, _soundBar);
-        _grid = new DirGodotScoreGrid(directorMediator, _gfxValues);
+        _grid = new DirGodotScoreGrid(directorMediator, _gfxValues, commandManager, historyManager);
         _mediator.Subscribe(_grid);
         _header = new DirGodotFrameHeader(_gfxValues);
         _frameScripts = new DirGodotFrameScriptsBar(_gfxValues);
@@ -165,6 +170,11 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         _soundBar.ScrollX = _masterScroller.ScrollHorizontal;
     }
 
+    private void RefreshGrid()
+    {
+        _grid.MarkSpriteDirty();
+    }
+
     private void UpdateScrollSize()
     {
         if (_movie == null) return;
@@ -242,6 +252,28 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
                 }
             }
         }
+    }
+
+    public bool CanExecute(ChangeSpriteRangeCommand command) => true;
+    public bool Handle(ChangeSpriteRangeCommand command)
+    {
+        if (command.EndChannel != command.Sprite.SpriteNum - 1)
+            command.Movie.ChangeSpriteChannel(command.Sprite, command.EndChannel);
+        command.Sprite.BeginFrame = command.EndBegin;
+        command.Sprite.EndFrame = command.EndEnd;
+        _historyManager.Push(command.ToUndo(RefreshGrid));
+        RefreshGrid();
+        return true;
+    }
+
+    public bool CanExecute(AddSpriteCommand command) => true;
+    public bool Handle(AddSpriteCommand command)
+    {
+        var sprite = command.Movie.AddSprite(command.Channel + 1, command.BeginFrame, command.EndFrame, 0, 0,
+            s => s.SetMember(command.Member));
+        _historyManager.Push(command.ToUndo(sprite, RefreshGrid));
+        RefreshGrid();
+        return true;
     }
 
  


### PR DESCRIPTION
## Summary
- implement `AddSpriteCommand` with undo capability
- trigger `AddSpriteCommand` when dropping a cast member on the score grid
- handle `AddSpriteCommand` in `DirGodotScoreWindow`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cae5752448332b7073d3a2c0f049d