### PR TITLE
Fix thumbnails disappearing when switching tabs

### DIFF
--- a/src/LingoEngine.LGodot/Gfx/LingoGodotGfxCanvas.cs
+++ b/src/LingoEngine.LGodot/Gfx/LingoGodotGfxCanvas.cs
@@ -59,11 +59,15 @@ namespace LingoEngine.LGodot.Gfx
 
         public override void _Draw()
         {
+            if (_clearColor.HasValue)
+                DrawRect(new Rect2(0, 0, Size.X, Size.Y), _clearColor.Value, true);
+
             foreach (var drawAction in _drawActions)
                 drawAction();
-          
-            _drawActions.Clear();
-            _clearColor = null;
+
+            // Keep the draw actions so that the canvas can redraw itself when
+            // becoming visible again (e.g. when switching tabs).  They will be
+            // cleared when a new Clear() call is issued via <see cref="Clear"/>.
             _dirty = false;
         }
 


### PR DESCRIPTION
## Summary
- persist draw actions in `LingoGodotGfxCanvas` so thumbnails are redrawn
- draw clear color before executing stored actions

## Testing
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7197a09c8332ba58716d4bf4d2a1