### PR TITLE
Add key/value ItemList widget

### DIFF
--- a/src/Director/LingoEngine.Director.Core/UI/GfxWrapPanelBuilder.cs
+++ b/src/Director/LingoEngine.Director.Core/UI/GfxWrapPanelBuilder.cs
@@ -4,6 +4,7 @@ using LingoEngine.FrameworkCommunication;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
 using LingoEngine.Tools;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace LingoEngine.Director.Core.UI
@@ -71,6 +72,18 @@ namespace LingoEngine.Director.Core.UI
             colorPicker.Color = getter(target);
             colorPicker.Width = width;
             _panel.AddItem(colorPicker);
+            return this;
+        }
+
+        public GfxWrapPanelBuilder AddItemList(string name, IEnumerable<KeyValuePair<string,string>> items, int width = 100, string? selectedKey = null, Action<string?>? onChange = null)
+        {
+            var list = _factory.CreateItemList(name, onChange);
+            foreach (var item in items)
+                list.AddItem(item.Key, item.Value);
+            if (selectedKey != null)
+                list.SelectedKey = selectedKey;
+            list.Width = width;
+            _panel.AddItem(list);
             return this;
         }
 

--- a/src/Director/LingoEngine.Director.Core/UI/GfxWrapPanelExtensions.cs
+++ b/src/Director/LingoEngine.Director.Core/UI/GfxWrapPanelExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using LingoEngine.FrameworkCommunication;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
+using System.Collections.Generic;
 
 namespace LingoEngine.Director.Core.UI
 {
@@ -27,6 +28,16 @@ namespace LingoEngine.Director.Core.UI
             if (paddingTop > 0) line.Margin = new LingoMargin(0, paddingTop, 0, 0);
             panel.AddItem(line);
             return panel;
+        }
+
+        public static LingoGfxItemList AddItemList(this LingoGfxWrapPanel panel, ILingoFrameworkFactory factory, string name, IEnumerable<KeyValuePair<string,string>> items, int width = 100)
+        {
+            var list = factory.CreateItemList(name);
+            foreach (var item in items)
+                list.AddItem(item.Key, item.Value);
+            list.Width = width;
+            panel.AddItem(list);
+            return list;
         }
     }
 }

--- a/src/LingoEngine.LGodot/Core/GodotFactory.cs
+++ b/src/LingoEngine.LGodot/Core/GodotFactory.cs
@@ -304,6 +304,14 @@ namespace LingoEngine.LGodot.Core
             return input;
         }
 
