### PR TITLE
Add name parameter for Gfx nodes

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Casts/DirectorMemberThumbnail.cs
+++ b/src/Director/LingoEngine.Director.Core/Casts/DirectorMemberThumbnail.cs
@@ -26,7 +26,7 @@ public class DirectorMemberThumbnail : IDisposable
     {
         ThumbWidth = width;
         ThumbHeight = height;
-        Canvas = factory.CreateGfxCanvas((int)width, (int)height);
+        Canvas = factory.CreateGfxCanvas((int)width, (int)height, "ThumbnailCanvas");
         _iconManager = iconManager;
     }
 

--- a/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
@@ -24,25 +24,25 @@ namespace LingoEngine.Director.Core.Inspector
         {
             var thumb = new DirectorMemberThumbnail(36, 36, factory, iconManager);
 
-            var thumbPanel = factory.CreatePanel();
+            var thumbPanel = factory.CreatePanel("ThumbPanel");
             thumbPanel.Margin = new LingoMargin(4, 2, 4, 2);
             thumbPanel.BackgroundColor = new LingoColor(255, 255, 255);
             thumbPanel.BorderColor = new LingoColor(64, 64, 64);
             thumbPanel.BorderWidth = 1;
             thumbPanel.AddChild(thumb.Canvas);
 
-            var container = factory.CreateWrapPanel(LingoOrientation.Vertical);
+            var container = factory.CreateWrapPanel(LingoOrientation.Vertical, "InfoContainer");
             container.ItemMargin = new LingoMargin(0, 0, 1, 0);
 
-            _sprite = factory.CreateLabel();
+            _sprite = factory.CreateLabel("SpriteLabel");
             _sprite.FontSize = 10;
             _sprite.FontColor = new LingoColor(0, 0, 0);
 
-            _member = factory.CreateLabel();
+            _member = factory.CreateLabel("MemberLabel");
             _member.FontSize = 10;
             _member.FontColor = new LingoColor(0, 0, 0);
 
-            _cast = factory.CreateLabel();
+            _cast = factory.CreateLabel("CastLabel");
             _cast.FontSize = 10;
             _cast.FontColor = new LingoColor(0, 0, 0);
 
@@ -50,11 +50,11 @@ namespace LingoEngine.Director.Core.Inspector
             container.AddChild(_member);
             container.AddChild(_cast);
 
-            var header = factory.CreateWrapPanel(LingoOrientation.Horizontal);
+            var header = factory.CreateWrapPanel(LingoOrientation.Horizontal, "HeaderPanel");
             header.AddChild(thumbPanel);
             header.AddChild(container);
 
-            var panel = factory.CreatePanel();
+            var panel = factory.CreatePanel("RootPanel");
             panel.BackgroundColor = DirectorColors.BG_WhiteMenus;
             panel.AddChild(header);
 

--- a/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
@@ -54,7 +54,7 @@ public partial class DirGodotPropertyInspector : BaseGodotWindow, IHasSpriteSele
         _thumb = headerElems.Thumbnail;
         _header = headerElems.Header;
         _headerPanel = headerElems.Panel;
-        _tabs = _player.Factory.CreateTabContainer();
+        _tabs = _player.Factory.CreateTabContainer("InspectorTabs");
         CreateHeader();
 
         var godotTabs = _tabs.Framework<LingoGodotTabContainer>();

--- a/src/LingoEngine.LGodot/Core/GodotFactory.cs
+++ b/src/LingoEngine.LGodot/Core/GodotFactory.cs
@@ -186,78 +186,87 @@ namespace LingoEngine.LGodot.Core
             return key;
         }
 
-        public LingoGfxCanvas CreateGfxCanvas(int width, int height)
+        public LingoGfxCanvas CreateGfxCanvas(int width, int height, string name)
         {
             var canvas = new LingoGfxCanvas();
             var impl = new LingoGodotGfxCanvas(canvas, _serviceProvider.GetRequiredService<ILingoFontManager>(), width, height);
             _rootNode.AddChild(impl);
             canvas.Width = width;
             canvas.Height = height;
+            canvas.Name = name;
             return canvas;
         }
 
-        public LingoGfxWrapPanel CreateWrapPanel(LingoOrientation orientation)
+        public LingoGfxWrapPanel CreateWrapPanel(LingoOrientation orientation, string name)
         {
             var panel = new LingoGfxWrapPanel();
             var impl = new LingoGodotWrapPanel(panel, orientation);
             _rootNode.AddChild(impl);
+            panel.Name = name;
             return panel;
         }
 
