### PR TITLE
Add stream annotation support for score parsing

### DIFF
--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/common/StreamAnnotationMarkdownWriter.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/common/StreamAnnotationMarkdownWriter.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ProjectorRays.Common;
+
+public static class StreamAnnotationMarkdownWriter
+{
+    public static string WriteMarkdown(StreamAnnotatorDecorator annotator, byte[] data)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("| Offset (hex) | Bytes | ASCII | Description | Keys |");
+        sb.AppendLine("|--------------|-------|--------|-------------|------|");
+
+        var annotations = annotator.Annotations.OrderBy(a => a.Address).ToList();
+        long current = annotator.StreamOffsetBase;
+        foreach (var annotation in annotations)
+        {
+            if (annotation.Address > current)
+            {
+                int unknownLength = (int)(annotation.Address - current);
+                string hex = string.Join(" ", data.Skip((int)current).Take(unknownLength).Select(_ => "??"));
+                string ascii = new string('?', unknownLength);
+                sb.AppendLine($"| 0x{current:X4} | `{hex}` | `{ascii}` | *(Unknown bytes)* | |");
+                current = annotation.Address;
+            }
+
+            string hexBytes = string.Join(" ", data.Skip((int)annotation.Address).Take(annotation.Length).Select(b => b.ToString("X2")));
+            string ascii = Encoding.ASCII.GetString(data, (int)annotation.Address, annotation.Length)
+                .Select(c => char.IsControl(c) ? '.' : c).Aggregate("", (a, b) => a + b);
+
+            string keys = string.Join(", ", annotation.Keys.Select(k => $"{k.Key}:{k.Value}"));
+            sb.AppendLine($"| 0x{annotation.Address:X4} | `{hexBytes}` | `{ascii}` | {annotation.Description} | {keys} |");
+
+            current = annotation.Address + annotation.Length;
+        }
+
+        if (current < annotator.StreamOffsetBase + data.Length)
+        {
+            int unknownLength = data.Length - (int)(current - annotator.StreamOffsetBase);
+            string hex = string.Join(" ", data.Skip((int)current).Take(unknownLength).Select(_ => "??"));
+            string ascii = new string('?', unknownLength);
+            sb.AppendLine($"| 0x{current:X4} | `{hex}` | `{ascii}` | *(Unknown bytes)* | |");
+        }
+
+        return sb.ToString();
+    }
+}

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/director/Scores/RayKeyframeDeltaDecoder.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/director/Scores/RayKeyframeDeltaDecoder.cs
@@ -1,12 +1,18 @@
 ﻿using ProjectorRays.Common;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using static ProjectorRays.director.Scores.RaysScoreChunk;
 
 namespace ProjectorRays.director.Scores
 {
-    internal class RayKeyframeDeltaDecoder
+internal class RayKeyframeDeltaDecoder
     {
+        public StreamAnnotatorDecorator Annotator { get; }
+        public RayKeyframeDeltaDecoder(StreamAnnotatorDecorator annotator)
+        {
+            Annotator = annotator;
+        }
         public record DecodedKeyframe(
             int Frame,
             int SpriteChannel,
@@ -19,36 +25,36 @@ namespace ProjectorRays.director.Scores
 
         public DecodedKeyframe Decode(int frame, int channel, byte[] data)
         {
-            var s = new ReadStream(data, data.Length, Endianness.BigEndian);
+            var s = new ReadStream(data, data.Length, Endianness.BigEndian, annotator: Annotator);
 
             // Skip header or unrelated bytes
             //s.Skip(4); // Unknown
-            int foreColor = s.ReadUint8();      // 0x32
-            int backColor = s.ReadUint8();      // 0x33
-            int frameOffset = s.ReadUint16();      
-            int someValue = s.ReadUint16();      //0x01 0x90 // 400 or 1 and 144
+            int foreColor = s.ReadUint8("foreColor");      // 0x32
+            int backColor = s.ReadUint8("backColor");      // 0x33
+            int frameOffset = s.ReadUint16("frameOffset");
+            int someValue = s.ReadUint16("someValue");      //0x01 0x90 // 400 or 1 and 144
 
-            int height = s.ReadUint16();        // 0x003E = 62
-            int width = s.ReadUint16();         // 0x003C = 60
-            int blendByte = s.ReadUint8();      // 0xCC
+            int height = s.ReadUint16("height");        // 0x003E = 62
+            int width = s.ReadUint16("width");         // 0x003C = 60
+            int blendByte = s.ReadUint8("blendRaw");      // 0xCC
             int blend = (int)Math.Round(100f - blendByte / 255f * 100f);
 
             // Continue decoding based on field position
-            int propOffset1 = s.ReadUint8();  
-            int propOffset2 = s.ReadUint8();  
-            int memberNum = s.ReadUint8();    
-            int memberNum2 = s.ReadUint8();    
-            int castLib = s.ReadUint8();       // 0x0000
-            int castLib2 = s.ReadUint8();       // 0x0000
+            int propOffset1 = s.ReadUint8("propOffset1");
+            int propOffset2 = s.ReadUint8("propOffset2");
+            int memberNum = s.ReadUint8("memberNum");
+            int memberNum2 = s.ReadUint8("memberNum2");
+            int castLib = s.ReadUint8("castLib");       // 0x0000
+            int castLib2 = s.ReadUint8("castLib2");       // 0x0000
 
-            int ink = s.ReadUint8();            // next block
-            int skew = s.ReadUint8();           // skew numerator
-            int rotation = s.ReadUint8();       // rotation numerator
-            int skewDenom = s.ReadUint8();      // skew denominator
-            int rotationDenom = s.ReadUint8();  // rotation denominator
+            int ink = s.ReadUint8("ink");            // next block
+            int skew = s.ReadUint8("skewNum");           // skew numerator
+            int rotation = s.ReadUint8("rotNum");       // rotation numerator
+            int skewDenom = s.ReadUint8("skewDen");      // skew denominator
+            int rotationDenom = s.ReadUint8("rotDen");  // rotation denominator
 
-            int locH = s.ReadUint8();          // x
-            int locV = s.ReadUint8();          // y
+            int locH = s.ReadUint8("locH");          // x
+            int locV = s.ReadUint8("locV");          // y
             //int locV2 = s.ReadUint8();          // y
 
             var refMember = new RaysBehaviourRef

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/director/Scores/RaysScoreChunk.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/director/Scores/RaysScoreChunk.cs
@@ -140,7 +140,7 @@ public class RaysScoreChunk : RaysChunk
         Dir?.Logger.LogInformation($"headerType={headerType},offsetsOffset={offsetsOffset},entryCount={entryCount},notationBase={notationBase},entrySizeSum={entrySizeSum}");
 
         int entriesStart = stream.Pos;
-        var scoreFrameParser = new RaysScoreFrameParser(Dir.Logger);
+        var scoreFrameParser = new RaysScoreFrameParser(Dir.Logger, stream.Offset);
         scoreFrameParser.ReadAllIntervals(entryCount,stream);
         scoreFrameParser.ReadFrameData();
         scoreFrameParser.ReadFrameDescriptors();


### PR DESCRIPTION
## Summary
- instrument `RaysScoreFrameParser` with annotation hooks
- annotate `RayKeyframeDeltaDecoder` parsing

## Testing
- `dotnet build WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/ProjectorRays.DotNet.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b207f41083329fde3146726974e2