+        public LingoGfxItemList CreateItemList(string name, Action<string?>? onChange = null)
+        {
+            var list = new LingoGfxItemList();
+            var impl = new LingoGodotItemList(list, onChange);
+            list.Name = name;
+            return list;
+        }
+
         public LingoGfxColorPicker CreateColorPicker(string name, Action<LingoColor>? onChange = null)
         {
             var picker = new LingoGfxColorPicker();

--- a/src/LingoEngine.LGodot/Gfx/LingoGodotItemList.cs
+++ b/src/LingoEngine.LGodot/Gfx/LingoGodotItemList.cs
@@ -1,0 +1,125 @@
+using Godot;
+using LingoEngine.Gfx;
+using System;
+using System.Collections.Generic;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.LGodot.Gfx
+{
+    /// <summary>
+    /// Godot implementation of <see cref="ILingoFrameworkGfxItemList"/>.
+    /// </summary>
+    public partial class LingoGodotItemList : ItemList, ILingoFrameworkGfxItemList, IDisposable
+    {
+        private readonly List<KeyValuePair<string,string>> _items = new();
+        private LingoMargin _margin = LingoMargin.Zero;
+        private Action<string?>? _onChange;
+        private event Action? _onValueChanged;
+
+        public LingoGodotItemList(LingoGfxItemList list, Action<string?>? onChange)
+        {
+            _onChange = onChange;
+            list.Init(this);
+            ItemSelected += idx => _onValueChanged?.Invoke();
+            if (_onChange != null)
+                ItemSelected += idx => _onChange(SelectedKey);
+        }
+
+        public float X { get => Position.X; set => Position = new Vector2(value, Position.Y); }
+        public float Y { get => Position.Y; set => Position = new Vector2(Position.X, value); }
+        public float Width { get => Size.X; set => Size = new Vector2(value, Size.Y); }
+        public float Height { get => Size.Y; set => Size = new Vector2(Size.X, value); }
+        public bool Visibility { get => Visible; set => Visible = value; }
+        public bool Enabled { get => !Disabled; set => Disabled = !value; }
+        string ILingoFrameworkGfxNode.Name { get => Name; set => Name = value; }
+
+        public LingoMargin Margin
+        {
+            get => _margin;
+            set
+            {
+                _margin = value;
+                AddThemeConstantOverride("margin_left", (int)_margin.Left);
+                AddThemeConstantOverride("margin_right", (int)_margin.Right);
+                AddThemeConstantOverride("margin_top", (int)_margin.Top);
+                AddThemeConstantOverride("margin_bottom", (int)_margin.Bottom);
+            }
+        }
+
+        public object FrameworkNode => this;
+        public IReadOnlyList<KeyValuePair<string,string>> Items => _items;
+        public void AddItem(string key, string value)
+        {
+            _items.Add(new KeyValuePair<string,string>(key, value));
+            int idx = ItemCount;
+            base.AddItem(value);
+            SetItemMetadata(idx, key);
+        }
+        public void ClearItems()
+        {
+            _items.Clear();
+            Clear();
+        }
+        public int SelectedIndex
+        {
+            get => SelectedItems.Length > 0 ? SelectedItems[0] : -1;
+            set
+            {
+                if (value < 0 || value >= ItemCount)
+                {
+                    UnselectAll();
+                }
+                else
+                {
+                    Select(value);
+                }
+            }
+        }
+        public string? SelectedKey
+        {
+            get => SelectedIndex >= 0 ? (string?)GetItemMetadata(SelectedIndex) : null;
+            set
+            {
+                if (value is null) { UnselectAll(); return; }
+                for (int i = 0; i < ItemCount; i++)
+                {
+                    if ((string?)GetItemMetadata(i) == value)
+                    {
+                        Select(i);
+                        break;
+                    }
+                }
+            }
+        }
+        public string? SelectedValue
+        {
+            get => SelectedIndex >= 0 ? GetItemText(SelectedIndex) : null;
+            set
+            {
+                for (int i = 0; i < ItemCount; i++)
+                {
+                    if (GetItemText(i) == value)
+                    {
+                        Select(i);
+                        break;
+                    }
+                }
+            }
+        }
+
+        event Action? ILingoFrameworkGfxNodeInput.ValueChanged
+        {
+            add => _onValueChanged += value;
+            remove => _onValueChanged -= value;
+        }
+
+        public new void Dispose()
+        {
+            if (_onChange != null)
+                ItemSelected -= idx => _onChange(SelectedKey);
+            ItemSelected -= idx => _onValueChanged?.Invoke();
+            QueueFree();
+            base.Dispose();
+        }
+    }
+}

--- a/src/LingoEngine.SDL2/Core/SdlFactory.cs
+++ b/src/LingoEngine.SDL2/Core/SdlFactory.cs
@@ -283,6 +283,17 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
         return input;
     }
 