-        public LingoGfxPanel CreatePanel()
+        public LingoGfxPanel CreatePanel(string name)
         {
             var panel = new LingoGfxPanel();
             var impl = new LingoGodotPanel(panel);
             _rootNode.AddChild(impl);
+            panel.Name = name;
             return panel;
         }
 
-        public LingoGfxTabContainer CreateTabContainer()
+        public LingoGfxTabContainer CreateTabContainer(string name)
         {
             var tab = new LingoGfxTabContainer();
             var impl = new LingoGodotTabContainer(tab);
             _rootNode.AddChild(impl);
+            tab.Name = name;
             return tab;
         }
 
-        public LingoGfxInputText CreateInputText(int maxLength = 0)
+        public LingoGfxInputText CreateInputText(string name, int maxLength = 0)
         {
             var input = new LingoGfxInputText { MaxLength = maxLength };
             var impl = new LingoGodotInputText(input, _serviceProvider.GetRequiredService<ILingoFontManager>());
             _rootNode.AddChild(impl);
+            input.Name = name;
             return input;
         }
 
-        public LingoGfxInputNumber CreateInputNumber(float min = 0, float max = 100)
+        public LingoGfxInputNumber CreateInputNumber(string name, float min = 0, float max = 100)
         {
             var input = new LingoGfxInputNumber { Min = min, Max = max };
             var impl = new LingoGodotInputNumber(input);
             _rootNode.AddChild(impl);
+            input.Name = name;
             return input;
         }
 
-        public LingoGfxInputCheckbox CreateInputCheckbox()
+        public LingoGfxInputCheckbox CreateInputCheckbox(string name)
         {
             var input = new LingoGfxInputCheckbox();
             var impl = new LingoGodotInputCheckbox(input);
             _rootNode.AddChild(impl);
+            input.Name = name;
             return input;
         }
 
-        public LingoGfxInputCombobox CreateInputCombobox()
+        public LingoGfxInputCombobox CreateInputCombobox(string name)
         {
             var input = new LingoGfxInputCombobox();
             var impl = new LingoGodotInputCombobox(input);
             _rootNode.AddChild(impl);
+            input.Name = name;
             return input;
         }
 
-        public LingoLabel CreateLabel(string text = "")
+        public LingoLabel CreateLabel(string name, string text = "")
         {
             var label = new LingoLabel();
             var impl = new LingoGodotLabel(label, _serviceProvider.GetRequiredService<ILingoFontManager>());
             label.Text = text;
             _rootNode.AddChild(impl);
+            label.Name = name;
             return label;
         }
 

--- a/src/LingoEngine.SDL2/Core/SdlFactory.cs
+++ b/src/LingoEngine.SDL2/Core/SdlFactory.cs
@@ -177,77 +177,86 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
         return key;
     }
 
-    public LingoGfxCanvas CreateGfxCanvas(int width, int height)
+    public LingoGfxCanvas CreateGfxCanvas(int width, int height, string name)
     {
         var canvas = new LingoGfxCanvas();
         var impl = new SdlGfxCanvas(_rootContext.Renderer, _serviceProvider.GetRequiredService<ILingoFontManager>(), width, height);
         canvas.Init(impl);
         canvas.Width = width;
         canvas.Height = height;
+        canvas.Name = name;
         return canvas;
     }
 
-    public LingoGfxWrapPanel CreateWrapPanel(LingoOrientation orientation)
+    public LingoGfxWrapPanel CreateWrapPanel(LingoOrientation orientation, string name)
     {
         var panel = new LingoGfxWrapPanel();
         var impl = new SdlGfxWrapPanel(orientation);
         panel.Init(impl);
+        panel.Name = name;
         return panel;
     }
 
-    public LingoGfxPanel CreatePanel()
+    public LingoGfxPanel CreatePanel(string name)
     {
         var panel = new LingoGfxPanel();
         var impl = new SdlGfxPanel();
         panel.Init(impl);
+        panel.Name = name;
         return panel;
     }
 
-    public LingoGfxTabContainer CreateTabContainer()
+    public LingoGfxTabContainer CreateTabContainer(string name)
     {
         var tab = new LingoGfxTabContainer();
         var impl = new SdlGfxTabContainer();
         tab.Init(impl);
+        tab.Name = name;
         return tab;
     }
 
-    public LingoGfxInputText CreateInputText(int maxLength = 0)
+    public LingoGfxInputText CreateInputText(string name, int maxLength = 0)
     {
         var input = new LingoGfxInputText { MaxLength = maxLength };
         var impl = new SdlGfxInputText();
         input.Init(impl);
+        input.Name = name;
         return input;
     }
 
