### PR TITLE
Implement window lifecycle events

### DIFF
--- a/src/LingoEngine/Gfx/ILingoFrameworkGfxWindow.cs
+++ b/src/LingoEngine/Gfx/ILingoFrameworkGfxWindow.cs
@@ -1,4 +1,5 @@
 using LingoEngine.Primitives;
+using System;
 
 namespace LingoEngine.Gfx
 {
@@ -11,6 +12,13 @@ namespace LingoEngine.Gfx
         string Title { get; set; }
         LingoColor BackgroundColor { get; set; }
         bool IsPopup { get; set; }
+
+        /// <summary>Raised when the window is opened.</summary>
+        event Action? OnOpen;
+        /// <summary>Raised when the window is closed.</summary>
+        event Action? OnClose;
+        /// <summary>Raised when the window is resized. Parameters are new width and height.</summary>
+        event Action<float, float>? OnResize;
 
 
         /// <summary>Adds a child node to the window.</summary>

--- a/src/LingoEngine/Gfx/LingoGfxWindow.cs
+++ b/src/LingoEngine/Gfx/LingoGfxWindow.cs
@@ -1,4 +1,5 @@
 using LingoEngine.Primitives;
+using System;
 
 namespace LingoEngine.Gfx
 {
@@ -10,6 +11,22 @@ namespace LingoEngine.Gfx
         public string Title { get => _framework.Title; set => _framework.Title = value; }
         public LingoColor BackgroundColor { get => _framework.BackgroundColor; set => _framework.BackgroundColor = value; }
         public bool IsPopup { get => _framework.IsPopup; set => _framework.IsPopup = value; }
+
+        public event Action? OnOpen
+        {
+            add { _framework.OnOpen += value; }
+            remove { _framework.OnOpen -= value; }
+        }
+        public event Action? OnClose
+        {
+            add { _framework.OnClose += value; }
+            remove { _framework.OnClose -= value; }
+        }
+        public event Action<float, float>? OnResize
+        {
+            add { _framework.OnResize += value; }
+            remove { _framework.OnResize -= value; }
+        }
 
         public LingoGfxWindow AddItem(ILingoGfxNode node)
         {


### PR DESCRIPTION
## Summary
- extend `ILingoFrameworkGfxWindow` with OnOpen, OnClose, and OnResize events
- surface the new events via `LingoGfxWindow`
- add event handling to `LingoGodotWindow`

## Testing
- `dotnet restore`
- `dotnet build --no-restore` *(fails: SdlGfxWrapPanel missing interface)*

------
https://chatgpt.com/codex/tasks/task_e_6863bc1085e083328123173f46e9306a