### PR TITLE
Refine main menu into framework component

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/UI/DirGodotMainMenu.cs
+++ b/src/Director/LingoEngine.Director.LGodot/UI/DirGodotMainMenu.cs
@@ -1,269 +1,64 @@
 using Godot;
-using LingoEngine.Director.Core.Events;
-using LingoEngine.Movies;
-using LingoEngine.Director.Core.Menus;
-using LingoEngine.Core;
 using LingoEngine.Director.Core.Gfx;
-using System.Collections.Generic;
-using LingoEngine.Director.Core.Projects;
-using LingoEngine.Director.Core.Tools;
 
 namespace LingoEngine.Director.LGodot;
 
 /// <summary>
-/// Top application menu bar with a follow-up icon bar.
+/// Godot wrapper for <see cref="DirectorMainMenu"/>.
 /// </summary>
 internal partial class DirGodotMainMenu : Control, IDirFrameworkMainMenuWindow
 {
-    private readonly HBoxContainer _menuBar = new HBoxContainer();
-    private readonly MenuButton _fileMenu = new MenuButton() { Text = "File" };
-    private readonly MenuButton _editMenu = new MenuButton() { Text = "Edit" };
-    private readonly MenuButton _WindowMenu = new MenuButton() { Text = "Window" };
-    private readonly HBoxContainer _iconBar = new HBoxContainer();
-    private readonly IDirectorWindowManager _windowManager;
-    private readonly DirectorProjectManager _projectManager;
-    private readonly LingoPlayer _player;
-    private readonly IDirectorShortCutManager _shortCutManager;
-    private readonly IHistoryManager _historyManager;
-    private readonly List<ShortCutInfo> _shortCuts = new();
-    private readonly Button _rewindButton;
-    private readonly Button _playButton;
-    private int _undoIndex;
-    private int _redoIndex;
-    private ILingoMovie? _lingoMovie;
+    private readonly LingoGodotWrapPanel _menuBar;
+    private readonly LingoGodotWrapPanel _iconBar;
+    private readonly LingoGodotButton _fileButton;
+    private readonly LingoGodotButton _editButton;
+    private readonly LingoGodotButton _windowButton;
 
-    private class ShortCutInfo
+    public DirGodotMainMenu(IDirectorWindowManager windowManager,
+        DirectorProjectManager projectManager,
+        LingoPlayer player,
+        IDirectorShortCutManager shortCutManager,
+        IHistoryManager historyManager,
+        DirectorMainMenu directorMainMenu)
     {
-        public DirectorShortCutMap Map { get; init; } = null!;
-        public string Key { get; init; } = string.Empty;
-        public bool Ctrl { get; init; }
-        public bool Alt { get; init; }
-        public bool Shift { get; init; }
-        public bool Meta { get; init; }
-    }
-
-    public DirGodotMainMenu(IDirectorWindowManager windowManager, DirectorProjectManager projectManager, LingoPlayer player, IDirectorShortCutManager shortCutManager, IHistoryManager historyManager, DirectorMainMenu directorMainMenu)
-    {
-        _windowManager = windowManager;
-        _projectManager = projectManager;
-        _player = player;
-        _shortCutManager = shortCutManager;
-        _historyManager = historyManager;
-        _player.ActiveMovieChanged += OnActiveMovieChanged;
-        _shortCutManager.ShortCutAdded += OnShortCutAdded;
-        _shortCutManager.ShortCutRemoved += OnShortCutRemoved;
         directorMainMenu.Init(this);
+
+        _menuBar = directorMainMenu.MenuBar.Framework<LingoGodotWrapPanel>();
+        _iconBar = directorMainMenu.IconBar.Framework<LingoGodotWrapPanel>();
 
         AddChild(_menuBar);
         _menuBar.SizeFlagsHorizontal = SizeFlags.ExpandFill;
 
-        ComposeMenu();
+        _fileButton = directorMainMenu.FileButton.Framework<LingoGodotButton>();
+        _editButton = directorMainMenu.EditButton.Framework<LingoGodotButton>();
+        _windowButton = directorMainMenu.WindowButton.Framework<LingoGodotButton>();
 
         AddChild(_iconBar);
         _iconBar.Position = new Vector2(300, 0);
         _iconBar.SizeFlagsHorizontal = SizeFlags.ExpandFill;
 
-        _rewindButton = new Button { Text = "|<" };
-        _rewindButton.CustomMinimumSize = new Vector2(20, 16);
-        _rewindButton.Position = new Vector2(3, 2);
-        _iconBar.AddChild(_rewindButton);
+        _iconBar.AddChild(directorMainMenu.RewindButton.Framework<LingoGodotButton>());
+        _iconBar.AddChild(directorMainMenu.PlayButton.Framework<LingoGodotButton>());
 
-        _playButton = new Button { Text = "Play", };
-        _playButton.CustomMinimumSize = new Vector2(40, 16);
-        _playButton.Position = new Vector2(26, 2);
-        _playButton.Pressed += OnPlayPressed;
-        _iconBar.AddChild(_playButton);
+        AddChild(directorMainMenu.FileMenu.Framework<LingoGodotMenu>());
+        AddChild(directorMainMenu.EditMenu.Framework<LingoGodotMenu>());
+        AddChild(directorMainMenu.WindowMenu.Framework<LingoGodotMenu>());
 
-        UpdatePlayButton();
-
-        foreach (var sc in _shortCutManager.GetShortCuts())
-            _shortCuts.Add(ParseShortCut(sc));
+        // button events handled in core
     }
 
-    private void ComposeMenu()
-    {
-        // FileMenu
-        _menuBar.AddChild(_fileMenu);
-        var popupFile = _fileMenu.GetPopup();
-        popupFile.AddItem("Load", 1);
-        popupFile.AddItem("Save", 2);
-        popupFile.AddItem("Import/Export", 4);
-        popupFile.AddItem("Quit", 3);
-        popupFile.IdPressed += id =>
-        {
-            switch (id)
-            {
-                case 1: _projectManager.LoadMovie(); break;
-                case 2: _projectManager.SaveMovie(); break;
-                case 4: _windowManager.OpenWindow(DirectorMenuCodes.ImportExportWindow); break;
-                case 3:
-                    // TODO: check project for unsaved changes before quitting
-                    GetTree().Quit();
-                    break;
-            }
-        };
-
-        _menuBar.AddChild(_editMenu);
-        var popupEdit = _editMenu.GetPopup();
-        _undoIndex = popupEdit.ItemCount;
-        popupEdit.AddItem("Undo\tCTRL+Z", 1);
-        _redoIndex = popupEdit.ItemCount;
-        popupEdit.AddItem("Redo\tCTRL+Y", 2);
-        popupEdit.SetItemDisabled(_undoIndex, !_historyManager.CanUndo);
-        popupEdit.SetItemDisabled(_redoIndex, !_historyManager.CanRedo);
-        popupEdit.AddSeparator();
-        popupEdit.AddItem("Project Settings", 20);
-        popupEdit.AboutToPopup += () =>
-        {
-            popupEdit.SetItemDisabled(_undoIndex, !_historyManager.CanUndo);
-            popupEdit.SetItemDisabled(_redoIndex, !_historyManager.CanRedo);
-        };
-        popupEdit.IdPressed += id =>
-        {
-            switch (id)
-            {
-                case 1: _historyManager.Undo(); break;
-                case 2: _historyManager.Redo(); break;
-                case 20: _windowManager.OpenWindow(DirectorMenuCodes.ProjectSettingsWindow); break;
-            }
-        };
-
-        // Window Menu
-        _menuBar.AddChild(_WindowMenu);
-        var popupWindow = _WindowMenu.GetPopup();
-        //popupWindow.AddItem("Script", 5);
-        popupWindow.AddItem("Stage  \tCTRL+1", 6);
-        //popupWindow.AddItem("Control Panel  \tCTRL+2", 7);
-        popupWindow.AddItem("Cast  \tCTRL+3", 8);
-        popupWindow.AddItem("Score  \tCTRL+4", 9);
-        popupWindow.AddItem("Text \tCTRL+T", 13);
-        popupWindow.AddItem("Property Inspector  \tCTRL+ALT+S", 15);
-        popupWindow.AddItem("Tools  \tCTRL+7", 16);
-        popupWindow.AddItem("Binary Viewer", 17);
-        popupWindow.AddItem("Paint  \tCTRL+5", 18);
-        popupWindow.IdPressed += id =>
-        {
-            switch (id)
-            {
-                case 5: _windowManager.OpenWindow(DirectorMenuCodes.ScriptWindow); break;
-                case 6: _windowManager.OpenWindow(DirectorMenuCodes.StageWindow); break;
-                case 7: _windowManager.OpenWindow(DirectorMenuCodes.ControlPanel); break;
-                case 8: _windowManager.OpenWindow(DirectorMenuCodes.CastWindow); break;
-                case 9: _windowManager.OpenWindow(DirectorMenuCodes.ScoreWindow); break;
-                case 13: _windowManager.OpenWindow(DirectorMenuCodes.TextEditWindow); break;
-                case 15: _windowManager.OpenWindow(DirectorMenuCodes.PropertyInspector); break;
-                case 16: _windowManager.OpenWindow(DirectorMenuCodes.ToolsWindow); break;
-                case 17: _windowManager.OpenWindow(DirectorMenuCodes.BinaryViewerWindow); break;
-                case 18: _windowManager.OpenWindow(DirectorMenuCodes.PictureEditWindow); break;
-                default:
-                    break;
-            }
-        };
-    }
-    private void OnActiveMovieChanged(ILingoMovie? movie)
-    {
-        if (_lingoMovie != null)
-        {
-            _lingoMovie.PlayStateChanged -= OnPlayStateChanged;
-            _rewindButton.Pressed -= () => _lingoMovie.GoTo(1);
-        }
-        _lingoMovie = movie;
-        if (_lingoMovie != null)
-        {
-            _lingoMovie.PlayStateChanged += OnPlayStateChanged;
-            _rewindButton.Pressed += () => _lingoMovie.GoTo(1);
-        }
-    }
-
-    private void OnPlayPressed()
-    {
-        if (_lingoMovie == null) return;
-        if (_lingoMovie.IsPlaying)
-            _lingoMovie.Halt();
-        else
-            _lingoMovie.Play();
-    }
-
-    private void OnPlayStateChanged(bool isPlaying)
-    {
-        UpdatePlayButton();
-    }
-
-    private void UpdatePlayButton()
-    {
-        _playButton.Text = _lingoMovie != null && _lingoMovie.IsPlaying ? "Stop" : "Play";
-    }
-
-    private void OnShortCutAdded(DirectorShortCutMap map)
-        => _shortCuts.Add(ParseShortCut(map));
-
-    private void OnShortCutRemoved(DirectorShortCutMap map)
-        => _shortCuts.RemoveAll(s => s.Map == map);
-
-    private ShortCutInfo ParseShortCut(DirectorShortCutMap map)
-    {
-        bool ctrl = false, alt = false, shift = false, meta = false;
-        string key = string.Empty;
-        var parts = map.KeyCombination.Split('+');
-        foreach (var p in parts)
-        {
-            var token = p.Trim();
-            if (token.Equals("CTRL", System.StringComparison.OrdinalIgnoreCase)) ctrl = true;
-            else if (token.Equals("ALT", System.StringComparison.OrdinalIgnoreCase)) alt = true;
-            else if (token.Equals("SHIFT", System.StringComparison.OrdinalIgnoreCase)) shift = true;
-            else if (token.Equals("CMD", System.StringComparison.OrdinalIgnoreCase) || token.Equals("META", System.StringComparison.OrdinalIgnoreCase)) meta = true;
-            else key = token;
-        }
-        return new ShortCutInfo { Map = map, Key = key.ToUpperInvariant(), Ctrl = ctrl, Alt = alt, Shift = shift, Meta = meta };
-    }
-
-    public HBoxContainer IconBar => _iconBar;
-
-    public bool IsOpen => throw new NotImplementedException();
-
-    protected override void Dispose(bool disposing)
-    {
-        OnActiveMovieChanged(null);
-        _player.ActiveMovieChanged -= OnActiveMovieChanged;
-        _shortCutManager.ShortCutAdded -= OnShortCutAdded;
-        _shortCutManager.ShortCutRemoved -= OnShortCutRemoved;
-        base.Dispose(disposing);
-    }
-
-    public override void _UnhandledInput(InputEvent @event)
-    {
-        if (@event is InputEventKey k && k.Pressed && !k.Echo)
-        {
-            var label = k.KeyLabel.ToString().ToUpperInvariant();
-            bool ctrl = Input.IsKeyPressed(Key.Ctrl);
-            bool alt = Input.IsKeyPressed(Key.Alt);
-            bool shift = Input.IsKeyPressed(Key.Shift);
-            bool meta = Input.IsKeyPressed(Key.Meta);
-
-            foreach (var sc in _shortCuts)
-            {
-                if (sc.Key == label && sc.Ctrl == ctrl && sc.Alt == alt && sc.Shift == shift && sc.Meta == meta)
-                {
-                    _shortCutManager.Execute(sc.Map.KeyCombination);
-                    GetViewport().SetInputAsHandled();
-                    break;
-                }
-            }
-        }
-    }
 
     public void OpenWindow()
     {
         // not allowed
     }
-
     public void CloseWindow()
     {
         // not allowed
     }
-
     public void MoveWindow(int x, int y)
     {
         // not allowed
     }
+    public bool IsOpen => true;
 }

