### PR TITLE
Add Gfx menu components

### DIFF
--- a/src/LingoEngine.3D.Core/Movies/Lingo3dFactory.cs
+++ b/src/LingoEngine.3D.Core/Movies/Lingo3dFactory.cs
@@ -49,6 +49,8 @@ public class Lingo3dFactory : ILingoFrameworkFactory
     public LingoInputCheckbox CreateInputCheckbox() => _baseFactory.CreateInputCheckbox();
     public LingoInputCombobox CreateInputCombobox() => _baseFactory.CreateInputCombobox();
     public LingoLabel CreateLabel(string text = "") => _baseFactory.CreateLabel(text);
+    public LingoMenu CreateMenu(string name) => _baseFactory.CreateMenu(name);
+    public LingoMenuItem CreateMenuItem(string name, string? shortcut = null) => _baseFactory.CreateMenuItem(name, shortcut);
     public T CreateSprite<T>(ILingoMovie movie, Action<LingoSprite> onRemoveMe) where T : LingoSprite => _baseFactory.CreateSprite<T>(movie, onRemoveMe);
     public T CreateBehavior<T>(LingoMovie lingoMovie) where T : LingoSpriteBehavior => _baseFactory.CreateBehavior<T>(lingoMovie);
     public T CreateMovieScript<T>(LingoMovie lingoMovie) where T : LingoMovieScript => _baseFactory.CreateMovieScript<T>(lingoMovie);

--- a/src/LingoEngine.LGodot/Gfx/LingoGodotMenu.cs
+++ b/src/LingoEngine.LGodot/Gfx/LingoGodotMenu.cs
@@ -1,0 +1,87 @@
+using Godot;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+using System;
+using System.Collections.Generic;
+
+namespace LingoEngine.LGodot.Gfx
+{
+    /// <summary>
+    /// Godot implementation of <see cref="ILingoFrameworkGfxMenu"/>.
+    /// </summary>
+    public partial class LingoGodotMenu : PopupMenu, ILingoFrameworkGfxMenu, IDisposable
+    {
+        private readonly Dictionary<int, LingoGodotMenuItem> _items = new();
+        private string _name;
+        private LingoMargin _margin;
+
+        public LingoGodotMenu(LingoMenu menu, string name)
+        {
+            _name = name;
+            _margin = LingoMargin.Zero;
+            menu.Init(this);
+            IdPressed += OnIdPressed;
+        }
+
+        public string Name { get => _name; set => _name = value; }
+
+        public float X { get => Position.X; set => Position = new Vector2(value, Position.Y); }
+        public float Y { get => Position.Y; set => Position = new Vector2(Position.X, value); }
+        public float Width { get => Size.X; set => Size = new Vector2(value, Size.Y); }
+        public float Height { get => Size.Y; set => Size = new Vector2(Size.X, value); }
+        public bool Visibility { get => Visible; set => Visible = value; }
+
+        public LingoMargin Margin
+        {
+            get => _margin;
+            set
+            {
+                _margin = value;
+                AddThemeConstantOverride("margin_left", (int)value.Left);
+                AddThemeConstantOverride("margin_right", (int)value.Right);
+                AddThemeConstantOverride("margin_top", (int)value.Top);
+                AddThemeConstantOverride("margin_bottom", (int)value.Bottom);
+            }
+        }
+
+        public void AddItem(ILingoFrameworkGfxMenuItem item)
+        {
+            if (item is not LingoGodotMenuItem godotItem)
+                return;
+            int id = ItemCount;
+            godotItem.Attach(this, id);
+            _items[id] = godotItem;
+            base.AddItem(godotItem.GetDisplayText(), id);
+            UpdateItem(godotItem);
+        }
+
+        public void ClearItems()
+        {
+            Clear();
+            _items.Clear();
+        }
+
+        internal void RegisterItem(LingoGodotMenuItem item)
+        {
+            UpdateItem(item);
+        }
+
+        internal void UpdateItem(LingoGodotMenuItem item)
+        {
+            if (!_items.ContainsKey(item.Id))
+                return;
+            int idx = GetItemIndex(item.Id);
+            SetItemText(idx, item.GetDisplayText());
+            SetItemDisabled(idx, !item.Enabled);
+            SetItemChecked(idx, item.CheckMark);
+        }
+
+        private void OnIdPressed(long id)
+        {
+            if (_items.TryGetValue((int)id, out var item))
+                item.RaiseActivated();
+        }
+
+        public void Dispose() => QueueFree();
+    }
+}

