### PR TITLE
Add advanced tempo sprite wait options

### DIFF
--- a/src/LingoEngine/Movies/ILingoMovie.cs
+++ b/src/LingoEngine/Movies/ILingoMovie.cs
@@ -135,6 +135,21 @@ namespace LingoEngine.Movies
         void Delay(int ticks);
 
         /// <summary>
+        /// Pause playback until either a mouse button is clicked or a key is pressed.
+        /// </summary>
+        void WaitForInput();
+
+        /// <summary>
+        /// Resumes playback after <see cref="WaitForInput"/> was called.
+        /// </summary>
+        void ContinueAfterInput();
+
+        /// <summary>
+        /// Pause playback until the specified cue point on a sound or video channel is reached.
+        /// </summary>
+        void WaitForCuePoint(int channel, int point);
+
+        /// <summary>
         /// Sends the playhead to the next marker in the movie.
         /// Lingo: goNext
         /// </summary>

--- a/src/LingoEngine/Movies/LingoMovie.cs
+++ b/src/LingoEngine/Movies/LingoMovie.cs
@@ -224,6 +224,9 @@ namespace LingoEngine.Movies
         {
             if (_isPlaying)
             {
+                if (_waitingForInput || _waitingForCuePoint)
+                    return;
+
                 if (_delayTicks > 0)
                 {
                     _delayTicks--;
@@ -332,10 +335,37 @@ namespace LingoEngine.Movies
         }
 
         private int _delayTicks;
+        private bool _waitingForInput;
+        private bool _waitingForCuePoint;
+        private int _waitCueChannel;
+        private int _waitCuePoint;
         public void Delay(int ticks)
         {
             if (ticks <= 0) return;
             _delayTicks += ticks;
+        }
+
+        public void WaitForInput()
+        {
+            _waitingForInput = true;
+        }
+
+        public void ContinueAfterInput()
+        {
+            _waitingForInput = false;
+        }
+
+        public void WaitForCuePoint(int channel, int point)
+        {
+            _waitingForCuePoint = true;
+            _waitCueChannel = channel;
+            _waitCuePoint = point;
+        }
+
+        public void CuePointReached(int channel, int point)
+        {
+            if (_waitingForCuePoint && channel == _waitCueChannel && point == _waitCuePoint)
+                _waitingForCuePoint = false;
         }
 
         public void GoNext()

--- a/src/LingoEngine/Tempos/LingoTempoSprite.cs
+++ b/src/LingoEngine/Tempos/LingoTempoSprite.cs
@@ -1,7 +1,17 @@
-﻿using LingoEngine.Movies;
+using LingoEngine.Movies;
 using LingoEngine.Sprites;
+using LingoEngine.Inputs.Events;
+using LingoEngine.Inputs;
 
 namespace LingoEngine.Tempos;
+
+public enum LingoTempoSpriteAction
+{
+    ChangeTempo,
+    WaitSeconds,
+    WaitForUserInput,
+    WaitForCuePoint
+}
 
 public class LingoTempoSprite : LingoSprite
 {
@@ -9,6 +19,13 @@ public class LingoTempoSprite : LingoSprite
     private int _tempo = 30;
 
     public int Frame { get; set; }
+
+    /// <summary>
+    /// Determines which action this tempo sprite performs.
+    /// Only one action can be active at a time.
+    /// </summary>
+    public LingoTempoSpriteAction Action { get; set; }
+
     public int Tempo
     {
         get => _tempo; set
@@ -17,20 +34,75 @@ public class LingoTempoSprite : LingoSprite
             Name = _tempo + "fps";
         }
     }
+
+    /// <summary>
+    /// Number of seconds to wait when <see cref="Action"/> is <see cref="LingoTempoSpriteAction.WaitSeconds"/>.
+    /// </summary>
+    public float WaitSeconds { get; set; }
+
+    /// <summary>
+    /// Cue channel to wait on when <see cref="Action"/> is <see cref="LingoTempoSpriteAction.WaitForCuePoint"/>.
+    /// </summary>
+    public int CueChannel { get; set; }
+
+    /// <summary>
+    /// Cue point to wait for when <see cref="Action"/> is <see cref="LingoTempoSpriteAction.WaitForCuePoint"/>.
+    /// </summary>
+    public int CuePoint { get; set; }
+
+    private class WaitForInputSubscription : IHasMouseDownEvent, IHasKeyDownEvent
+    {
+        private readonly LingoTempoSprite _owner;
+        public WaitForInputSubscription(LingoTempoSprite owner) => _owner = owner;
+        public void MouseDown(LingoMouseEvent mouse) => _owner.Resume();
+        public void KeyDown(ILingoKey key) => _owner.Resume();
+    }
+
+    private WaitForInputSubscription? _waitForInputSubscription;
     public LingoTempoSprite(ILingoMovieEnvironment environment, Action<LingoTempoSprite> removeMe) : base(environment)
     {
         _removeMe = removeMe;
         IsSingleFrame = true;
+        Action = LingoTempoSpriteAction.ChangeTempo;
     }
 
     protected override void BeginSprite()
     {
         base.BeginSprite();
-        _environment.Movie.Tempos.ChangeTempo(this);
+        switch (Action)
+        {
+            case LingoTempoSpriteAction.ChangeTempo:
+                _environment.Movie.Tempos.ChangeTempo(this);
+                break;
+            case LingoTempoSpriteAction.WaitSeconds:
+                var ticks = (int)(_environment.Clock.FrameRate * WaitSeconds);
+                _environment.Movie.Delay(ticks);
+                break;
+            case LingoTempoSpriteAction.WaitForUserInput:
+                _environment.Movie.WaitForInput();
+                _waitForInputSubscription = new WaitForInputSubscription(this);
+                _eventMediator.Subscribe(_waitForInputSubscription, SpriteNum + 6);
+                break;
+            case LingoTempoSpriteAction.WaitForCuePoint:
+                _environment.Movie.WaitForCuePoint(CueChannel, CuePoint);
+                break;
+        }
+    }
+
+    protected override void EndSprite()
+    {
+        if (_waitForInputSubscription != null)
+        {
+            _eventMediator.Unsubscribe(_waitForInputSubscription);
+            _waitForInputSubscription = null;
+        }
+        base.EndSprite();
     }
 
     public override void RemoveMe()
     {
         _removeMe(this);
     }
+
+    private void Resume() => _environment.Movie.ContinueAfterInput();
 }


### PR DESCRIPTION
## Summary
- extend `LingoTempoSprite` with modes for changing tempo, waiting for time, user input or media cue
- expose wait helpers on `ILingoMovie`/`LingoMovie`
- halt frame advancement while waiting

## Testing
- `dotnet test` *(fails: 6 failed, 29 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68901b7ad02c8332ab7702c141b5d7bd