### PR TITLE
Add toggle state button component

### DIFF
--- a/src/Director/LingoEngine.Director.Core/UI/UIExtensions.cs
+++ b/src/Director/LingoEngine.Director.Core/UI/UIExtensions.cs
@@ -3,6 +3,7 @@ using LingoEngine.FrameworkCommunication;
 using LingoEngine.Gfx;
 using System.Linq.Expressions;
 using LingoEngine.Tools;
+using LingoEngine.Bitmaps;
 
 namespace LingoEngine.Director.Core.UI
 {
@@ -53,6 +54,15 @@ namespace LingoEngine.Director.Core.UI
             control.SelectedKey = propertyKey.CompileGetter()(element);
             //lbl.FontSize = 10;
             //lbl.FontColor = DirectorColors.TextColorLabels;
+            container.AddItem(control, x, y);
+            return control;
+        }
+
+        public static LingoGfxStateButton SetStateButtonAt<T>(this LingoGfxPanel container, ILingoFrameworkFactory factory, T element, string name, float x, float y, Expression<Func<T,bool>> property, Bitmaps.ILingoTexture2D? texture = null)
+        {
+            Action<T, bool> setter = property.CompileSetter();
+            LingoGfxStateButton control = factory.CreateStateButton(name, texture, string.Empty, onChange: val => setter(element, val));
+            control.IsOn = property.CompileGetter()(element);
             container.AddItem(control, x, y);
             return control;
         }

--- a/src/LingoEngine.LGodot/Core/GodotFactory.cs
+++ b/src/LingoEngine.LGodot/Core/GodotFactory.cs
@@ -18,6 +18,7 @@ using LingoEngine.Members;
 using LingoEngine.Casts;
 using LingoEngine.Shapes;
 using LingoEngine.Gfx;
+using LingoEngine.Bitmaps;
 using LingoEngine.LGodot.Gfx;
 using LingoEngine.Sprites;
 using LingoEngine.Stages;
@@ -319,6 +320,18 @@ namespace LingoEngine.LGodot.Core
             button.Name = name;
             if (!string.IsNullOrWhiteSpace(text))
                 button.Text = text;
+            return button;
+        }
+
+        public LingoGfxStateButton CreateStateButton(string name, ILingoTexture2D? texture = null, string text = "", Action<bool>? onChange = null)
+        {
+            var button = new LingoGfxStateButton();
+            var impl = new LingoGodotStateButton(button, onChange);
+            button.Name = name;
+            if (!string.IsNullOrWhiteSpace(text))
+                button.Text = text;
+            if (texture != null)
+                button.Texture = texture;
             return button;
         }
 

--- a/src/LingoEngine.LGodot/Gfx/LingoGodotStateButton.cs
+++ b/src/LingoEngine.LGodot/Gfx/LingoGodotStateButton.cs
@@ -1,0 +1,113 @@
+using Godot;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+using LingoEngine.Bitmaps;
+
+namespace LingoEngine.LGodot.Gfx
+{
+    /// <summary>
+    /// Godot implementation of <see cref="ILingoFrameworkGfxStateButton"/>.
+    /// </summary>
+    public partial class LingoGodotStateButton : Button, ILingoFrameworkGfxStateButton, IDisposable
+    {
+        private LingoMargin _margin = LingoMargin.Zero;
+        private Bitmaps.ILingoTexture2D? _texture;
+        private readonly StyleBoxFlat _style = new StyleBoxFlat();
+        private readonly Action<bool> _toggleHandler;
+        private Action<bool>? _onChange;
+        private event Action? _onValueChanged;
+
+        public LingoGodotStateButton(LingoGfxStateButton button, Action<bool>? onChange)
+        {
+            _onChange = onChange;
+            ToggleMode = true;
+            CustomMinimumSize = new Vector2(2, 2);
+            button.Init(this);
+            _toggleHandler = pressed =>
+            {
+                UpdateStyle();
+                _onValueChanged?.Invoke();
+                _onChange?.Invoke(pressed);
+            };
+            Toggled += _toggleHandler;
+            UpdateStyle();
+        }
+
+        public float X { get => Position.X; set => Position = new Vector2(value, Position.Y); }
+        public float Y { get => Position.Y; set => Position = new Vector2(Position.X, value); }
+        public float Width { get => CustomMinimumSize.X; set => CustomMinimumSize = new Vector2(value, CustomMinimumSize.Y); }
+        public float Height { get => CustomMinimumSize.Y; set => CustomMinimumSize = new Vector2(CustomMinimumSize.X, value); }
+        public bool Visibility { get => Visible; set => Visible = value; }
+        public bool Enabled { get => !Disabled; set => Disabled = !value; }
+        string ILingoFrameworkGfxNode.Name { get => Name; set => Name = value; }
+
+        public LingoMargin Margin
+        {
+            get => _margin;
+            set
+            {
+                _margin = value;
+                AddThemeConstantOverride("margin_left", (int)_margin.Left);
+                AddThemeConstantOverride("margin_right", (int)_margin.Right);
+                AddThemeConstantOverride("margin_top", (int)_margin.Top);
+                AddThemeConstantOverride("margin_bottom", (int)_margin.Bottom);
+            }
+        }
+
+        public string Text { get => base.Text; set => base.Text = value; }
+        public Bitmaps.ILingoTexture2D? Texture
+        {
+            get => _texture;
+            set
+            {
+                _texture = value;
+                if (value is Bitmaps.ILingoTexture2D tex && tex is LingoEngine.LGodot.Bitmaps.LingoGodotTexture2D godot)
+                    Icon = godot.Texture;
+            }
+        }
+        public bool IsOn
+        {
+            get => ButtonPressed;
+            set
+            {
+                ButtonPressed = value;
+                UpdateStyle();
+            }
+        }
+
+        public object FrameworkNode => this;
+
+        event Action? ILingoFrameworkGfxNodeInput.ValueChanged
+        {
+            add => _onValueChanged += value;
+            remove => _onValueChanged -= value;
+        }
+
+        public new void Dispose()
+        {
+            Toggled -= _toggleHandler;
+            QueueFree();
+            base.Dispose();
+        }
+
+        private void UpdateStyle()
+        {
+            _style.ContentMarginLeft = _style.ContentMarginRight = 0;
+            _style.ContentMarginTop = _style.ContentMarginBottom = 0;
+            if (ButtonPressed)
+            {
+                _style.BgColor = Colors.DarkGray;
+                _style.BorderWidthAll = 1;
+                _style.BorderColor = Colors.White;
+            }
+            else
+            {
+                _style.BgColor = Colors.Transparent;
+                _style.BorderWidthAll = 0;
+            }
+
+            AddThemeStyleboxOverride("normal", _style);
+            AddThemeStyleboxOverride("hover", _style);
+        }
+    }
+}

