### PR TITLE
Add dropdown for InkType selection

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
@@ -234,7 +234,7 @@ namespace LingoEngine.Director.Core.Inspector
                    .AddNumericInput("SpriteBottom", "B:", sprite, s => s.Bottom)
                    .AddNumericInput("SpriteWidth", "W:", sprite, s => s.Width)
                    .AddNumericInput("SpriteHeight", "H:", sprite, s => s.Height, inputSpan: 5)
-                   .AddNumericInput("SpriteInk", "Ink:", sprite, s => s.Ink, inputSpan: 6)
+                   .AddEnumInput<LingoInkType>("SpriteInk", "Ink:", sprite, s => s.Ink, inputSpan: 6)
                    .AddNumericInput("SpriteBlend", "%", sprite, s => s.Blend, showLabel: false)
                    .AddNumericInput("SpriteBeginFrame", "StartFrame:", sprite, s => s.BeginFrame, labelSpan: 3)
                    .AddNumericInput("SpriteEndFrame", "End:", sprite, s => s.EndFrame, inputSpan: 1, labelSpan: 3)

--- a/src/Director/LingoEngine.Director.Core/Inspector/SpriteFormBuilder.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/SpriteFormBuilder.cs
@@ -139,6 +139,32 @@ namespace LingoEngine.Director.Core.Inspector
             Advance(labelSpan + inputSpan);
             return this;
         }
+
+        public GfxPanelBuilder AddEnumInput<T, TEnum>(string name, string label, T target,
+            Expression<Func<T, int>> property, int inputSpan = 1, bool showLabel = true,
+            int labelSpan = 1) where TEnum : Enum
+        {
+            var setter = property.CompileSetter();
+            var getter = property.CompileGetter();
+            var (xLabel, xInput, y) = Layout(showLabel ? labelSpan : 0, inputSpan);
+            if (showLabel)
+                _panel.SetLabelAt(_factory, name + "Label", xLabel, y + _labelYOffset, label);
+            var combo = _factory.CreateInputCombobox(name + "Combo", val =>
+            {
+                if (int.TryParse(val, out int v))
+                    setter(target, v);
+            });
+            foreach (var value in Enum.GetValues(typeof(TEnum)))
+            {
+                int key = Convert.ToInt32(value);
+                combo.AddItem(key.ToString(), value!.ToString());
+            }
+            combo.SelectedKey = getter(target).ToString();
+            combo.Width = (int)ComputeInputWidth(inputSpan, showLabel, stretch: true);
+            _panel.AddItem(combo, xInput, y);
+            Advance((showLabel ? labelSpan : 0) + inputSpan);
+            return this;
+        }
         public GfxPanelBuilder Finalize()
         {
             _panel.Height = CurrentHeight- _rowHeight;


### PR DESCRIPTION
## Summary
- add `AddEnumInput` to `GfxPanelBuilder` to create dropdowns for enum properties
- use the new dropdown to edit sprite ink in `DirectorPropertyInspectorWindow`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a75231488332a3d55e0f4e1184a2