### PR TITLE
Add reusable bounding box overlay

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Stages/StageBoundingBoxesOverlay.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/StageBoundingBoxesOverlay.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LingoEngine.Director.Core.Sprites;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+using LingoEngine.Sprites;
+using LingoEngine.Inputs;
+
+namespace LingoEngine.Director.Core.Stages;
+
+/// <summary>
+/// Overlay that draws bounding boxes with resize anchors for selected sprites.
+/// </summary>
+public class StageBoundingBoxesOverlay : IHasSpriteSelectedEvent, ILingoMouseEventHandler, IDisposable
+{
+    private readonly LingoGfxCanvas _canvas;
+    private readonly IDirectorEventMediator _mediator;
+    private ILingoMouse _mouse;
+    private ILingoKey _key;
+    private readonly List<LingoSprite> _sprites = new();
+    private LingoSprite? _primary;
+
+    public bool Visible { get => _canvas.Visibility; set => _canvas.Visibility = value; }
+
+    public LingoGfxCanvas Canvas => _canvas;
+
+    public StageBoundingBoxesOverlay(ILingoFrameworkFactory factory, IDirectorEventMediator mediator)
+    {
+        _mediator = mediator;
+        _mouse = null!;
+        _key = null!;
+        _canvas = factory.CreateGfxCanvas("BoundingBoxesCanvas", 640, 480);
+        _mediator.Subscribe(this);
+    }
+
+    public void SetInput(ILingoMouse mouse, ILingoKey key)
+    {
+        if (_mouse != null)
+            _mouse.Unsubscribe(this);
+        _mouse = mouse;
+        _key = key;
+        _mouse.Subscribe(this);
+    }
+
+    public void Dispose()
+    {
+        _mediator.Unsubscribe(this);
+        if (_mouse != null)
+            _mouse.Unsubscribe(this);
+        _canvas.Dispose();
+    }
+
+    public void SetSprites(IEnumerable<LingoSprite> sprites)
+    {
+        _sprites.Clear();
+        _sprites.AddRange(sprites);
+        Draw();
+    }
+
+    public void SpriteSelected(ILingoSprite sprite)
+    {
+        _primary = sprite as LingoSprite;
+        if (_primary != null && !_sprites.Contains(_primary))
+        {
+            _sprites.Clear();
+            _sprites.Add(_primary);
+        }
+        Draw();
+    }
+
+    private enum Anchor
+    {
+        None,
+        TopLeft, Top, TopRight, Right, BottomRight, Bottom, BottomLeft, Left
+    }
+
+    private Anchor _dragAnchor = Anchor.None;
+    private float _startLocH, _startLocV, _startWidth, _startHeight;
+    private float _startMouseX, _startMouseY;
+
+    private void OnMouseDown(LingoMouse mouse)
+    {
+        if (_primary == null) return;
+        var anchor = HitTest(mouse.MouseH, mouse.MouseV);
+        if (anchor != Anchor.None)
+        {
+            _dragAnchor = anchor;
+            _startLocH = _primary.LocH;
+            _startLocV = _primary.LocV;
+            _startWidth = _primary.Width;
+            _startHeight = _primary.Height;
+            _startMouseX = mouse.MouseH;
+            _startMouseY = mouse.MouseV;
+        }
+    }
+
+    void ILingoMouseEventHandler.RaiseMouseDown(LingoMouse mouse) => OnMouseDown(mouse);
+
+    private void OnMouseUp(LingoMouse mouse)
+    {
+        _dragAnchor = Anchor.None;
+    }
+
+    void ILingoMouseEventHandler.RaiseMouseUp(LingoMouse mouse) => OnMouseUp(mouse);
+
+    private void OnMouseMove(LingoMouse mouse)
+    {
+        if (_dragAnchor == Anchor.None || _primary == null) return;
+        float dx = mouse.MouseH - _startMouseX;
+        float dy = mouse.MouseV - _startMouseY;
+        bool alt = _key.OptionDown;
+
+        float locH = _startLocH;
+        float locV = _startLocV;
+        float width = _startWidth;
+        float height = _startHeight;
+
+        switch (_dragAnchor)
+        {
+            case Anchor.TopLeft:
+                if (alt) { width = _startWidth - 2 * dx; height = _startHeight - 2 * dy; }
+                else { width = _startWidth - dx; height = _startHeight - dy; locH = _startLocH + dx / 2; locV = _startLocV + dy / 2; }
+                break;
+            case Anchor.Top:
+                if (alt) { height = _startHeight - 2 * dy; }
+                else { height = _startHeight - dy; locV = _startLocV + dy / 2; }
+                break;
+            case Anchor.TopRight:
+                if (alt) { width = _startWidth + 2 * dx; height = _startHeight - 2 * dy; }
+                else { width = _startWidth + dx; height = _startHeight - dy; locH = _startLocH + dx / 2; locV = _startLocV + dy / 2; }
+                break;
+            case Anchor.Right:
+                if (alt) { width = _startWidth + 2 * dx; }
+                else { width = _startWidth + dx; locH = _startLocH + dx / 2; }
+                break;
+            case Anchor.BottomRight:
+                if (alt) { width = _startWidth + 2 * dx; height = _startHeight + 2 * dy; }
+                else { width = _startWidth + dx; height = _startHeight + dy; locH = _startLocH + dx / 2; locV = _startLocV + dy / 2; }
+                break;
+            case Anchor.Bottom:
+                if (alt) { height = _startHeight + 2 * dy; }
+                else { height = _startHeight + dy; locV = _startLocV + dy / 2; }
+                break;
+            case Anchor.BottomLeft:
+                if (alt) { width = _startWidth - 2 * dx; height = _startHeight + 2 * dy; }
+                else { width = _startWidth - dx; height = _startHeight + dy; locH = _startLocH + dx / 2; locV = _startLocV + dy / 2; }
+                break;
+            case Anchor.Left:
+                if (alt) { width = _startWidth - 2 * dx; }
+                else { width = _startWidth - dx; locH = _startLocH + dx / 2; }
+                break;
+        }
+
+        width = Math.Max(1, width);
+        height = Math.Max(1, height);
+
+        _primary.LocH = locH;
+        _primary.LocV = locV;
+        _primary.Width = width;
+        _primary.Height = height;
+        Draw();
+    }
+
+    void ILingoMouseEventHandler.RaiseMouseMove(LingoMouse mouse) => OnMouseMove(mouse);
+
+    private Anchor HitTest(float x, float y)
+    {
+        if (_primary == null) return Anchor.None;
+        var r = _primary.Rect;
+        var points = GetAnchorPoints(r).ToArray();
+        for (int i = 0; i < points.Length; i++)
+        {
+            var p = points[i];
+            if (x >= p.X - 1 && x <= p.X + 1 && y >= p.Y - 1 && y <= p.Y + 1)
+                return (Anchor)i + 1; // Anchor enum after None
+        }
+        return Anchor.None;
+    }
+
+    private IEnumerable<LingoPoint> GetAnchorPoints(LingoRect r)
+    {
+        yield return new LingoPoint(r.Left, r.Top); // TL
+        yield return new LingoPoint((r.Left + r.Right) / 2, r.Top); // T
+        yield return new LingoPoint(r.Right, r.Top); // TR
+        yield return new LingoPoint(r.Right, (r.Top + r.Bottom) / 2); // R
+        yield return new LingoPoint(r.Right, r.Bottom); // BR
+        yield return new LingoPoint((r.Left + r.Right) / 2, r.Bottom); // B
+        yield return new LingoPoint(r.Left, r.Bottom); // BL
+        yield return new LingoPoint(r.Left, (r.Top + r.Bottom) / 2); // L
+    }
+
+    private void Draw()
+    {
+        _canvas.Clear(LingoColorList.Black);
+        foreach (var sprite in _sprites)
+        {
+            if (sprite.Member is LingoMemberText || sprite.Member is LingoMemberField)
+            {
+                var r = sprite.Rect;
+                _canvas.DrawRect(LingoRect.New(r.Left, r.Top, r.Right - r.Left, r.Bottom - r.Top), LingoColorList.Yellow, false, 1);
+                foreach (var p in GetAnchorPoints(r))
+                    _canvas.DrawRect(LingoRect.New(p.X - 1, p.Y - 1, 2, 2), LingoColorList.Yellow, true);
+            }
+        }
+    }
+}

