### PR TITLE
Add basic 3D movie and sprite types

### DIFF
--- a/src/LingoEngine.3D.Core/Lingo3dSetup.cs
+++ b/src/LingoEngine.3D.Core/Lingo3dSetup.cs
@@ -1,0 +1,17 @@
+using LingoEngine.FrameworkCommunication;
+using Microsoft.Extensions.DependencyInjection;
+using LingoEngine;
+
+namespace LingoEngine._3D;
+
+/// <summary>
+/// Extension helpers to register the 3D engine services.
+/// </summary>
+public static class Lingo3dSetup
+{
+    public static ILingoEngineRegistration WithLingo3d(this ILingoEngineRegistration reg)
+    {
+        reg.Services(s => s.AddSingleton<ILingoFrameworkFactory, Lingo3dFactory>());
+        return reg;
+    }
+}

--- a/src/LingoEngine.3D.Core/Members/ILingoFrameworkMember3D.cs
+++ b/src/LingoEngine.3D.Core/Members/ILingoFrameworkMember3D.cs
@@ -1,4 +1,4 @@
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Members;
 
 using LingoEngine.FrameworkCommunication;
 

--- a/src/LingoEngine.3D.Core/Members/LingoCamera.cs
+++ b/src/LingoEngine.3D.Core/Members/LingoCamera.cs
@@ -1,6 +1,6 @@
 using LingoEngine.Primitives;
 
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Members;
 
 /// <summary>
 /// Camera used by a 3D sprite to view the world.

--- a/src/LingoEngine.3D.Core/Members/LingoGroup.cs
+++ b/src/LingoEngine.3D.Core/Members/LingoGroup.cs
@@ -1,4 +1,4 @@
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Members;
 
 /// <summary>
 /// A basic node in a 3D world used to group objects.

--- a/src/LingoEngine.3D.Core/Members/LingoLight.cs
+++ b/src/LingoEngine.3D.Core/Members/LingoLight.cs
@@ -1,6 +1,6 @@
 using LingoEngine.Primitives;
 
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Members;
 
 /// <summary>
 /// Light used to illuminate a 3D world.

--- a/src/LingoEngine.3D.Core/Members/LingoMember3D.cs
+++ b/src/LingoEngine.3D.Core/Members/LingoMember3D.cs
@@ -4,7 +4,7 @@ using LingoEngine.Primitives;
 using LingoEngine.Casts;
 using LingoEngine.Members;
 
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Members;
 
 /// <summary>
 /// Represents a Shockwave 3D cast member containing a complete 3D world.

--- a/src/LingoEngine.3D.Core/Members/LingoModel.cs
+++ b/src/LingoEngine.3D.Core/Members/LingoModel.cs
@@ -1,4 +1,4 @@
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Members;
 
 /// <summary>
 /// Visible object within a 3D world.

--- a/src/LingoEngine.3D.Core/Members/LingoModelResource.cs
+++ b/src/LingoEngine.3D.Core/Members/LingoModelResource.cs
@@ -1,4 +1,4 @@
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Members;
 
 /// <summary>
 /// Element of 3D geometry used to draw models.

--- a/src/LingoEngine.3D.Core/Members/LingoMotion.cs
+++ b/src/LingoEngine.3D.Core/Members/LingoMotion.cs
@@ -1,4 +1,4 @@
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Members;
 
 /// <summary>
 /// Motion data applied to a model for animation.

--- a/src/LingoEngine.3D.Core/Members/LingoShader.cs
+++ b/src/LingoEngine.3D.Core/Members/LingoShader.cs
@@ -1,6 +1,6 @@
 using LingoEngine.Primitives;
 
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Members;
 
 /// <summary>
 /// Defines how a model surface is shaded.

--- a/src/LingoEngine.3D.Core/Members/LingoTexture.cs
+++ b/src/LingoEngine.3D.Core/Members/LingoTexture.cs
@@ -1,5 +1,5 @@
 using LingoEngine.Primitives;
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Members;
 
 /// <summary>
 /// Texture applied to a model surface.