+    public LingoGfxItemList CreateItemList(string name, Action<string?>? onChange = null)
+    {
+        var list = new LingoGfxItemList();
+        var impl = new SdlGfxItemList();
+        list.Init(impl);
+        list.Name = name;
+        if (onChange != null)
+            list.ValueChanged += () => onChange(list.SelectedKey);
+        return list;
+    }
+
     public LingoGfxColorPicker CreateColorPicker(string name, Action<LingoColor>? onChange = null)
     {
         var picker = new LingoGfxColorPicker();

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxItemList.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxItemList.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.SDL2.Gfx
+{
+    internal class SdlGfxItemList : ILingoFrameworkGfxItemList, IDisposable
+    {
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Width { get; set; }
+        public float Height { get; set; }
+        public bool Visibility { get; set; } = true;
+        public string Name { get; set; } = string.Empty;
+        public bool Enabled { get; set; } = true;
+        public LingoMargin Margin { get; set; } = LingoMargin.Zero;
+
+        private readonly List<KeyValuePair<string,string>> _items = new();
+        public IReadOnlyList<KeyValuePair<string,string>> Items => _items;
+        public int SelectedIndex { get; set; } = -1;
+        public string? SelectedKey { get; set; }
+        public string? SelectedValue { get; set; }
+
+        public event Action? ValueChanged;
+        public object FrameworkNode => this;
+        public void AddItem(string key, string value)
+        {
+            _items.Add(new KeyValuePair<string,string>(key, value));
+        }
+        public void ClearItems()
+        {
+            _items.Clear();
+            SelectedIndex = -1;
+            SelectedKey = null;
+            SelectedValue = null;
+        }
+        public void Dispose() { }
+    }
+}

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
@@ -107,6 +107,9 @@ namespace LingoEngine.FrameworkCommunication
         /// <summary>Creates a combo box input.</summary>
         LingoGfxInputCombobox CreateInputCombobox(string name, Action<string?>? onChange = null);
 
+        /// <summary>Creates a list widget.</summary>
+        LingoGfxItemList CreateItemList(string name, Action<string?>? onChange = null);
+
         /// <summary>Creates a color picker input.</summary>
         LingoGfxColorPicker CreateColorPicker(string name, Action<Primitives.LingoColor>? onChange = null);
 

--- a/src/LingoEngine/Gfx/ILingoFrameworkGfxItemList.cs
+++ b/src/LingoEngine/Gfx/ILingoFrameworkGfxItemList.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Framework specific list widget allowing selection of items.
+    /// </summary>
+    public interface ILingoFrameworkGfxItemList : ILingoFrameworkGfxNodeInput
+    {
+        /// <summary>Current items in the list.</summary>
+        IReadOnlyList<KeyValuePair<string,string>> Items { get; }
+        /// <summary>Adds an item to the list.</summary>
+        void AddItem(string key, string value);
+        /// <summary>Removes all items.</summary>
+        void ClearItems();
+        /// <summary>Selected item index.</summary>
+        int SelectedIndex { get; set; }
+        /// <summary>Selected item key.</summary>
+        string? SelectedKey { get; set; }
+        /// <summary>Selected item value.</summary>
+        string? SelectedValue { get; set; }
+    }
+}

--- a/src/LingoEngine/Gfx/LingoGfxItemList.cs
+++ b/src/LingoEngine/Gfx/LingoGfxItemList.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Engine level wrapper around a framework item list widget.
+    /// </summary>
+    public class LingoGfxItemList : LingoGfxInputBase<ILingoFrameworkGfxItemList>
+    {
+        public IReadOnlyList<KeyValuePair<string,string>> Items => _framework.Items;
+        public void AddItem(string key, string value) => _framework.AddItem(key, value);
+        public void ClearItems() => _framework.ClearItems();
+        public int SelectedIndex { get => _framework.SelectedIndex; set => _framework.SelectedIndex = value; }
+        public string? SelectedKey { get => _framework.SelectedKey; set => _framework.SelectedKey = value; }
+        public string? SelectedValue { get => _framework.SelectedValue; set => _framework.SelectedValue = value; }
+    }
+}


### PR DESCRIPTION
## Summary
- support key/value pairs for item list element
- implement Godot and SDL2 item list classes
- expose item list creation via factories
- update wrap panel helpers to handle key/value item lists

## Testing
- `dotnet build -v q` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862ce507d8083328c2c2e8bf95f2d3b