--- a/src/LingoEngine/Inputs/LingoMouse.cs
+++ b/src/LingoEngine/Inputs/LingoMouse.cs
@@ -85,6 +85,16 @@ namespace LingoEngine.Inputs
         bool LeftMouseDown { get; }
         bool MiddleMouseDown { get; }
         ILingoCursor Cursor { get; }
+
+        /// <summary>
+        /// Subscribe to mouse events.
+        /// </summary>
+        ILingoMouse Subscribe(ILingoMouseEventHandler handler);
+
+        /// <summary>
+        /// Unsubscribe from mouse events.
+        /// </summary>
+        ILingoMouse Unsubscribe(ILingoMouseEventHandler handler);
     }
 
 
@@ -142,13 +152,17 @@ namespace LingoEngine.Inputs
         /// <summary>
         /// Subscribe to mouse events
         /// </summary>
-        public LingoMouse Subscribe(ILingoMouseEventHandler handler)
+        public ILingoMouse Subscribe(ILingoMouseEventHandler handler)
         {
             if (_subscriptions.Contains(handler)) return this;
             _subscriptions.Add(handler);
             return this;
         }
-        public LingoMouse Unsubscribe(ILingoMouseEventHandler handler)
+
+        /// <summary>
+        /// Unsubscribe from mouse events
+        /// </summary>
+        public ILingoMouse Unsubscribe(ILingoMouseEventHandler handler)
         {
             _subscriptions.Remove(handler);
             return this;


### PR DESCRIPTION
## Summary
- move bounding box drawing to StageBoundingBoxesOverlay
- draw resize anchors and allow dragging with ALT to mirror
- hook overlay up in Godot stage window
- expose Subscribe and Unsubscribe via ILingoMouse
- return interface type from LingoMouse.Subscribe/Unsubscribe

## Testing
- `dotnet test -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68787cccc1f08332bab0f9dbe4a4421d