### PR TITLE
Add CLI option to dump score bytes

### DIFF
--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays_Python/program.py
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays_Python/program.py
@@ -34,12 +34,18 @@ if __name__ == "__main__":
         action="store_true",
         help="Parse score blocks and link keyframes"
     )
+    parser.add_argument(
+        "--log-score-hex",
+        action="store_true",
+        help="Log full score bytes after reading intervals",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger("projector")
 
     RaysScoreFrameParserV2.enable_full_parsing = args.full_score
+    RaysScoreFrameParserV2.dump_score_hex = args.log_score_hex
 
     with open(args.dir_file, "rb") as f:
         stream = ReadStream(f.read())


### PR DESCRIPTION
## Summary
- expose `--log-score-hex` in the Python CLI for ProjectorRays
- support optional logging of the entire score bytes in `RaysScoreFrameParserV2`

## Testing
- `bash scripts/install-dotnet.sh`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68732e82da508332829649de9a60e53d