--- a/src/LingoEngine.3D.Core/Movies/ILingoFrameworkMovie3D.cs
+++ b/src/LingoEngine.3D.Core/Movies/ILingoFrameworkMovie3D.cs
@@ -1,0 +1,10 @@
+using LingoEngine.FrameworkCommunication;
+
+namespace LingoEngine._3D.Movies;
+
+/// <summary>
+/// Framework interface for 3D movies.
+/// </summary>
+public interface ILingoFrameworkMovie3D : ILingoFrameworkMovie
+{
+}

--- a/src/LingoEngine.3D.Core/Movies/ILingoFrameworkSprite3D.cs
+++ b/src/LingoEngine.3D.Core/Movies/ILingoFrameworkSprite3D.cs
@@ -1,0 +1,10 @@
+using LingoEngine.FrameworkCommunication;
+
+namespace LingoEngine._3D.Movies;
+
+/// <summary>
+/// Framework interface for 3D sprites.
+/// </summary>
+public interface ILingoFrameworkSprite3D : ILingoFrameworkSprite
+{
+}

--- a/src/LingoEngine.3D.Core/Movies/Lingo3DMovie.cs
+++ b/src/LingoEngine.3D.Core/Movies/Lingo3DMovie.cs
@@ -1,0 +1,25 @@
+using LingoEngine.Casts;
+using LingoEngine.Core;
+using LingoEngine.Events;
+using LingoEngine.Members;
+using LingoEngine.Movies;
+
+namespace LingoEngine._3D.Movies;
+
+/// <summary>
+/// Movie subclass exposing basic 3D related properties.
+/// </summary>
+public class Lingo3DMovie : LingoMovie
+{
+    public string Active3dRenderer { get; set; } = string.Empty;
+    public string Preferred3dRenderer { get; set; } = string.Empty;
+
+    public Lingo3DMovie(LingoMovieEnvironment environment, LingoStage movieStage,
+        LingoCastLibsContainer castLibContainer, ILingoMemberFactory memberFactory,
+        string name, int number, LingoEventMediator mediator,
+        Action<LingoMovie> onRemoveMe, ProjectSettings projectSettings)
+        : base(environment, movieStage, castLibContainer, memberFactory, name,
+            number, mediator, onRemoveMe, projectSettings)
+    {
+    }
+}

--- a/src/LingoEngine.3D.Core/Movies/Lingo3DSprite.cs
+++ b/src/LingoEngine.3D.Core/Movies/Lingo3DSprite.cs
@@ -1,0 +1,29 @@
+using LingoEngine.Movies;
+using LingoEngine._3D.Members;
+using LingoEngine.Events;
+
+namespace LingoEngine._3D.Movies;
+
+/// <summary>
+/// Sprite type that exposes basic 3D functionality.
+/// </summary>
+public class Lingo3DSprite : LingoSprite
+{
+    private readonly List<LingoCamera> _cameras = new();
+
+    public Lingo3DSprite(ILingoMovieEnvironment environment) : base(environment)
+    {
+    }
+
+    /// <summary>Active camera for this sprite.</summary>
+    public LingoCamera? Camera { get; set; }
+
+    /// <summary>Adds a camera to the sprite.</summary>
+    public void AddCamera(LingoCamera camera) => _cameras.Add(camera);
+
+    /// <summary>Deletes a camera from the sprite.</summary>
+    public void DeleteCamera(LingoCamera camera) => _cameras.Remove(camera);
+
+    /// <summary>Number of cameras associated with the sprite.</summary>
+    public int CameraCount => _cameras.Count;
+}

