### PR TITLE
Expose behavior property container

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
@@ -337,6 +337,33 @@ public partial class DirGodotPropertyInspector : BaseGodotWindow, IHasSpriteSele
         }
         var container = new VBoxContainer();
         BuildProperties(container, behavior);
+        if (behavior is ILingoPropertyDescriptionList descProvider)
+        {
+            string? desc = descProvider.GetBehaviorDescription();
+            if (!string.IsNullOrEmpty(desc))
+                container.AddChild(new Label { Text = desc });
+
+            var props = behavior.UserProperties;
+            if (props.Count > 0)
+            {
+                container.AddChild(new Label { Text = "Properties" });
+                foreach (var item in props)
+                {
+                    string labelText = item.Key.ToString();
+                    if (props.DescriptionList != null &&
+                        props.DescriptionList.TryGetValue(item.Key, out var desc) &&
+                        !string.IsNullOrEmpty(desc.Comment))
+                    {
+                        labelText = desc.Comment!;
+                    }
+
+                    var h = new HBoxContainer();
+                    h.AddChild(new Label { Text = labelText, CustomMinimumSize = new Vector2(80, 16) });
+                    h.AddChild(new Label { Text = item.Value?.ToString() ?? string.Empty });
+                    container.AddChild(h);
+                }
+            }
+        }
         _behaviorBox.AddChild(container);
         _behaviorPanel.Visible = true;
         OnResizing(Size);

--- a/src/LingoEngine/Movies/BehaviorPropertiesContainer.cs
+++ b/src/LingoEngine/Movies/BehaviorPropertiesContainer.cs
@@ -1,0 +1,50 @@
+using System.Collections;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.Movies;
+
+/// <summary>
+/// Container for behavior properties set by the user. Holds the values
+/// and, optionally, the description list returned by
+/// <c>getPropertyDescriptionList</c>.
+/// </summary>
+public class BehaviorPropertiesContainer : IEnumerable<LingoPropertyItem>
+{
+    /// <summary>A single property entry.</summary>
+    public class LingoPropertyItem
+    {
+        public LingoSymbol Key { get; set; } = LingoSymbol.Empty;
+        public object? Value { get; set; }
+    }
+
+    private readonly List<LingoPropertyItem> _items = new();
+
+    /// <summary>
+    /// Optional property description list describing each property as
+    /// returned by <c>getPropertyDescriptionList</c>.
+    /// </summary>
+    public LingoPropertyList<LingoPropertyDescription>? DescriptionList { get; set; }
+
+    /// <summary>Gets or sets a property by key.</summary>
+    public object? this[LingoSymbol key]
+    {
+        get => _items.FirstOrDefault(i => i.Key.Equals(key))?.Value;
+        set
+        {
+            var idx = _items.FindIndex(i => i.Key.Equals(key));
+            if (idx >= 0)
+                _items[idx].Value = value;
+            else
+                _items.Add(new LingoPropertyItem { Key = key, Value = value });
+        }
+    }
+
+    /// <summary>Enumerates all property keys.</summary>
+    public IEnumerable<LingoSymbol> Keys => _items.Select(i => i.Key);
+
+    /// <summary>The number of stored properties.</summary>
+    public int Count => _items.Count;
+
+    public IEnumerator<LingoPropertyItem> GetEnumerator() => _items.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/LingoEngine/Movies/ILingoPropertyDescriptionList.cs
+++ b/src/LingoEngine/Movies/ILingoPropertyDescriptionList.cs
@@ -1,0 +1,33 @@
+namespace LingoEngine.Movies
+{
+    using LingoEngine.Primitives;
+
+    /// <summary>
+    /// Interface for behaviors that expose property description list support.
+    /// Mirrors the Lingo handlers getPropertyDescriptionList, getBehaviorDescription,
+    /// getBehaviorTooltip, runPropertyDialog and isOKToAttach.
+    /// </summary>
+    public interface ILingoPropertyDescriptionList
+    {
+        /// <summary>Returns property descriptions for this behavior.</summary>
+        BehaviorPropertiesContainer? GetPropertyDescriptionList();
+
+        /// <summary>Returns a descriptive string for the behavior.</summary>
+        string? GetBehaviorDescription();
+
+        /// <summary>Returns the tooltip string for the behavior.</summary>
+        string? GetBehaviorTooltip();
+
+        /// <summary>
+        /// Called when the user edits properties. Implementations should
+        /// update and return the initializer list.
+        /// </summary>
+        BehaviorPropertiesContainer? RunPropertyDialog(BehaviorPropertiesContainer currentInitializerList);
+
+        /// <summary>
+        /// Called before attaching the behavior to a sprite. Should return
+        /// <see langword="true"/> if the attachment is allowed.
+        /// </summary>
+        bool IsOKToAttach(LingoSymbol spriteType, int spriteNum);
+    }
+}

--- a/src/LingoEngine/Movies/LingoSpriteBehavior.cs
+++ b/src/LingoEngine/Movies/LingoSpriteBehavior.cs
@@ -1,4 +1,5 @@
 ﻿using LingoEngine.Core;
+using LingoEngine.Primitives;
 
 namespace LingoEngine.Movies
 {
@@ -6,9 +7,15 @@ namespace LingoEngine.Movies
     {
         protected LingoSprite Me;
         public LingoSprite GetSprite() => Me;
-#pragma warning disable CS8618 
+
+        /// <summary>
+        /// Properties configured by the user via the property dialog.
+        /// </summary>
+        public BehaviorPropertiesContainer UserProperties { get; } = new();
+
+#pragma warning disable CS8618
         public LingoSpriteBehavior(ILingoMovieEnvironment env) : base(env)
-#pragma warning restore CS8618 
+#pragma warning restore CS8618
         {
         }
 

--- a/src/LingoEngine/Primitives/LingoPropertyDescription.cs
+++ b/src/LingoEngine/Primitives/LingoPropertyDescription.cs
@@ -1,0 +1,20 @@
+namespace LingoEngine.Primitives
+{
+    /// <summary>
+    /// Describes a configurable behavior property.
+    /// </summary>
+    public class LingoPropertyDescription
+    {
+        /// <summary>The property's initial value.</summary>
+        public object? Default { get; set; }
+
+        /// <summary>The expected data type of the value.</summary>
+        public LingoSymbol Format { get; set; } = LingoSymbol.Empty;
+
+        /// <summary>Label shown in the Parameters dialog.</summary>
+        public string? Comment { get; set; }
+
+        /// <summary>Optional range or list of valid values.</summary>
+        public IEnumerable<object?>? Range { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add `LingoPropertyDescription` for property dialog metadata
- rename `PropertyItem` to `LingoPropertyItem` and expose description list strongly typed
- extend `ILingoPropertyDescriptionList` with `IsOKToAttach`
- show descriptions in property inspector when a behavior implements the interface
- make property description range an `IEnumerable` to address review feedback
- show behavior description text when available

## Testing
- `dotnet build LingoEngine.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685cc3fe492883329d95ce37d4a99a1a