### PR TITLE
feat: add dialog support to window manager

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Windowing/DirectorWindowManager.cs
+++ b/src/Director/LingoEngine.Director.Core/Windowing/DirectorWindowManager.cs
@@ -2,6 +2,7 @@
 using LingoEngine.Director.Core.Tools;
 using LingoEngine.Director.Core.Tools.Commands;
 using LingoEngine.Director.Core.Windowing.Commands;
+using LingoEngine.Gfx;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LingoEngine.Director.Core.Windowing
@@ -9,6 +10,9 @@ namespace LingoEngine.Director.Core.Windowing
     public interface IDirFrameworkWindowManager
     {
         void SetActiveWindow(IDirectorWindowRegistration window);
+        void ShowConfirmDialog(string title, string message, Action<bool> onResult);
+        void ShowCustomDialog(string title, ILingoFrameworkGfxPanel panel);
+        void ShowNotification(string message);
     }
     public interface IDirectorWindowRegistration
     {
@@ -24,6 +28,9 @@ namespace LingoEngine.Director.Core.Windowing
         bool CloseWindow(string windowCode);
         void Init(IDirFrameworkWindowManager frameworkWindowManager);
         void SetActiveWindow(string windowCode);
+        void ShowConfirmDialog(string title, string message, Action<bool> onResult);
+        void ShowCustomDialog(string title, ILingoFrameworkGfxPanel panel);
+        void ShowNotification(string message);
     }
     public class DirectorWindowManager : IDirectorWindowManager,
         ICommandHandler<OpenWindowCommand>,
@@ -88,6 +95,15 @@ namespace LingoEngine.Director.Core.Windowing
             _ActiveWindow = window;
             _frameworkWindowManager.SetActiveWindow(registration);
         }
+
+        public void ShowConfirmDialog(string title, string message, Action<bool> onResult)
+            => _frameworkWindowManager.ShowConfirmDialog(title, message, onResult);
+
+        public void ShowCustomDialog(string title, ILingoFrameworkGfxPanel panel)
+            => _frameworkWindowManager.ShowCustomDialog(title, panel);
+
+        public void ShowNotification(string message)
+            => _frameworkWindowManager.ShowNotification(message);
 
 
         public bool OpenWindow(string windowCode)

--- a/src/Director/LingoEngine.Director.LGodot/Windowing/GodotWindowManager.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Windowing/GodotWindowManager.cs
@@ -1,4 +1,6 @@
+using Godot;
 using LingoEngine.Director.Core.Windowing;
+using LingoEngine.Gfx;
 
 namespace LingoEngine.Director.LGodot.Windowing;
 
@@ -43,6 +45,74 @@ internal class DirGodotWindowManager : IDirGodotWindowManager
     {
         var window = _godotWindows[windowRegistration.WindowCode];
         SetTheActiveWindow(window);
+    }
+
+    public void ShowConfirmDialog(string title, string message, Action<bool> onResult)
+    {
+        var root = ActiveWindow?.GetTree().Root;
+        if (root == null)
+            return;
+
+        var dialog = new ConfirmationDialog
+        {
+            Title = title,
+            DialogText = message
+        };
+
+        dialog.Confirmed += () => { onResult(true); dialog.QueueFree(); };
+        dialog.Canceled += () => { onResult(false); dialog.QueueFree(); };
+
+        root.AddChild(dialog);
+        dialog.PopupCentered();
+    }
+
+    public void ShowCustomDialog(string title, ILingoFrameworkGfxPanel panel)
+    {
+        var root = ActiveWindow?.GetTree().Root;
+        if (root == null)
+            return;
+
+        if (panel is not Node node)
+            throw new ArgumentException("Panel must be a Godot node", nameof(panel));
+
+        var dialog = new AcceptDialog
+        {
+            Title = title
+        };
+        dialog.GetOkButton().Text = "Close";
+        dialog.Confirmed += () => dialog.QueueFree();
+        dialog.Canceled += () => dialog.QueueFree();
+
+        dialog.AddChild(node);
+
+        root.AddChild(dialog);
+        dialog.PopupCentered();
+    }
+
+    public void ShowNotification(string message)
+    {
+        var root = ActiveWindow?.GetTree().Root;
+        if (root == null)
+            return;
+
+        var panel = new Panel
+        {
+            CustomMinimumSize = new Vector2(200, 40)
+        };
+        var style = new StyleBoxFlat { BgColor = new Color(1f, 1f, 0.8f) };
+        panel.AddThemeStyleboxOverride("panel", style);
+
+        var label = new Label { Text = message };
+        label.Position = new Vector2(5, 5);
+        panel.AddChild(label);
+
+        root.AddChild(panel);
+        panel.Position = new Vector2(root.Size.X - panel.CustomMinimumSize.X - 10, 10);
+
+        var timer = new Timer { WaitTime = 5, OneShot = true };
+        timer.Timeout += () => panel.QueueFree();
+        panel.AddChild(timer);
+        timer.Start();
     }
 
     private void SetTheActiveWindow(BaseGodotWindow window)


### PR DESCRIPTION
## Summary
- add dialog methods to window manager interfaces
- implement confirm, custom, and notification dialogs for Godot

## Testing
- `dotnet build LingoEngine.sln` *(fails: LingoMouseEvent type not found)*

------
https://chatgpt.com/codex/tasks/task_e_68903dc4457c83329e70fb7c760712f9