### PR TITLE
Ensure movie stop halts audio

### DIFF
--- a/src/LingoEngine/Movies/LingoMovie.cs
+++ b/src/LingoEngine/Movies/LingoMovie.cs
@@ -280,6 +280,7 @@ namespace LingoEngine.Movies
         {
             _isPlaying = false;
             PlayStateChanged?.Invoke(false);
+            _environment.Sound.StopAll();
             _spriteManager.EndSprites();
             _EventMediator.RaiseStopMovie();
             // EndSprite
@@ -352,6 +353,7 @@ namespace LingoEngine.Movies
                 AdvanceFrame();
                 _isPlaying = false;
                 PlayStateChanged?.Invoke(false);
+                _environment.Sound.StopAll();
             }
         }
 


### PR DESCRIPTION
## Summary
- stop all sounds when movie halts
- stop audio when using `GoToAndStop`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68734118f3148332a6c66fb051e46d9d