--- a/src/LingoEngine.LGodot/Gfx/LingoGodotMenuItem.cs
+++ b/src/LingoEngine.LGodot/Gfx/LingoGodotMenuItem.cs
@@ -1,0 +1,50 @@
+using Godot;
+using LingoEngine.Gfx;
+using System;
+
+namespace LingoEngine.LGodot.Gfx
+{
+    /// <summary>
+    /// Godot implementation of <see cref="ILingoFrameworkGfxMenuItem"/>.
+    /// </summary>
+    internal partial class LingoGodotMenuItem : ILingoFrameworkGfxMenuItem, IDisposable
+    {
+        private string _name;
+        private bool _enabled = true;
+        private bool _check;
+        private string? _shortcut;
+        private LingoGodotMenu? _menu;
+        internal int Id { get; private set; }
+
+        public event Action? Activated;
+
+        public LingoGodotMenuItem(string name, string? shortcut)
+        {
+            _name = name;
+            _shortcut = shortcut;
+        }
+
+        public string Name { get => _name; set { _name = value; Update(); } }
+        public bool Enabled { get => _enabled; set { _enabled = value; Update(); } }
+        public bool CheckMark { get => _check; set { _check = value; Update(); } }
+        public string? Shortcut { get => _shortcut; set { _shortcut = value; Update(); } }
+
+        internal void Attach(LingoGodotMenu menu, int id)
+        {
+            _menu = menu;
+            Id = id;
+            menu.RegisterItem(this);
+        }
+
+        internal void RaiseActivated() => Activated?.Invoke();
+
+        internal void Update()
+        {
+            _menu?.UpdateItem(this);
+        }
+
+        internal string GetDisplayText() => string.IsNullOrEmpty(_shortcut) ? _name : $"{_name}\t{_shortcut}";
+
+        public void Dispose() { }
+    }
+}

--- a/src/LingoEngine.LGodot/GodotFactory.cs
+++ b/src/LingoEngine.LGodot/GodotFactory.cs
@@ -258,5 +258,21 @@ namespace LingoEngine.LGodot
             _rootNode.AddChild(impl);
             return label;
         }
+
+        public LingoMenu CreateMenu(string name)
+        {
+            var menu = new LingoMenu();
+            var impl = new LingoGodotMenu(menu, name);
+            _rootNode.AddChild(impl);
+            return menu;
+        }
+
+        public LingoMenuItem CreateMenuItem(string name, string? shortcut = null)
+        {
+            var item = new LingoMenuItem();
+            var impl = new LingoGodotMenuItem(name, shortcut);
+            item.Init(impl);
+            return item;
+        }
     }
 }

--- a/src/LingoEngine.SDL2/Gfx/SdlMenu.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlMenu.cs
@@ -1,0 +1,26 @@
+using System;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.SDL2.Gfx
+{
+    internal class SdlMenu : ILingoFrameworkGfxMenu, IDisposable
+    {
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Width { get; set; }
+        public float Height { get; set; }
+        public bool Visibility { get; set; } = true;
+        public LingoMargin Margin { get; set; } = LingoMargin.Zero;
+        public string Name { get; set; }
+
+        public SdlMenu(string name)
+        {
+            Name = name;
+        }
+
+        public void AddItem(ILingoFrameworkGfxMenuItem item) { }
+        public void ClearItems() { }
+        public void Dispose() { }
+    }
+}

--- a/src/LingoEngine.SDL2/Gfx/SdlMenuItem.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlMenuItem.cs
@@ -1,0 +1,23 @@
+using System;
+using LingoEngine.Gfx;
+
+namespace LingoEngine.SDL2.Gfx
+{
+    internal class SdlMenuItem : ILingoFrameworkGfxMenuItem, IDisposable
+    {
+        public string Name { get; set; }
+        public bool Enabled { get; set; } = true;
+        public bool CheckMark { get; set; }
+        public string? Shortcut { get; set; }
+        public event Action? Activated;
+
+        public SdlMenuItem(string name, string? shortcut)
+        {
+            Name = name;
+            Shortcut = shortcut;
+        }
+
+        public void Invoke() => Activated?.Invoke();
+        public void Dispose() { }
+    }
+}

--- a/src/LingoEngine.SDL2/SdlFactory.cs
+++ b/src/LingoEngine.SDL2/SdlFactory.cs
@@ -247,4 +247,20 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
         label.Init(impl);
         return label;
     }
