### PR TITLE
Add stub implementations for director modules

### DIFF
--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/__init__.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/__init__.py
@@ -1,0 +1,1 @@
+from .director import *

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/common/json_writer.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/common/json_writer.py
@@ -1,0 +1,55 @@
+import json
+
+class JSONWriter:
+    def __init__(self):
+        self._stack = []
+        self._root = None
+        self._current_key = None
+
+    def start_object(self):
+        obj = {}
+        if self._stack:
+            parent = self._stack[-1]
+            if isinstance(parent, list):
+                parent.append(obj)
+            elif isinstance(parent, dict):
+                parent[self._current_key] = obj
+                self._current_key = None
+        else:
+            self._root = obj
+        self._stack.append(obj)
+
+    def end_object(self):
+        if self._stack and isinstance(self._stack[-1], dict):
+            self._stack.pop()
+
+    def start_array(self):
+        arr = []
+        if self._stack:
+            parent = self._stack[-1]
+            if isinstance(parent, dict):
+                parent[self._current_key] = arr
+                self._current_key = None
+            elif isinstance(parent, list):
+                parent.append(arr)
+        else:
+            self._root = arr
+        self._stack.append(arr)
+
+    def end_array(self):
+        if self._stack and isinstance(self._stack[-1], list):
+            self._stack.pop()
+
+    def write_key(self, key):
+        self._current_key = key
+
+    def write_val(self, val):
+        parent = self._stack[-1]
+        if isinstance(parent, dict):
+            parent[self._current_key] = val
+            self._current_key = None
+        elif isinstance(parent, list):
+            parent.append(val)
+
+    def to_string(self, indent=2):
+        return json.dumps(self._root, indent=indent)

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/common/stream.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/common/stream.py
@@ -1,0 +1,56 @@
+import struct
+from enum import Enum
+
+class Endianness(Enum):
+    BIG = '>'
+    LITTLE = '<'
+
+class BufferView:
+    def __init__(self, data=b"", offset=0, size=None):
+        self.data = data
+        self.offset = offset
+        self.size = len(data) if size is None else size
+
+    @property
+    def bytes(self):
+        return self.data[self.offset:self.offset + self.size]
+
+    def log_hex(self, length=256, bytes_per_line=16):
+        limit = min(self.size, length)
+        lines = []
+        for i in range(0, limit, bytes_per_line):
+            chunk = self.bytes[i:i+bytes_per_line]
+            hex_part = ' '.join(f"{b:02X}" for b in chunk)
+            lines.append(f"{i:04X}: {hex_part}")
+        return '\n'.join(lines)
+
+class ReadStream:
+    def __init__(self, data, endianness=Endianness.BIG, pos=0):
+        if isinstance(data, BufferView):
+            self.data = data.bytes
+        else:
+            self.data = data
+        self.pos = pos
+        self.endianness = endianness
+
+    def eof(self):
+        return self.pos >= len(self.data)
+
+    def read_bytes(self, n):
+        if self.pos + n > len(self.data):
+            raise EOFError('Read past end of stream')
+        b = self.data[self.pos:self.pos+n]
+        self.pos += n
+        return b
+
+    def read_uint8(self):
+        return self.read_bytes(1)[0]
+
+    def read_uint16(self):
+        return struct.unpack(self.endianness.value + 'H', self.read_bytes(2))[0]
+
+    def read_uint32(self):
+        return struct.unpack(self.endianness.value + 'I', self.read_bytes(4))[0]
+
+    def read_string(self, length):
+        return self.read_bytes(length).decode('utf-8')

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/common/util.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/common/util.py
@@ -1,0 +1,27 @@
+from enum import Enum
+
+class RaysUtil:
+    @staticmethod
+    def fourcc_to_string(fourcc: int) -> str:
+        chars = [chr((fourcc >> 24) & 0xFF),
+                 chr((fourcc >> 16) & 0xFF),
+                 chr((fourcc >> 8) & 0xFF),
+                 chr(fourcc & 0xFF)]
+        return ''.join(chars)
+
+    @staticmethod
+    def human_version(ver: int) -> int:
+        if ver >= 1951: return 1200
+        if ver >= 1922: return 1150
+        if ver >= 1921: return 1100
+        if ver >= 1851: return 1000
+        if ver >= 1700: return 850
+        if ver >= 1410: return 800
+        if ver >= 1224: return 700
+        if ver >= 1218: return 600
+        if ver >= 1201: return 500
+        if ver >= 1117: return 404
+        if ver >= 1115: return 400
+        if ver >= 1029: return 310
+        if ver >= 1028: return 300
+        return 200

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/__init__.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/__init__.py
@@ -1,0 +1,25 @@
+from .scores import *
+from .rays_director_file import RaysDirectorFile
+from .rays_cast_member import RaysCastMember, RaysScriptMember, RaysMemberType
+from .rays_subchunk import CastListEntry, MemoryMapEntry, KeyTableEntry
+from .ray_guid import RayGuid, LingoGuidConstants
+from .rays_font_map import RaysFontMap
+from .rle_temp import RleTemp
+from .sound import Sound
+from . import chunks
+
+__all__ = [
+    'RaysDirectorFile',
+    'RaysCastMember',
+    'RaysScriptMember',
+    'RaysMemberType',
+    'CastListEntry',
+    'MemoryMapEntry',
+    'KeyTableEntry',
+    'RayGuid',
+    'LingoGuidConstants',
+    'RaysFontMap',
+    'RleTemp',
+    'Sound',
+    'chunks'
+] + __all__

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/__init__.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/__init__.py
@@ -1,0 +1,33 @@
+from .rays_chunk import RaysChunk, ChunkType
+from .rays_list_chunk import RaysListChunk
+from .rays_cast_chunk import RaysCastChunk
+from .rays_cast_list_chunk import RaysCastListChunk
+from .rays_cast_member_chunk import RaysCastMemberChunk
+from .rays_cast_info_chunk import RaysCastInfoChunk
+from .rays_config_chunk import RaysConfigChunk
+from .rays_initial_map_chunk import RaysInitialMapChunk
+from .rays_key_table_chunk import RaysKeyTableChunk
+from .rays_memory_map_chunk import RaysMemoryMapChunk
+from .rays_script_chunk import RaysScriptChunk
+from .rays_script_context_chunk import RaysScriptContextChunk
+from .rays_script_names_chunk import RaysScriptNamesChunk, ScriptNames
+from .rays_xmed_chunk import RaysXmedChunk
+
+__all__ = [
+    'RaysChunk',
+    'ChunkType',
+    'RaysListChunk',
+    'RaysCastChunk',
+    'RaysCastListChunk',
+    'RaysCastMemberChunk',
+    'RaysCastInfoChunk',
+    'RaysConfigChunk',
+    'RaysInitialMapChunk',
+    'RaysKeyTableChunk',
+    'RaysMemoryMapChunk',
+    'RaysScriptChunk',
+    'RaysScriptContextChunk',
+    'RaysScriptNamesChunk',
+    'ScriptNames',
+    'RaysXmedChunk',
+]

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_cast_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_cast_chunk.py
@@ -1,0 +1,20 @@
+from .rays_chunk import RaysChunk, ChunkType
+
+class RaysCastChunk(RaysChunk):
+    def __init__(self, dir=None):
+        super().__init__(dir, ChunkType.CastChunk)
+        self.member_ids = []
+
+    def read(self, stream):
+        while not stream.eof():
+            member_id = stream.read_uint32()
+            self.member_ids.append(member_id)
+
+    def write_json(self, writer):
+        writer.start_object()
+        writer.write_key('memberIDs')
+        writer.start_array()
+        for mid in self.member_ids:
+            writer.write_val(mid)
+        writer.end_array()
+        writer.end_object()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_cast_info_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_cast_info_chunk.py
@@ -1,0 +1,16 @@
+from .rays_chunk import RaysChunk, ChunkType
+from ...common.stream import ReadStream
+
+class RaysCastInfoChunk(RaysChunk):
+    def __init__(self, dir=None):
+        super().__init__(dir, ChunkType.CastInfoChunk)
+        self.name = ''
+        self.script_id = 0
+
+    def read(self, stream: ReadStream):
+        self.script_id = stream.read_uint32()
+
+    def write_json(self, writer):
+        writer.start_object()
+        writer.write_key('scriptId'); writer.write_val(self.script_id)
+        writer.end_object()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_cast_list_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_cast_list_chunk.py
@@ -1,0 +1,30 @@
+from .rays_list_chunk import RaysListChunk
+from .rays_chunk import ChunkType
+from ...common.stream import ReadStream
+from ..rays_subchunk import CastListEntry
+
+class RaysCastListChunk(RaysListChunk):
+    def __init__(self, dir=None):
+        super().__init__(dir, ChunkType.CastListChunk)
+        self.cast_count = 0
+        self.items_per_cast = 0
+        self.entries = []
+
+    def read_header(self, stream: ReadStream):
+        self.data_offset = stream.read_uint32()
+        stream.read_uint16()
+        self.cast_count = stream.read_uint16()
+        self.items_per_cast = stream.read_uint16()
+        stream.read_uint16()
+        self.offset_table_len = stream.read_uint16()
+        self.items_len = stream.read_uint32()
+
+    def read(self, stream: ReadStream):
+        super().read(stream)
+        for _ in range(self.cast_count):
+            self.entries.append(CastListEntry())
+
+    def write_json(self, writer):
+        writer.start_object()
+        writer.write_key('count'); writer.write_val(len(self.entries))
+        writer.end_object()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_cast_member_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_cast_member_chunk.py
@@ -1,0 +1,22 @@
+from .rays_chunk import RaysChunk, ChunkType
+from ...common.stream import ReadStream
+from ..rays_cast_member import RaysMemberType
+
+class RaysCastMemberChunk(RaysChunk):
+    def __init__(self, dir=None):
+        super().__init__(dir, ChunkType.CastMemberChunk)
+        self.type = RaysMemberType.NullMember
+        self.info_len = 0
+        self.specific_data_len = 0
+
+    def read(self, stream: ReadStream):
+        self.type = RaysMemberType(stream.read_uint32())
+        self.info_len = stream.read_uint32()
+        self.specific_data_len = stream.read_uint32()
+        stream.read_bytes(self.info_len)
+        stream.read_bytes(self.specific_data_len)
+
+    def write_json(self, writer):
+        writer.start_object()
+        writer.write_key('type'); writer.write_val(self.type.name)
+        writer.end_object()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_chunk.py
@@ -1,0 +1,33 @@
+from enum import Enum
+from ...common.json_writer import JSONWriter
+
+class ChunkType(Enum):
+    CastChunk = 'CastChunk'
+    CastListChunk = 'CastListChunk'
+    CastMemberChunk = 'CastMemberChunk'
+    CastInfoChunk = 'CastInfoChunk'
+    ConfigChunk = 'ConfigChunk'
+    InitialMapChunk = 'InitialMapChunk'
+    KeyTableChunk = 'KeyTableChunk'
+    MemoryMapChunk = 'MemoryMapChunk'
+    ScriptChunk = 'ScriptChunk'
+    ScriptContextChunk = 'ScriptContextChunk'
+    ScriptNamesChunk = 'ScriptNamesChunk'
+    ScoreChunk = 'ScoreChunk'
+    XmedChunk = 'XmedChunk'
+    StyledText = 'StyledText'
+
+class RaysChunk:
+    def __init__(self, dir=None, chunk_type=None):
+        self.dir = dir
+        self.chunk_type = chunk_type
+        self.writable = False
+
+    def read(self, stream):
+        raise NotImplementedError
+
+    def write_json(self, writer: JSONWriter):
+        writer.start_object()
+        writer.write_key('chunkType')
+        writer.write_val(self.chunk_type.value if isinstance(self.chunk_type, ChunkType) else self.chunk_type)
+        writer.end_object()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_config_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_config_chunk.py
@@ -1,0 +1,18 @@
+from .rays_chunk import RaysChunk, ChunkType
+from ...common.stream import ReadStream
+
+class RaysConfigChunk(RaysChunk):
+    def __init__(self, dir=None):
+        super().__init__(dir, ChunkType.ConfigChunk)
+        self.director_version = 0
+        self.min_member = 0
+
+    def read(self, stream: ReadStream):
+        self.director_version = stream.read_uint16()
+        self.min_member = stream.read_uint16()
+
+    def write_json(self, writer):
+        writer.start_object()
+        writer.write_key('directorVersion'); writer.write_val(self.director_version)
+        writer.write_key('minMember'); writer.write_val(self.min_member)
+        writer.end_object()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_initial_map_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_initial_map_chunk.py
@@ -1,0 +1,16 @@
+from .rays_chunk import RaysChunk, ChunkType
+from ...common.stream import ReadStream
+from ..rays_subchunk import MemoryMapEntry
+
+class RaysInitialMapChunk(RaysChunk):
+    def __init__(self, dir=None):
+        super().__init__(dir, ChunkType.InitialMapChunk)
+        self.mmap_offset = 0
+
+    def read(self, stream: ReadStream):
+        self.mmap_offset = stream.read_uint32()
+
+    def write_json(self, writer):
+        writer.start_object()
+        writer.write_key('mmapOffset'); writer.write_val(self.mmap_offset)
+        writer.end_object()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_key_table_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_key_table_chunk.py
@@ -1,0 +1,22 @@
+from .rays_list_chunk import RaysListChunk
+from .rays_chunk import ChunkType
+from ...common.stream import ReadStream
+from ..rays_subchunk import KeyTableEntry
+
+class RaysKeyTableChunk(RaysListChunk):
+    def __init__(self, dir=None):
+        super().__init__(dir, ChunkType.KeyTableChunk)
+        self.entries = []
+
+    def read(self, stream: ReadStream):
+        super().read(stream)
+        for view in self.items:
+            rs = ReadStream(view, self.item_endianness)
+            entry = KeyTableEntry()
+            entry.read(rs)
+            self.entries.append(entry)
+
+    def write_json(self, writer):
+        writer.start_object()
+        writer.write_key('count'); writer.write_val(len(self.entries))
+        writer.end_object()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_list_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_list_chunk.py
@@ -1,0 +1,46 @@
+from .rays_chunk import RaysChunk, ChunkType
+from ...common.stream import BufferView, ReadStream, Endianness
+
+class RaysListChunk(RaysChunk):
+    def __init__(self, dir=None, chunk_type=ChunkType.CastListChunk):
+        super().__init__(dir, chunk_type)
+        self.data_offset = 0
+        self.offset_table_len = 0
+        self.offset_table = []
+        self.items_len = 0
+        self.item_endianness = Endianness.BIG
+        self.items = []
+
+    def read(self, stream: ReadStream):
+        self.read_header(stream)
+        self.read_offset_table(stream)
+        self.read_items(stream)
+
+    def read_header(self, stream: ReadStream):
+        self.data_offset = stream.read_uint32()
+        self.offset_table_len = stream.read_uint16()
+        self.items_len = stream.read_uint32()
+        self.item_endianness = stream.endianness
+
+    def read_offset_table(self, stream: ReadStream):
+        for _ in range(self.offset_table_len):
+            self.offset_table.append(stream.read_uint32())
+
+    def read_items(self, stream: ReadStream):
+        for i in range(self.offset_table_len):
+            start = self.offset_table[i]
+            end = self.offset_table[i+1] if i + 1 < self.offset_table_len else self.items_len
+            length = end - start
+            if length <= 0:
+                self.items.append(BufferView())
+                continue
+            self.items.append(BufferView(stream.read_bytes(length), 0, length))
+
+    def write_json(self, writer):
+        writer.start_object()
+        writer.write_key('offsetTable')
+        writer.start_array()
+        for o in self.offset_table:
+            writer.write_val(o)
+        writer.end_array()
+        writer.end_object()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_memory_map_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_memory_map_chunk.py
@@ -1,0 +1,22 @@
+from .rays_list_chunk import RaysListChunk
+from .rays_chunk import ChunkType
+from ...common.stream import ReadStream
+from ..rays_subchunk import MemoryMapEntry
+
+class RaysMemoryMapChunk(RaysListChunk):
+    def __init__(self, dir=None):
+        super().__init__(dir, ChunkType.MemoryMapChunk)
+        self.map_array = []
+
+    def read(self, stream: ReadStream):
+        super().read(stream)
+        for view in self.items:
+            rs = ReadStream(view, self.item_endianness)
+            entry = MemoryMapEntry()
+            entry.read(rs)
+            self.map_array.append(entry)
+
+    def write_json(self, writer):
+        writer.start_object()
+        writer.write_key('count'); writer.write_val(len(self.map_array))
+        writer.end_object()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_script_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_script_chunk.py
@@ -1,0 +1,16 @@
+from .rays_chunk import RaysChunk, ChunkType
+from ...common.stream import ReadStream
+
+class RaysScriptChunk(RaysChunk):
+    def __init__(self, dir=None):
+        super().__init__(dir, ChunkType.ScriptChunk)
+        self.script_data = b""
+        self.member = None
+
+    def read(self, stream: ReadStream):
+        self.script_data = stream.read_bytes(len(stream.data) - stream.pos)
+
+    def write_json(self, writer):
+        writer.start_object()
+        writer.write_key('length'); writer.write_val(len(self.script_data))
+        writer.end_object()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_script_context_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_script_context_chunk.py
@@ -1,0 +1,10 @@
+from .rays_chunk import RaysChunk, ChunkType
+from ...common.stream import ReadStream
+
+class RaysScriptContextChunk(RaysChunk):
+    def __init__(self, dir=None):
+        super().__init__(dir, ChunkType.ScriptContextChunk)
+        self.context_data = b""
+
+    def read(self, stream: ReadStream):
+        self.context_data = stream.read_bytes(len(stream.data) - stream.pos)

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_script_names_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_script_names_chunk.py
@@ -1,0 +1,16 @@
+from .rays_chunk import RaysChunk, ChunkType
+from ...common.stream import ReadStream
+
+class ScriptNames:
+    def __init__(self):
+        self.names = []
+
+class RaysScriptNamesChunk(RaysChunk):
+    def __init__(self, dir=None):
+        super().__init__(dir, ChunkType.ScriptNamesChunk)
+        self.names = ScriptNames()
+
+    def read(self, stream: ReadStream):
+        while not stream.eof():
+            length = stream.read_uint8()
+            self.names.names.append(stream.read_string(length))

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_xmed_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/chunks/rays_xmed_chunk.py
@@ -1,0 +1,10 @@
+from .rays_chunk import RaysChunk, ChunkType
+from ...common.stream import ReadStream
+
+class RaysXmedChunk(RaysChunk):
+    def __init__(self, dir=None, chunk_type=ChunkType.XmedChunk):
+        super().__init__(dir, chunk_type)
+        self.data = b""
+
+    def read(self, stream: ReadStream):
+        self.data = stream.read_bytes(len(stream.data) - stream.pos)

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/ray_guid.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/ray_guid.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+from ..common.stream import ReadStream
+
+@dataclass
+class RayGuid:
+    data1: int = 0
+    data2: int = 0
+    data3: int = 0
+    data4: bytes = b"\x00" * 8
+
+    def read(self, stream: ReadStream):
+        self.data1 = stream.read_uint32()
+        self.data2 = stream.read_uint16()
+        self.data3 = stream.read_uint16()
+        self.data4 = bytes(stream.read_bytes(8))
+
+    def __str__(self) -> str:
+        d = self.data4
+        return f"{self.data1:08X}-{self.data2:04X}-{self.data3:04X}-{d[0]:02X}{d[1]:02X}-{d[2]:02X}{d[3]:02X}{d[4]:02X}{d[5]:02X}{d[6]:02X}{d[7]:02X}"
+
+    def __eq__(self, other):
+        if not isinstance(other, RayGuid):
+            return False
+        return (self.data1 == other.data1 and self.data2 == other.data2 and
+                self.data3 == other.data3 and self.data4 == other.data4)
+
+
+class LingoGuidConstants:
+    FONTMAP_COMPRESSION_GUID = RayGuid(0x8A4679A1, 0x3720, 0x11D0,
+                                        b"\x92\x23\x00\xA0\xC9\x08\x68\xB1")
+    NULL_COMPRESSION_GUID = RayGuid(0xAC99982E, 0x005D, 0x0D50,
+                                     b"\x00\x00\x08\x00\x07\x37\x7A\x34")
+    SND_COMPRESSION_GUID = RayGuid(0x7204A889, 0xAFD0, 0x11CF,
+                                    b"\xA2\x22\x00\xA0\x24\x53\x44\x4C")
+    ZLIB_COMPRESSION_GUID = RayGuid(0xAC99E904, 0x0070, 0x0B36,
+                                     b"\x00\x00\x08\x00\x07\x37\x7A\x34")

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/rays_cast_member.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/rays_cast_member.py
@@ -1,0 +1,52 @@
+from enum import Enum
+from ..common.json_writer import JSONWriter
+from ..common.stream import ReadStream
+
+class RaysMemberType(Enum):
+    NullMember = 0
+    BitmapMember = 1
+    FilmLoopMember = 2
+    TextMember = 3
+    PaletteMember = 4
+    PictureMember = 5
+    SoundMember = 6
+    ButtonMember = 7
+    ShapeMember = 8
+    MovieMember = 9
+    DigitalVideoMember = 10
+    ScriptMember = 11
+    RTEMember = 12
+    FontMember = 13
+    XrayMember = 14
+    FieldMember = 15
+
+class RaysCastMember:
+    def __init__(self, dir=None, member_type=RaysMemberType.NullMember):
+        self.dir = dir
+        self.type = member_type
+
+    def read(self, stream: ReadStream):
+        pass
+
+    def write_json(self, writer: JSONWriter):
+        writer.start_object()
+        writer.write_key('type'); writer.write_val(self.type.name)
+        writer.end_object()
+
+class RaysScriptType(Enum):
+    ScoreScript = 1
+    MovieScript = 3
+    ParentScript = 7
+
+class RaysScriptMember(RaysCastMember):
+    def __init__(self, dir=None):
+        super().__init__(dir, RaysMemberType.ScriptMember)
+        self.script_type = RaysScriptType.ScoreScript
+
+    def read(self, stream: ReadStream):
+        self.script_type = RaysScriptType(stream.read_uint16())
+
+    def write_json(self, writer: JSONWriter):
+        writer.start_object()
+        writer.write_key('scriptType'); writer.write_val(self.script_type.value)
+        writer.end_object()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/rays_director_file.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/rays_director_file.py
@@ -1,0 +1,41 @@
+from typing import List, Dict
+from ..common.stream import ReadStream, Endianness, BufferView
+from ..common.json_writer import JSONWriter
+from .chunks.rays_chunk import RaysChunk, ChunkType
+from .chunks.rays_cast_chunk import RaysCastChunk
+from .scores import RaysScoreChunk
+from .rays_subchunk import KeyTableEntry
+from .ray_guid import RayGuid
+
+class ChunkInfo:
+    def __init__(self):
+        self.id = 0
+        self.fourcc = 0
+        self.length = 0
+        self.uncompressed_len = 0
+        self.offset = 0
+        self.compression_id = RayGuid()
+
+class RaysDirectorFile:
+    def __init__(self, name: str = ""):
+        self.name = name
+        self.endianness = Endianness.BIG
+        self.casts: List[RaysCastChunk] = []
+        self.score: RaysScoreChunk | None = None
+        self.chunk_info_map: Dict[int, ChunkInfo] = {}
+        self.stream: ReadStream | None = None
+
+    @staticmethod
+    def FOURCC(a: str, b: str, c: str, d: str) -> int:
+        return (ord(a) << 24) | (ord(b) << 16) | (ord(c) << 8) | ord(d)
+
+    def read(self, stream: ReadStream) -> bool:
+        self.stream = stream
+        stream.endianness = Endianness.BIG
+        self.endianness = stream.endianness
+        return True
+
+    def write_json(self, writer: JSONWriter):
+        writer.start_object()
+        writer.write_key('name'); writer.write_val(self.name)
+        writer.end_object()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/rays_font_map.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/rays_font_map.py
@@ -1,0 +1,34 @@
+import os
+from ..common.stream import BufferView
+
+class RaysFontMap:
+    @staticmethod
+    def get_font_map(version: int) -> BufferView:
+        file = {
+            True: 'fontmap_D11_5.txt' if version >= 1150 else None
+        }
+        if version >= 1150:
+            fname = 'fontmap_D11_5.txt'
+        elif version >= 1100:
+            fname = 'fontmap_D11.txt'
+        elif version >= 1000:
+            fname = 'fontmap_D10.txt'
+        elif version >= 900:
+            fname = 'fontmap_D9.txt'
+        elif version >= 850:
+            fname = 'fontmap_D8_5.txt'
+        elif version >= 800:
+            fname = 'fontmap_D8.txt'
+        elif version >= 700:
+            fname = 'fontmap_D7.txt'
+        else:
+            fname = 'fontmap_D6.txt'
+
+        base_dir = os.path.dirname(__file__)
+        path = os.path.join(base_dir, '..', 'fontmaps', fname)
+        path = os.path.normpath(path)
+        if not os.path.exists(path):
+            return BufferView()
+        with open(path, 'rb') as f:
+            data = f.read()
+        return BufferView(data, 0, len(data))

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/rays_subchunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/rays_subchunk.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass, field
+from ..common.stream import ReadStream
+from ..common.json_writer import JSONWriter
+
+@dataclass
+class CastListEntry:
+    name: str = ''
+    file_path: str = ''
+    preload_settings: int = 0
+    min_member: int = 0
+    max_member: int = 0
+    id: int = 0
+
+    def write_json(self, writer: JSONWriter):
+        writer.start_object()
+        writer.write_key('name'); writer.write_val(self.name)
+        writer.write_key('filePath'); writer.write_val(self.file_path)
+        writer.write_key('preloadSettings'); writer.write_val(self.preload_settings)
+        writer.write_key('minMember'); writer.write_val(self.min_member)
+        writer.write_key('maxMember'); writer.write_val(self.max_member)
+        writer.write_key('id'); writer.write_val(self.id)
+        writer.end_object()
+
+@dataclass
+class MemoryMapEntry:
+    fourcc: int = 0
+    length: int = 0
+    offset: int = 0
+    flags: int = 0
+    unknown0: int = 0
+    next: int = 0
+
+    def read(self, stream: ReadStream):
+        self.fourcc = stream.read_uint32()
+        self.length = stream.read_uint32()
+        self.offset = stream.read_uint32()
+        self.flags = stream.read_uint16()
+        self.unknown0 = stream.read_uint16()
+        self.next = stream.read_uint32()
+
+    def write_json(self, writer: JSONWriter):
+        writer.start_object()
+        writer.write_key('fourCC'); writer.write_val(self.fourcc)
+        writer.write_key('len'); writer.write_val(self.length)
+        writer.write_key('offset'); writer.write_val(self.offset)
+        writer.write_key('flags'); writer.write_val(self.flags)
+        writer.write_key('unknown0'); writer.write_val(self.unknown0)
+        writer.write_key('next'); writer.write_val(self.next)
+        writer.end_object()
+
+@dataclass
+class KeyTableEntry:
+    fourcc: int = 0
+    resource_id: int = 0
+    section_id: int = 0
+    cast_id: int = 0
+
+    def read(self, stream: ReadStream):
+        self.fourcc = stream.read_uint32()
+        self.resource_id = stream.read_uint16()
+        self.section_id = stream.read_uint16()
+        self.cast_id = stream.read_uint32()
+
+    def write_json(self, writer: JSONWriter):
+        writer.start_object()
+        writer.write_key('fourCC'); writer.write_val(self.fourcc)
+        writer.write_key('resourceID'); writer.write_val(self.resource_id)
+        writer.write_key('sectionID'); writer.write_val(self.section_id)
+        writer.write_key('castID'); writer.write_val(self.cast_id)
+        writer.end_object()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/rays_utilities.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/rays_utilities.py
@@ -1,0 +1,43 @@
+from ..common.util import RaysUtil
+
+class RaysUtilities:
+    human_version = staticmethod(RaysUtil.human_version)
+
+    @staticmethod
+    def dump_ascii(data: bytes, offset: int = 0, length: int = 12) -> str:
+        end = min(len(data), offset + length)
+        chars = [chr(b) if 32 <= b <= 126 else '.' for b in data[offset:end]]
+        return ''.join(chars)
+
+    @staticmethod
+    def dump_hex_with_ascii(data: bytes, offset: int = 0, length: int = 12, paint_ascii: bool = True) -> str:
+        end = min(len(data), offset + length)
+        hex_part = ' '.join(f"{b:02X}" for b in data[offset:end])
+        if paint_ascii:
+            ascii_part = RaysUtilities.dump_ascii(data, offset, length)
+            return f"{hex_part}|{ascii_part}|"
+        return hex_part
+
+    @staticmethod
+    def version_number(ver: int, fver_version_string: str) -> str:
+        major = ver // 100
+        minor = (ver // 10) % 10
+        patch = ver % 10
+        if not fver_version_string:
+            res = f"{major}.{minor}"
+            if patch:
+                res += f".{patch}"
+            return res
+        return fver_version_string
+
+    @staticmethod
+    def version_string(ver: int, fver_version_string: str) -> str:
+        major = ver // 100
+        version_num = RaysUtilities.version_number(ver, fver_version_string)
+        if major >= 11:
+            return f"Adobe Director {version_num}"
+        if major == 10:
+            return f"Macromedia Director MX 2004 ({version_num})"
+        if major == 9:
+            return f"Macromedia Director MX ({version_num})"
+        return f"Macromedia Director {version_num}"

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/rle_temp.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/rle_temp.py
@@ -1,0 +1,27 @@
+class RleTemp:
+    @staticmethod
+    def rle_decode(width: int, height: int, fullwidth: int, bpp: int, encoded: bytes) -> bytes:
+        bytes_to_output = fullwidth * height
+        res = bytearray(bytes_to_output)
+        in_pos = 0
+        out_pos = 0
+        while in_pos < len(encoded) and out_pos < bytes_to_output:
+            d = encoded[in_pos]
+            in_pos += 1
+            if d >= 128:
+                run_length = 257 - d
+                if in_pos >= len(encoded):
+                    break
+                v = encoded[in_pos]
+                in_pos += 1
+                for _ in range(run_length):
+                    if out_pos >= bytes_to_output:
+                        break
+                    res[out_pos] = v
+                    out_pos += 1
+            else:
+                lit_length = 1 + d
+                res[out_pos:out_pos+lit_length] = encoded[in_pos:in_pos+lit_length]
+                in_pos += lit_length
+                out_pos += lit_length
+        return bytes(res)

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/__init__.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/__init__.py
@@ -1,0 +1,18 @@
+from .rays_score_chunk import RaysScoreChunk
+from .ray_score_parse_context import RayScoreParseContext
+from .rays_score_reader import RaysScoreReader
+from .rays_score_frame_parser_v2 import RaysScoreFrameParserV2
+from .ray_sprite_factory import RaySpriteFactory
+from .ray_score_tags_v2 import ScoreTagV2, ScoreTagMain
+from .data import *
+from . import data
+
+__all__ = [
+    'RaysScoreChunk',
+    'RayScoreParseContext',
+    'RaysScoreReader',
+    'RaysScoreFrameParserV2',
+    'RaySpriteFactory',
+    'ScoreTagV2',
+    'ScoreTagMain',
+] + data.__all__

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/data/__init__.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/data/__init__.py
@@ -1,0 +1,14 @@
+from .ray_score_header import RayScoreHeader
+from .ray_score_interval_descriptor import RayScoreIntervalDescriptor
+from .ray_score_keyframe import RayScoreKeyFrame
+from .ray_sprite import RaySprite, UnknownTag
+from .ray_tween_flags import RayTweenFlags
+
+__all__ = [
+    'RayScoreHeader',
+    'RayScoreIntervalDescriptor',
+    'RayScoreKeyFrame',
+    'RaySprite',
+    'UnknownTag',
+    'RayTweenFlags',
+]

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/data/ray_score_header.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/data/ray_score_header.py
@@ -1,0 +1,21 @@
+class RayScoreHeader:
+    """Holds header values for a score chunk."""
+    def __init__(self):
+        self.actual_size = 0
+        self.unk_a1 = 0
+        self.unk_a2 = 0
+        self.unk_a3 = 0
+        self.unk_a4 = 0
+        self.highest_frame = 0
+        self.unk_b1 = 0
+        self.unk_b2 = 0
+        self.sprite_size = 0
+        self.unk_c1 = 0
+        self.unk_c2 = 0
+        self.channel_count = 0
+        self.entry_count = 0
+        self.entry_size_sum = 0
+        self.notation_base = 0
+        self.offsets_offset = 0
+        self.header_type = 0
+        self.total_length = 0

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/data/ray_score_interval_descriptor.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/data/ray_score_interval_descriptor.py
@@ -1,0 +1,23 @@
+class RayScoreIntervalDescriptor:
+    """Frame descriptor for sprite timeline intervals."""
+    def __init__(self):
+        self.start_frame = 0
+        self.end_frame = 0
+        self.unknown1 = 0
+        self.unknown2 = 0
+        self.sprite_number = 0
+        self.unknown_always_one = 0
+        self.unknown_near_constant15_0 = 0
+        self.unknown_e1 = 0
+        self.unknown_fd = 0
+        self.unknown7 = 0
+        self.unknown8 = 0
+        self.extra_values = []
+        self.channel = 0
+        self.behaviors = []
+        self.flip_h = False
+        self.flip_v = False
+        self.editable = False
+        self.moveable = False
+        self.trails = False
+        self.is_locked = False

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/data/ray_score_keyframe.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/data/ray_score_keyframe.py
@@ -1,0 +1,21 @@
+class RayScoreKeyFrame:
+    def __init__(self):
+        self.enabled_properties = 0
+        self.loc_h = 0
+        self.loc_v = 0
+        self.width = 0
+        self.height = 0
+        self.rotation = 0.0
+        self.skew = 0.0
+        self.blend = 0
+        self.ink = 0
+        self.fore_color = 0
+        self.back_color = 0
+        self.member_cast_lib = 0
+        self.member_num = 0
+        self.duration = 0
+        self.frame_num = 0
+        self.sprite_num = 0
+        self.scale_x = 0.0
+        self.scale_y = 0.0
+        self.unknown_tags = []

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/data/ray_sprite.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/data/ray_sprite.py
@@ -1,0 +1,40 @@
+class UnknownTag:
+    def __init__(self, tag, data):
+        self.tag = tag
+        self.data = data
+
+
+class RaySprite:
+    """Descriptor of a sprite on the score timeline."""
+    def __init__(self):
+        self.start_frame = 0
+        self.end_frame = 0
+        self.sprite_number = 0
+        self.member_cast_lib = 0
+        self.member_num = 0
+        self.sprite_properties_offset = 0
+        self.loc_h = 0
+        self.loc_v = 0
+        self.width = 0
+        self.height = 0
+        self.rotation = 0.0
+        self.skew = 0.0
+        self.ink = 0
+        self.fore_color = 0
+        self.back_color = 0
+        self.score_color = 0
+        self.blend = 0
+        self.flip_h = False
+        self.flip_v = False
+        self.editable = False
+        self.moveable = False
+        self.trails = False
+        self.is_locked = False
+        self.ease_in = 0
+        self.ease_out = 0
+        self.curvature = 0
+        self.tween_flags = None
+        self.behaviors = []
+        self.keyframes = []
+        self.loc_z = 0
+        self.extra_values = []

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/data/ray_tween_flags.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/data/ray_tween_flags.py
@@ -1,0 +1,51 @@
+class RayTweenFlags:
+    """Represents tweening flags for a score sprite or keyframe."""
+    def __init__(self, tweening_enabled=False, path=False, size=False,
+                 rotation=False, skew=False, blend=False,
+                 fore_color=False, back_color=False):
+        self.tweening_enabled = tweening_enabled
+        self.path = path
+        self.size = size
+        self.rotation = rotation
+        self.skew = skew
+        self.blend = blend
+        self.fore_color = fore_color
+        self.back_color = back_color
+
+    def to_byte(self):
+        val = 0
+        if self.tweening_enabled:
+            val |= 0x01
+        if self.path:
+            val |= 0x02
+        if self.size:
+            val |= 0x04
+        if self.rotation:
+            val |= 0x08
+        if self.skew:
+            val |= 0x10
+        if self.blend:
+            val |= 0x20
+        if self.fore_color:
+            val |= 0x40
+        if self.back_color:
+            val |= 0x80
+        return val
+
+    def __str__(self):
+        flags = []
+        if self.path:
+            flags.append('Path')
+        if self.size:
+            flags.append('Size')
+        if self.rotation:
+            flags.append('Rotation')
+        if self.skew:
+            flags.append('Skew')
+        if self.blend:
+            flags.append('Blend')
+        if self.fore_color:
+            flags.append('ForeColor')
+        if self.back_color:
+            flags.append('BackColor')
+        return f"Tweening: {'On' if self.tweening_enabled else 'Off'} | " + ', '.join(flags)

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/ray_score_parse_context.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/ray_score_parse_context.py
@@ -1,0 +1,55 @@
+from .data import RaySprite, RayScoreIntervalDescriptor, RayScoreKeyFrame
+
+class RayScoreParseContext:
+    """Maintains state while parsing a score chunk."""
+    def __init__(self, logger=None):
+        self.logger = logger
+        self.sprites = []
+        self.frame_data_buffer_view = None
+        self.frame_interval_descriptor_buffers = []
+        self.behavior_script_buffers = []
+        self.descriptors = []
+        self.channel_to_descriptor = {}
+        self.frame_scripts = []
+        self.keyframes = []
+        self.current_frame = 0
+        self.current_sprite = None
+        self.current_sprite_num = 0
+        self.block_depth = 0
+        self.upcoming_block_size = 0
+        self.is_in_advance_frame_mode = False
+        self.current_keyframe = None
+
+    def set_current_frame(self, frame: int):
+        self.current_frame = frame
+
+    def set_current_sprite(self, sprite: RaySprite):
+        self.current_sprite = sprite
+        self.current_sprite_num = sprite.sprite_number - 6
+        self.current_frame = sprite.start_frame
+
+    def add_keyframe(self, kf: RayScoreKeyFrame):
+        self.keyframes.append(kf)
+        self.current_keyframe = kf
+
+    def add_sprite(self, sprite: RaySprite):
+        self.sprites.append(sprite)
+
+    def get_sprite(self, channel: int, frame: int):
+        for sp in self.sprites:
+            if sp.sprite_number == channel and sp.start_frame <= frame <= sp.end_frame:
+                return sp
+        return None
+
+    def get_or_create_sprite(self, channel: int):
+        sp = self.get_sprite(channel, self.current_frame)
+        if sp:
+            self.set_current_sprite(sp)
+            return sp
+        sp = RaySprite()
+        sp.sprite_number = channel
+        sp.start_frame = self.current_frame
+        sp.end_frame = self.current_frame
+        self.sprites.append(sp)
+        self.set_current_sprite(sp)
+        return sp

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/ray_score_tags_v2.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/ray_score_tags_v2.py
@@ -1,0 +1,63 @@
+from enum import Enum
+
+class ScoreTagV2(Enum):
+    Size = 0x0130
+    Position = 0x015C
+    Ease = 0x0120
+    AdvanceFrame = 0x0136
+    PathPart = 0x0166
+    Ink = 0x0196
+    Rotation = 0x019E
+    Skew = 0x01A2
+    Colors = 0x0212
+    Composite = 0x0190
+    BlockControl = 0x0180
+    FrameRect = 0x01EC
+    Curvature = 0x01F4
+    Flags = 0x01FE
+    FlagsControl = 0x01FC
+    TweenFlags = 0x01F6
+    Unknown012A = 0x012A
+    Unknown013E = 0x013E
+    Unknown0142 = 0x0142
+
+class ScoreTagMain(Enum):
+    NextByteIsSpriteIf10Hex = 0x0120
+    ThisIsASpriteBlock = 0x1000
+
+BLOCK_END = 0x0008
+SPRITE_BLOCK_PREFIX = 0x0030
+KEYFRAME_CREATE_FLAG = 0x8100
+KEYFRAME_NO_CREATE_FLAG = 0x0100
+
+def try_parse_tag_main(raw):
+    try:
+        return ScoreTagMain(raw)
+    except ValueError:
+        return None
+
+def try_parse_tag(raw):
+    try:
+        return ScoreTagV2(raw)
+    except ValueError:
+        return None
+
+def get_data_length(tag: ScoreTagV2) -> int:
+    return {
+        ScoreTagV2.Size: 4,
+        ScoreTagV2.Position: 4,
+        ScoreTagV2.Ease: 2,
+        ScoreTagV2.AdvanceFrame: 2,
+        ScoreTagV2.PathPart: 2,
+        ScoreTagV2.Ink: 2,
+        ScoreTagV2.Rotation: 2,
+        ScoreTagV2.Skew: 2,
+        ScoreTagV2.Colors: 2,
+        ScoreTagV2.Composite: 6,
+        ScoreTagV2.FrameRect: 8,
+        ScoreTagV2.Curvature: 2,
+        ScoreTagV2.Flags: 2,
+        ScoreTagV2.FlagsControl: 2,
+        ScoreTagV2.TweenFlags: 1,
+        ScoreTagV2.BlockControl: 2,
+    }.get(tag, 0)

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/ray_sprite_factory.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/ray_sprite_factory.py
@@ -1,0 +1,19 @@
+from .data import RayScoreKeyFrame, RaySprite
+
+class RaySpriteFactory:
+    @staticmethod
+    def create_keyframe(sprite: RaySprite, sprite_num: int, frame: int) -> RayScoreKeyFrame:
+        kf = RayScoreKeyFrame()
+        kf.frame_num = frame
+        kf.sprite_num = sprite_num
+        kf.loc_h = sprite.loc_h
+        kf.loc_v = sprite.loc_v
+        kf.width = sprite.width
+        kf.height = sprite.height
+        kf.rotation = sprite.rotation
+        kf.skew = sprite.skew
+        kf.blend = sprite.blend
+        kf.fore_color = sprite.fore_color
+        kf.back_color = sprite.back_color
+        kf.ink = sprite.ink
+        return kf

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/rays_score_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/rays_score_chunk.py
@@ -1,0 +1,29 @@
+from ..chunks.rays_chunk import RaysChunk, ChunkType
+from ..common.json_writer import JSONWriter
+from ..common.stream import ReadStream
+from .rays_score_frame_parser_v2 import RaysScoreFrameParserV2
+
+class RaysScoreChunk(RaysChunk):
+    def __init__(self, dir=None):
+        super().__init__(dir, ChunkType.ScoreChunk)
+        self.sprites = []
+
+    def read(self, stream: ReadStream):
+        parser = RaysScoreFrameParserV2()
+        self.sprites = parser.parse_score(stream)
+
+    def write_json(self, writer: JSONWriter):
+        writer.start_object()
+        writer.write_key('frames')
+        writer.start_array()
+        for sp in self.sprites:
+            writer.start_object()
+            writer.write_key('start')
+            writer.write_val(sp.start_frame)
+            writer.write_key('end')
+            writer.write_val(sp.end_frame)
+            writer.write_key('sprite')
+            writer.write_val(sp.sprite_number)
+            writer.end_object()
+        writer.end_array()
+        writer.end_object()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/rays_score_frame_parser_v2.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/rays_score_frame_parser_v2.py
@@ -1,0 +1,19 @@
+from ..common.stream import ReadStream, Endianness
+from .ray_score_parse_context import RayScoreParseContext
+from .rays_score_reader import RaysScoreReader
+from .ray_sprite_factory import RaySpriteFactory
+
+class RaysScoreFrameParserV2:
+    def __init__(self, logger=None):
+        self.logger = logger
+        self.reader = RaysScoreReader(logger)
+
+    def parse_score(self, stream: ReadStream):
+        stream.endianness = Endianness.BIG
+        ctx = RayScoreParseContext(self.logger)
+        header = self.reader.read_main_header(stream)
+        # This simplified parser only reads a single sprite block
+        sprite = self.reader.create_channel_sprite(stream)
+        sprite.sprite_number = 6
+        ctx.add_sprite(sprite)
+        return ctx.sprites

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/rays_score_reader.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/scores/rays_score_reader.py
@@ -1,0 +1,95 @@
+from ..chunks.rays_chunk import RaysChunk, ChunkType
+from ..common.stream import ReadStream, Endianness
+from .data import RaySprite, RayScoreHeader, RayScoreIntervalDescriptor, RayScoreKeyFrame, RayTweenFlags
+from . import ray_score_tags_v2 as tags
+from .ray_sprite_factory import RaySpriteFactory
+
+class RaysScoreReader:
+    """Very small subset reader for score chunks."""
+    def __init__(self, logger=None):
+        self.logger = logger
+
+    def read_main_header(self, stream: ReadStream) -> RayScoreHeader:
+        header = RayScoreHeader()
+        header.total_length = stream.read_uint32()
+        header.header_type = stream.read_uint32()
+        header.offsets_offset = stream.read_uint32()
+        header.entry_count = stream.read_uint32()
+        header.notation_base = stream.read_uint32()
+        header.entry_size_sum = stream.read_uint32()
+        return header
+
+    def parse_tween_flags(self, value: int) -> RayTweenFlags:
+        return RayTweenFlags(
+            tweening_enabled=bool(value & 0x01),
+            path=bool(value & 0x02),
+            size=bool(value & 0x04),
+            rotation=bool(value & 0x08),
+            skew=bool(value & 0x10),
+            blend=bool(value & 0x20),
+            fore_color=bool(value & 0x40),
+            back_color=bool(value & 0x80),
+        )
+
+    def create_channel_sprite(self, stream: ReadStream) -> RaySprite:
+        sp = RaySprite()
+        sp.tween_flags = self.parse_tween_flags(stream.read_uint8())
+        stream.read_uint16()  # unknown
+        sp.ink = stream.read_uint8()
+        sp.fore_color = stream.read_uint8()
+        sp.back_color = stream.read_uint8()
+        sp.member_cast_lib = stream.read_uint16()
+        sp.member_num = stream.read_uint16()
+        stream.read_uint16()
+        sp.sprite_properties_offset = stream.read_uint16()
+        sp.loc_v = stream.read_int16()
+        sp.loc_h = stream.read_int16()
+        sp.height = stream.read_int16()
+        sp.width = stream.read_int16()
+        sp.editable = bool(stream.read_uint8() & 0x40)
+        sp.blend = 100 - int(stream.read_uint8() * 100 / 255)
+        flip = stream.read_uint8()
+        sp.flip_v = bool(flip & 0x04)
+        sp.flip_h = bool(flip & 0x02)
+        stream.read_bytes(5)
+        sp.rotation = stream.read_int32() / 100.0
+        sp.skew = stream.read_int32() / 100.0
+        return sp
+    def apply_known_tag_sprite(self, sprite: RaySprite, tag: tags.ScoreTagV2, data: bytes):
+        rs = ReadStream(data, Endianness.BIG)
+        if tag == tags.ScoreTagV2.Ease:
+            sprite.ease_in = rs.read_uint8()
+            sprite.ease_out = rs.read_uint8()
+        elif tag == tags.ScoreTagV2.Curvature:
+            sprite.curvature = rs.read_uint16()
+        elif tag == tags.ScoreTagV2.TweenFlags:
+            sprite.tween_flags = self.parse_tween_flags(rs.read_uint8())
+
+    def apply_known_tag_keyframe(self, kf: RayScoreKeyFrame, tag: tags.ScoreTagV2, data: bytes):
+        rs = ReadStream(data, Endianness.BIG)
+        if tag == tags.ScoreTagV2.Size:
+            kf.width = rs.read_int16()
+            kf.height = rs.read_int16()
+        elif tag == tags.ScoreTagV2.Position:
+            kf.loc_h = rs.read_int16()
+            kf.loc_v = rs.read_int16()
+        elif tag == tags.ScoreTagV2.Colors:
+            kf.fore_color = rs.read_uint8()
+            kf.back_color = rs.read_uint8()
+        elif tag == tags.ScoreTagV2.Ink:
+            kf.ink = rs.read_int16()
+        elif tag == tags.ScoreTagV2.Rotation:
+            kf.rotation = rs.read_int16() / 100.0
+        elif tag == tags.ScoreTagV2.Skew:
+            kf.skew = rs.read_int16() / 100.0
+        elif tag == tags.ScoreTagV2.Composite:
+            kf.width = rs.read_int16()
+            kf.height = rs.read_int16()
+            blend_raw = rs.read_uint8()
+            kf.blend = 100 - int(blend_raw * 100 / 255)
+            kf.ink = rs.read_uint8()
+        elif tag == tags.ScoreTagV2.FrameRect:
+            kf.loc_h = rs.read_int16()
+            kf.loc_v = rs.read_int16()
+            kf.width = rs.read_int16()
+            kf.height = rs.read_int16()

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/sound.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/sound.py
@@ -1,0 +1,9 @@
+from ..common.stream import ReadStream
+
+class Sound:
+    @staticmethod
+    def decompress_snd(input_stream: ReadStream) -> bytes:
+        if input_stream is None or input_stream.eof():
+            return b""
+        remaining = len(input_stream.data) - input_stream.pos
+        return input_stream.read_bytes(remaining)

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/utilities.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/director/utilities.py
@@ -1,0 +1,4 @@
+from ..common.util import RaysUtil
+
+class RaysUtilities:
+    human_version = staticmethod(RaysUtil.human_version)

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/program.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/program.py
@@ -1,0 +1,25 @@
+from .common.json_writer import JSONWriter
+from .director.chunks.rays_cast_chunk import RaysCastChunk
+from .common.stream import ReadStream, Endianness
+
+
+def demo():
+    writer = JSONWriter()
+    writer.start_object()
+    writer.write_key('message')
+    writer.write_val('Hello from ProjectorRays Python')
+
+    # simple stream demo
+    data = b'\x00\x00\x00\x01\x00\x00\x00\x02'
+    rs = ReadStream(data, Endianness.BIG)
+    chunk = RaysCastChunk()
+    chunk.read(rs)
+    writer.write_key('castChunk')
+    chunk_writer = JSONWriter()
+    chunk.write_json(chunk_writer)
+    writer.write_val(chunk_writer._root)
+    writer.end_object()
+    print(writer.to_string())
+
+if __name__ == '__main__':
+    demo()


### PR DESCRIPTION
## Summary
- extend Python port with placeholders for the remaining Director classes
- wire new modules through package `__init__` files
- provide small helpers such as `RayGuid`, `RleTemp`, and `RaysUtilities`

## Testing
- `python -m py_compile $(git ls-files 'WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/**/*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687055cdb5a08332b096de31eb92589e