### PR TITLE
Improve behavior inspector inputs

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Inspector/DirectorBehaviorDescriptionManager.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/DirectorBehaviorDescriptionManager.cs
@@ -51,8 +51,56 @@ namespace LingoEngine.Director.Core.Inspector
             {
                 foreach (var prop in definitions)
                 {
-                    //if (Symbol Type == #string)
-                    // show label with value from behavior.UserProperties
+                    var row = _factory.CreateWrapPanel(LingoOrientation.Horizontal, $"PropRow_{prop.Key}");
+                    string labelText = !string.IsNullOrEmpty(prop.Value.Comment) ? prop.Value.Comment! : prop.Key.ToString();
+                    var label = _factory.CreateLabel($"PropLabel_{prop.Key}", labelText);
+                    label.Width = 80;
+                    row.AddItem(label);
+
+                    object? current = props[prop.Key];
+                    if (current == null)
+                        current = prop.Value.Default;
+
+                    string format = prop.Value.Format.Name.ToLowerInvariant();
+                    if (format == "string")
+                    {
+                        var input = _factory.CreateInputText($"PropInput_{prop.Key}");
+                        input.Text = current?.ToString() ?? string.Empty;
+                        input.ValueChanged += () => props[prop.Key] = input.Text;
+                        row.AddItem(input);
+                    }
+                    else if (format == "int" || format == "integer")
+                    {
+                        var input = _factory.CreateInputNumber($"PropInput_{prop.Key}");
+                        input.NumberType = LingoNumberType.Integer;
+                        if (current is int i)
+                            input.Value = i;
+                        else if (current is float f)
+                            input.Value = f;
+                        else if (current != null && float.TryParse(current.ToString(), out var fv))
+                            input.Value = fv;
+                        input.ValueChanged += () => props[prop.Key] = (int)input.Value;
+                        row.AddItem(input);
+                    }
+                    else if (format == "boolean" || format == "bool")
+                    {
+                        var input = _factory.CreateInputCheckbox($"PropInput_{prop.Key}");
+                        if (current is bool bval)
+                            input.Checked = bval;
+                        else if (current is string s && bool.TryParse(s, out var bv))
+                            input.Checked = bv;
+                        input.ValueChanged += () => props[prop.Key] = input.Checked;
+                        row.AddItem(input);
+                    }
+                    else
+                    {
+                        var input = _factory.CreateInputText($"PropInput_{prop.Key}");
+                        input.Text = current?.ToString() ?? string.Empty;
+                        input.ValueChanged += () => props[prop.Key] = input.Text;
+                        row.AddItem(input);
+                    }
+
+                    container.AddItem(row);
                 }
             }
             //// old, wrong


### PR DESCRIPTION
## Summary
- show input controls for behavior properties using their declared format

## Testing
- `dotnet test` *(fails: Could not find file '/workspace/LingoEngine/WillMoveToOwnRepo/ProjectorRays/Test/TestData/TextCast.cst')*

------
https://chatgpt.com/codex/tasks/task_e_68638b4bcc648332870981bca15e3770