-    public LingoGfxInputNumber CreateInputNumber(float min = 0, float max = 100)
+    public LingoGfxInputNumber CreateInputNumber(string name, float min = 0, float max = 100)
     {
         var input = new LingoGfxInputNumber { Min = min, Max = max };
         var impl = new SdlGfxInputNumber();
         input.Init(impl);
+        input.Name = name;
         return input;
     }
 
-    public LingoGfxInputCheckbox CreateInputCheckbox()
+    public LingoGfxInputCheckbox CreateInputCheckbox(string name)
     {
         var input = new LingoGfxInputCheckbox();
         var impl = new SdlGfxInputCheckbox();
         input.Init(impl);
+        input.Name = name;
         return input;
     }
 
-    public LingoGfxInputCombobox CreateInputCombobox()
+    public LingoGfxInputCombobox CreateInputCombobox(string name)
     {
         var input = new LingoGfxInputCombobox();
         var impl = new SdlGfxInputCombobox();
         input.Init(impl);
+        input.Name = name;
         return input;
     }
 
-    public LingoLabel CreateLabel(string text = "")
+    public LingoLabel CreateLabel(string name, string text = "")
     {
         var label = new LingoLabel { Text = text };
         var impl = new SdlGfxLabel();
         label.Init(impl);
+        label.Name = name;
         return label;
     }
 

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxCanvas.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxCanvas.cs
@@ -16,6 +16,7 @@ namespace LingoEngine.SDL2.Gfx
         public float Width { get; set; }
         public float Height { get; set; }
         public bool Visibility { get; set; } = true;
+        public string Name { get; set; } = string.Empty;
         public LingoMargin Margin { get; set; } = LingoMargin.Zero;
         private readonly nint _renderer;
         private readonly ILingoFontManager _fontManager;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxInputCheckbox.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxInputCheckbox.cs
@@ -11,6 +11,7 @@ namespace LingoEngine.SDL2.Gfx
         public float Width { get; set; }
         public float Height { get; set; }
         public bool Visibility { get; set; } = true;
+        public string Name { get; set; } = string.Empty;
         public bool Enabled { get; set; } = true;
         private bool _checked;
         public bool Checked

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxInputCombobox.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxInputCombobox.cs
@@ -12,6 +12,7 @@ namespace LingoEngine.SDL2.Gfx
         public float Width { get; set; }
         public float Height { get; set; }
         public bool Visibility { get; set; } = true;
+        public string Name { get; set; } = string.Empty;
         public bool Enabled { get; set; } = true;
         public LingoMargin Margin { get; set; } = LingoMargin.Zero;
 

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxInputNumber.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxInputNumber.cs
@@ -11,6 +11,7 @@ namespace LingoEngine.SDL2.Gfx
         public float Width { get; set; }
         public float Height { get; set; }
         public bool Visibility { get; set; } = true;
+        public string Name { get; set; } = string.Empty;
         public bool Enabled { get; set; } = true;
         private float _value;
         public float Value

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxInputText.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxInputText.cs
@@ -11,6 +11,7 @@ namespace LingoEngine.SDL2.Gfx
         public float Width { get; set; }
         public float Height { get; set; }
         public bool Visibility { get; set; } = true;
+        public string Name { get; set; } = string.Empty;
         public bool Enabled { get; set; } = true;
         private string _text = string.Empty;
         public string Text

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxLabel.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxLabel.cs
@@ -11,6 +11,7 @@ namespace LingoEngine.SDL2.Gfx
         public float Width { get; set; }
         public float Height { get; set; }
         public bool Visibility { get; set; } = true;
+        public string Name { get; set; } = string.Empty;
         public LingoMargin Margin { get; set; } = LingoMargin.Zero;
 
         public string Text { get; set; } = string.Empty;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxPanel.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxPanel.cs
@@ -11,6 +11,7 @@ namespace LingoEngine.SDL2.Gfx
         public float Width { get; set; }
         public float Height { get; set; }
         public bool Visibility { get; set; } = true;
+        public string Name { get; set; } = string.Empty;
         public LingoMargin Margin { get; set; } = LingoMargin.Zero;
         public LingoColor BackgroundColor { get; set; }
         public LingoColor BorderColor { get; set; }

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxTabContainer.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxTabContainer.cs
@@ -13,6 +13,7 @@ namespace LingoEngine.SDL2.Gfx
         public float Width { get; set; }
         public float Height { get; set; }
         public bool Visibility { get; set; } = true;
