### PR TITLE
Show behavior parameters in popup

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Inspector/DirectorBehaviorDescriptionManager.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/DirectorBehaviorDescriptionManager.cs
@@ -8,6 +8,8 @@ namespace LingoEngine.Director.Core.Inspector
     public interface IDirectorBehaviorDescriptionManager
     {
         LingoGfxWrapPanel BuildBehaviorPanel(LingoSpriteBehavior behavior);
+        /// <summary>Builds a popup window for editing the given behavior.</summary>
+        LingoGfxWindow BuildBehaviorPopup(LingoSpriteBehavior behavior);
     }
 
     internal class DirectorBehaviorDescriptionManager : IDirectorBehaviorDescriptionManager
@@ -28,6 +30,30 @@ namespace LingoEngine.Director.Core.Inspector
                 BuildDescriptionList(behavior, container, descProvider);
 
             return container;
+        }
+
+        public LingoGfxWindow BuildBehaviorPopup(LingoSpriteBehavior behavior)
+        {
+            var win = _factory.CreateWindow("BehaviorParams", $"Parameters for \"{behavior.Name}\"");
+            var root = _factory.CreateWrapPanel(LingoOrientation.Horizontal, "BehaviorPopupRoot");
+            win.AddItem(root);
+
+            var panel = BuildBehaviorPanel(behavior);
+            root.AddItem(panel);
+
+            root.AddItem(_factory.CreateVerticalLineSeparator("BehaviorPopupLine"));
+
+            var right = _factory.CreateWrapPanel(LingoOrientation.Vertical, "BehaviorPopupRight");
+            right.Width = 90;
+            var ok = _factory.CreateButton("BehaviorPopupOk", "OK");
+            ok.Width = 14;
+            float margin = (90 - 14) / 2f;
+            ok.Margin = new LingoMargin(margin, 0, margin, 0);
+            ok.Pressed += () => win.Hide();
+            right.AddItem(ok);
+            root.AddItem(right);
+
+            return win;
         }
 
 

--- a/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
@@ -40,15 +40,16 @@ namespace LingoEngine.Director.Core.Inspector
         private LingoGfxPanel? _header;
         private ILingoFrameworkFactory _factory;
         private IDirectorIconManager _iconManager;
+        public ILingoFrameworkFactory Factory => _factory;
         private LingoGfxPanel _headerPanel;
         private IDirectorEventMediator _mediator;
         private readonly IDirectorBehaviorDescriptionManager _descriptionManager;
         private LingoGfxWrapPanel _behaviorPanel;
-        private LingoGfxWrapPanel _behaviorDetail;
         private float _lastWidh;
         private float _lastHeight;
         private Dictionary<string, LingoSpriteBehavior> _behaviors = new();
         private LingoGfxItemList _behaviorList;
+        public event Action<LingoSpriteBehavior>? BehaviorSelected;
 
         public LingoGfxPanel HeaderPanel => _headerPanel;
         public LingoGfxTabContainer Tabs => _tabs;
@@ -138,7 +139,6 @@ namespace LingoEngine.Director.Core.Inspector
             _tabs.Width = width - 10;
             _tabs.Height = height - 30 - HeaderHeight;
             _behaviorList.Width = _lastWidh - 15;
-            _behaviorDetail.Width = _lastWidh - 15;
         }
 
        
@@ -267,35 +267,24 @@ namespace LingoEngine.Director.Core.Inspector
         private void CreateBehaviorPanel()
         {
             _behaviorPanel = _factory.CreateWrapPanel(LingoOrientation.Vertical, "InspectorBehaviors");
-            _behaviorDetail = _factory.CreateWrapPanel(LingoOrientation.Vertical, "InspectorBehaviorsWrapPanel");
 
             _behaviorList = _factory.CreateItemList("BehaviorList", x =>
             {
                 if (x != null && _behaviors.TryGetValue(x, out var behavior))
-                {
-                    _behaviorDetail.Visibility = true;
-                    ShowBehavior(behavior);
-                }
-                else
-                    _behaviorDetail.Visibility = false;
+                    BehaviorSelected?.Invoke(behavior);
             });
             _behaviorList.Height = 45;
             _behaviorList.Width = _lastWidh - 15;
-            _behaviorDetail.Width = _lastWidh - 15;
             _behaviorList.Margin = new LingoMargin(5,0,0,0);
             _behaviorPanel.AddItem(_behaviorList);
-            _behaviorPanel.AddItem(_behaviorDetail);
-            _behaviorDetail.Visibility = false;
-      
+
         }
