### PR TITLE
Fix docfx API link

### DIFF
--- a/docs/docfx/toc.yml
+++ b/docs/docfx/toc.yml
@@ -1,4 +1,4 @@
 - name: API Reference
-  href: api/index.md
+  href: api/
 - name: Articles
   href: articles/overview.md


### PR DESCRIPTION
## Summary
- fix the path to API docs in toc.yml

## Testing
- `bash scripts/build-docs.sh` *(fails: docfx not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656596456c8332bd7ee6da189bb428