### PR TITLE
Add additional tag constants from documentation

### DIFF
--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/director/Scores/RayScoreTagsV2.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/director/Scores/RayScoreTagsV2.cs
@@ -9,8 +9,18 @@ namespace ProjectorRays.director.Scores;
 internal static class RayScoreTagsV2
 {
     // Prefix constants used by the score parser
+    public const ushort Padding = 0x0000; // empty marker between tags
     public const ushort BlockEnd = 0x0008;
     public const ushort SpriteBlockPrefix = 0x0030;
+    public const ushort ShortTagPrefix = 0x0002; // variable tag length prefix
+    public const ushort IntTagPrefix = 0x0004;   // 4 byte payload prefix
+    public const ushort BlockSizePrefix = 0x0036; // indicates upcoming block size
+    public const ushort CompositePrefix = 0x000C; // composite block indicator
+    public const ushort Control1E = 0x001E; // frame control markers
+    public const ushort Control20 = 0x0020;
+    public const ushort Control26 = 0x0026;
+    public const ushort Control28 = 0x0028;
+    public const ushort Control94 = 0x0094;
 
     // Flags observed in advance tags (0x0136)
     public const ushort KeyframeCreateFlag = 0x8100;
@@ -26,10 +36,12 @@ internal static class RayScoreTagsV2
         Rotation = 0x019E,
         Skew = 0x01A2,
         Colors = 0x0212,
+        ColorsShort = 0x0182,
         Composite = 0x0190,
         BlockControl = 0x0180,
         FrameRect = 0x01EC,
         Curvature = 0x01F4,
+        Speed = 0x012E,
         Flags = 0x01FE,
         FlagsControl = 0x01FC,
         TweenFlags = 0x01F6,
@@ -37,6 +49,13 @@ internal static class RayScoreTagsV2
         Unknown012A = 0x012A,
         Unknown013E = 0x013E,
         Unknown0142 = 0x0142,
+        Unknown018A = 0x018A,
+        Unknown01C6 = 0x01C6,
+        Unknown01D2 = 0x01D2,
+        Unknown01B0 = 0x01B0,
+        Unknown01BA = 0x01BA,
+        Unknown01CE = 0x01CE,
+        TransitionCode = 0x0202,
     }
     public enum ScoreTagMain : ushort
     {
@@ -68,13 +87,19 @@ internal static class RayScoreTagsV2
             ScoreTagV2.Rotation => 2,
             ScoreTagV2.Skew => 2,
             ScoreTagV2.Colors => 2,
+            ScoreTagV2.ColorsShort => 2,
             ScoreTagV2.Composite => 6,
             ScoreTagV2.FrameRect => 8,
             ScoreTagV2.Curvature => 2,
+            ScoreTagV2.Speed => 2,
             ScoreTagV2.Flags => 2,
             ScoreTagV2.FlagsControl => 2,
             ScoreTagV2.TweenFlags => 1,
+            ScoreTagV2.TransitionCode => 1,
             ScoreTagV2.BlockControl => 2,
+            ScoreTagV2.Unknown01CE => 2,
+            ScoreTagV2.Unknown01C6 => 2,
+            ScoreTagV2.Unknown01D2 => 2,
             _ => 0
         };
 }

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/director/Scores/RaysScoreReader.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/director/Scores/RaysScoreReader.cs
@@ -174,6 +174,7 @@ internal class RaysScoreReader
                 kf.LocV = rs.ReadInt16("locV", ctx.GetAnnotationKeys());
                 break;
             case ScoreTagV2.Colors:
+            case ScoreTagV2.ColorsShort:
                 kf.ForeColor = rs.ReadUint8("foreColor", ctx.GetAnnotationKeys());
                 kf.BackColor = rs.ReadUint8("backColor", ctx.GetAnnotationKeys());
                 break;


### PR DESCRIPTION
## Summary
- define `Padding` prefix constant
- add `ColorsShort`, `TransitionCode` and several unknown tag enums
- map tag lengths and parse `ColorsShort`

## Testing
- `dotnet test LingoEngine.sln --no-build` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_686a52f5de648332b85fb922fd3bfb19