### PR TITLE
Add hover tooltip and selection in Binary Viewer V2

### DIFF
--- a/src/Director/LingoEngine.Director.LGodot/Importer/DirGodotBinaryViewerWindowV2.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Importer/DirGodotBinaryViewerWindowV2.cs
@@ -13,6 +13,10 @@ internal partial class DirGodotBinaryViewerWindowV2 : BaseGodotWindow, IDirFrame
     private readonly ScrollContainer _scroll = new();
     private readonly ScrollContainer _descScroll = new();
     private readonly VBoxContainer _descTable = new();
+    private readonly List<HBoxContainer> _descRows = new();
+    private readonly StyleBoxFlat _normalRowStyle = new();
+    private readonly StyleBoxFlat _selectedRowStyle = new() { BgColor = Colors.SkyBlue };
+    private int _selectedRow = -1;
     private SubViewport _viewport;
     private TextureRect _textureRect;
 
@@ -94,6 +98,7 @@ internal partial class DirGodotBinaryViewerWindowV2 : BaseGodotWindow, IDirFrame
             }
 
         var drawControl = new HexDrawControlV2(data, annotator);
+        drawControl.ByteClicked += OnByteClicked;
         var rowHeight = 24;
         var totalRows = (int)Math.Ceiling(data.Length / 32.0);
         var contentSize = new Vector2(1400, totalRows * rowHeight);
@@ -115,10 +120,12 @@ internal partial class DirGodotBinaryViewerWindowV2 : BaseGodotWindow, IDirFrame
 
     private void RenderDescriptions()
     {
+        _descRows.Clear();
         int idx = 0;
         foreach (var block in _blocks)
         {
             var h = new HBoxContainer();
+            h.AddThemeStyleboxOverride("panel", _normalRowStyle);
             var range = block.Length == 1
                 ? $"0x{block.Address:X4}"
                 : $"0x{block.Address:X4}-0x{block.Address + block.Length - 1:X4}";
@@ -132,6 +139,7 @@ internal partial class DirGodotBinaryViewerWindowV2 : BaseGodotWindow, IDirFrame
             h.AddChild(offsetLabel);
             h.AddChild(descLabel);
             _descTable.AddChild(h);
+            _descRows.Add(h);
             idx++;
         }
     }
@@ -144,6 +152,24 @@ internal partial class DirGodotBinaryViewerWindowV2 : BaseGodotWindow, IDirFrame
                 container.RemoveChild(node);
                 node.QueueFree();
             }
+    }
+
+    private void OnByteClicked(int blockIndex)
+    {
+        HighlightRow(blockIndex);
+    }
+
+    private void HighlightRow(int index)
+    {
+        if (_selectedRow >= 0 && _selectedRow < _descRows.Count)
+            _descRows[_selectedRow].AddThemeStyleboxOverride("panel", _normalRowStyle);
+
+        _selectedRow = index;
+        if (index >= 0 && index < _descRows.Count)
+        {
+            _descRows[index].AddThemeStyleboxOverride("panel", _selectedRowStyle);
+            _descScroll.ScrollVertical = _descRows[index].Position.Y;
+        }
     }
 
     protected override void OnResizing(Vector2 size)


### PR DESCRIPTION
## Summary
- show tooltip for annotated bytes in `HexDrawControlV2`
- emit click event when byte clicked
- highlight description rows on selection in `DirGodotBinaryViewerWindowV2`

## Testing
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686575d19f1883329936178f4637b1b1