### PR TITLE
Fix wrap panel orientation initialization

### DIFF
--- a/src/LingoEngine.LGodot/Core/GodotFactory.cs
+++ b/src/LingoEngine.LGodot/Core/GodotFactory.cs
@@ -206,6 +206,8 @@ namespace LingoEngine.LGodot.Core
             var impl = new LingoGodotWrapPanel(panel, orientation);
 
             panel.Name = name;
+            // Ensure the public wrapper reflects the initial orientation
+            panel.Orientation = orientation;
             return panel;
         }
 

--- a/src/LingoEngine.LGodot/Gfx/LingoGodotPanel.cs
+++ b/src/LingoEngine.LGodot/Gfx/LingoGodotPanel.cs
@@ -2,6 +2,7 @@ using Godot;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
 using System;
+using System.Linq;
 
 namespace LingoEngine.LGodot.Gfx
 {
@@ -50,7 +51,9 @@ namespace LingoEngine.LGodot.Gfx
                 return;
             RemoveChild(node);
         }
-        public IEnumerable<ILingoFrameworkGfxNode> GetChildren() => GetChildren().OfType<ILingoFrameworkGfxNode>().ToArray();
+        public IEnumerable<ILingoFrameworkGfxNode> GetChildren()
+            => base.GetChildren().OfType<Node>()
+                .OfType<ILingoFrameworkGfxNode>().ToArray();
 
         public LingoColor BackgroundColor
         {

--- a/src/LingoEngine.LGodot/Gfx/LingoGodotScrollContainer.cs
+++ b/src/LingoEngine.LGodot/Gfx/LingoGodotScrollContainer.cs
@@ -1,6 +1,7 @@
 using Godot;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
+using System.Linq;
 
 namespace LingoEngine.LGodot.Gfx
 {
@@ -60,7 +61,8 @@ namespace LingoEngine.LGodot.Gfx
         }
 
         public IEnumerable<ILingoFrameworkGfxNode> GetChildren()
-            => GetChildren().OfType<ILingoFrameworkGfxNode>();
+            => base.GetChildren().OfType<Node>()
+                .OfType<ILingoFrameworkGfxNode>();
 
 
 

--- a/src/LingoEngine.LGodot/Gfx/LingoGodotTabContainer.cs
+++ b/src/LingoEngine.LGodot/Gfx/LingoGodotTabContainer.cs
@@ -2,6 +2,7 @@ using Godot;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
 using System;
+using System.Linq;
 
 namespace LingoEngine.LGodot.Gfx
 {
@@ -54,7 +55,9 @@ namespace LingoEngine.LGodot.Gfx
                 RemoveChild(node);
         }
 
-        public IEnumerable<ILingoFrameworkGfxTabItem> GetTabs() => GetChildren().OfType<ILingoFrameworkGfxTabItem>();
+        public IEnumerable<ILingoFrameworkGfxTabItem> GetTabs()
+            => base.GetChildren().OfType<Node>()
+                .OfType<ILingoFrameworkGfxTabItem>();
         public void AddTab(string title, Node node)
         {
             AddChild(node);

--- a/src/LingoEngine.SDL2/Core/SdlFactory.cs
+++ b/src/LingoEngine.SDL2/Core/SdlFactory.cs
@@ -197,6 +197,8 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
         var impl = new SdlGfxWrapPanel(orientation);
         panel.Init(impl);
         panel.Name = name;
+        // Keep orientation in sync on creation
+        panel.Orientation = orientation;
         return panel;
     }
 


### PR DESCRIPTION
## Summary
- propagate orientation value from the factory to the newly created wrap panel
- ensure SDL and Godot factories keep the public wrapper in sync

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f6c3a422483329400e1a9a577fd6d