-        private void ShowBehavior(LingoSpriteBehavior behavior)
-        {
-            _behaviorDetail.RemoveAll();
-            
-            var panel = _descriptionManager.BuildBehaviorPanel(behavior);
-            _behaviorDetail.AddItem(panel);
-            OnResizing(_lastWidh, _lastHeight);
-        }
+
+        public LingoGfxWrapPanel BuildBehaviorPanel(LingoSpriteBehavior behavior)
+            => _descriptionManager.BuildBehaviorPanel(behavior);
+
+        public LingoGfxWindow BuildBehaviorPopup(LingoSpriteBehavior behavior)
+            => _descriptionManager.BuildBehaviorPopup(behavior);
 
         private void AddMemberTab(ILingoMember member)
         {

--- a/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
@@ -6,6 +6,9 @@ using LingoEngine.Director.LGodot.Windowing;
 using LingoEngine.Director.Core.Gfx;
 using LingoEngine.Director.Core.Icons;
 using LingoEngine.Director.Core.Styles;
+using LingoEngine.Sprites;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
 
 namespace LingoEngine.Director.LGodot.Inspector;
 
@@ -14,6 +17,7 @@ public partial class DirGodotPropertyInspector : BaseGodotWindow, IDirFrameworkP
    
     private readonly DirectorPropertyInspectorWindow _inspectorWindow;
     private LingoGodotPanel _headerPanel;
+    private LingoGfxWindow? _behaviorWindow;
 
     public DirGodotPropertyInspector(DirectorPropertyInspectorWindow inspectorWindow, ILingoPlayer player, IDirGodotWindowManager windowManager, IDirectorIconManager iconManager)
         : base(DirectorMenuCodes.PropertyInspector, "Property Inspector", windowManager)
@@ -35,6 +39,8 @@ public partial class DirGodotPropertyInspector : BaseGodotWindow, IDirFrameworkP
         tabs.Size = new Vector2(Size.X, Size.Y - 30 - DirectorPropertyInspectorWindow.HeaderHeight);
         AddChild(tabs);
 
+        _inspectorWindow.BehaviorSelected += OnBehaviorSelected;
+
         //var behaviorPanel = _inspectorWindow.BehaviorPanel.Framework<LingoGodotPanel>();
         //behaviorPanel.Visibility = false;
         //behaviorPanel.Position = new Vector2(0, TitleBarHeight + DirectorPropertyInspectorWindow.HeaderHeight);
@@ -46,9 +52,24 @@ public partial class DirGodotPropertyInspector : BaseGodotWindow, IDirFrameworkP
     protected override void OnResizing(Vector2 size)
     {
         base.OnResizing(size);
-        
+
        _inspectorWindow.OnResizing(size.X, size.Y);
-        
+
+    }
+
+    private void OnBehaviorSelected(LingoSpriteBehavior behavior)
+    {
+        if (_behaviorWindow != null && _behaviorWindow.Framework<ILingoFrameworkGfxWindow>().FrameworkNode is Node oldNode)
+        {
+            oldNode.QueueFree();
+            _behaviorWindow = null;
+        }
+
+        var win = _inspectorWindow.BuildBehaviorPopup(behavior);
+        if (win.Framework<ILingoFrameworkGfxWindow>().FrameworkNode is Node node)
+            GetTree().Root.AddChild(node);
+        win.PopupCentered();
+        _behaviorWindow = win;
     }
  
 


### PR DESCRIPTION
## Summary
- expose factory from property inspector core
- fire `BehaviorSelected` when choosing a behavior
- build popup window on the Godot side and center it
- move popup creation to core manager for reuse

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a715e69483328484263621286090