### PR TITLE
Fix misaligned text in cast viewer

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Casts/DirectorMemberThumbnail.cs
+++ b/src/Director/LingoEngine.Director.Core/Casts/DirectorMemberThumbnail.cs
@@ -77,7 +77,14 @@ public class DirectorMemberThumbnail : IDisposable
 
     private void DrawText(string text)
     {
-        Canvas.DrawText(new LingoPoint(2, 2), text, null, new LingoColor(0, 0, 0), 10);
+        const int fontSize = 10;
+        const int lineHeight = fontSize + 2;
+
+        int lineCount = text.Split('\n').Length;
+        int textHeight = lineCount * lineHeight;
+        int startY = (int)Math.Max((ThumbHeight - textHeight) / 2f, 0);
+
+        Canvas.DrawText(new LingoPoint(2, startY), text, null, new LingoColor(0, 0, 0), fontSize);
     }
 
     private static string GetPreviewText(ILingoMemberTextBase text)

--- a/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
@@ -33,6 +33,8 @@ namespace LingoEngine.Director.Core.Inspector
 
             var container = factory.CreateWrapPanel(LingoOrientation.Vertical, "InfoContainer");
             container.ItemMargin = new LingoMargin(0, 0, 1, 0);
+            // Center the labels within the header panel
+            container.Margin = new LingoMargin(0, 7, 0, 0);
 
             _sprite = factory.CreateLabel("SpriteLabel");
             _sprite.FontSize = 10;

--- a/src/LingoEngine.LGodot/Gfx/LingoGodotGfxCanvas.cs
+++ b/src/LingoEngine.LGodot/Gfx/LingoGodotGfxCanvas.cs
@@ -132,7 +132,26 @@ namespace LingoEngine.LGodot.Gfx
         public void DrawText(LingoPoint position, string text, string? font = null, LingoColor? color = null, int fontSize = 12)
         {
             Font fontGodot = _fontManager.Get<FontFile>(font ?? "") ?? ThemeDB.FallbackFont;
-            _drawActions.Add(() => DrawString(fontGodot, position.ToVector2(), text, HorizontalAlignment.Left, -1, fontSize, color.HasValue ? color.Value.ToGodotColor() : Colors.Black));
+            Color col = color.HasValue ? color.Value.ToGodotColor() : Colors.Black;
+
+            if (!text.Contains('\n'))
+            {
+                _drawActions.Add(() => DrawString(fontGodot, position.ToVector2(), text, HorizontalAlignment.Left, -1, fontSize, col));
+            }
+            else
+            {
+                var lines = text.Split('\n');
+                _drawActions.Add(() =>
+                {
+                    int lineHeight = fontGodot.GetHeight();
+                    for (int i = 0; i < lines.Length; i++)
+                    {
+                        Vector2 pos = new Vector2(position.X, position.Y + i * lineHeight);
+                        DrawString(fontGodot, pos, lines[i], HorizontalAlignment.Left, -1, fontSize, col);
+                    }
+                });
+            }
+
             MarkDirty();
         }
 

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxCanvas.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxCanvas.cs
@@ -166,7 +166,10 @@ namespace LingoEngine.SDL2.Gfx
                 nint fnt = SDL_ttf.TTF_OpenFont(path, fontSize);
                 if (fnt == nint.Zero) return;
                 SDL.SDL_Color c = new SDL.SDL_Color { r = color?.R ?? 0, g = color?.G ?? 0, b = color?.B ?? 0, a = 255 };
-                nint surf = SDL_ttf.TTF_RenderUTF8_Blended(fnt, text, c);
+
+                nint surf = text.Contains('\n')
+                    ? SDL_ttf.TTF_RenderUTF8_Blended_Wrapped(fnt, text, c, 0)
+                    : SDL_ttf.TTF_RenderUTF8_Blended(fnt, text, c);
                 if (surf == nint.Zero)
                 {
                     SDL_ttf.TTF_CloseFont(fnt);


### PR DESCRIPTION
## Summary
- center preview text in cast member thumbnails using canvas multiline
- add multiline support to SDL and Godot canvases
- adjust property inspector header margins so text is vertically centered

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7827db348332ad36ddf1d20536a9