### PR TITLE
Clean up demo and use existing Python director reader

### DIFF
--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/common/stream.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/common/stream.py
@@ -36,21 +36,23 @@ class ReadStream:
     def eof(self):
         return self.pos >= len(self.data)
 
-    def read_bytes(self, n):
-        if self.pos + n > len(self.data):
-            raise EOFError('Read past end of stream')
-        b = self.data[self.pos:self.pos+n]
-        self.pos += n
-        return b
+    def read_bytes(self, count):
+        result = self.data[self.pos:self.pos + count]
+        self.pos += count
+        return result
 
     def read_uint8(self):
         return self.read_bytes(1)[0]
 
     def read_uint16(self):
-        return struct.unpack(self.endianness.value + 'H', self.read_bytes(2))[0]
+        data = self.read_bytes(2)
+        fmt = '<H' if self.endianness == Endianness.LITTLE else '>H'
+        return struct.unpack(fmt, data)[0]
 
     def read_uint32(self):
-        return struct.unpack(self.endianness.value + 'I', self.read_bytes(4))[0]
+        data = self.read_bytes(4)
+        fmt = '<I' if self.endianness == Endianness.LITTLE else '>I'
+        return struct.unpack(fmt, data)[0]
 
     def read_string(self, length):
         return self.read_bytes(length).decode('utf-8')

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/program.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Python/program.py
@@ -1,6 +1,14 @@
-"""Simple command line interface for ProjectorRays.Python."""
+"""Simple command line interface for ``ProjectorRays.Python``."""
 
+from __future__ import annotations
+
+import os
 import sys
+
+if __package__ is None or __package__ == "":
+    # Allow running the script directly without installing the package
+    sys.path.append(os.path.dirname(__file__))
+
 from .common.json_writer import JSONWriter
 from .common.stream import ReadStream, Endianness
 from .director.rays_director_file import RaysDirectorFile


### PR DESCRIPTION
## Summary
- drop stray `projector_rays` demo package
- remove `program_patched.py`
- extend `ProjectorRays.Python` demo script with command-line interface to load a Director file
- unify byte reading helpers in `ReadStream`

## Testing
- `python3 -m unittest discover -v`
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871df3a3f9483328eb884f55d0c5721