### PR TITLE
Add hex-based dir script parsing test

### DIFF
--- a/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/DirScriptParsingTests.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/DirScriptParsingTests.cs
@@ -1,0 +1,61 @@
+using System;
+using Microsoft.Extensions.Logging;
+using ProjectorRays.director;
+using ProjectorRays.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ProjectorRays.DotNet.Test;
+
+public class DirScriptParsingTests
+{
+    private readonly ILogger<DirScriptParsingTests> _logger;
+
+    public DirScriptParsingTests(ITestOutputHelper output)
+    {
+        var factory = LoggerFactory.Create(builder => builder.AddProvider(new XunitLoggerProvider(output)));
+        _logger = factory.CreateLogger<DirScriptParsingTests>();
+    }
+
+    [Fact]
+    public void CanParseScriptFromHex()
+    {
+        var data = DirectorHexData.DirData;
+        var stream = new ReadStream(data, data.Length, Endianness.BigEndian);
+        var dir = new RaysDirectorFile(_logger, "hex.dir");
+        Assert.True(dir.Read(stream));
+
+        dir.ParseScripts();
+        dir.RestoreScriptText();
+
+        const uint CASt = ((uint)'C' << 24) | ((uint)'A' << 16) | ((uint)'S' << 8) | (uint)'t';
+
+        string expected = "on mousedown me\n" +
+                          "  sprite(me.spritenum).locH = sprite(me.spritenum).locH  +5\n" +
+                          "end\n" +
+                          "on exitframe\n" +
+                          "  go to the frame\n" +
+                          "end";
+
+        bool found = false;
+        foreach (var cast in dir.Casts)
+        {
+            foreach (var id in cast.MemberIDs)
+            {
+                var chunk = (RaysCastMemberChunk)dir.GetChunk(CASt, id);
+                if (chunk.GetScriptID() != 0)
+                {
+                    var text = chunk.GetScriptText().Replace("\r\n", "\n").Trim();
+                    if (text == expected)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            if (found) break;
+        }
+
+        Assert.True(found);
+    }
+}

--- a/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/DirectorHexData.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/DirectorHexData.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Linq;
+
+namespace ProjectorRays.DotNet.Test;
+
+public static class DirectorHexData
+{
+    private const string HexString = @"58 46 49 52 2a 3a 00 00 33 39 56 4d 70 61 6d 69 18 00 00 00 01 00 00 00 2c 00 00 00 44 07 00 00 00 00 00 00 00 00 00 00 00 00 00 00 70 61 6d 6d 38 03 00 00 18 00 14 00 28 00 00 00 23 00 00 00 1c 00 00 00 ff ff ff ff 0f 00 00 00 58 46 49 52 2a 3a 00 00 00 00 00 00 01 00 00 00 00 00 00 00";
+
+    public static byte[] DirData => HexString
+        .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
+        .Select(h => Convert.ToByte(h, 16))
+        .ToArray();
+}


### PR DESCRIPTION
## Summary
- add DirScriptParsingTests verifying script text of hex-loaded .dir file
- convert hex string to bytes using token-based parsing

## Testing
- `dotnet test WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/ProjectorRays.DotNet.Test.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883045b9ef48332b68bba282154d03c