### PR TITLE
Implement frame manager for movie

### DIFF
--- a/src/LingoEngine/Movies/ILingoMovie.cs
+++ b/src/LingoEngine/Movies/ILingoMovie.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using LingoEngine.Casts;
 using LingoEngine.Core;
 using LingoEngine.Members;
@@ -93,10 +94,65 @@ namespace LingoEngine.Movies
         void PrevFrame();
 
         /// <summary>
+        /// Inserts a duplicate of the current frame during score recording.
+        /// Lingo: insertFrame
+        /// </summary>
+        void InsertFrame();
+
+        /// <summary>
+        /// Deletes the current frame during score recording.
+        /// Lingo: deleteFrame
+        /// </summary>
+        void DeleteFrame();
+
+        /// <summary>
+        /// Finalizes any pending changes to the current frame during recording.
+        /// Lingo: updateFrame
+        /// </summary>
+        void UpdateFrame();
+
+        // --- Additional Lingo movie controls ---
+        /// <summary>
+        /// Pauses the playhead for the specified number of ticks (1 tick = 1/60 sec).
+        /// Lingo: delay
+        /// </summary>
+        void Delay(int ticks);
+
+        /// <summary>
+        /// Sends the playhead to the next marker in the movie.
+        /// Lingo: goNext
+        /// </summary>
+        void GoNext();
+
+        /// <summary>
+        /// Sends the playhead to the previous marker in the movie.
+        /// Lingo: goPrevious
+        /// </summary>
+        void GoPrevious();
+
+        /// <summary>
+        /// Sends the playhead to the marker immediately preceding the current frame.
+        /// Lingo: goLoop
+        /// </summary>
+        void GoLoop();
+
+        /// <summary>
         /// Goes to a specific frame and stops playback.
         /// Lingo: go to frame
         /// </summary>
         void GoToAndStop(int frame);
+
+        /// <summary>
+        /// Constrain a horizontal position within the bounds of the specified sprite.
+        /// Lingo: constrainH
+        /// </summary>
+        int ConstrainH(int spriteNumber, int pos);
+
+        /// <summary>
+        /// Constrain a vertical position within the bounds of the specified sprite.
+        /// Lingo: constrainV
+        /// </summary>
+        int ConstrainV(int spriteNumber, int pos);
         
         void UpdateStage();
         ILingoSpriteChannel Channel(int channelNumber);
@@ -182,6 +238,45 @@ namespace LingoEngine.Movies
         /// The rollover() method indicates whether the pointer is over the specified sprite.
         /// </summary>
         bool RollOver(int spriteNumber);
+        /// <summary>
+        /// Returns the sprite number currently under the pointer or 0 if none.
+        /// Lingo: rollOver with no parameter
+        /// </summary>
+        int RollOver();
+
+        /// <summary>
+        /// Performs an action on all active sprite channels.
+        /// Lingo: sendAllSprites
+        /// </summary>
+        void SendAllSprites(Action<ILingoSpriteChannel> actionOnSprite);
+
+        /// <summary>
+        /// Calls the given action on the requested behaviour of all active sprites.
+        /// </summary>
+        void SendAllSprites<T>(Action<T> actionOnSprite) where T : LingoSpriteBehavior;
+
+        /// <summary>
+        /// Calls the given function on the requested behaviour of all active sprites and returns the results.
+        /// </summary>
+        IEnumerable<TResult?> SendAllSprites<T, TResult>(Func<T, TResult> actionOnSprite) where T : LingoSpriteBehavior;
+
+        /// <summary>
+        /// Total number of sprite channels in the movie.
+        /// Lingo: lastChannel
+        /// </summary>
+        int LastChannel { get; }
+
+        /// <summary>
+        /// Number of the last frame in the movie.
+        /// Lingo: lastFrame
+        /// </summary>
+        int LastFrame { get; }
+
+        /// <summary>
+        /// List of markers in the movie as frameNumber:label.
+        /// Lingo: markerList
+        /// </summary>
+        IReadOnlyDictionary<int, string> MarkerList { get; }
 
         IEnumerable<LingoSprite> GetSpritesAtPoint(float x, float y, bool skipLockedSprites = false);
         LingoSprite? GetSpriteAtPoint(float x, float y, bool skipLockedSprites = false);

