### PR TITLE
Add line separator GFX elements

### DIFF
--- a/src/LingoEngine.LGodot/Core/GodotFactory.cs
+++ b/src/LingoEngine.LGodot/Core/GodotFactory.cs
@@ -357,7 +357,23 @@ namespace LingoEngine.LGodot.Core
             return item;
         }
 
-        
+        public LingoGfxHorizontalLineSeparator CreateHorizontalLineSeparator(string name)
+        {
+            var sep = new LingoGfxHorizontalLineSeparator();
+            var impl = new LingoGodotHorizontalLineSeparator(sep);
+            sep.Name = name;
+            return sep;
+        }
+
+        public LingoGfxVerticalLineSeparator CreateVerticalLineSeparator(string name)
+        {
+            var sep = new LingoGfxVerticalLineSeparator();
+            var impl = new LingoGodotVerticalLineSeparator(sep);
+            sep.Name = name;
+            return sep;
+        }
+
+
         #endregion
 
 

--- a/src/LingoEngine.LGodot/Gfx/LingoGodotHorizontalLineSeparator.cs
+++ b/src/LingoEngine.LGodot/Gfx/LingoGodotHorizontalLineSeparator.cs
@@ -1,9 +1,21 @@
-﻿using Godot;
+using Godot;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
 
 namespace LingoEngine.LGodot.Gfx
 {
-    public partial class LingoGodotHorizontalLineSeparator : Control
+    /// <summary>
+    /// Godot implementation of <see cref="ILingoFrameworkGfxHorizontalLineSeparator"/>.
+    /// </summary>
+    public partial class LingoGodotHorizontalLineSeparator : Control, ILingoFrameworkGfxHorizontalLineSeparator, IDisposable
     {
+        private LingoMargin _margin = LingoMargin.Zero;
+
+        public LingoGodotHorizontalLineSeparator(LingoGfxHorizontalLineSeparator separator)
+        {
+            separator.Init(this);
+        }
+
         public override void _Ready()
         {
             CustomMinimumSize = new Vector2(0, 2); // 2px tall
@@ -15,7 +27,6 @@ namespace LingoEngine.LGodot.Gfx
             DrawLine(new Vector2(0, 0), new Vector2(Size.X, 0), new Color(1, 1, 1), 1);
             // Bottom: dark gray
             DrawLine(new Vector2(0, 1), new Vector2(Size.X, 1), new Color(0.4f, 0.4f, 0.4f), 1);
-
         }
 
         public override void _Notification(int what)
@@ -24,6 +35,32 @@ namespace LingoEngine.LGodot.Gfx
             {
                 QueueRedraw();
             }
+        }
+
+        public float Width { get => Size.X; set => Size = new Vector2(value, Size.Y); }
+        public float Height { get => Size.Y; set => Size = new Vector2(Size.X, value); }
+        public bool Visibility { get => Visible; set => Visible = value; }
+        string ILingoFrameworkGfxNode.Name { get => Name; set => Name = value; }
+
+        public LingoMargin Margin
+        {
+            get => _margin;
+            set
+            {
+                _margin = value;
+                AddThemeConstantOverride("margin_left", (int)_margin.Left);
+                AddThemeConstantOverride("margin_right", (int)_margin.Right);
+                AddThemeConstantOverride("margin_top", (int)_margin.Top);
+                AddThemeConstantOverride("margin_bottom", (int)_margin.Bottom);
+            }
+        }
+
+        public object FrameworkNode => this;
+
+        public new void Dispose()
+        {
+            QueueFree();
+            base.Dispose();
         }
     }
 }

