### PR TITLE
Fix drag preview update

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastItem.cs
@@ -103,7 +103,9 @@ namespace LingoEngine.Director.LGodot.Casts
 
 
             _thumb = new DirectorMemberThumbnail(Width - 1, Height - LabelHeight, _factory, iconManager);
-            AddChild(_thumb.Canvas.Framework<LingoGodotGfxCanvas>());
+            var thumbCanvas = _thumb.Canvas.Framework<LingoGodotGfxCanvas>();
+            thumbCanvas.MouseFilter = MouseFilterEnum.Ignore;
+            AddChild(thumbCanvas);
 
             // separator line above the caption
             _separator = new ColorRect

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreGrid.cs
@@ -320,6 +320,11 @@ internal partial class DirGodotScoreGrid : Control, IHasSpriteSelectedEvent
             _lastFrame = cur;
             _spriteCanvas.QueueRedraw();
         }
+        // When dragging from external controls (like the Cast window), mouse
+        // motion events may be captured and never reach the score grid. Invoke
+        // the drag handler each frame so previews update correctly.
+        if (_movie != null)
+            _dragHandler.HandleMouseMotion();
     }
 
     public void SpriteSelected(ILingoSprite sprite)


### PR DESCRIPTION
## Summary
- ensure score grid refreshes drag preview each frame
- allow drag events on cast item thumbnail canvas

## Testing
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_685e7b5bb498833285f465d52be0ad43