+        public string Name { get; set; } = string.Empty;
         public LingoMargin Margin { get; set; } = LingoMargin.Zero;
 
         public void AddTab(string title, ILingoFrameworkGfxNode content)

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxWrapPanel.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxWrapPanel.cs
@@ -11,6 +11,7 @@ namespace LingoEngine.SDL2.Gfx
         public float Width { get; set; }
         public float Height { get; set; }
         public bool Visibility { get; set; } = true;
+        public string Name { get; set; } = string.Empty;
         public LingoOrientation Orientation { get; set; }
         public LingoMargin ItemMargin { get; set; }
         public LingoMargin Margin { get; set; }

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
@@ -67,37 +67,37 @@ namespace LingoEngine.FrameworkCommunication
         /// <summary>
         /// Creates a generic drawing canvas instance.
         /// </summary>
-        LingoGfxCanvas CreateGfxCanvas(int width, int height);
+        LingoGfxCanvas CreateGfxCanvas(int width, int height, string name);
 
         /// <summary>
         /// Creates a wrapping panel container.
         /// </summary>
-        LingoGfxWrapPanel CreateWrapPanel(LingoOrientation orientation);
+        LingoGfxWrapPanel CreateWrapPanel(LingoOrientation orientation, string name);
 
         /// <summary>
         /// Creates a simple panel container for absolute positioning.
         /// </summary>
-        LingoGfxPanel CreatePanel();
+        LingoGfxPanel CreatePanel(string name);
 
         /// <summary>
         /// Creates a tab container for organizing child panels.
         /// </summary>
-        LingoGfxTabContainer CreateTabContainer();
+        LingoGfxTabContainer CreateTabContainer(string name);
 
         /// <summary>Creates a single line text input.</summary>
-        LingoGfxInputText CreateInputText(int maxLength = 0);
+        LingoGfxInputText CreateInputText(string name, int maxLength = 0);
 
         /// <summary>Creates a numeric input field.</summary>
-        LingoGfxInputNumber CreateInputNumber(float min = 0, float max = 100);
+        LingoGfxInputNumber CreateInputNumber(string name, float min = 0, float max = 100);
 
         /// <summary>Creates a checkbox input.</summary>
-        LingoGfxInputCheckbox CreateInputCheckbox();
+        LingoGfxInputCheckbox CreateInputCheckbox(string name);
 
         /// <summary>Creates a combo box input.</summary>
-        LingoGfxInputCombobox CreateInputCombobox();
+        LingoGfxInputCombobox CreateInputCombobox(string name);
 
         /// <summary>Creates a simple text label.</summary>
-        LingoLabel CreateLabel(string text = "");
+        LingoLabel CreateLabel(string name, string text = "");
 
         /// <summary>Creates a menu container.</summary>
         LingoMenu CreateMenu(string name);

--- a/src/LingoEngine/Gfx/ILingoFrameworkGfxNode.cs
+++ b/src/LingoEngine/Gfx/ILingoFrameworkGfxNode.cs
@@ -7,6 +7,8 @@ namespace LingoEngine.Gfx
     /// </summary>
     public interface ILingoFrameworkGfxNode : System.IDisposable
     {
+        /// <summary>Name of the node.</summary>
+        string Name { get; set; }
         float X { get; set; }
         float Y { get; set; }
         float Width { get; set; }

--- a/src/LingoEngine/Gfx/LingoGfxNodeBase.cs
+++ b/src/LingoEngine/Gfx/LingoGfxNodeBase.cs
@@ -19,7 +19,7 @@ namespace LingoEngine.Gfx
         public float Height { get => _framework.Height; set => _framework.Height = value; }
         public bool Visibility { get => _framework.Visibility; set => _framework.Visibility = value; }
         public LingoMargin Margin { get => _framework.Margin; set => _framework.Margin = value; }
-        public string Name { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public string Name { get => _framework.Name; set => _framework.Name = value; }
 
         public T Framework<T>() where T : ILingoFrameworkGfxNode => (T)(object)_framework;
 


### PR DESCRIPTION
## Summary
- require a `name` parameter for all Gfx factory methods
- implement `Name` on `ILingoFrameworkGfxNode` and `LingoGfxNodeBase`
- propagate names in Godot and SDL2 factories
- support names in SDL2 Gfx classes
- update inspector code to supply names for created nodes

## Testing
- `dotnet build LingoEngine.sln -c Release` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3e25da908332a92061eba705f833