### PR TITLE
Add DirectorStageGuides overlay

### DIFF
--- a/src/Director/LingoEngine.Director.Core/DirectorSetup.cs
+++ b/src/Director/LingoEngine.Director.Core/DirectorSetup.cs
@@ -48,6 +48,7 @@ namespace LingoEngine.Director.Core
                     .AddSingleton<DirectorCastWindow>()
                     .AddSingleton<DirectorScoreWindow>()
                     .AddSingleton<DirectorPropertyInspectorWindow>()
+                    .AddSingleton<DirectorStageGuides>()
                     .AddSingleton<DirectorBinaryViewerWindow>()
                     .AddSingleton<DirectorBinaryViewerWindowV2>()
                     .AddSingleton<DirectorStageWindow>()

--- a/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
@@ -18,6 +18,7 @@ using LingoEngine.Director.Core.Tools;
 using LingoEngine.Director.Core.UI;
 using LingoEngine.Tools;
 using LingoEngine.Director.Core.Windowing;
+using LingoEngine.Director.Core.Stages;
 using LingoEngine.Bitmaps;
 using static System.Net.Mime.MediaTypeNames;
 using LingoEngine.Casts;
@@ -33,6 +34,7 @@ namespace LingoEngine.Director.Core.Inspector
         {
             Movie,
             Sprite,
+            Guides,
             Behavior,
             Member,
             Bitmap,
@@ -58,6 +60,7 @@ namespace LingoEngine.Director.Core.Inspector
         private IDirectorEventMediator _mediator;
         private readonly IDirectorBehaviorDescriptionManager _descriptionManager;
         private readonly ILogger<DirectorPropertyInspectorWindow> _logger;
+        private readonly DirectorStageGuides _guides;
         private LingoGfxWrapPanel _behaviorPanel;
         private float _lastWidh;
         private float _lastHeight;
@@ -73,7 +76,7 @@ namespace LingoEngine.Director.Core.Inspector
 
         public record HeaderElements(LingoGfxPanel Panel, LingoGfxWrapPanel Header, DirectorMemberThumbnail Thumbnail);
 
-        public DirectorPropertyInspectorWindow(LingoPlayer player, ILingoCommandManager commandManager, ILingoFrameworkFactory factory, IDirectorIconManager iconManager, IDirectorEventMediator mediator, IDirectorBehaviorDescriptionManager descriptionManager, ILogger<DirectorPropertyInspectorWindow> logger)
+        public DirectorPropertyInspectorWindow(LingoPlayer player, ILingoCommandManager commandManager, ILingoFrameworkFactory factory, IDirectorIconManager iconManager, IDirectorEventMediator mediator, IDirectorBehaviorDescriptionManager descriptionManager, DirectorStageGuides guides, ILogger<DirectorPropertyInspectorWindow> logger)
         {
             _player = player;
             _commandManager = commandManager;
@@ -81,6 +84,7 @@ namespace LingoEngine.Director.Core.Inspector
             _iconManager = iconManager;
             _mediator = mediator;
             _descriptionManager = descriptionManager;
+            _guides = guides;
             _logger = logger;
             _mediator.Subscribe(this);
         }
@@ -196,6 +200,7 @@ namespace LingoEngine.Director.Core.Inspector
             {
                 case LingoSprite sp2:
                     AddSpriteTab(sp2);
+                    AddGuidesTab(_guides);
                     if (sp2.Member != null)
                         AddMemberTabs(sp2.Member);
                     if (_player.ActiveMovie != null)
@@ -531,6 +536,39 @@ namespace LingoEngine.Director.Core.Inspector
                    .Finalize();
             ;
             wrap.AddItem(rowChannels);
+        }
+
+        private void AddGuidesTab(DirectorStageGuides guides)
+        {
+            var wrap = AddTab(PropetyTabNames.Guides);
+            var guidesPanel = _factory.CreatePanel("GuidesPanel");
+            guidesPanel.Margin = new LingoMargin(5, 5, 0, 0);
+            guidesPanel.Compose(_factory)
+                   .Columns(4)
+                   .AddColorPicker("GuideColor", "Color:", guides, g => g.GuidesColor)
+                   .AddCheckBox("GuideVisible", "Visible:", guides, g => g.GuidesVisible)
+                   .AddCheckBox("GuideSnap", "SnapTo:", guides, g => g.GuidesSnap)
+                   .AddCheckBox("GuideLock", "Lock:", guides, g => g.GuidesLocked)
+                   .Finalize();
+            wrap.AddItem(guidesPanel);
+
+            var gridPanel = _factory.CreatePanel("GridPanel");
+            gridPanel.Margin = new LingoMargin(5, 5, 0, 0);
+            gridPanel.Compose(_factory)
+                   .Columns(4)
+                   .AddColorPicker("GridColor", "Color:", guides, g => g.GridColor)
+                   .AddCheckBox("GridVisible", "Visible:", guides, g => g.GridVisible)
+                   .AddCheckBox("GridSnap", "SnapTo:", guides, g => g.GridSnap)
+                   .NextRow()
+                   .AddButton("AddVerticalGuide", "Add vertical", () => guides.AddVertical(0), 2)
+                   .AddButton("AddHorizontalGuide", "Add horizontal", () => guides.AddHorizontal(0), 2)
+                   .NextRow()
+                   .AddButton("RemoveGuides", "Remove all", () => guides.RemoveAll(), 4)
+                   .NextRow()
+                   .AddNumericInput("GridWidth", "W:", guides, g => g.GridWidth)
+                   .AddNumericInput("GridHeight", "H:", guides, g => g.GridHeight)
+                   .Finalize();
+            wrap.AddItem(gridPanel);
         }
 
 

--- a/src/Director/LingoEngine.Director.Core/Stages/DirectorStageGuides.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/DirectorStageGuides.cs
@@ -1,0 +1,72 @@
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+using System.Collections.Generic;
+
+namespace LingoEngine.Director.Core.Stages;
+
+/// <summary>
+/// Draws user defined guides and a configurable grid on the stage canvas.
+/// </summary>
+public class DirectorStageGuides
+{
+    private readonly LingoGfxCanvas _canvas;
+
+    public IList<float> VerticalGuides { get; } = new List<float>();
+    public IList<float> HorizontalGuides { get; } = new List<float>();
+
+    private LingoColor _guidesColor = LingoColorList.Blue;
+    public LingoColor GuidesColor { get => _guidesColor; set { _guidesColor = value; Draw(); } }
+    private bool _guidesVisible = true;
+    public bool GuidesVisible { get => _guidesVisible; set { _guidesVisible = value; Draw(); } }
+    private bool _guidesSnap;
+    public bool GuidesSnap { get => _guidesSnap; set { _guidesSnap = value; } }
+    private bool _guidesLocked;
+    public bool GuidesLocked { get => _guidesLocked; set { _guidesLocked = value; } }
+
+    private LingoColor _gridColor = LingoColorList.Gray;
+    public LingoColor GridColor { get => _gridColor; set { _gridColor = value; Draw(); } }
+    private bool _gridVisible;
+    public bool GridVisible { get => _gridVisible; set { _gridVisible = value; Draw(); } }
+    private bool _gridSnap;
+    public bool GridSnap { get => _gridSnap; set { _gridSnap = value; } }
+    private float _gridWidth = 32;
+    public float GridWidth { get => _gridWidth; set { _gridWidth = value; Draw(); } }
+    private float _gridHeight = 32;
+    public float GridHeight { get => _gridHeight; set { _gridHeight = value; Draw(); } }
+
+    public LingoGfxCanvas Canvas => _canvas;
+
+    public DirectorStageGuides(ILingoFrameworkFactory factory)
+    {
+        _canvas = factory.CreateGfxCanvas("StageGuidesCanvas", 3000, 2000);
+        _canvas.Visibility = false;
+    }
+
+    public void AddVertical(float x) { if (!GuidesLocked) { VerticalGuides.Add(x); Draw(); } }
+    public void AddHorizontal(float y) { if (!GuidesLocked) { HorizontalGuides.Add(y); Draw(); } }
+    public void RemoveAll() { if (!GuidesLocked) { VerticalGuides.Clear(); HorizontalGuides.Clear(); Draw(); } }
+
+    public void Draw()
+    {
+        _canvas.Clear(LingoColorList.Transparent);
+
+        if (GridVisible && GridWidth > 0 && GridHeight > 0)
+        {
+            for (float x = 0; x <= _canvas.Width; x += GridWidth)
+                _canvas.DrawLine(new LingoPoint(x, 0), new LingoPoint(x, _canvas.Height), GridColor);
+            for (float y = 0; y <= _canvas.Height; y += GridHeight)
+                _canvas.DrawLine(new LingoPoint(0, y), new LingoPoint(_canvas.Width, y), GridColor);
+        }
+
+        if (GuidesVisible)
+        {
+            foreach (var x in VerticalGuides)
+                _canvas.DrawLine(new LingoPoint(x, 0), new LingoPoint(x, _canvas.Height), GuidesColor);
+            foreach (var y in HorizontalGuides)
+                _canvas.DrawLine(new LingoPoint(0, y), new LingoPoint(_canvas.Width, y), GuidesColor);
+        }
+
+        _canvas.Visibility = GuidesVisible || GridVisible;
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
@@ -49,6 +49,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
     private readonly SelectionBox _selectionBox = new SelectionBox();
     private readonly StageBoundingBoxesOverlay _boundingBoxes;
     private readonly StageSpriteSummaryOverlay _spriteSummary;
+    private readonly DirectorStageGuides _guides;
     private readonly IDirectorEventSubscription _stageChangedSubscription;
 
     private LingoMovie? _movie;
@@ -65,7 +66,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
     private bool _panning;
     private float _scale = 1f;
 
-    public DirGodotStageWindow(ILingoFrameworkStageContainer stageContainer, IDirectorEventMediator directorEventMediator, ILingoCommandManager commandManager, IHistoryManager historyManager, ILingoPlayer player, DirectorStageWindow directorStageWindow, IDirGodotWindowManager windowManager, IDirectorIconManager iconManager)
+    public DirGodotStageWindow(ILingoFrameworkStageContainer stageContainer, IDirectorEventMediator directorEventMediator, ILingoCommandManager commandManager, IHistoryManager historyManager, ILingoPlayer player, DirectorStageWindow directorStageWindow, DirectorStageGuides guides, IDirGodotWindowManager windowManager, IDirectorIconManager iconManager)
         : base(DirectorMenuCodes.StageWindow, "Stage", windowManager)
     {
         // TempFix
@@ -88,12 +89,16 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         {
             _spriteSummary = new StageSpriteSummaryOverlay(lp.Factory, _mediator, iconManager);
             _boundingBoxes = new StageBoundingBoxesOverlay(lp.Factory, _mediator);
+            _guides = guides;
+            _guides.Draw();
         }
         else
         {
             var p = (LingoPlayer)_player!;
             _spriteSummary = new StageSpriteSummaryOverlay(p.Factory, _mediator, iconManager);
             _boundingBoxes = new StageBoundingBoxesOverlay(p.Factory, _mediator);
+            _guides = guides;
+            _guides.Draw();
         }
 
 
@@ -136,8 +141,10 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
 
         var spriteSummaryCanvas = _spriteSummary.Canvas.Framework<LingoGodotGfxCanvas>();
         var boundingBoxesCanvas = _boundingBoxes.Canvas.Framework<LingoGodotGfxCanvas>();
+        var guidesCanvas = _guides.Canvas.Framework<LingoGodotGfxCanvas>();
         spriteSummaryCanvas.ZIndex = 1000;
         boundingBoxesCanvas.ZIndex = 1001;
+        guidesCanvas.ZIndex = 999;
         _selectionBox.ZIndex = 1002;
         _selectionBox.Visible = false;
         _stageContainer.Container.ZIndex = zIndexStageStart;
@@ -147,6 +154,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         _stageLayer.Name = "StageLayer";
         _stageLayer.AddChild(_stageBgRect);
         _stageLayer.AddChild(_stageContainer.Container);
+        _stageLayer.AddChild(guidesCanvas);
         _stageLayer.AddChild(spriteSummaryCanvas);
         _stageLayer.AddChild(_selectionBox);
 


### PR DESCRIPTION
## Summary
- rename `StageGuides` overlay to `DirectorStageGuides`
- register `DirectorStageGuides` in DI setup
- update property inspector and Godot stage window to use new class

## Testing
- `dotnet build --no-restore` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68828f4251088332a272eb039bd5655c