--- a/src/LingoEngine.3D.Core/Movies/Lingo3dFactory.cs
+++ b/src/LingoEngine.3D.Core/Movies/Lingo3dFactory.cs
@@ -1,0 +1,55 @@
+using LingoEngine.Casts;
+using LingoEngine.Core;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Inputs;
+using LingoEngine.Members;
+using LingoEngine.Movies;
+using LingoEngine.Pictures;
+using LingoEngine.Primitives;
+using LingoEngine.Sounds;
+using LingoEngine.Shapes;
+using LingoEngine.Texts;
+using LingoEngine.Gfx;
+
+namespace LingoEngine._3D;
+
+/// <summary>
+/// Simple factory that delegates to an underlying <see cref="ILingoFrameworkFactory"/>
+/// while exposing helpers for 3D specific sprites and movies.
+/// </summary>
+public class Lingo3dFactory : ILingoFrameworkFactory
+{
+    private readonly ILingoFrameworkFactory _baseFactory;
+
+    public Lingo3dFactory(ILingoFrameworkFactory baseFactory)
+    {
+        _baseFactory = baseFactory;
+    }
+
+    public LingoStage CreateStage(LingoPlayer lingoPlayer) => _baseFactory.CreateStage(lingoPlayer);
+    public LingoMovie AddMovie(LingoStage stage, LingoMovie lingoMovie) => _baseFactory.AddMovie(stage, lingoMovie);
+    public T CreateMember<T>(ILingoCast cast, int numberInCast, string name = "") where T : LingoMember => _baseFactory.CreateMember<T>(cast, numberInCast, name);
+    public LingoMemberPicture CreateMemberPicture(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default) => _baseFactory.CreateMemberPicture(cast, numberInCast, name, fileName, regPoint);
+    public LingoMemberSound CreateMemberSound(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default) => _baseFactory.CreateMemberSound(cast, numberInCast, name, fileName, regPoint);
+    public LingoMemberFilmLoop CreateMemberFilmLoop(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default) => _baseFactory.CreateMemberFilmLoop(cast, numberInCast, name, fileName, regPoint);
+    public LingoMemberShape CreateMemberShape(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default) => _baseFactory.CreateMemberShape(cast, numberInCast, name, fileName, regPoint);
+    public LingoMemberField CreateMemberField(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default) => _baseFactory.CreateMemberField(cast, numberInCast, name, fileName, regPoint);
+    public LingoMemberText CreateMemberText(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default) => _baseFactory.CreateMemberText(cast, numberInCast, name, fileName, regPoint);
+    public LingoMember CreateEmpty(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default) => _baseFactory.CreateEmpty(cast, numberInCast, name, fileName, regPoint);
+    public LingoSound CreateSound(ILingoCastLibsContainer castLibsContainer) => _baseFactory.CreateSound(castLibsContainer);
+    public LingoSoundChannel CreateSoundChannel(int number) => _baseFactory.CreateSoundChannel(number);
+    public LingoMouse CreateMouse(LingoStage stage) => _baseFactory.CreateMouse(stage);
+    public LingoKey CreateKey() => _baseFactory.CreateKey();
+    public LingoGfxCanvas CreateGfxCanvas(int width, int height) => _baseFactory.CreateGfxCanvas(width, height);
+    public LingoWrapPanel CreateWrapPanel(LingoOrientation orientation) => _baseFactory.CreateWrapPanel(orientation);
+    public LingoPanel CreatePanel() => _baseFactory.CreatePanel();
+    public LingoGfxTabContainer CreateTabContainer() => _baseFactory.CreateTabContainer();
+    public LingoInputText CreateInputText(int maxLength = 0) => _baseFactory.CreateInputText(maxLength);
+    public LingoInputNumber CreateInputNumber(float min = 0, float max = 100) => _baseFactory.CreateInputNumber(min, max);
+    public LingoInputCheckbox CreateInputCheckbox() => _baseFactory.CreateInputCheckbox();
+    public LingoInputCombobox CreateInputCombobox() => _baseFactory.CreateInputCombobox();
+    public LingoLabel CreateLabel(string text = "") => _baseFactory.CreateLabel(text);
+    public T CreateSprite<T>(ILingoMovie movie, Action<LingoSprite> onRemoveMe) where T : LingoSprite => _baseFactory.CreateSprite<T>(movie, onRemoveMe);
+    public T CreateBehavior<T>(LingoMovie lingoMovie) where T : LingoSpriteBehavior => _baseFactory.CreateBehavior<T>(lingoMovie);
+    public T CreateMovieScript<T>(LingoMovie lingoMovie) where T : LingoMovieScript => _baseFactory.CreateMovieScript<T>(lingoMovie);
+}

