### PR TITLE
Refactor sprite form builder

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
@@ -19,11 +19,8 @@ using System;
 using LingoEngine.Director.Core.Events;
 using LingoEngine.Director.Core.Sprites;
 using LingoEngine.Director.Core.Tools;
-using System.Drawing;
 using System.Numerics;
-using System.Xml.Linq;
 using LingoEngine.Director.Core.UI;
-using System.ComponentModel;
 
 namespace LingoEngine.Director.Core.Inspector
 {
@@ -263,67 +260,35 @@ namespace LingoEngine.Director.Core.Inspector
             var containerIcons = _factory.CreateWrapPanel(LingoOrientation.Horizontal, "SpriteDetailIcons");
             wrapContainer.AddItem(containerIcons);
 
-
             var container = _factory.CreatePanel("SpriteDetailPanel");
             wrapContainer.AddItem(container);
 
+            var builder = new SpriteFormBuilder(container, _factory).Columns(4);
 
-            var lineHeight  = 22;
-            var marginLeft = 5;
-            var defaultSmallWidth = 30;
-            var quadX1 = 33;
-            var quadX2 = 88;
-            var doubleX2 = 70;
-            var doubleX3 = 130;
-            var doubleX4 = 180;
+            builder.AddTextInput("Name", "Name:", sprite, s => s.Name, inputSpan: 3)
+                   .Columns(2)
+                   .AddNumericInput("LocH", "X:", sprite, s => s.LocH)
+                   .AddNumericInput("LocV", "Y:", sprite, s => s.LocV)
+                   .Columns(4)
+                   .AddNumericInput("Left", "L:", sprite, s => s.Left)
+                   .AddNumericInput("Top", "T:", sprite, s => s.Top)
+                   .AddNumericInput("Right", "R:", sprite, s => s.Right)
+                   .AddNumericInput("Bottom", "B:", sprite, s => s.Bottom)
+                   .Columns(2)
+                   .AddNumericInput("Width", "W:", sprite, s => s.Width)
+                   .AddNumericInput("Height", "H:", sprite, s => s.Height)
+                   .Columns(4)
+                   .AddNumericInput("Ink", "Ink:", sprite, s => s.Ink, inputSpan: 2)
+                   .AddNumericInput("Blend", "%", sprite, s => s.Blend, showLabel: false)
+                   .Columns(2)
+                   .AddNumericInput("BeginFrame", "Start Frame:", sprite, s => s.BeginFrame)
+                   .AddNumericInput("EndFrame", "End:", sprite, s => s.EndFrame)
+                   .AddNumericInput("Rotation", "Rotation:", sprite, s => s.Rotation)
+                   .AddNumericInput("Skew", "Skew:", sprite, s => s.Skew)
+                   .AddColorInput("ForeColor", "Fore:", sprite, s => s.ForeColor)
+                   .AddColorInput("BackColor", "Back:", sprite, s => s.BackColor);
 
-
-            
-            container.SetLabelAt(_factory, "SpriteLabel", marginLeft, 2,"Name:");
-            container.SetInputTextAt(_factory, sprite, "SpriteNameInput", 60, 0,140, x => x.Name);
-
-            // Row 2: X / Y
-            container.SetLabelAt(_factory, "SpriteX", 5, lineHeight * 1, "X:");
-            container.SetInputNumberAt(_factory, sprite, "XInput", quadX1, lineHeight * 1, defaultSmallWidth, x => x.LocH);
-            container.SetLabelAt(_factory, "SpriteY", 70, lineHeight * 1, "Y:");
-            container.SetInputNumberAt(_factory, sprite, "YInput", quadX2, lineHeight * 1, defaultSmallWidth, x => x.LocV);
-
-            // Row 3: L / T / R / B
-            container.SetLabelAt(_factory, "SpriteL", 5, lineHeight * 2, "L:");
-            container.SetInputNumberAt(_factory, sprite, "LInput", quadX1, lineHeight * 2, defaultSmallWidth, x => x.Left);
-            container.SetLabelAt(_factory, "SpriteT", 70, lineHeight * 2, "T:");
-            container.SetInputNumberAt(_factory, sprite, "TInput", quadX2, lineHeight * 2, defaultSmallWidth, x => x.Top);
-            container.SetLabelAt(_factory, "SpriteR", 125, lineHeight * 2, "R:");
-            container.SetInputNumberAt(_factory, sprite, "RInput", 141, lineHeight * 2, defaultSmallWidth, x => x.Right);
-            container.SetLabelAt(_factory, "SpriteB", 178, lineHeight * 2, "B:");
-            container.SetInputNumberAt(_factory, sprite, "BInput", 194, lineHeight * 2, defaultSmallWidth, x => x.Bottom);
-
-            // Row 4: W / H
-            container.SetLabelAt(_factory, "SpriteW", 5, lineHeight * 3, "W:");
-            container.SetInputNumberAt(_factory, sprite, "WInput", quadX1, lineHeight * 3, defaultSmallWidth, x => x.Width);
-            container.SetLabelAt(_factory, "SpriteH", 70, lineHeight * 3, "H:");
-            container.SetInputNumberAt(_factory, sprite, "HInput", quadX2, lineHeight * 3, defaultSmallWidth, x => x.Height);
-
-            // Row 5: Ink / %
-            container.SetLabelAt(_factory, "SpriteInk", 5, lineHeight * 4, "Ink:");
-            container.SetInputNumberAt(_factory, sprite, "InkCombo", quadX1, lineHeight * 4, 120, x => x.Ink);
-            container.SetInputNumberAt(_factory, sprite, "OpacityCombo", 150, lineHeight * 4, 40, x => x.Blend);
-            //container.SetComboBoxAt(_factory, sprite, "InkCombo", quadX1, lineHeight * 4, x => x.Ink.ToString());
-            //container.SetComboBoxAt(_factory, sprite, "OpacityCombo", 110, lineHeight * 4, x => x.Blend.ToString());
-
-            // Row 6: Start Frame / End Frame
-            container.SetLabelAt(_factory, "SpriteStartFrame", 5, lineHeight * 5 + 4, "Start Frame:");
-            container.SetInputNumberAt(_factory, sprite, "StartFrameInput", doubleX2, lineHeight * 5 + 4, defaultSmallWidth + 5, x => x.BeginFrame);
-            container.SetLabelAt(_factory, "SpriteEndFrame", doubleX3, lineHeight * 5 + 4, "End:");
-            container.SetInputNumberAt(_factory, sprite, "EndFrameInput", doubleX4, lineHeight * 5 + 4, defaultSmallWidth, x => x.EndFrame);
-
-            // Row 7: Rotation / Skew
-            container.SetLabelAt(_factory, "SpriteRotation", 5, lineHeight * 6 + 4, "Rotation:");
-            container.SetInputNumberAt(_factory, sprite, "RotationInput", doubleX2, lineHeight * 6 + 4, defaultSmallWidth + 10, x => x.Rotation);
-            container.SetLabelAt(_factory, "SpriteSkew", doubleX3, lineHeight * 6 + 4, "Skew:");
-            container.SetInputNumberAt(_factory, sprite, "SkewInput", doubleX4, lineHeight * 6 + 4, defaultSmallWidth, x => x.Skew);
-
-
+            container.Height = builder.CurrentHeight;
 
         }
         private LingoGfxWrapPanel AddTab(string name)

