### PR TITLE
Add stricter property list interface check

### DIFF
--- a/Test/LingoEngine.Lingo.Core.Tests/ClassGenerationTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/ClassGenerationTests.cs
@@ -68,4 +68,50 @@ public class ClassGenerationTests
             "}");
         Assert.Equal(expected, result);
     }
+
+    [Fact]
+    public void BehaviorScriptWithAllPropertyDescriptionHandlersImplementsInterface()
+    {
+        var file = new LingoScriptFile
+        {
+            Name = "MyBehavior",
+            Source = string.Join('\n',
+                "on getPropertyDescriptionList",
+                "end",
+                "on getBehaviorDescription",
+                "end",
+                "on getBehaviorTooltip",
+                "end",
+                "on runPropertyDialog",
+                "end",
+                "on isOKToAttach",
+                "end"),
+            Type = LingoScriptType.Behavior
+        };
+        var result = LingoToCSharpConverter.ConvertClass(file).Trim();
+        var expected = string.Join('\n',
+            "public class MyBehaviorBehavior : LingoSpriteBehavior, ILingoPropertyDescriptionList",
+            "{",
+            "    public MyBehaviorBehavior(ILingoMovieEnvironment env) : base(env) { }",
+            "}");
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void BehaviorScriptWithPartialPropertyDescriptionHandlersDoesNotImplementInterface()
+    {
+        var file = new LingoScriptFile
+        {
+            Name = "MyBehavior",
+            Source = "on getPropertyDescriptionList\nend",
+            Type = LingoScriptType.Behavior
+        };
+        var result = LingoToCSharpConverter.ConvertClass(file).Trim();
+        var expected = string.Join('\n',
+            "public class MyBehaviorBehavior : LingoSpriteBehavior",
+            "{",
+            "    public MyBehaviorBehavior(ILingoMovieEnvironment env) : base(env) { }",
+            "}");
+        Assert.Equal(expected, result);
+    }
 }

--- a/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
+++ b/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
@@ -96,8 +96,27 @@ public static class LingoToCSharpConverter
 
         var className = script.Name + suffix;
 
+        var handlers = ExtractHandlerNames(script.Source);
+        string[] propDescRequired =
+        {
+            "getPropertyDescriptionList",
+            "getBehaviorDescription",
+            "getBehaviorTooltip",
+            "runPropertyDialog",
+            "isOKToAttach"
+        };
+        bool hasPropDescHandlers = true;
+        foreach (string h in propDescRequired)
+        {
+            if (!handlers.Contains(h))
+            {
+                hasPropDescHandlers = false;
+                break;
+            }
+        }
+
         var sb = new System.Text.StringBuilder();
-        sb.AppendLine($"public class {className} : {baseType}");
+        sb.AppendLine($"public class {className} : {baseType}{(hasPropDescHandlers ? ", ILingoPropertyDescriptionList" : string.Empty)}");
         sb.AppendLine("{");
 
         bool needsGlobal = script.Type == LingoScriptType.Movie || script.Type == LingoScriptType.Parent;


### PR DESCRIPTION
## Summary
- require all property description handlers before implementing `ILingoPropertyDescriptionList`
- verify interface inclusion only when all handlers exist
- ensure partial implementations do not implement the interface

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ccfe7ad64833287d8fd29681e1ed3