### PR TITLE
Add Binary hex viewer using annotations

### DIFF
--- a/src/Director/LingoEngine.Director.Core/DirectorSetup.cs
+++ b/src/Director/LingoEngine.Director.Core/DirectorSetup.cs
@@ -43,6 +43,7 @@ namespace LingoEngine.Director.Core
                     .AddSingleton<DirectorScoreWindow>()
                     .AddSingleton<DirectorPropertyInspectorWindow>()
                     .AddSingleton<DirectorBinaryViewerWindow>()
+                    .AddSingleton<DirectorBinaryViewerWindowV2>()
                     .AddSingleton<DirectorStageWindow>()
                     .AddSingleton<DirectorTextEditWindow>()
                     .AddSingleton<DirectorBitmapEditWindow>()

--- a/src/Director/LingoEngine.Director.Core/Importer/DirectorBinaryViewerWindowV2.cs
+++ b/src/Director/LingoEngine.Director.Core/Importer/DirectorBinaryViewerWindowV2.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Logging;
+using ProjectorRays.Common;
+using ProjectorRays.Director;
+using System;
+using System.IO;
+
+namespace LingoEngine.Director.Core.Importer;
+
+/// <summary>
+/// Experimental binary viewer window that parses test data and exposes stream annotations.
+/// </summary>
+public class DirectorBinaryViewerWindowV2 : DirectorBinaryViewerWindow
+{
+    private readonly ILogger<DirectorBinaryViewerWindowV2> _logger;
+
+    /// <summary>Annotations gathered from the parsed score chunk.</summary>
+    public RayStreamAnnotatorDecorator? InfoToShow { get; private set; }
+
+    /// <summary>The raw bytes read from the test file.</summary>
+    public byte[]? Data { get; private set; }
+
+    public DirectorBinaryViewerWindowV2(ILogger<DirectorBinaryViewerWindowV2> logger)
+    {
+        _logger = logger;
+        LoadTestData();
+    }
+
+    private void LoadTestData()
+    {
+        try
+        {
+            string path = Path.Combine(
+                "WillMoveToOwnRepo",
+                "ProjectorRays",
+                "Test",
+                "TestData",
+                "KeyFramesTest.dir");
+            Data = File.ReadAllBytes(path);
+            var stream = new ReadStream(Data, Data.Length, Endianness.BigEndian);
+            var dir = new RaysDirectorFile(_logger);
+            if (dir.Read(stream))
+                InfoToShow = RaysScoreChunk.Annotator;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load test data for BinaryViewerWindowV2");
+        }
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Inspector/IDirFrameworkBinaryViewerWindowV2.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/IDirFrameworkBinaryViewerWindowV2.cs
@@ -1,0 +1,5 @@
+using LingoEngine.Director.Core.Windowing;
+
+namespace LingoEngine.Director.Core.Inspector;
+
+public interface IDirFrameworkBinaryViewerWindowV2 : IDirFrameworkWindow { }

--- a/src/Director/LingoEngine.Director.Core/UI/DirectorMainMenu.cs
+++ b/src/Director/LingoEngine.Director.Core/UI/DirectorMainMenu.cs
@@ -151,6 +151,10 @@ namespace LingoEngine.Director.Core.UI
             binary.Activated += () => _windowManager.OpenWindow(DirectorMenuCodes.BinaryViewerWindow);
             _windowMenu.AddItem(binary);
 
+            var binaryV2 = factory.CreateMenuItem("Binary Viewer V2");
+            binaryV2.Activated += () => _windowManager.OpenWindow(DirectorMenuCodes.BinaryViewerWindowV2);
+            _windowMenu.AddItem(binaryV2);
+
             var paint = factory.CreateMenuItem("Paint  \tCTRL+5");
             paint.Activated += () => _windowManager.OpenWindow(DirectorMenuCodes.PictureEditWindow);
             _windowMenu.AddItem(paint);

--- a/src/Director/LingoEngine.Director.Core/UI/DirectorMenuCodes.cs
+++ b/src/Director/LingoEngine.Director.Core/UI/DirectorMenuCodes.cs
@@ -13,6 +13,7 @@ namespace LingoEngine.Director.Core.UI
         public const string FileSave = "FileSave";
         public const string FileLoad = "FileLoad";
         public const string BinaryViewerWindow = "BinaryViewerWindow";
+        public const string BinaryViewerWindowV2 = "BinaryViewerWindowV2";
         public const string TextEditWindow = "TextEditWindow";
         public const string PictureEditWindow = "PictureEditWindow";
         public const string ImportExportWindow = "ImportExportWindow";

--- a/src/Director/LingoEngine.Director.Core/Windowing/DirectorWindowRegistrator.cs
+++ b/src/Director/LingoEngine.Director.Core/Windowing/DirectorWindowRegistrator.cs
@@ -27,6 +27,7 @@ namespace LingoEngine.Director.Core.Windowing
                 .Register<DirectorScoreWindow>(DirectorMenuCodes.ScoreWindow, shortCutManager.CreateShortCut(DirectorMenuCodes.ScoreWindow, "Ctrl+4", sc => new ExecuteShortCutCommand(sc)))
                 .Register<DirectorPropertyInspectorWindow>(DirectorMenuCodes.PropertyInspector, shortCutManager.CreateShortCut(DirectorMenuCodes.PropertyInspector, "Ctrl+Alt+S", sc => new ExecuteShortCutCommand(sc)))
                 .Register<DirectorBinaryViewerWindow>(DirectorMenuCodes.BinaryViewerWindow)
+                .Register<DirectorBinaryViewerWindowV2>(DirectorMenuCodes.BinaryViewerWindowV2)
                 .Register<DirectorStageWindow>(DirectorMenuCodes.StageWindow, shortCutManager.CreateShortCut(DirectorMenuCodes.StageWindow, "Ctrl+1", sc => new ExecuteShortCutCommand(sc)))
                 .Register<DirectorTextEditWindow>(DirectorMenuCodes.TextEditWindow, shortCutManager.CreateShortCut(DirectorMenuCodes.TextEditWindow, "Ctrl+T", sc => new ExecuteShortCutCommand(sc)))
                 .Register<DirectorBitmapEditWindow>(DirectorMenuCodes.PictureEditWindow, shortCutManager.CreateShortCut(DirectorMenuCodes.PictureEditWindow, "Ctrl+5", sc => new ExecuteShortCutCommand(sc)))

--- a/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
@@ -48,6 +48,7 @@ namespace LingoEngine.Director.LGodot
                 s.AddSingleton<DirGodotScoreWindow>();
                 s.AddSingleton<DirGodotStageWindow>();
                 s.AddSingleton<DirGodotBinaryViewerWindow>();
+                s.AddSingleton<DirGodotBinaryViewerWindowV2>();
                 s.AddSingleton<DirGodotImportExportWindow>();
                 s.AddSingleton<DirGodotPropertyInspector>();
                 s.AddSingleton<DirGodotTextableMemberWindow>();
@@ -72,6 +73,7 @@ namespace LingoEngine.Director.LGodot
                 s.AddTransient<IDirFrameworkScoreWindow>(p => p.GetRequiredService<DirGodotScoreWindow>());
                 s.AddTransient<IDirFrameworkStageWindow>(p => p.GetRequiredService<DirGodotStageWindow>());
                 s.AddTransient<IDirFrameworkBinaryViewerWindow>(p => p.GetRequiredService<DirGodotBinaryViewerWindow>());
+                s.AddTransient<IDirFrameworkBinaryViewerWindowV2>(p => p.GetRequiredService<DirGodotBinaryViewerWindowV2>());
                 s.AddTransient<IDirFrameworkPropertyInspectorWindow>(p => p.GetRequiredService<DirGodotPropertyInspector>());
                 s.AddTransient<IDirFrameworkBitmapEditWindow>(p => p.GetRequiredService<DirGodotPictureMemberEditorWindow>());
                 s.AddTransient<IDirFrameworkImportExportWindow>(p => p.GetRequiredService<DirGodotImportExportWindow>());

--- a/src/Director/LingoEngine.Director.LGodot/Importer/DirGodotBinaryViewerWindowV2.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Importer/DirGodotBinaryViewerWindowV2.cs
@@ -1,0 +1,155 @@
+using Godot;
+using LingoEngine.Director.Core.Importer;
+using LingoEngine.Director.LGodot.Windowing;
+using LingoEngine.Director.Core.UI;
+using ProjectorRays.Common;
+using System;
+using System.Collections.Generic;
+
+namespace LingoEngine.Director.LGodot.Gfx;
+
+internal partial class DirGodotBinaryViewerWindowV2 : BaseGodotWindow, IDirFrameworkBinaryViewerWindowV2
+{
+    private readonly ScrollContainer _scroll = new();
+    private readonly ScrollContainer _descScroll = new();
+    private readonly VBoxContainer _descTable = new();
+    private SubViewport _viewport;
+    private TextureRect _textureRect;
+
+    private readonly Dictionary<int, Color> _blockColors = new();
+    private readonly Dictionary<int, int> _blockIndexByOffset = new();
+    private readonly List<RayStreamAnnotation> _blocks = new();
+
+    public DirGodotBinaryViewerWindowV2(DirectorBinaryViewerWindowV2 viewerWindow, IDirGodotWindowManager windowManager)
+        : base(DirectorMenuCodes.BinaryViewerWindowV2, "Binary Viewer V2", windowManager)
+    {
+        viewerWindow.Init(this);
+        Size = new Vector2(1000, 600);
+        CustomMinimumSize = Size;
+
+        _viewport = new SubViewport();
+        _viewport.SetDisable3D(true);
+        _viewport.TransparentBg = false;
+        _viewport.SetUpdateMode(SubViewport.UpdateMode.Once);
+        AddChild(_viewport);
+
+        _textureRect = new TextureRect { Texture = _viewport.GetTexture() };
+        _scroll.AddChild(_textureRect);
+
+        var root = new HBoxContainer();
+        root.Position = new Vector2(0, TitleBarHeight);
+        root.Size = new Vector2(Size.X, Size.Y - TitleBarHeight);
+        AddChild(root);
+
+        root.AddChild(_scroll);
+        _descScroll.AddChild(_descTable);
+        root.AddChild(_descScroll);
+        _scroll.SizeFlagsHorizontal = SizeFlags.ExpandFill;
+        _scroll.SizeFlagsVertical = SizeFlags.ExpandFill;
+        _descScroll.CustomMinimumSize = new Vector2(200, 400);
+        _descScroll.SizeFlagsVertical = SizeFlags.ExpandFill;
+
+        if (viewerWindow.Data != null && viewerWindow.InfoToShow != null)
+            LoadBytes(viewerWindow.Data, viewerWindow.InfoToShow);
+    }
+
+    private void ForceRefreshViewPort()
+    {
+        _viewport.RenderTargetUpdateMode = SubViewport.UpdateMode.Once;
+        _viewport.RenderTargetUpdateMode = SubViewport.UpdateMode.Disabled;
+        _viewport.RenderTargetUpdateMode = SubViewport.UpdateMode.Once;
+    }
+
+    private void LoadBytes(byte[] data, RayStreamAnnotatorDecorator annotator)
+    {
+        _blockColors.Clear();
+        _blockIndexByOffset.Clear();
+        _blocks.Clear();
+        ClearChildren(_descTable);
+
+        _blocks.AddRange(annotator.Annotations);
+        long baseOffset = annotator.StreamOffsetBase;
+        int colorIndex = 0;
+        for (int idx = 0; idx < _blocks.Count; idx++)
+        {
+            var block = _blocks[idx];
+            var hue = (colorIndex * 0.1f) % 1f;
+            var color = Color.FromHsv(hue, 0.3f, 1f);
+            _blockColors[idx] = color;
+            int start = (int)(block.Address - baseOffset);
+            for (int i = 0; i < block.Length; i++)
+            {
+                int off = start + i;
+                if (off >= 0 && off < data.Length)
+                    _blockIndexByOffset[off] = idx;
+            }
+            colorIndex++;
+        }
+
+        foreach (var child in _viewport.GetChildren())
+            if (child is Node node)
+            {
+                _viewport.RemoveChild(node);
+                node.QueueFree();
+            }
+
+        var drawControl = new HexDrawControlV2(data, annotator);
+        var rowHeight = 24;
+        var totalRows = (int)Math.Ceiling(data.Length / 32.0);
+        var contentSize = new Vector2(1400, totalRows * rowHeight);
+
+        drawControl.CustomMinimumSize = contentSize;
+        drawControl.Size = contentSize;
+        drawControl.CallDeferred("queue_redraw");
+
+        _viewport.SetSize(new Vector2I((int)contentSize.X, (int)contentSize.Y));
+        _viewport.AddChild(drawControl);
+
+        _textureRect.Texture = _viewport.GetTexture();
+        _textureRect.SetStretchMode(TextureRect.StretchModeEnum.Scale);
+        _textureRect.CustomMinimumSize = contentSize;
+
+        RenderDescriptions();
+        ForceRefreshViewPort();
+    }
+
+    private void RenderDescriptions()
+    {
+        int idx = 0;
+        foreach (var block in _blocks)
+        {
+            var h = new HBoxContainer();
+            var range = block.Length == 1
+                ? $"0x{block.Address:X4}"
+                : $"0x{block.Address:X4}-0x{block.Address + block.Length - 1:X4}";
+            var offsetLabel = new Label { Text = range };
+            var descLabel = new Label { Text = block.Description };
+
+            var c = _blockColors.TryGetValue(idx, out var col) ? col : Color.FromHsv((idx * 0.1f) % 1f, 0.3f, 1f);
+            var style = new StyleBoxFlat { BgColor = c };
+            offsetLabel.AddThemeStyleboxOverride("panel", style);
+            descLabel.AddThemeStyleboxOverride("panel", style);
+            h.AddChild(offsetLabel);
+            h.AddChild(descLabel);
+            _descTable.AddChild(h);
+            idx++;
+        }
+    }
+
+    private static void ClearChildren(Container container)
+    {
+        foreach (var child in container.GetChildren().ToArray())
+            if (child is Node node)
+            {
+                container.RemoveChild(node);
+                node.QueueFree();
+            }
+    }
+
+    protected override void OnResizing(Vector2 size)
+    {
+        base.OnResizing(size);
+        _scroll.Size = new Vector2(size.X - 200, size.Y - TitleBarHeight);
+        _descScroll.Size = new Vector2(200, size.Y - TitleBarHeight);
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/Importer/HexDrawControlV2.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Importer/HexDrawControlV2.cs
@@ -1,0 +1,103 @@
+using Godot;
+using ProjectorRays.Common;
+using System;
+using System.Collections.Generic;
+
+namespace LingoEngine.Director.LGodot.Gfx
+{
+    internal partial class HexDrawControlV2 : Control
+    {
+        private readonly byte[] _data;
+        private readonly RayStreamAnnotatorDecorator _annotator;
+        private readonly Dictionary<int, Color> _blockColors = new();
+        private readonly Dictionary<int, int> _blockIndexByOffset = new();
+
+        private const int BytesPerRow = 32;
+        private const int ByteSpacing = 24;
+        private const int GroupGap = 8;
+        private const int RowHeight = 22;
+        private const int LeftMargin = 10;
+        private const int AsciiOffsetX = 900;
+
+        public HexDrawControlV2(byte[] data, RayStreamAnnotatorDecorator annotator)
+        {
+            _data = data;
+            _annotator = annotator;
+
+            int colorIndex = 0;
+            long baseOffset = annotator.StreamOffsetBase;
+            for (int idx = 0; idx < annotator.Annotations.Count; idx++)
+            {
+                var ann = annotator.Annotations[idx];
+                var hue = (colorIndex * 0.1f) % 1f;
+                var color = Color.FromHsv(hue, 0.3f, 1f);
+                _blockColors[idx] = color;
+                int start = (int)(ann.Address - baseOffset);
+                for (int i = 0; i < ann.Length; i++)
+                {
+                    int off = start + i;
+                    if (off >= 0 && off < data.Length)
+                        _blockIndexByOffset[off] = idx;
+                }
+                colorIndex++;
+            }
+
+            int totalRows = (int)Math.Ceiling(data.Length / (float)BytesPerRow);
+            CustomMinimumSize = new Vector2(AsciiOffsetX + 300, totalRows * RowHeight);
+            Size = CustomMinimumSize;
+        }
+
+        public override void _Draw()
+        {
+            var font = GetThemeDefaultFont();
+            if (font == null)
+            {
+                GD.PushWarning("HexDrawControlV2: No default font found.");
+                return;
+            }
+
+            long baseOffset = _annotator.StreamOffsetBase;
+            for (int i = 0; i < _data.Length; i += BytesPerRow)
+            {
+                float y = (i / BytesPerRow) * RowHeight;
+                string ascii = string.Empty;
+
+                for (int j = 0; j < BytesPerRow && i + j < _data.Length; j++)
+                {
+                    int offset = i + j;
+                    byte b = _data[offset];
+
+                    int group = j / GroupGap;
+                    float hexX = LeftMargin + (j + group) * ByteSpacing;
+
+                    string tag = string.Empty;
+                    Color? bg = null;
+
+                    if (_blockIndexByOffset.TryGetValue(offset, out int blockId))
+                    {
+                        if (_blockColors.TryGetValue(blockId, out var c))
+                            bg = c;
+
+                        var ann = _annotator.Annotations[blockId];
+                        int relStart = (int)(ann.Address - baseOffset);
+                        if (offset == relStart)
+                            tag = ann.Description.Length > 6 ? ann.Description.Substring(0, 6) : ann.Description;
+                    }
+
+                    if (bg != null)
+                    {
+                        DrawRect(new Rect2(hexX, y, ByteSpacing - 2, RowHeight), bg.Value, true);
+                    }
+
+                    DrawString(font, new Vector2(hexX, y + 12), $"{b:X2}", HorizontalAlignment.Center, -1, 12, Colors.Black);
+                    if (!string.IsNullOrEmpty(tag))
+                        DrawString(font, new Vector2(hexX, y + 20), tag, HorizontalAlignment.Left, -1, 8, Colors.Black);
+
+                    ascii += (b >= 32 && b <= 126) ? (char)b : '.';
+                }
+
+                DrawString(font, new Vector2(AsciiOffsetX, y + 16), ascii, HorizontalAlignment.Left, -1, 12, Colors.Black);
+            }
+        }
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/UI/LingoGodotDirectorRoot.cs
+++ b/src/Director/LingoEngine.Director.LGodot/UI/LingoGodotDirectorRoot.cs
@@ -23,6 +23,7 @@ namespace LingoEngine.Director.LGodot.UI
         private readonly DirGodotMainMenu _dirGodotMainMenu;
         private readonly DirGodotProjectSettingsWindow _projectSettingsWindow;
         private readonly DirGodotBinaryViewerWindow _binaryViewer;
+        private readonly DirGodotBinaryViewerWindowV2 _binaryViewerV2;
         private readonly DirGodotImportExportWindow _importExportWindow;
         private readonly DirGodotTextableMemberWindow _textWindow;
         private readonly DirGodotPictureMemberEditorWindow _picture;
@@ -47,6 +48,7 @@ namespace LingoEngine.Director.LGodot.UI
             _propertyInspector = serviceProvider.GetRequiredService<DirGodotPropertyInspector>();
             _toolsWindow = serviceProvider.GetRequiredService<DirGodotToolsWindow>();
             _binaryViewer = serviceProvider.GetRequiredService<DirGodotBinaryViewerWindow>();
+            _binaryViewerV2 = serviceProvider.GetRequiredService<DirGodotBinaryViewerWindowV2>();
             _importExportWindow = serviceProvider.GetRequiredService<DirGodotImportExportWindow>();
             _textWindow = serviceProvider.GetRequiredService<DirGodotTextableMemberWindow>();
             _picture = serviceProvider.GetRequiredService<DirGodotPictureMemberEditorWindow>();
@@ -62,6 +64,7 @@ namespace LingoEngine.Director.LGodot.UI
             _directorParent.AddChild(_textWindow);
             _directorParent.AddChild(_propertyInspector);
             _directorParent.AddChild(_binaryViewer);
+            _directorParent.AddChild(_binaryViewerV2);
 
             // Set all positions
             SetDefaultPositions();
@@ -69,6 +72,7 @@ namespace LingoEngine.Director.LGodot.UI
             // close some windows
             _projectSettingsWindow.CloseWindow();
             _binaryViewer.CloseWindow();
+            _binaryViewerV2.CloseWindow();
             _importExportWindow.CloseWindow();
             _textWindow.CloseWindow();
             _picture.CloseWindow();
@@ -83,6 +87,7 @@ namespace LingoEngine.Director.LGodot.UI
             _propertyInspector.Position = new Vector2(1330, 25);
             _toolsWindow.Position = new Vector2(10, 25);
             _binaryViewer.Position = new Vector2(20, 120);
+            _binaryViewerV2.Position = new Vector2(20, 280);
             _importExportWindow.Position = new Vector2(120, 120);
             _projectSettingsWindow.Position = new Vector2(100, 100);
             _textWindow.Position = new Vector2(20, 120);
@@ -99,6 +104,7 @@ namespace LingoEngine.Director.LGodot.UI
             _propertyInspector.Dispose();
             _toolsWindow.Dispose();
             _binaryViewer.Dispose();
+            _binaryViewerV2.Dispose();
             _importExportWindow.Dispose();
         }
     }


### PR DESCRIPTION
## Summary
- implement `HexDrawControlV2` to render hex data using `RayStreamAnnotatorDecorator`
- update `DirGodotBinaryViewerWindowV2` to use the new control for annotated binary display

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686548478e408332acbb6b44a972d282