### PR TITLE
Add icons to sprite info overlay

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Stages/StageBoundingBoxesOverlay.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/StageBoundingBoxesOverlay.cs
@@ -7,6 +7,10 @@ using LingoEngine.Gfx;
 using LingoEngine.Primitives;
 using LingoEngine.Sprites;
 using LingoEngine.Inputs;
+using LingoEngine.Events;
+using LingoEngine.Director.Core.Tools;
+using LingoEngine.Members;
+using LingoEngine.Texts;
 
 namespace LingoEngine.Director.Core.Stages;
 

--- a/src/Director/LingoEngine.Director.Core/Stages/StageSpriteSummaryOverlay.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/StageSpriteSummaryOverlay.cs
@@ -6,6 +6,8 @@ using LingoEngine.Primitives;
 using LingoEngine.Director.Core.Sprites;
 using LingoEngine.Director.Core.Tools;
 using LingoEngine.Sprites;
+using LingoEngine.Director.Core.Icons;
+using LingoEngine.Bitmaps;
 
 namespace LingoEngine.Director.Core.Stages;
 
@@ -17,15 +19,21 @@ public class StageSpriteSummaryOverlay : IHasSpriteSelectedEvent, IDisposable
 {
     private readonly LingoGfxCanvas _canvas;
     private readonly IDirectorEventMediator _mediator;
+    private readonly IDirectorIconManager _iconManager;
+    private readonly ILingoImageTexture _infoIcon;
+    private readonly ILingoImageTexture _behaviorIcon;
 
     public LingoGfxCanvas Canvas => _canvas;
 
-    public StageSpriteSummaryOverlay(ILingoFrameworkFactory factory, IDirectorEventMediator mediator)
+    public StageSpriteSummaryOverlay(ILingoFrameworkFactory factory, IDirectorEventMediator mediator, IDirectorIconManager iconManager)
     {
         _mediator = mediator;
         _canvas = factory.CreateGfxCanvas("SpriteSummaryCanvas", 0, 0);
         _canvas.Visibility = false;
         _mediator.Subscribe(this);
+        _iconManager = iconManager;
+        _infoIcon = _iconManager.Get(DirectorIcon.Info);
+        _behaviorIcon = _iconManager.Get(DirectorIcon.BehaviorScript);
     }
 
     /// <summary>Called when a sprite is selected.</summary>
@@ -48,14 +56,20 @@ public class StageSpriteSummaryOverlay : IHasSpriteSelectedEvent, IDisposable
 
         var line1 = $"{member.Name} ({sp.Cast?.Name}) {member.Type}";
         var line2 = $"Sprite {sp.SpriteNum} ({(int)sp.LocH},{(int)sp.LocV},{(int)sp.Width}x{(int)sp.Height}) {(LingoInkType)sp.Ink} {(int)(sp.Blend * 100)}%";
-        string text = line1 + "\n" + line2;
-        if (!string.IsNullOrEmpty(behaviors))
-            text += "\n" + behaviors;
 
         const int fontSize = 10;
-        var lines = text.Split('\n');
+        const int iconSize = 16;
+        var lines = new[] { line1, line2 };
+        var icons = new[] { _infoIcon, _infoIcon };
+        if (!string.IsNullOrEmpty(behaviors))
+        {
+            lines = lines.Append(behaviors).ToArray();
+            icons = icons.Append(_behaviorIcon).ToArray();
+        }
+
         int height = lines.Length * (fontSize + 2) + 4;
-        int width = Math.Max(120, lines.Max(l => l.Length) * 6 + 8);
+        int widthText = lines.Max(l => l.Length * 6);
+        int width = Math.Max(120, widthText + iconSize + 8);
 
         _canvas.Width = width;
         _canvas.Height = height;
@@ -63,7 +77,14 @@ public class StageSpriteSummaryOverlay : IHasSpriteSelectedEvent, IDisposable
         _canvas.Y = sp.Rect.Bottom;
 
         _canvas.DrawRect(LingoRect.New(0, 0, width, height), LingoColorList.Gray, true);
-        _canvas.DrawText(new LingoPoint(4, 2), text, null, LingoColorList.White, fontSize);
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            int y = 2 + i * (fontSize + 2);
+            _canvas.DrawPicture(icons[i], iconSize, iconSize, new LingoPoint(2, y));
+            _canvas.DrawText(new LingoPoint(iconSize + 4, y), lines[i], null, LingoColorList.White, fontSize);
+        }
+
         _canvas.Visibility = true;
     }
 

--- a/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
@@ -18,6 +18,7 @@ using LingoEngine.Director.Core.Sprites;
 using LingoEngine.Director.Core.UI;
 using LingoEngine.LGodot.Gfx;
 using LingoEngine.Inputs;
+using LingoEngine.Director.Core.Icons;
 
 
 namespace LingoEngine.Director.LGodot.Movies;
@@ -59,7 +60,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
     private bool _panning;
     private float _scale = 1f;
 
-    public DirGodotStageWindow(ILingoFrameworkStageContainer stageContainer, IDirectorEventMediator directorEventMediator, ILingoCommandManager commandManager, IHistoryManager historyManager, ILingoPlayer player, DirectorStageWindow directorStageWindow, IDirGodotWindowManager windowManager)
+    public DirGodotStageWindow(ILingoFrameworkStageContainer stageContainer, IDirectorEventMediator directorEventMediator, ILingoCommandManager commandManager, IHistoryManager historyManager, ILingoPlayer player, DirectorStageWindow directorStageWindow, IDirGodotWindowManager windowManager, IDirectorIconManager iconManager)
         : base(DirectorMenuCodes.StageWindow, "Stage", windowManager)
     {
         _stageContainer = (LingoGodotStageContainer)stageContainer;
@@ -75,13 +76,13 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         var lp = _player as LingoPlayer;
         if (lp != null)
         {
-            _spriteSummary = new StageSpriteSummaryOverlay(lp.Factory, _mediator);
+            _spriteSummary = new StageSpriteSummaryOverlay(lp.Factory, _mediator, iconManager);
             _boundingBoxes = new StageBoundingBoxesOverlay(lp.Factory, _mediator);
         }
         else
         {
             var p = (LingoPlayer)_player!;
-            _spriteSummary = new StageSpriteSummaryOverlay(p.Factory, _mediator);
+            _spriteSummary = new StageSpriteSummaryOverlay(p.Factory, _mediator, iconManager);
             _boundingBoxes = new StageBoundingBoxesOverlay(p.Factory, _mediator);
         }
 


### PR DESCRIPTION
## Summary
- display icons alongside sprite info in `StageSpriteSummaryOverlay`
- wire icon manager to `StageSpriteSummaryOverlay` from stage window
- fix missing usings in `StageBoundingBoxesOverlay`

## Testing
- `dotnet build LingoEngine.sln`
- `dotnet test LingoEngine.sln` *(fails: FileNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_6879d617475483329e24faffae0022ea