+
+    public LingoMenu CreateMenu(string name)
+    {
+        var menu = new LingoMenu();
+        var impl = new SdlMenu(name);
+        menu.Init(impl);
+        return menu;
+    }
+
+    public LingoMenuItem CreateMenuItem(string name, string? shortcut = null)
+    {
+        var item = new LingoMenuItem();
+        var impl = new SdlMenuItem(name, shortcut);
+        item.Init(impl);
+        return item;
+    }
 }

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
@@ -97,6 +97,12 @@ namespace LingoEngine.FrameworkCommunication
         /// <summary>Creates a simple text label.</summary>
         LingoLabel CreateLabel(string text = "");
 
+        /// <summary>Creates a menu container.</summary>
+        LingoMenu CreateMenu(string name);
+
+        /// <summary>Creates a menu item.</summary>
+        LingoMenuItem CreateMenuItem(string name, string? shortcut = null);
+
         /// <summary>Creates a sprite instance.</summary>
         T CreateSprite<T>(ILingoMovie movie, Action<LingoSprite> onRemoveMe) where T : LingoSprite;
         /// <summary>Creates a sprite behaviour.</summary>

--- a/src/LingoEngine/Gfx/ILingoFrameworkGfxMenu.cs
+++ b/src/LingoEngine/Gfx/ILingoFrameworkGfxMenu.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Framework specific menu container capable of holding menu items.
+    /// </summary>
+    public interface ILingoFrameworkGfxMenu : ILingoFrameworkGfxNode
+    {
+        /// <summary>Name of the menu.</summary>
+        string Name { get; set; }
+        /// <summary>Adds an item to the menu.</summary>
+        void AddItem(ILingoFrameworkGfxMenuItem item);
+        /// <summary>Removes all items from the menu.</summary>
+        void ClearItems();
+    }
+}

--- a/src/LingoEngine/Gfx/ILingoFrameworkGfxMenuItem.cs
+++ b/src/LingoEngine/Gfx/ILingoFrameworkGfxMenuItem.cs
@@ -1,0 +1,19 @@
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Framework specific representation of a single menu entry.
+    /// </summary>
+    public interface ILingoFrameworkGfxMenuItem
+    {
+        /// <summary>Displayed name of the item.</summary>
+        string Name { get; set; }
+        /// <summary>Whether the item can be selected.</summary>
+        bool Enabled { get; set; }
+        /// <summary>Whether the item shows a check mark.</summary>
+        bool CheckMark { get; set; }
+        /// <summary>Keyboard shortcut shown for this item.</summary>
+        string? Shortcut { get; set; }
+        /// <summary>Raised when the item is activated by the user.</summary>
+        event System.Action? Activated;
+    }
+}

--- a/src/LingoEngine/Gfx/LingoMenu.cs
+++ b/src/LingoEngine/Gfx/LingoMenu.cs
@@ -1,0 +1,12 @@
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Engine level wrapper around a framework menu object.
+    /// </summary>
+    public class LingoMenu : LingoGfxNodeBase<ILingoFrameworkGfxMenu>
+    {
+        public string Name { get => _framework.Name; set => _framework.Name = value; }
+        public void AddItem(LingoMenuItem item) => _framework.AddItem(item.Framework);
+        public void ClearItems() => _framework.ClearItems();
+    }
+}

--- a/src/LingoEngine/Gfx/LingoMenuItem.cs
+++ b/src/LingoEngine/Gfx/LingoMenuItem.cs
@@ -1,0 +1,22 @@
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Engine level wrapper for a single menu item.
+    /// </summary>
+    public class LingoMenuItem
+    {
+        private ILingoFrameworkGfxMenuItem _framework = null!;
+        internal void Init(ILingoFrameworkGfxMenuItem framework) => _framework = framework;
+        internal ILingoFrameworkGfxMenuItem Framework => _framework;
+
+        public string Name { get => _framework.Name; set => _framework.Name = value; }
+        public bool Enabled { get => _framework.Enabled; set => _framework.Enabled = value; }
+        public bool CheckMark { get => _framework.CheckMark; set => _framework.CheckMark = value; }
+        public string? Shortcut { get => _framework.Shortcut; set => _framework.Shortcut = value; }
+        public event System.Action? Activated
+        {
+            add { _framework.Activated += value; }
+            remove { _framework.Activated -= value; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `LingoMenu` and `LingoMenuItem` types and framework interfaces
- implement menu creation in SDL and Godot
- expose new menu factories via `ILingoFrameworkFactory`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce52bde5083328760b235a5a5ae67