### PR TITLE
Save film loops in JSON state

### DIFF
--- a/src/LingoEngine.IO.Data/DTO/LingoFilmLoopDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoFilmLoopDTO.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace LingoEngine.IO.Data.DTO;
+
+public class LingoFilmLoopDTO
+{
+    public int FrameCount { get; set; }
+    public List<LingoFilmLoopSpriteEntryDTO> SpriteEntries { get; set; } = new();
+    public List<LingoFilmLoopSoundEntryDTO> SoundEntries { get; set; } = new();
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoFilmLoopFramingDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoFilmLoopFramingDTO.cs
@@ -1,0 +1,8 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public enum LingoFilmLoopFramingDTO
+{
+    Crop,
+    Scale,
+    Auto
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoFilmLoopSoundEntryDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoFilmLoopSoundEntryDTO.cs
@@ -1,0 +1,8 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public class LingoFilmLoopSoundEntryDTO
+{
+    public int Channel { get; set; }
+    public int StartFrame { get; set; }
+    public int SoundMemberNum { get; set; }
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoFilmLoopSpriteEntryDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoFilmLoopSpriteEntryDTO.cs
@@ -1,0 +1,9 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public class LingoFilmLoopSpriteEntryDTO
+{
+    public int Channel { get; set; }
+    public int BeginFrame { get; set; }
+    public int EndFrame { get; set; }
+    public LingoSpriteDTO Sprite { get; set; } = new();
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoMemberFilmLoopDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoMemberFilmLoopDTO.cs
@@ -1,0 +1,8 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public class LingoMemberFilmLoopDTO : LingoMemberDTO
+{
+    public LingoFilmLoopFramingDTO Framing { get; set; }
+    public bool Loop { get; set; }
+    public LingoFilmLoopDTO FilmLoop { get; set; } = new();
+}


### PR DESCRIPTION
## Summary
- add DTOs representing film loop data
- preserve film loop members and timelines when saving and loading movies

## Testing
- `dotnet test` *(fails: ProjectorRays.DotNet.Test.DirectorFileTests.CanDumpScriptText)*
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689018e7ead4833289491517facc367e