--- a/src/LingoEngine.SDL2/Core/SdlFactory.cs
+++ b/src/LingoEngine.SDL2/Core/SdlFactory.cs
@@ -300,6 +300,18 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
         return button;
     }
 
+    public LingoGfxStateButton CreateStateButton(string name, LingoEngine.Bitmaps.ILingoTexture2D? texture = null, string text = "", Action<bool>? onChange = null)
+    {
+        var button = new LingoGfxStateButton { Text = text };
+        var impl = new SdlGfxStateButton();
+        if (onChange != null) button.ValueChanged += () => onChange(button.IsOn); // hooking in wrapper since SDL button is dummy
+        button.Init(impl);
+        button.Name = name;
+        if (texture != null)
+            button.Texture = texture;
+        return button;
+    }
+
     public LingoGfxMenu CreateMenu(string name)
     {
         var menu = new LingoGfxMenu();

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxStateButton.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxStateButton.cs
@@ -1,0 +1,37 @@
+using System;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+using LingoEngine.Bitmaps;
+
+namespace LingoEngine.SDL2.Gfx
+{
+    internal class SdlGfxStateButton : ILingoFrameworkGfxStateButton, IDisposable
+    {
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Width { get; set; }
+        public float Height { get; set; }
+        public bool Visibility { get; set; } = true;
+        public string Name { get; set; } = string.Empty;
+        public bool Enabled { get; set; } = true;
+        public string Text { get; set; } = string.Empty;
+        public Bitmaps.ILingoTexture2D? Texture { get; set; }
+        private bool _isOn;
+        public bool IsOn
+        {
+            get => _isOn;
+            set
+            {
+                if (_isOn != value)
+                {
+                    _isOn = value;
+                    ValueChanged?.Invoke();
+                }
+            }
+        }
+        public LingoMargin Margin { get; set; } = LingoMargin.Zero;
+        public event Action? ValueChanged;
+        public object FrameworkNode => this;
+        public void Dispose() { }
+    }
+}

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
@@ -113,6 +113,9 @@ namespace LingoEngine.FrameworkCommunication
         /// <summary>Creates a clickable button.</summary>
         LingoGfxButton CreateButton(string name, string text = "");
 
+        /// <summary>Creates a toggle state button.</summary>
+        LingoGfxStateButton CreateStateButton(string name, Bitmaps.ILingoTexture2D? texture = null, string text = "", Action<bool>? onChange = null);
+
         /// <summary>Creates a menu container.</summary>
         LingoGfxMenu CreateMenu(string name);
 

--- a/src/LingoEngine/Gfx/ILingoFrameworkGfxStateButton.cs
+++ b/src/LingoEngine/Gfx/ILingoFrameworkGfxStateButton.cs
@@ -1,0 +1,15 @@
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Framework specific toggle button control.
+    /// </summary>
+    public interface ILingoFrameworkGfxStateButton : ILingoFrameworkGfxNodeInput
+    {
+        /// <summary>Displayed text on the button.</summary>
+        string Text { get; set; }
+        /// <summary>Icon texture displayed on the button.</summary>
+        Bitmaps.ILingoTexture2D? Texture { get; set; }
+        /// <summary>Whether the button is toggled on.</summary>
+        bool IsOn { get; set; }
+    }
+}

--- a/src/LingoEngine/Gfx/LingoGfxStateButton.cs
+++ b/src/LingoEngine/Gfx/LingoGfxStateButton.cs
@@ -1,0 +1,15 @@
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Engine level wrapper for a state (toggle) button.
+    /// </summary>
+    public class LingoGfxStateButton : LingoGfxInputBase<ILingoFrameworkGfxStateButton>
+    {
+        /// <summary>Displayed text on the button.</summary>
+        public string Text { get => _framework.Text; set => _framework.Text = value; }
+        /// <summary>Icon texture displayed on the button.</summary>
+        public Bitmaps.ILingoTexture2D? Texture { get => _framework.Texture; set => _framework.Texture = value; }
+        /// <summary>Current toggle state.</summary>
+        public bool IsOn { get => _framework.IsOn; set => _framework.IsOn = value; }
+    }
+}


### PR DESCRIPTION
## Summary
- implement framework independent state button and wrappers
- add Godot and SDL2 implementations
- expose creation method through factory interfaces
- include extension helper for placing state buttons
- fix disposal pattern and remove border from state button style
- refine state button styling

## Testing
- `./scripts/install-dotnet.sh`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6861050102b08332b6e9a567f45bad10