### PR TITLE
Add ink prerender helper

### DIFF
--- a/src/LingoEngine.LGodot/Bitmaps/LingoGodotMemberBitmap.cs
+++ b/src/LingoEngine.LGodot/Bitmaps/LingoGodotMemberBitmap.cs
@@ -4,6 +4,7 @@ using LingoEngine.LGodot.Helpers;
 using LingoEngine.Sprites;
 using LingoEngine.Tools;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 
 namespace LingoEngine.LGodot.Bitmaps
 {
@@ -14,6 +15,7 @@ namespace LingoEngine.LGodot.Bitmaps
         private ILingoImageTexture? _imageTextureLingo;
         private Image? _image;
         private readonly ILogger _logger;
+        private readonly Dictionary<LingoInkType, ImageTexture> _inkCache = new();
 
         public ILingoImageTexture? Texture => _imageTextureLingo;
         public ImageTexture? TextureGodot
@@ -130,6 +132,7 @@ namespace LingoEngine.LGodot.Bitmaps
 
         public void Unload()
         {
+            ClearCache();
             _imageTexture?.Dispose();
             _imageTexture = null;
             _imageTextureLingo = null;
@@ -138,6 +141,7 @@ namespace LingoEngine.LGodot.Bitmaps
 
         public void Dispose()
         {
+            ClearCache();
             _image?.Dispose();
             _imageTexture?.Dispose();
         }
@@ -179,8 +183,33 @@ namespace LingoEngine.LGodot.Bitmaps
             _lingoMemberPicture.SetImageData(_image.GetData());
         }
 
+        public ImageTexture GetTextureForInk(LingoInkType ink, LingoColor backColor)
+        {
+            if (!InkPreRenderer.CanHandle(ink) || _image == null)
+                return TextureGodot!;
+
+            if (_inkCache.TryGetValue(ink, out var tex))
+                return tex;
+
+            var img = GetImageCopy();
+            var data = InkPreRenderer.Apply(img.GetData(), ink, backColor);
+            var newImg = Image.CreateFromData(img.GetWidth(), img.GetHeight(), false, Image.Format.Rgba8, data);
+            tex = ImageTexture.CreateFromImage(newImg);
+            newImg.Dispose();
+            _inkCache[ink] = tex;
+            return tex;
+        }
+
         public void SetImageData(byte[] bytes) => ImageData = bytes;
 
+        private void ClearCache()
+        {
+            foreach (var tex in _inkCache.Values)
+            {
+                tex.Dispose();
+            }
+            _inkCache.Clear();
+        }
 
     }
 }

--- a/src/LingoEngine.LGodot/Sprites/LingoGodotSprite.cs
+++ b/src/LingoEngine.LGodot/Sprites/LingoGodotSprite.cs
@@ -7,6 +7,7 @@ using LingoEngine.Members;
 using LingoEngine.Sprites;
 using LingoEngine.Bitmaps;
 using LingoEngine.LGodot.Bitmaps;
+using LingoEngine.Tools;
 using LingoEngine.Texts.FrameworkCommunication;
 using LingoEngine.Shapes;
 using LingoEngine.LGodot.Shapes;
