### PR TITLE
Fix pixel filter setup

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Bitmaps/PixelPerfectMaterial.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Bitmaps/PixelPerfectMaterial.cs
@@ -16,7 +16,7 @@ public static class PixelPerfectMaterial
             var shader = new Shader();
             shader.Code = """
                 shader_type canvas_item;
-                render_mode unshaded, texture_filter_nearest;
+                render_mode unshaded;
             """;
 
             _sharedMaterial = new ShaderMaterial();
@@ -32,5 +32,6 @@ public static class PixelPerfectMaterial
     public static void ApplyTo(CanvasItem target)
     {
         target.Material = GetMaterial();
+        target.TextureFilter = CanvasItem.TextureFilterEnum.Nearest;
     }
 }


### PR DESCRIPTION
## Summary
- rewrite pixel-perfect material to use Godot's `TextureFilter` property
- keep unshaded shader

## Testing
- ❌ `dotnet --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e790b53f08332b1c82110b5b24e45