### PR TITLE
Fix duplicate movie addition

### DIFF
--- a/src/LingoEngine.LGodot/Stages/LingoGodotStage.cs
+++ b/src/LingoEngine.LGodot/Stages/LingoGodotStage.cs
@@ -51,11 +51,19 @@ namespace LingoEngine.LGodot.Movies
 
         internal void ShowMovie(LingoGodotMovie lingoGodotMovie)
         {
-            AddChild(lingoGodotMovie.GetNode2D());
+            var node = lingoGodotMovie.GetNode2D();
+            // Avoid adding the same node multiple times which results in an error
+            if (node.GetParent() != this)
+            {
+                AddChild(node);
+            }
         }
+
         internal void HideMovie(LingoGodotMovie lingoGodotMovie)
         {
-            RemoveChild(lingoGodotMovie.GetNode2D());
+            var node = lingoGodotMovie.GetNode2D();
+            if (node.GetParent() == this)
+                RemoveChild(node);
         }
 
     public void SetActiveMovie(LingoMovie? lingoMovie)


### PR DESCRIPTION
## Summary
- avoid adding a movie node twice in Godot stage

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f649b18a483328b10ae3d7b3531f3