--- a/src/LingoEngine.LGodot/Gfx/LingoGodotVerticalLineSeparator.cs
+++ b/src/LingoEngine.LGodot/Gfx/LingoGodotVerticalLineSeparator.cs
@@ -1,19 +1,30 @@
-﻿using Godot;
+using Godot;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
 
 namespace LingoEngine.LGodot.Gfx
 {
-    public partial class LingoGodotVerticalLineSeparator : Control
+    /// <summary>
+    /// Godot implementation of <see cref="ILingoFrameworkGfxVerticalLineSeparator"/>.
+    /// </summary>
+    public partial class LingoGodotVerticalLineSeparator : Control, ILingoFrameworkGfxVerticalLineSeparator, IDisposable
     {
+        private LingoMargin _margin = LingoMargin.Zero;
+
+        public LingoGodotVerticalLineSeparator(LingoGfxVerticalLineSeparator separator)
+        {
+            separator.Init(this);
+        }
+
         public override void _Ready()
         {
-            CustomMinimumSize = new Vector2(2, 0); // or (2, 0) for vertical
+            CustomMinimumSize = new Vector2(2, 0); // 2px wide
         }
 
         public override void _Draw()
         {
             DrawLine(new Vector2(0, 0), new Vector2(0, Size.Y), new Color(1, 1, 1), 1); // left light
             DrawLine(new Vector2(1, 0), new Vector2(1, Size.Y), new Color(0.4f, 0.4f, 0.4f), 1); // right dark
-
         }
 
         public override void _Notification(int what)
@@ -22,6 +33,32 @@ namespace LingoEngine.LGodot.Gfx
             {
                 QueueRedraw();
             }
+        }
+
+        public float Width { get => Size.X; set => Size = new Vector2(value, Size.Y); }
+        public float Height { get => Size.Y; set => Size = new Vector2(Size.X, value); }
+        public bool Visibility { get => Visible; set => Visible = value; }
+        string ILingoFrameworkGfxNode.Name { get => Name; set => Name = value; }
+
+        public LingoMargin Margin
+        {
+            get => _margin;
+            set
+            {
+                _margin = value;
+                AddThemeConstantOverride("margin_left", (int)_margin.Left);
+                AddThemeConstantOverride("margin_right", (int)_margin.Right);
+                AddThemeConstantOverride("margin_top", (int)_margin.Top);
+                AddThemeConstantOverride("margin_bottom", (int)_margin.Bottom);
+            }
+        }
+
+        public object FrameworkNode => this;
+
+        public new void Dispose()
+        {
+            QueueFree();
+            base.Dispose();
         }
     }
 }

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
@@ -125,6 +125,12 @@ namespace LingoEngine.FrameworkCommunication
         /// <summary>Creates a menu item.</summary>
         LingoGfxMenuItem CreateMenuItem(string name, string? shortcut = null);
 
+        /// <summary>Creates a horizontal line separator.</summary>
+        LingoGfxHorizontalLineSeparator CreateHorizontalLineSeparator(string name);
+
+        /// <summary>Creates a vertical line separator.</summary>
+        LingoGfxVerticalLineSeparator CreateVerticalLineSeparator(string name);
+
         #endregion
 
         /// <summary>Creates a sprite instance.</summary>

--- a/src/LingoEngine/Gfx/ILingoFrameworkGfxHorizontalLineSeparator.cs
+++ b/src/LingoEngine/Gfx/ILingoFrameworkGfxHorizontalLineSeparator.cs
@@ -1,0 +1,11 @@
+using LingoEngine.Primitives;
+
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Framework specific horizontal line separator control.
+    /// </summary>
+    public interface ILingoFrameworkGfxHorizontalLineSeparator : ILingoFrameworkGfxNode
+    {
+    }
+}

--- a/src/LingoEngine/Gfx/ILingoFrameworkGfxVerticalLineSeparator.cs
+++ b/src/LingoEngine/Gfx/ILingoFrameworkGfxVerticalLineSeparator.cs
@@ -1,0 +1,11 @@
+using LingoEngine.Primitives;
+
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Framework specific vertical line separator control.
+    /// </summary>
+    public interface ILingoFrameworkGfxVerticalLineSeparator : ILingoFrameworkGfxNode
+    {
+    }
+}

--- a/src/LingoEngine/Gfx/LingoGfxHorizontalLineSeparator.cs
+++ b/src/LingoEngine/Gfx/LingoGfxHorizontalLineSeparator.cs
@@ -1,0 +1,9 @@
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Engine level wrapper for a horizontal line separator.
+    /// </summary>
+    public class LingoGfxHorizontalLineSeparator : LingoGfxNodeBase<ILingoFrameworkGfxHorizontalLineSeparator>
+    {
+    }
+}

--- a/src/LingoEngine/Gfx/LingoGfxVerticalLineSeparator.cs
+++ b/src/LingoEngine/Gfx/LingoGfxVerticalLineSeparator.cs
@@ -1,0 +1,9 @@
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Engine level wrapper for a vertical line separator.
+    /// </summary>
+    public class LingoGfxVerticalLineSeparator : LingoGfxNodeBase<ILingoFrameworkGfxVerticalLineSeparator>
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- implement `LingoGodotHorizontalLineSeparator` and `LingoGodotVerticalLineSeparator` as framework nodes
- add wrapper classes and interfaces for horizontal/vertical line separators
- expose creation methods in `ILingoFrameworkFactory` and implement them in `GodotFactory`

## Testing
- `./scripts/install-dotnet.sh`
- `dotnet test` *(fails: ProjectorRays.DotNet.Test.DirectorFileTests)*

------
https://chatgpt.com/codex/tasks/task_e_6862a03e352883328a95040c87d02ccd