### PR TITLE
Add movie inspector tab

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
@@ -13,6 +13,7 @@ using LingoEngine.Sounds;
 using LingoEngine.Movies;
 using LingoEngine.Director.Core.Windowing.Commands;
 using System;
+using System.Collections.Generic;
 using LingoEngine.Director.Core.Events;
 using LingoEngine.Director.Core.Sprites;
 using LingoEngine.Director.Core.Tools;
@@ -173,9 +174,11 @@ namespace LingoEngine.Director.Core.Inspector
             {
                 case LingoSprite sp2:
                     AddSpriteTab(sp2);
-                    //AddTab("Sprite", sp2);
                     if (sp2.Member != null)
                         AddMemberTabs(sp2.Member);
+                    break;
+                case LingoMovie movie:
+                    AddMovieTab(movie);
                     break;
                 case ILingoMember member2:
                     AddMemberTabs(member2);
@@ -360,6 +363,62 @@ namespace LingoEngine.Director.Core.Inspector
                 .AddLabel("SoundChannels", "Channels: ", 2)
                 .AddLabel("SoundChannelsV", member.Stereo ? "Stereo" : "Mono", 2)
                 .Finalize();
+        }
+
+        private void AddMovieTab(LingoMovie movie)
+        {
+            var wrap = AddTab("Movie");
+
+            var rowSize = _factory.CreateWrapPanel(LingoOrientation.Horizontal, "MovieStageSizeRow");
+            rowSize.Compose(_factory)
+                .AddLabel("Stage size:")
+                .AddNumericInput("MovieStageWidth", movie, m => m.StageWidth, 40)
+                .AddLabel("x")
+                .AddNumericInput("MovieStageHeight", movie, m => m.StageHeight, 40)
+                .AddItemList("MovieResolutions", new[]
+                {
+                    new KeyValuePair<string,string>("640x480","640x480"),
+                    new KeyValuePair<string,string>("800x600","800x600"),
+                    new KeyValuePair<string,string>("1024x768","1024x768"),
+                    new KeyValuePair<string,string>("1280x720","1280x720"),
+                    new KeyValuePair<string,string>("1920x1080","1920x1080")
+                }, 90, $"{movie.StageWidth}x{movie.StageHeight}", val =>
+                {
+                    if (!string.IsNullOrEmpty(val))
+                    {
+                        var p = val.Split('x');
+                        if (p.Length == 2 && int.TryParse(p[0], out var w) && int.TryParse(p[1], out var h))
+                        {
+                            movie.StageWidth = w;
+                            movie.StageHeight = h;
+                        }
+                    }
+                });
+            wrap.AddItem(rowSize);
+
+            var rowChannels = _factory.CreateWrapPanel(LingoOrientation.Horizontal, "MovieChannelsRow");
+            rowChannels.Compose(_factory)
+                .AddLabel("Channels:")
+                .AddNumericInput("MovieChannels", movie, m => m.MaxSpriteChannelCount, 60, 2, 1999);
+            wrap.AddItem(rowChannels);
+
+            var rowColor = _factory.CreateWrapPanel(LingoOrientation.Horizontal, "MovieColorRow");
+            rowColor.Compose(_factory)
+                .AddLabel("Color:")
+                .AddColorPicker("MovieColor", movie, m => m.StageColor, 20);
+            wrap.AddItem(rowColor);
+
+            var rowAbout = _factory.CreateWrapPanel(LingoOrientation.Horizontal, "MovieAboutRow");
+            rowAbout.Compose(_factory)
+                .AddLabel("About:")
+                .AddTextInput("MovieAbout", movie, m => m.About, 150);
+            wrap.AddItem(rowAbout);
+
+            var rowCopyright = _factory.CreateWrapPanel(LingoOrientation.Horizontal, "MovieCopyrightRow");
+            rowCopyright.Compose(_factory)
+                .AddLabel("Copyright:")
+                .AddTextInput("MovieCopyright", movie, m => m.Copyright, 150);
+            wrap.AddItem(rowCopyright);
         }
         private LingoGfxWrapPanel AddTab(string name)
         { 

--- a/src/LingoEngine.IO.Data/DTO/LingoMovieDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoMovieDTO.cs
@@ -8,6 +8,11 @@ public class LingoMovieDTO
     public int Number { get; set; }
     public int Tempo { get; set; }
     public int FrameCount { get; set; }
+    public int StageWidth { get; set; } = 640;
+    public int StageHeight { get; set; } = 480;
+    public LingoColorDTO StageColor { get; set; } = new();
+    public string About { get; set; } = string.Empty;
+    public string Copyright { get; set; } = string.Empty;
     public List<LingoCastDTO> Casts { get; set; } = new();
     public List<LingoSpriteDTO> Sprites { get; set; } = new();
 }

--- a/src/LingoEngine.IO/JsonStateRepository.cs
+++ b/src/LingoEngine.IO/JsonStateRepository.cs
@@ -53,6 +53,11 @@ public class JsonStateRepository
     {
         var movie = (LingoMovie)player.NewMovie(dto.Name);
         movie.Tempo = dto.Tempo;
+        movie.StageWidth = dto.StageWidth;
+        movie.StageHeight = dto.StageHeight;
+        movie.StageColor = FromDto(dto.StageColor);
+        movie.About = dto.About;
+        movie.Copyright = dto.Copyright;
 
         var castMap = new Dictionary<int, LingoCast>();
         var memberMap = new Dictionary<int, LingoMember>();
@@ -165,6 +170,11 @@ public class JsonStateRepository
             Number = movie.Number,
             Tempo = movie.Tempo,
             FrameCount = movie.FrameCount,
+            StageWidth = movie.StageWidth,
+            StageHeight = movie.StageHeight,
+            StageColor = ToDto(movie.StageColor),
+            About = movie.About,
+            Copyright = movie.Copyright,
             Casts = movie.CastLib.GetAll().Select(c => ToDto((LingoCast)c, dir)).ToList(),
             Sprites = GetAllSprites(movie).Select(ToDto).ToList()
         };

--- a/src/LingoEngine/Movies/LingoMovie.cs
+++ b/src/LingoEngine/Movies/LingoMovie.cs
@@ -55,8 +55,14 @@ namespace LingoEngine.Movies
         public T Framework<T>() where T : class, ILingoFrameworkMovie => (T)_FrameworkMovie;
 
         public string Name { get; set; }
-       
+
         public int Number { get; private set; }
+
+        public int StageWidth { get; set; } = 640;
+        public int StageHeight { get; set; } = 480;
+        public LingoColor StageColor { get; set; } = LingoColorList.Black;
+        public string About { get; set; } = string.Empty;
+        public string Copyright { get; set; } = string.Empty;
 
         private readonly LingoEventMediator _EventMediator;
 


### PR DESCRIPTION
## Summary
- add new movie properties for stage settings and metadata
- persist movie properties in JSON
- show new "Movie" tab in the property inspector to edit stage size, channels, color, about and copyright

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_687da1e8783c8332a8fab10a44d4df49