--- a/src/LingoEngine.LGodot/Gfx/LingoGodotMenu.cs
+++ b/src/LingoEngine.LGodot/Gfx/LingoGodotMenu.cs
@@ -61,6 +61,15 @@ namespace LingoEngine.LGodot.Gfx
             _items.Clear();
         }
 
+        public void PositionPopup(ILingoFrameworkGfxButton button)
+        {
+            if (button is not Button btn)
+                return;
+            Position = btn.GlobalPosition + new Vector2I(0, (int)btn.Size.Y);
+        }
+
+        public void Popup() => base.Popup();
+
         internal void RegisterItem(LingoGodotMenuItem item)
         {
             UpdateItem(item);

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxMenu.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxMenu.cs
@@ -21,6 +21,8 @@ namespace LingoEngine.SDL2.Gfx
 
         public void AddItem(ILingoFrameworkGfxMenuItem item) { }
         public void ClearItems() { }
+        public void PositionPopup(ILingoFrameworkGfxButton button) { }
+        public void Popup() { }
         public void Dispose() { }
     }
 }

--- a/src/LingoEngine/Gfx/ILingoFrameworkGfxMenu.cs
+++ b/src/LingoEngine/Gfx/ILingoFrameworkGfxMenu.cs
@@ -13,5 +13,9 @@ namespace LingoEngine.Gfx
         void AddItem(ILingoFrameworkGfxMenuItem item);
         /// <summary>Removes all items from the menu.</summary>
         void ClearItems();
+        /// <summary>Positions the popup relative to a button.</summary>
+        void PositionPopup(ILingoFrameworkGfxButton button);
+        /// <summary>Shows the menu.</summary>
+        void Popup();
     }
 }

--- a/src/LingoEngine/Gfx/LingoGfxMenu.cs
+++ b/src/LingoEngine/Gfx/LingoGfxMenu.cs
@@ -7,5 +7,8 @@ namespace LingoEngine.Gfx
     {
         public void AddItem(LingoGfxMenuItem item) => _framework.AddItem(item.Framework);
         public void ClearItems() => _framework.ClearItems();
+        public void Popup() => _framework.Popup();
+        public void PositionPopup(LingoGfxButton button)
+            => _framework.PositionPopup(button.Framework<ILingoFrameworkGfxButton>());
     }
 }


### PR DESCRIPTION
## Summary
- add popup helpers to menu interfaces
- create menu buttons inside `DirectorMainMenu`
- allow framework menus to position and display themselves
- remove button logic from `DirGodotMainMenu` and keep not-allowed comments

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e855755948332af8e7e980e5b0a02