### PR TITLE
Fix bitmap factory naming

### DIFF
--- a/Lingo_vs_CSharp.md
+++ b/Lingo_vs_CSharp.md
@@ -92,10 +92,10 @@ In C#, use the `New` factory on `ILingoMovie` to create typed members:
 
 ```csharp
 // equivalent to the Lingo example above
-var newBitmap = _movie.New.Picture(name: "Background");
+var newBitmap = _movie.New.Bitmap(name: "Background");
 ```
 
-The factory exposes helper methods for each member type, such as `Picture()`, `Sound()`, `FilmLoop()` and `Text()`. Optional arguments let you specify the cast slot or member name.
+The factory exposes helper methods for each member type, such as `Bitmap()`, `Sound()`, `FilmLoop()` and `Text()`. Optional arguments let you specify the cast slot or member name.
 
 
 ## 🔁 `put ... into ...` Handling in C#

--- a/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
@@ -125,14 +125,14 @@ public class LingoToCSharpConverterTests
     public void NewMemberCallIsConverted()
     {
         var result = LingoToCSharpConverter.Convert("_movie.newMember(#bitmap)");
-        Assert.Equal("_movie.New.Picture()", result.Trim());
+        Assert.Equal("_movie.New.Bitmap()", result.Trim());
     }
 
     [Fact]
     public void NewMemberAssignmentIsConverted()
     {
         var result = LingoToCSharpConverter.Convert("img = _movie.newMember(#bitmap)");
-        Assert.Equal("img = _movie.New.Picture();", result.Trim());
+        Assert.Equal("img = _movie.New.Bitmap();", result.Trim());
     }
 
     [Fact(Skip = "Converter does not yet fully match the reference implementation")]

--- a/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
+++ b/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
@@ -192,7 +192,7 @@ public static class LingoToCSharpConverter
         string type = tokens[pos].Lexeme.ToLowerInvariant();
         string method = type switch
         {
-            "bitmap" => "Picture",
+            "bitmap" => "Bitmap",
             "sound" => "Sound",
             "filmloop" => "FilmLoop",
             "text" => "Text",

--- a/src/LingoEngine/Members/LingoMemberFactory.cs
+++ b/src/LingoEngine/Members/LingoMemberFactory.cs
@@ -10,7 +10,7 @@ namespace LingoEngine.Members
     public interface ILingoMemberFactory
     {
         T Member<T>(int numberInCast = 0, string name = "") where T : LingoMember;
-        LingoMemberBitmap Picture(int numberInCast = 0, string name = "");
+        LingoMemberBitmap Bitmap(int numberInCast = 0, string name = "");
         LingoMemberSound Sound(int numberInCast = 0, string name = "");
         LingoMemberFilmLoop FilmLoop(int numberInCast = 0, string name = "");
         LingoMemberShape Shape(int numberInCast = 0, string name = "");
@@ -29,7 +29,7 @@ namespace LingoEngine.Members
         }
         public T Member<T>(int numberInCast = 0, string name = "") where T : LingoMember => _frameworkFactory.CreateMember<T>(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
 
-        public LingoMemberBitmap Picture(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberBitmap(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
+        public LingoMemberBitmap Bitmap(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberBitmap(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
         public LingoMemberSound Sound(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberSound(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
         public LingoMemberFilmLoop FilmLoop(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberFilmLoop(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
         public LingoMemberShape Shape(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberShape(_environment.CastLibsContainer.ActiveCast, numberInCast, name);


### PR DESCRIPTION
## Summary
- rename picture factory methods to `Bitmap`
- update converter mapping for bitmap
- fix tests and docs accordingly

## Testing
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6862eb363e0c83328125dd18acc08bed