### PR TITLE
Add window popup methods

### DIFF
--- a/src/LingoEngine.LGodot/Core/GodotFactory.cs
+++ b/src/LingoEngine.LGodot/Core/GodotFactory.cs
@@ -382,6 +382,16 @@ namespace LingoEngine.LGodot.Core
             return sep;
         }
 
+        public LingoGfxWindow CreateWindow(string name, string title = "")
+        {
+            var win = new LingoGfxWindow();
+            var impl = new LingoGodotWindow(win);
+            win.Name = name;
+            if (!string.IsNullOrWhiteSpace(title))
+                win.Title = title;
+            return win;
+        }
+
 
         #endregion
 

--- a/src/LingoEngine.LGodot/Gfx/LingoGodotWindow.cs
+++ b/src/LingoEngine.LGodot/Gfx/LingoGodotWindow.cs
@@ -1,0 +1,70 @@
+using Godot;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+using System.Collections.Generic;
+
+namespace LingoEngine.LGodot.Gfx
+{
+    /// <summary>
+    /// Godot implementation of <see cref="ILingoFrameworkGfxWindow"/>.
+    /// </summary>
+    public partial class LingoGodotWindow : Window, ILingoFrameworkGfxWindow, IDisposable
+    {
+        private LingoMargin _margin = LingoMargin.Zero;
+        private readonly List<ILingoFrameworkGfxLayoutNode> _nodes = new();
+
+        public LingoGodotWindow(LingoGfxWindow window)
+        {
+            window.Init(this);
+        }
+
+        public float X { get => Position.X; set => Position = new Vector2I((int)value, Position.Y); }
+        public float Y { get => Position.Y; set => Position = new Vector2I(Position.X, (int)value); }
+        public float Width { get => Size.X; set => Size = new Vector2I((int)value, Size.Y); }
+        public float Height { get => Size.Y; set => Size = new Vector2I(Size.X, (int)value); }
+        public bool Visibility { get => Visible; set => Visible = value; }
+        string ILingoFrameworkGfxNode.Name { get => Name; set => Name = value; }
+        public new string Title { get => base.Title; set => base.Title = value; }
+
+        public LingoMargin Margin
+        {
+            get => _margin;
+            set
+            {
+                _margin = value;
+                AddThemeConstantOverride("margin_left", (int)_margin.Left);
+                AddThemeConstantOverride("margin_right", (int)_margin.Right);
+                AddThemeConstantOverride("margin_top", (int)_margin.Top);
+                AddThemeConstantOverride("margin_bottom", (int)_margin.Bottom);
+            }
+        }
+
+        public object FrameworkNode => this;
+
+        public void AddItem(ILingoFrameworkGfxLayoutNode child)
+        {
+            if (child.FrameworkNode is Node node)
+                AddChild(node);
+            _nodes.Add(child);
+        }
+
+        public void RemoveItem(ILingoFrameworkGfxLayoutNode child)
+        {
+            if (child.FrameworkNode is Node node)
+                RemoveChild(node);
+            _nodes.Remove(child);
+        }
+
+        public IEnumerable<ILingoFrameworkGfxLayoutNode> GetItems() => _nodes.ToArray();
+
+        public void Popup() => base.Popup();
+        public void PopupCentered() => base.PopupCentered();
+        public new void Hide() => base.Hide();
+
+        public new void Dispose()
+        {
+            QueueFree();
+            base.Dispose();
+        }
+    }
+}

--- a/src/LingoEngine.SDL2/Core/SdlFactory.cs
+++ b/src/LingoEngine.SDL2/Core/SdlFactory.cs
@@ -380,6 +380,11 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
     {
         throw new NotImplementedException();
     }
+
+    public LingoGfxWindow CreateWindow(string name, string title = "")
+    {
+        throw new NotImplementedException();
+    }
     #endregion
 
 

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
@@ -134,6 +134,9 @@ namespace LingoEngine.FrameworkCommunication
         /// <summary>Creates a vertical line separator.</summary>
         LingoGfxVerticalLineSeparator CreateVerticalLineSeparator(string name);
 
+        /// <summary>Creates a window container.</summary>
+        LingoGfxWindow CreateWindow(string name, string title = "");
+
         #endregion
 
         /// <summary>Creates a sprite instance.</summary>

--- a/src/LingoEngine/Gfx/ILingoFrameworkGfxWindow.cs
+++ b/src/LingoEngine/Gfx/ILingoFrameworkGfxWindow.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Framework specific window container.
+    /// </summary>
+    public interface ILingoFrameworkGfxWindow : ILingoFrameworkGfxLayoutNode
+    {
+        /// <summary>Window title.</summary>
+        string Title { get; set; }
+
+        /// <summary>Adds a child node to the window.</summary>
+        void AddItem(ILingoFrameworkGfxLayoutNode child);
+        void RemoveItem(ILingoFrameworkGfxLayoutNode child);
+        IEnumerable<ILingoFrameworkGfxLayoutNode> GetItems();
+
+        /// <summary>Shows the window at its current position.</summary>
+        void Popup();
+        /// <summary>Centers the window on screen and shows it.</summary>
+        void PopupCentered();
+        /// <summary>Hides the window.</summary>
+        void Hide();
+    }
+}

--- a/src/LingoEngine/Gfx/LingoGfxWindow.cs
+++ b/src/LingoEngine/Gfx/LingoGfxWindow.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Engine level wrapper for a window element.
+    /// </summary>
+    public class LingoGfxWindow : LingoGfxNodeLayoutBase<ILingoFrameworkGfxWindow>
+    {
+        public string Title { get => _framework.Title; set => _framework.Title = value; }
+
+        public LingoGfxWindow AddItem(ILingoGfxNode node)
+        {
+            _framework.AddItem(node.Framework<ILingoFrameworkGfxLayoutNode>());
+            return this;
+        }
+
+        public LingoGfxWindow AddItem(ILingoFrameworkGfxLayoutNode node)
+        {
+            _framework.AddItem(node);
+            return this;
+        }
+
+        public void RemoveItem(ILingoGfxNode node) => _framework.RemoveItem(node.Framework<ILingoFrameworkGfxLayoutNode>());
+        public void RemoveItem(ILingoFrameworkGfxLayoutNode node) => _framework.RemoveItem(node);
+        public IEnumerable<ILingoFrameworkGfxLayoutNode> GetItems() => _framework.GetItems();
+
+        public void Popup() => _framework.Popup();
+        public void PopupCentered() => _framework.PopupCentered();
+        public void Hide() => _framework.Hide();
+    }
+}


### PR DESCRIPTION
## Summary
- extend `ILingoFrameworkGfxWindow` with Popup/PopupCentered/Hide
- expose these operations through `LingoGfxWindow`
- implement the methods in Godot backend

## Testing
- `dotnet test` *(fails: missing `TextCast.cst` test data)*
- `dotnet build` *(fails: SDL2 project errors)*

------
https://chatgpt.com/codex/tasks/task_e_6863a2d87cd88332967623a06894dbc9