### PR TITLE
Fix bitmap edit click out-of-bounds

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Bitmaps/DirGodotPictureMemberEditorWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Bitmaps/DirGodotPictureMemberEditorWindow.cs
@@ -501,6 +501,7 @@ internal partial class DirGodotPictureMemberEditorWindow : BaseGodotWindow, IHas
                         SelectingPixels();
                     else if (_painter != null && _imageRect.Texture != null)
                         DrawingPixels();
+                    GetViewport().SetInputAsHandled();
                     return;
                 }
 


### PR DESCRIPTION
## Summary
- prevent `DirGodotPictureMemberEditorWindow` from propagating mouse clicks

## Testing
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685f74080cc48332b16639d65447ffcf