--- a/src/LingoEngine/Movies/LingoFrameManager.cs
+++ b/src/LingoEngine/Movies/LingoFrameManager.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LingoEngine.Movies
+{
+    /// <summary>
+    /// Handles frame related data such as score labels and frame specific behaviours.
+    /// </summary>
+    internal class LingoFrameManager
+    {
+        private readonly LingoMovieEnvironment _environment;
+        private readonly LingoMovie _movie;
+        private readonly Action _raiseSpriteListChanged;
+        private readonly List<LingoSprite> _allTimeSprites;
+        private readonly Dictionary<string, int> _scoreLabels = new();
+
+        internal LingoFrameManager(LingoMovie movie, LingoMovieEnvironment environment, List<LingoSprite> allTimeSprites, Action raiseSpriteListChanged)
+        {
+            _movie = movie;
+            _environment = environment;
+            _allTimeSprites = allTimeSprites;
+            _raiseSpriteListChanged = raiseSpriteListChanged;
+        }
+
+        internal IReadOnlyDictionary<int, string> MarkerList =>
+            _scoreLabels.ToDictionary(kv => kv.Value, kv => kv.Key);
+
+        internal IReadOnlyDictionary<string, int> ScoreLabels => _scoreLabels;
+
+
+        internal void SetScoreLabel(int frameNumber, string? name)
+        {
+            string? existingLabel = null;
+            foreach (var item in _scoreLabels)
+            {
+                if (item.Value == frameNumber)
+                {
+                    existingLabel = item.Key;
+                    break;
+                }
+            }
+            if (existingLabel != null)
+                _scoreLabels.Remove(existingLabel);
+            if (!string.IsNullOrEmpty(name))
+                _scoreLabels[name] = frameNumber;
+        }
+
+        internal int GetNextLabelFrame(int frame)
+        {
+            var next = _scoreLabels.Values
+                .Where(v => v > frame)
+                .DefaultIfEmpty(int.MaxValue)
+                .Min();
+            if (next == int.MaxValue)
+                return frame + 10;
+            return next;
+        }
+
+        internal int GetNextSpriteStart(int channel, int frame)
+        {
+            int next = int.MaxValue;
+            foreach (var sp in _allTimeSprites)
+            {
+                if (sp.SpriteNum - 1 == channel && sp.BeginFrame > frame)
+                    next = Math.Min(next, sp.BeginFrame);
+            }
+            return next == int.MaxValue ? -1 : next;
+        }
+
+        internal int GetPrevSpriteEnd(int channel, int frame)
+        {
+            int prev = -1;
+            foreach (var sp in _allTimeSprites)
+            {
+                if (sp.SpriteNum - 1 == channel && sp.EndFrame < frame)
+                    prev = Math.Max(prev, sp.EndFrame);
+            }
+            return prev;
+        }
+
+        internal int GetNextMarker(int frame)
+        {
+            if (_scoreLabels.Count == 0)
+                return 1;
+            var next = _scoreLabels.Values.Where(v => v > frame).DefaultIfEmpty(_scoreLabels.Values.Max()).Min();
+            return next;
+        }
+
+        internal int GetPreviousMarker(int frame)
+        {
+            if (_scoreLabels.Count == 0)
+                return 1;
+            var markers = _scoreLabels.Values.OrderBy(v => v).ToList();
+            bool currentIsMarker = markers.Contains(frame);
+            int target;
+            if (currentIsMarker)
+            {
+                int idx = markers.IndexOf(frame);
+                target = idx > 0 ? markers[idx - 1] : frame;
+            }
+            else
+            {
+                int prev = markers.Where(v => v < frame).DefaultIfEmpty(0).Max();
+                if (prev == 0)
+                {
+                    int right = markers.Where(v => v > frame).DefaultIfEmpty(1).Min();
+                    target = right;
+                }
+                else
+                {
+                    int idx = markers.IndexOf(prev);
+                    target = idx > 0 ? markers[idx - 1] : prev;
+                }
+            }
+            return target;
+        }
+
+        internal int GetLoopMarker(int frame)
+        {
+            if (_scoreLabels.Count == 0)
+                return 1;
+            var markers = _scoreLabels.Values.OrderBy(v => v).ToList();
+            int prev = markers.Where(v => v < frame).DefaultIfEmpty(0).Max();
+            if (prev > 0)
+            {
+                return prev;
+            }
+            else
+            {
+                if (markers.Contains(frame))
+                    return frame;
+                else
+                {
+                    int right = markers.Where(v => v > frame).DefaultIfEmpty(1).Min();
+                    return right;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `LingoFrameManager` to centralize frame markers and sprite behaviors
- refactor `LingoMovie` to delegate frame label logic to the new manager
- redesign `SendAllSprites` API using generics
- implement non-blocking `delay` using clock ticks
- revert frame behaviour storage back to `LingoMovie`

## Testing
- `dotnet restore`
- `dotnet build --no-restore` *(fails: 6 errors in unrelated projects)*
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685ce3bdf9f4833282c3247138c78239