### PR TITLE
Fix property inspector tabs display

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
@@ -125,6 +125,7 @@ namespace LingoEngine.Director.Core.Inspector
             _headerPanel.BackgroundColor = DirectorColors.BG_WhiteMenus;
             _headerPanel.AddChild(header);
             _headerPanel.Height = HeaderHeight;
+            _header = header;
             return _headerPanel;
         }
 

--- a/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
@@ -34,8 +34,8 @@ public partial class DirGodotPropertyInspector : BaseGodotWindow, IDirFrameworkP
         tabs.Size = new Vector2(Size.X - 10, Size.Y - 30 - DirectorPropertyInspectorWindow.HeaderHeight);
         AddChild(tabs);
 
-        var behaviorPanel = _inspectorWindow.Tabs.Framework<LingoGodotTabContainer>();
-        behaviorPanel.Visible = false;
+        var behaviorPanel = _inspectorWindow.BehaviorPanel.Framework<LingoGodotPanel>();
+        behaviorPanel.Visibility = false;
         behaviorPanel.Position = new Vector2(0, TitleBarHeight + DirectorPropertyInspectorWindow.HeaderHeight);
         behaviorPanel.Size = new Vector2(Size.X - 10, 0);
         AddChild(behaviorPanel);


### PR DESCRIPTION
## Summary
- ensure inspector header panel reference is set
- hook up behavior panel correctly in the Godot implementation

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f67fbf4908332b3f7ad4090fdb914