### PR TITLE
Fix descriptor logging by passing logger

### DIFF
--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays_Python/director/scores/rays_score_chunk.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays_Python/director/scores/rays_score_chunk.py
@@ -9,7 +9,8 @@ class RaysScoreChunk(RaysChunk):
         self.sprites = []
 
     def read(self, stream: ReadStream):
-        parser = RaysScoreFrameParserV2()
+        logger = getattr(self.dir, "_logger", None)
+        parser = RaysScoreFrameParserV2(logger)
         self.sprites = parser.parse_score(stream)
 
     def write_json(self, writer: RaysJSONWriter):

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays_Python/director/scores/rays_score_reader.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays_Python/director/scores/rays_score_reader.py
@@ -144,6 +144,28 @@ class RaysScoreReader:
         desc.unknown8 = stream.read_int32()
         while stream.pos + 4 <= len(stream.data):
             desc.extra_values.append(stream.read_int32())
+        if self.logger:
+            self.logger.info(
+                "Item Desc. %d: Start=%d, End=%d, Channel=%d, U1=%d, "
+                "Flip=%s,%s,🔒=%s,Trails=%s,Editable=%s,Moveable=%s , "
+                "U3=%d, U4A=%d, U4B=%d, U5=%d, U6=%d",
+                index,
+                desc.start_frame,
+                desc.end_frame,
+                desc.channel,
+                desc.unknown1,
+                desc.flip_h,
+                desc.flip_v,
+                desc.is_locked,
+                desc.trails,
+                desc.editable,
+                desc.moveable,
+                desc.unknown_always_one,
+                desc.unkown_a,
+                desc.unkown_b,
+                desc.unknown_e1,
+                desc.unknown_fd,
+            )
         return desc
 
     def read_frame_descriptors(self, ctx):


### PR DESCRIPTION
## Summary
- pass the DirectorFile logger to `RaysScoreFrameParserV2`

## Testing
- `python -m compileall -q WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays_Python`
- `bash scripts/test_channelhow.sh > /tmp/test_channelhow.log 2>&1`

------
https://chatgpt.com/codex/tasks/task_e_687269ed0e4c8332beaf4d2e0c7f9112