--- a/src/Director/LingoEngine.Director.Core/Inspector/SpriteFormBuilder.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/SpriteFormBuilder.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Linq.Expressions;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+using LingoEngine.Tools;
+
+namespace LingoEngine.Director.Core.Inspector
+{
+    /// <summary>
+    /// Helper to fluently build sprite property forms with automatic column layout.
+    /// </summary>
+    internal class SpriteFormBuilder
+    {
+        private readonly ILingoFrameworkFactory _factory;
+        private readonly LingoGfxPanel _panel;
+        private int _columns = 1;
+        private int _currentColumn;
+        private int _currentRow;
+        private readonly float _rowHeight = 22f;
+        private readonly float _labelWidth = 50f;
+        private readonly float _inputWidth = 60f;
+        private readonly float _gap = 5f;
+        private readonly float _margin = 5f;
+
+        private float ColumnWidth => _labelWidth + _inputWidth + _gap * 2;
+
+        public float CurrentHeight => (_currentRow + 1) * _rowHeight;
+
+        public SpriteFormBuilder(LingoGfxPanel panel, ILingoFrameworkFactory factory)
+        {
+            _panel = panel;
+            _factory = factory;
+        }
+
+        public SpriteFormBuilder Columns(int cols)
+        {
+            _columns = Math.Max(1, cols);
+            _currentColumn = 0;
+            return this;
+        }
+
+        private float ColumnX(int col) => _margin + col * ColumnWidth;
+
+        private (float labelX, float inputX, float y) Layout(bool showLabel, int inputSpan)
+        {
+            float baseX = ColumnX(_currentColumn);
+            float y = _currentRow * _rowHeight;
+            float labelX = baseX;
+            float inputX = baseX + (showLabel ? _labelWidth + _gap : _gap);
+            return (labelX, inputX, y);
+        }
+
+        private float ComputeInputWidth(int span)
+        {
+            return _inputWidth * span + _gap * 2 * (span - 1);
+        }
+
+        private void Advance(int span)
+        {
+            _currentColumn += span;
+            while (_currentColumn >= _columns)
+            {
+                _currentColumn -= _columns;
+                _currentRow++;
+            }
+        }
+
+        public SpriteFormBuilder AddTextInput<T>(string name, string label, T target, Expression<Func<T, string?>> property, int inputSpan = 1)
+        {
+            var setter = property.CompileSetter();
+            var getter = property.CompileGetter();
+            var (xLabel, xInput, y) = Layout(true, inputSpan);
+            _panel.SetLabelAt(_factory, name + "Label", xLabel, y, label);
+            var input = _panel.SetInputTextAt(_factory, target, name + "Input", xInput, y, (int)ComputeInputWidth(inputSpan), property);
+            input.Text = getter(target) ?? string.Empty;
+            Advance(1 + inputSpan);
+            return this;
+        }
+
+        public SpriteFormBuilder AddNumericInput<T>(string name, string label, T target, Expression<Func<T, float>> property, int inputSpan = 1, bool showLabel = true)
+        {
+            var (xLabel, xInput, y) = Layout(showLabel, inputSpan);
+            if (showLabel)
+                _panel.SetLabelAt(_factory, name + "Label", xLabel, y, label);
+            _panel.SetInputNumberAt(_factory, target, name + "Input", xInput, y, (int)ComputeInputWidth(inputSpan), property);
+            Advance((showLabel ? 1 : 0) + inputSpan);
+            return this;
+        }
+
+        public SpriteFormBuilder AddColorInput<T>(string name, string label, T target, Expression<Func<T, LingoColor>> property, int inputSpan = 1)
+        {
+            var setter = property.CompileSetter();
+            var getter = property.CompileGetter();
+            var (xLabel, xInput, y) = Layout(true, inputSpan);
+            _panel.SetLabelAt(_factory, name + "Label", xLabel, y, label);
+            var picker = _factory.CreateColorPicker(name + "Picker", color => setter(target, color));
+            picker.Color = getter(target);
+            picker.Width = ComputeInputWidth(inputSpan);
+            _panel.AddItem(picker, xInput, y);
+            Advance(1 + inputSpan);
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor sprite property inspector tab
- introduce `SpriteFormBuilder` for fluent form layout
- add foreground and background color pickers
- support column spanning for label-less inputs

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862408a0e6883329d283bce3a0454ed