### PR TITLE
Highlight active window title bar

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Styles/DirectorColors.cs
+++ b/src/Director/LingoEngine.Director.Core/Styles/DirectorColors.cs
@@ -10,8 +10,10 @@ namespace LingoEngine.Director.Core.Styles
         public static LingoColor BG_WhiteMenus = new LingoColor(240, 240, 240);       // Common window background
 
         // Windows
-        public static LingoColor Window_Title_Line_Under = new LingoColor(178, 180, 191); // THe line just beneath the title of the window 
-        public static LingoColor Window_Title_BG = LingoColor.FromHex("#d2e0ed"); // THe line just beneath the title of the window 
+        public static LingoColor Window_Title_Line_Under = new LingoColor(178, 180, 191); // The line just beneath the title of the window
+        public static LingoColor Window_Title_BG = LingoColor.FromHex("#d2e0ed"); // Base color of the window title bar
+        public static LingoColor Window_Title_BG_Active = Window_Title_BG.Darken(0.2f); // Darker when window is active
+        public static LingoColor Window_Title_BG_Inactive = Window_Title_BG.Lighten(0.2f); // Lighter when window is inactive
 
 
         // Thumbnail of a member

--- a/src/Director/LingoEngine.Director.LGodot/Windowing/BaseGodotWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Windowing/BaseGodotWindow.cs
@@ -79,7 +79,8 @@ namespace LingoEngine.Director.LGodot
 
         public override void _Draw()
         {
-            DrawRect(new Rect2(0, 0, Size.X, TitleBarHeight), DirectorColors.Window_Title_BG.ToGodotColor());
+            var titleColor = IsActiveWindow ? DirectorColors.Window_Title_BG_Active : DirectorColors.Window_Title_BG_Inactive;
+            DrawRect(new Rect2(0, 0, Size.X, TitleBarHeight), titleColor.ToGodotColor());
             DrawLine(new Vector2(0, TitleBarHeight), new Vector2(Size.X, TitleBarHeight), DirectorColors.Window_Title_Line_Under.ToGodotColor());
             _closeButton.Position = new Vector2(Size.X - 18, 1);
             // draw resize handle

--- a/src/Director/LingoEngine.Director.LGodot/Windowing/GodotWindowManager.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Windowing/GodotWindowManager.cs
@@ -118,12 +118,16 @@ internal class DirGodotWindowManager : IDirGodotWindowManager
     private void SetTheActiveWindow(BaseGodotWindow window)
     {
         if (ActiveWindow != null)
+        {
             ActiveWindow.ZIndex = ZIndexInactiveWindow;
+            ActiveWindow.QueueRedraw();
+        }
         ActiveWindow = window;
         ActiveWindow.ZIndex = 0;
         var parent = window.GetParent();
         if (parent != null)
             parent.MoveChild(window, parent.GetChildCount() - 1);
         window.GrabFocus();
+        window.QueueRedraw();
     }
 }


### PR DESCRIPTION
## Summary
- darken window title bar for the active window and lighten for inactive windows
- refresh windows when switching active window

## Testing
- `dotnet test` *(fails: Could not find file '/workspace/LingoEngine/WillMoveToOwnRepo/ProjectorRays/Test/TestData/TextCast.cst')*


------
https://chatgpt.com/codex/tasks/task_e_68907a23577c83328bee4afbce82cf98