### PR TITLE
Add sprite summary overlay

### DIFF
--- a/src/Director/LingoEngine.Director.Core/FileSystems/IdeLauncher.cs
+++ b/src/Director/LingoEngine.Director.Core/FileSystems/IdeLauncher.cs
@@ -38,7 +38,7 @@ namespace LingoEngine.Director.Core.FileSystems
 #if USE_WINDOWS_FEATURES
                     OpenInVisualStudio(_directorSettings, lingoProjectSettings, filePath, line);
 #else
-                    OpenInVisualStudio(settings.VisualStudioPath, filePath, line);
+                    OpenInVisualStudio(_directorSettings.VisualStudioPath, filePath, line);
 #endif
                     break;
 

--- a/src/Director/LingoEngine.Director.Core/Stages/StageSpriteSummaryOverlay.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/StageSpriteSummaryOverlay.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+using LingoEngine.Director.Core.Sprites;
+using LingoEngine.Director.Core.Tools;
+using LingoEngine.Sprites;
+
+namespace LingoEngine.Director.Core.Stages;
+
+/// <summary>
+/// Simple canvas overlay that displays information about the currently
+/// selected sprite.
+/// </summary>
+public class StageSpriteSummaryOverlay : IHasSpriteSelectedEvent, IDisposable
+{
+    private readonly LingoGfxCanvas _canvas;
+    private readonly IDirectorEventMediator _mediator;
+
+    public LingoGfxCanvas Canvas => _canvas;
+
+    public StageSpriteSummaryOverlay(ILingoFrameworkFactory factory, IDirectorEventMediator mediator)
+    {
+        _mediator = mediator;
+        _canvas = factory.CreateGfxCanvas("SpriteSummaryCanvas", 0, 0);
+        _canvas.Visibility = false;
+        _mediator.Subscribe(this);
+    }
+
+    /// <summary>Called when a sprite is selected.</summary>
+    public void SpriteSelected(ILingoSprite sprite)
+    {
+        DrawInfo(sprite);
+    }
+
+    private void DrawInfo(ILingoSprite sprite)
+    {
+        _canvas.Clear(LingoColorList.White);
+        if (sprite is not LingoSprite sp || sp.Member == null)
+        {
+            _canvas.Visibility = false;
+            return;
+        }
+
+        var member = sp.Member;
+        var behaviors = string.Join(", ", sp.Behaviors.Select(b => b.Name));
+
+        var line1 = $"{member.Name} ({sp.Cast?.Name}) {member.Type}";
+        var line2 = $"Sprite {sp.SpriteNum} ({(int)sp.LocH},{(int)sp.LocV},{(int)sp.Width}x{(int)sp.Height}) {(LingoInkType)sp.Ink} {(int)(sp.Blend * 100)}%";
+        string text = line1 + "\n" + line2;
+        if (!string.IsNullOrEmpty(behaviors))
+            text += "\n" + behaviors;
+
+        const int fontSize = 10;
+        var lines = text.Split('\n');
+        int height = lines.Length * (fontSize + 2) + 4;
+        int width = Math.Max(120, lines.Max(l => l.Length) * 6 + 8);
+
+        _canvas.Width = width;
+        _canvas.Height = height;
+        _canvas.X = sp.Rect.Left;
+        _canvas.Y = sp.Rect.Bottom;
+
+        _canvas.DrawRect(LingoRect.New(0, 0, width, height), LingoColorList.Gray, true);
+        _canvas.DrawText(new LingoPoint(4, 2), text, null, LingoColorList.White, fontSize);
+        _canvas.Visibility = true;
+    }
+
+    public void Dispose()
+    {
+        _mediator.Unsubscribe(this);
+        _canvas.Dispose();
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
@@ -16,6 +16,7 @@ using LingoEngine.Movies.Commands;
 using LingoEngine.Stages;
 using LingoEngine.Director.Core.Sprites;
 using LingoEngine.Director.Core.UI;
+using LingoEngine.LGodot.Gfx;
 
 
 namespace LingoEngine.Director.LGodot.Movies;
@@ -42,6 +43,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
     private readonly ScrollContainer _scrollContainer = new ScrollContainer();
     private readonly SelectionBox _selectionBox = new SelectionBox();
     private readonly BoundingBoxesOverlay _boundingBoxes = new BoundingBoxesOverlay();
+    private readonly StageSpriteSummaryOverlay _spriteSummary;
 
     private LingoMovie? _movie;
     private ILingoFrameworkStage? _stage;
@@ -69,6 +71,11 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         _directorStageWindow = directorStageWindow;
 
         _mediator.Subscribe(this);
+        var lp = _player as LingoPlayer;
+        if (lp != null)
+            _spriteSummary = new StageSpriteSummaryOverlay(lp.Factory, _mediator);
+        else
+            _spriteSummary = new StageSpriteSummaryOverlay(((LingoPlayer)_player!).Factory, _mediator);
 
         
         
@@ -111,7 +118,9 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         _scrollContainer.AddChild(_stageContainer.Container);
         _stageContainer.Container.AddChild(_boundingBoxes);
         _stageContainer.Container.AddChild(_selectionBox);
+        _stageContainer.Container.AddChild(_spriteSummary.Canvas.Framework<LingoGodotGfxCanvas>());
         _boundingBoxes.ZIndex = 500;
+        _spriteSummary.Canvas.Framework<LingoGodotGfxCanvas>().ZIndex = 750;
         //_boundingBoxes.MouseFilter = MouseFilterEnum.Ignore; // ensure mouse clicks pass through
         _selectionBox.Visible = false;
         _selectionBox.ZIndex = 1000;
@@ -566,6 +575,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         }
         _player.ActiveMovieChanged -= OnActiveMovieChanged;
         _mediator.Unsubscribe(this);
+        _spriteSummary.Dispose();
         base.Dispose(disposing);
     }
 


### PR DESCRIPTION
## Summary
- add StageSpriteSummaryOverlay framework-independent canvas to display sprite info
- integrate overlay into Godot stage window and dispose it when the window closes
- fix Visual Studio launcher code using director settings

## Testing
- `dotnet build LingoEngine.sln`

------
https://chatgpt.com/codex/tasks/task_e_687339c1f02c8332ade394118a063eb7