### PR TITLE
Add build-docs.ps1 script

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Need to install the SDK?
 
 ### API Reference
 
-Documentation generated from the source code is available using [DocFX](https://github.com/dotnet/docfx). Run `scripts/build-docs.sh` to produce the site in `docs/docfx/_site`. The pages include "View Source" links back to the repository.
+Documentation generated from the source code is available using [DocFX](https://github.com/dotnet/docfx). Run `scripts/build-docs.sh` (or `scripts/build-docs.ps1` on Windows) to produce the site in `docs/docfx/_site`. The pages include "View Source" links back to the repository.
 
 ### Component READMEs
 

--- a/docs/docfx/articles/overview.md
+++ b/docs/docfx/articles/overview.md
@@ -1,0 +1,3 @@
+# Overview
+
+This section hosts manual articles for LingoEngine.

--- a/docs/docfx/index.md
+++ b/docs/docfx/index.md
@@ -1,3 +1,3 @@
 # LingoEngine Documentation
 
-Generated API reference and guides live here. Run `scripts/build-docs.sh` to rebuild this site.
+Generated API reference and guides live here. Run `scripts/build-docs.sh` (or `scripts/build-docs.ps1` on Windows) to rebuild this site.

--- a/docs/docfx/toc.yml
+++ b/docs/docfx/toc.yml
@@ -1,2 +1,4 @@
 - name: API Reference
   href: api/index.md
+- name: Articles
+  href: articles/overview.md

--- a/scripts/build-docs.ps1
+++ b/scripts/build-docs.ps1
@@ -1,0 +1,38 @@
+# Requires PowerShell 5+
+$ErrorActionPreference = "Stop"
+
+$rootDir = Resolve-Path (Join-Path $PSScriptRoot "..")
+$docfxJson = Join-Path $rootDir "docs/docfx/docfx.json"
+$docfxOutput = Join-Path $rootDir "docs/docfx/_site"
+$wikiTempDir = Join-Path $rootDir ".wiki-tmp"
+$wikiRepoUrl = "https://github.com/EmmanuelTheCreator/LingoEngine.wiki.git"
+
+# Ensure DocFX is available
+if (-not (Get-Command "docfx" -ErrorAction SilentlyContinue)) {
+    throw "DocFX not found. Install with 'dotnet tool install -g docfx'"
+}
+
+Write-Host "🧱 Running DocFX..."
+docfx build $docfxJson --output $docfxOutput
+
+Write-Host "🧹 Cleaning old wiki clone..."
+Remove-Item -Recurse -Force -ErrorAction Ignore $wikiTempDir
+
+Write-Host "🔄 Cloning wiki repository..."
+git clone $wikiRepoUrl $wikiTempDir
+
+# Copy generated Markdown to wiki
+$articlesPath = Join-Path $docfxOutput "articles"
+Write-Host "📄 Copying generated .md files from $articlesPath"
+Get-ChildItem "$articlesPath\*.md" | ForEach-Object {
+    Copy-Item $_.FullName -Destination $wikiTempDir -Force
+}
+
+# Commit and push
+Set-Location $wikiTempDir
+git add .
+git commit -m "Update wiki with generated docs" -ErrorAction SilentlyContinue
+# Push may fail on read-only or CI environments
+try { git push } catch { Write-Warning $_ }
+
+Write-Host "`n✅ Wiki updated!"


### PR DESCRIPTION
## Summary
- add PowerShell script to publish DocFX output to the wiki
- update documentation references to use the new script
- expose articles section in DocFX

## Testing
- `bash scripts/install-dotnet.sh` *(fails: domain not in allowlist)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864bc073594833299b5d7d09114f9b8