@@ -134,6 +135,14 @@ namespace LingoEngine.LGodot.Sprites
         private void ApplyInk()
         {
             if (_ink == 0) return;
+
+            if (InkPreRenderer.CanHandle((LingoInkType)_ink))
+            {
+                _material.BlendMode = CanvasItemMaterial.BlendModeEnum.Mix;
+                _Sprite2D.Material = _material;
+                return;
+            }
+
             CanvasItemMaterial.BlendModeEnum mode = _ink switch
             {
                 (int)LingoInkType.AddPin => CanvasItemMaterial.BlendModeEnum.Add,
@@ -144,13 +153,15 @@ namespace LingoEngine.LGodot.Sprites
                 (int)LingoInkType.Lighten => CanvasItemMaterial.BlendModeEnum.Add,
                 _ => CanvasItemMaterial.BlendModeEnum.Mix,
             };
+
             if (mode == CanvasItemMaterial.BlendModeEnum.Mix)
-            { 
-                var inkNumber = (int)_lingoSprite.InkType;
-                _Sprite2D.Material = InkShaderMaterial.Create(_lingoSprite.InkType, _lingoSprite.BackColor.ToGodotColor());
+            {
+                _Sprite2D.Material = InkShaderMaterial.Create(
+                    _lingoSprite.InkType,
+                    _lingoSprite.BackColor.ToGodotColor());
             }
-            else 
-            { 
+            else
+            {
                 _material.BlendMode = mode;
                 _Sprite2D.Material = _material;
             }
@@ -327,10 +338,17 @@ namespace LingoEngine.LGodot.Sprites
         private void UpdateMemberPicture(LingoGodotMemberBitmap godotPicture)
         {
             godotPicture.Preload();
-            // Set the texture using the ImageTexture from the picture member
             if (godotPicture.TextureGodot == null)
                 return;
-            _Sprite2D.Texture = godotPicture.TextureGodot;
+
+            if (InkPreRenderer.CanHandle(_lingoSprite.InkType))
+            {
+                _Sprite2D.Texture = godotPicture.GetTextureForInk(_lingoSprite.InkType, _lingoSprite.BackColor);
+            }
+            else
+            {
+                _Sprite2D.Texture = godotPicture.TextureGodot;
+            }
         }
         private ILingoMember? _previousChildElement;
         private Node? _previousChildElementNode;

--- a/src/LingoEngine.SDL2/Sprites/SdlSprite.cs
+++ b/src/LingoEngine.SDL2/Sprites/SdlSprite.cs
@@ -167,11 +167,21 @@ public class SdlSprite : ILingoFrameworkSprite, IDisposable
 
                 if (p.Surface != nint.Zero)
                 {
-                    _texture = SDL.SDL_CreateTextureFromSurface(_renderer, p.Surface);
-                    if (_texture != nint.Zero)
+                    var tex = p.GetTextureForInk(_lingoSprite.InkType, _lingoSprite.BackColor, _renderer);
+                    if (tex != nint.Zero)
                     {
+                        _texture = tex;
                         Width = p.Width;
                         Height = p.Height;
+                    }
+                    else
+                    {
+                        _texture = SDL.SDL_CreateTextureFromSurface(_renderer, p.Surface);
+                        if (_texture != nint.Zero)
+                        {
+                            Width = p.Width;
+                            Height = p.Height;
+                        }
                     }
                 }
                 break;

--- a/src/LingoEngine/Tools/InkPreRenderer.cs
+++ b/src/LingoEngine/Tools/InkPreRenderer.cs
@@ -1,0 +1,101 @@
+using System;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.Tools
+{
+    /// <summary>
+    /// Utility helper to pre-render simple ink effects directly on pixel data.
+    /// </summary>
+    public static class InkPreRenderer
+    {
+        /// <summary>
+        /// Returns <c>true</c> if the given ink type can be pre-rendered without
+        /// reading the destination buffer.
+        /// </summary>
+        public static bool CanHandle(LingoInkType ink) => ink switch
+        {
+            LingoInkType.Blend or
+            LingoInkType.BackgroundTransparent or
+            LingoInkType.Reverse or
+            LingoInkType.NotCopy or
+            LingoInkType.NotReverse or
+            LingoInkType.Ghost or
+            LingoInkType.NotGhost or
+            LingoInkType.Mask or
+            LingoInkType.NotTransparent or
+            LingoInkType.Matte => true,
+            _ => false,
+        };
+        /// <summary>
+        /// Applies the given ink effect to an RGBA pixel buffer and returns a new array.
+        /// Handles ink types that do not require knowledge of the destination
+        /// buffer, allowing preprocessing of the bitmap.
+        /// </summary>
+        /// <param name="rgba">Source pixels in RGBA8888 format.</param>
+        /// <param name="ink">Ink type to apply.</param>
+        /// <param name="transparentColor">Stage background color used for <c>BackgroundTransparent</c>.</param>
+        public static byte[] Apply(ReadOnlySpan<byte> rgba, LingoInkType ink, LingoColor transparentColor)
+        {
+            byte[] result = rgba.ToArray();
+
+            switch (ink)
+            {
+                case LingoInkType.BackgroundTransparent:
+                case LingoInkType.Matte:
+                    for (int i = 0; i < result.Length; i += 4)
+                    {
+                        if (result[i] == transparentColor.R &&
+                            result[i + 1] == transparentColor.G &&
+                            result[i + 2] == transparentColor.B)
+                        {
+                            result[i + 3] = 0;
+                        }
+                    }
+                    break;
+                case LingoInkType.Blend:
+                    for (int i = 0; i < result.Length; i += 4)
+                    {
+                        byte a = result[i + 3];
+                        result[i] = (byte)(result[i] * a / 255);
+                        result[i + 1] = (byte)(result[i + 1] * a / 255);
+                        result[i + 2] = (byte)(result[i + 2] * a / 255);
+                    }
+                    break;
+                case LingoInkType.Reverse:
+                case LingoInkType.NotCopy:
+                case LingoInkType.NotReverse:
+                    for (int i = 0; i < result.Length; i += 4)
+                    {
+                        result[i] = (byte)(255 - result[i]);
+                        result[i + 1] = (byte)(255 - result[i + 1]);
+                        result[i + 2] = (byte)(255 - result[i + 2]);
+                    }
+                    break;
+                case LingoInkType.Ghost:
+                case LingoInkType.NotGhost:
+                    for (int i = 0; i < result.Length; i += 4)
+                    {
+                        result[i + 3] = (byte)(result[i + 3] / 2);
+                    }
+                    break;
+                case LingoInkType.Mask:
+                    for (int i = 0; i < result.Length; i += 4)
+                    {
+                        result[i] = (byte)(255 - result[i]);
+                        result[i + 1] = (byte)(255 - result[i + 1]);
+                        result[i + 2] = (byte)(255 - result[i + 2]);
+                        result[i + 3] = (byte)(result[i + 3] / 2);
+                    }
+                    break;
+                case LingoInkType.NotTransparent:
+                    for (int i = 0; i < result.Length; i += 4)
+                    {
+                        result[i + 3] = 255;
+                    }
+                    break;
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- prerender simple ink modes into pixel buffers
- preprocess bitmap members in SDL and Godot sprite implementations
- avoid shader for simple inks
- add helper method to detect prerenderable inks

## Testing
- `dotnet build LingoEngine.sln -v minimal` *(fails: command not found)*
- `dotnet test LingoEngine.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688afbd1e0f0833296a88bf1a2ebb37a