--- a/src/LingoEngine.3D.Core/Primitives/LingoBox.cs
+++ b/src/LingoEngine.3D.Core/Primitives/LingoBox.cs
@@ -1,4 +1,4 @@
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Primitives;
 
 /// <summary>
 /// Model resource primitive of type #box.

--- a/src/LingoEngine.3D.Core/Primitives/LingoColorRange.cs
+++ b/src/LingoEngine.3D.Core/Primitives/LingoColorRange.cs
@@ -1,6 +1,6 @@
 using LingoEngine.Primitives;
 
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Primitives;
 
 /// <summary>
 /// Represents the start and end colors for particle systems.

--- a/src/LingoEngine.3D.Core/Primitives/LingoCylinder.cs
+++ b/src/LingoEngine.3D.Core/Primitives/LingoCylinder.cs
@@ -1,4 +1,4 @@
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Primitives;
 
 /// <summary>
 /// Model resource primitive of type #cylinder.

--- a/src/LingoEngine.3D.Core/Primitives/LingoEmitter.cs
+++ b/src/LingoEngine.3D.Core/Primitives/LingoEmitter.cs
@@ -1,4 +1,4 @@
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Primitives;
 
 /// <summary>
 /// Describes how particles are emitted in a particle system.

--- a/src/LingoEngine.3D.Core/Primitives/LingoParticle.cs
+++ b/src/LingoEngine.3D.Core/Primitives/LingoParticle.cs
@@ -1,6 +1,6 @@
 using LingoEngine.Primitives;
 
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Primitives;
 
 /// <summary>
 /// Model resource primitive of type #particle.

--- a/src/LingoEngine.3D.Core/Primitives/LingoPlane.cs
+++ b/src/LingoEngine.3D.Core/Primitives/LingoPlane.cs
@@ -1,4 +1,4 @@
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Primitives;
 
 /// <summary>
 /// Model resource primitive of type #plane.

--- a/src/LingoEngine.3D.Core/Primitives/LingoSphere.cs
+++ b/src/LingoEngine.3D.Core/Primitives/LingoSphere.cs
@@ -1,4 +1,4 @@
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Primitives;
 
 /// <summary>
 /// Model resource primitive of type #sphere.

--- a/src/LingoEngine.3D.Core/Primitives/LingoVector3.cs
+++ b/src/LingoEngine.3D.Core/Primitives/LingoVector3.cs
@@ -1,4 +1,4 @@
-namespace LingoEngine.Primitives3D;
+namespace LingoEngine._3D.Primitives;
 
 /// <summary>
 /// Represents a point or direction in 3D space.

--- a/src/LingoEngine/Movies/LingoMovie.cs
+++ b/src/LingoEngine/Movies/LingoMovie.cs
@@ -110,8 +110,8 @@ namespace LingoEngine.Movies
 
 
 #pragma warning disable CS8618
-        internal LingoMovie(LingoMovieEnvironment environment, LingoStage movieStage, LingoCastLibsContainer castLibContainer, ILingoMemberFactory memberFactory, string name, int number, LingoEventMediator mediator, Action<LingoMovie> onRemoveMe, ProjectSettings projectSettings)
-#pragma warning restore CS8618 
+        protected internal LingoMovie(LingoMovieEnvironment environment, LingoStage movieStage, LingoCastLibsContainer castLibContainer, ILingoMemberFactory memberFactory, string name, int number, LingoEventMediator mediator, Action<LingoMovie> onRemoveMe, ProjectSettings projectSettings)
+#pragma warning restore CS8618
         {
             _castLibContainer = castLibContainer;
             _environment = environment;


### PR DESCRIPTION
## Summary
- add Lingo3DSprite and simple camera helpers
- add Lingo3DMovie with renderer properties
- provide 3D factory and setup utilities
- expose framework interfaces for 3D sprites and movies
- allow external projects to derive from `LingoMovie`
- update 3D namespaces to match `LingoEngine.3D.Core`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cde9e7570833282aa2a1f5d49f86c