### PR TITLE
refactor: move score labels bar to core

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Scores/DirScoreLabelsBar.cs
+++ b/src/Director/LingoEngine.Director.Core/Scores/DirScoreLabelsBar.cs
@@ -1,0 +1,191 @@
+using LingoEngine.Commands;
+using LingoEngine.Movies;
+using LingoEngine.Movies.Commands;
+using LingoEngine.Primitives;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Inputs;
+using LingoEngine.Gfx;
+using LingoEngine.Events;
+
+namespace LingoEngine.Director.Core.Scores;
+
+public class DirScoreLabelsBar : IDisposable
+{
+    private readonly DirScoreGfxValues _gfxValues;
+    private readonly ILingoCommandManager _commandManager;
+    private readonly ILingoMouse _mouse;
+    private readonly LingoGfxCanvas _canvas;
+    private readonly LingoGfxInputText _editField;
+    private readonly ILingoMouseSubscription _mouseDownSub;
+    private readonly ILingoMouseSubscription _mouseUpSub;
+    private readonly ILingoMouseSubscription _mouseMoveSub;
+    private LingoMovie? _movie;
+    private LingoPoint _position;
+    private string? _activeLabel;
+    private int _activeFrame;
+    private int _startFrame;
+    private bool _dragging;
+    private bool _headerCollapsed;
+
+    public event Action<bool>? HeaderCollapseChanged;
+    public Action? RequestRedraw;
+
+    public DirScoreLabelsBar(DirScoreGfxValues gfxValues, ILingoFrameworkFactory factory, ILingoMouse mouse, ILingoCommandManager commandManager, LingoPoint position)
+    {
+        _gfxValues = gfxValues;
+        _commandManager = commandManager;
+        _mouse = mouse;
+        _position = position;
+        _canvas = factory.CreateGfxCanvas("ScoreLabelsBar", 0, _gfxValues.LabelsBarHeight);
+        _editField = factory.CreateInputText("ScoreLabelsEdit", onChange: _ => CommitEdit());
+        _editField.Visibility = false;
+        _editField.Width = 120;
+        _editField.Height = 16;
+        _mouseDownSub = _mouse.OnMouseDown(OnMouseDown);
+        _mouseUpSub = _mouse.OnMouseUp(OnMouseUp);
+        _mouseMoveSub = _mouse.OnMouseMove(OnMouseMove);
+    }
+
+    public bool HeaderCollapsed
+    {
+        get => _headerCollapsed;
+        set
+        {
+            _headerCollapsed = value;
+            RequestRedraw?.Invoke();
+        }
+    }
+
+    public float Width => _canvas.Width;
+    public float Height => _canvas.Height;
+    public LingoGfxCanvas Canvas => _canvas;
+    public LingoGfxInputText EditField => _editField;
+
+    public void Dispose()
+    {
+        _mouseDownSub.Release();
+        _mouseUpSub.Release();
+        _mouseMoveSub.Release();
+        _canvas.Dispose();
+        _editField.Dispose();
+    }
+
+    public void ToggleCollapsed()
+    {
+        HeaderCollapsed = !HeaderCollapsed;
+        HeaderCollapseChanged?.Invoke(HeaderCollapsed);
+    }
+
+    public void SetMovie(LingoMovie? movie)
+    {
+        _movie = movie;
+        _canvas.Width = _gfxValues.LeftMargin + (_movie?.FrameCount ?? 0) * _gfxValues.FrameWidth;
+        _canvas.Height = _gfxValues.LabelsBarHeight;
+        _editField.Visibility = false;
+        RequestRedraw?.Invoke();
+    }
+
+    public void UpdatePosition(LingoPoint position) => _position = position;
+
+    public void Draw()
+    {
+        if (_movie == null) return;
+        _canvas.Clear(LingoColorList.White);
+        foreach (var kv in _movie.GetScoreLabels())
+        {
+            float x = _gfxValues.LeftMargin + (kv.Value - 1) * _gfxValues.FrameWidth;
+            var pts = new[]
+            {
+                new LingoPoint(x,5),
+                new LingoPoint(x+10,5),
+                new LingoPoint(x+5,15)
+            };
+            _canvas.DrawPolygon(pts, LingoColorList.Black);
+            _canvas.DrawText(new LingoPoint(x+12,10), kv.Key, null, LingoColorList.Black, 10);
+        }
+    }
+
+    private bool InBar(float mouseH, float mouseV)
+    {
+        return mouseH >= _position.X && mouseH <= _position.X + Width &&
+               mouseV >= _position.Y && mouseV <= _position.Y + Height;
+    }
+
+    private void OnMouseDown(LingoMouseEvent e)
+    {
+        if (_movie == null) return;
+        if (!InBar(e.MouseH, e.MouseV)) return;
+        if (!e.Mouse.LeftMouseDown) return;
+        float localX = e.MouseH - _position.X;
+        if (localX > Width - 20)
+        {
+            ToggleCollapsed();
+            return;
+        }
+        foreach (var kv in _movie.GetScoreLabels())
+        {
+            float x = _gfxValues.LeftMargin + (kv.Value - 1) * _gfxValues.FrameWidth;
+            float width = EstimateLabelWidth(kv.Key) + 20;
+            if (localX >= x && localX <= x + width)
+            {
+                _activeLabel = kv.Key;
+                _activeFrame = kv.Value;
+                _startFrame = kv.Value;
+                _editField.Text = kv.Key;
+                if (e.Mouse.DoubleClick)
+                {
+                    _dragging = false;
+                    UpdateEditFieldPosition();
+                    _editField.Visibility = true;
+                }
+                else
+                {
+                    _dragging = true;
+                }
+                break;
+            }
+        }
+    }
+
+    private void OnMouseUp(LingoMouseEvent e)
+    {
+        if (_dragging)
+        {
+            CommitEdit();
+            _dragging = false;
+        }
+    }
+
+    private void OnMouseMove(LingoMouseEvent e)
+    {
+        if (_movie == null || !_dragging) return;
+        float localX = e.MouseH - _position.X;
+        float frameF = (localX - _gfxValues.LeftMargin) / _gfxValues.FrameWidth;
+        int frame = LingoMath.Clamp(LingoMath.RoundToInt(frameF) + 1, 1, _movie.FrameCount);
+        if (frame != _activeFrame)
+        {
+            _activeFrame = frame;
+            UpdateEditFieldPosition();
+            RequestRedraw?.Invoke();
+        }
+    }
+
+    private void UpdateEditFieldPosition()
+    {
+        float x = _gfxValues.LeftMargin + (_activeFrame - 1) * _gfxValues.FrameWidth + 12;
+        _editField.X = x;
+        _editField.Y = 2;
+    }
+
+    private void CommitEdit()
+    {
+        if (_activeLabel == null || _movie == null) return;
+        if (_activeFrame != _startFrame || _editField.Text != _activeLabel)
+            _commandManager.Handle(new UpdateFrameLabelCommand(_startFrame, _activeFrame, _editField.Text));
+        _activeLabel = null;
+        _editField.Visibility = false;
+        RequestRedraw?.Invoke();
+    }
+
+    private float EstimateLabelWidth(string text) => text.Length * 8;
+}

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreLabelsBar.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreLabelsBar.cs
@@ -1,149 +1,63 @@
-﻿using Godot;
-using LingoEngine.Movies;
+using Godot;
 using LingoEngine.Commands;
-using LingoEngine.Movies.Commands;
 using LingoEngine.Director.Core.Scores;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Inputs;
+using LingoEngine.Movies;
+using LingoEngine.LGodot.Primitives;
 using LingoEngine.Director.LGodot.Styles;
+using LingoEngine.Primitives;
 
 namespace LingoEngine.Director.LGodot.Scores;
 
 internal partial class DirGodotScoreLabelsBar : Control
 {
-    private LingoMovie? _movie;
+    private readonly DirScoreLabelsBar _labelsBar;
 
-    private readonly DirScoreGfxValues _gfxValues;
-    private readonly ILingoCommandManager _commandManager;
-    private readonly LineEdit _editField = new();
-    private string? _activeLabel;
-    private int _activeFrame;
-    private int _startFrame;
-    private bool _dragging;
-    private bool _headerCollapsed;
-
-    public event Action<bool>? HeaderCollapseChanged;
-
-    // todo : move all code to reusable Director layer
-    public DirGodotScoreLabelsBar(DirScoreGfxValues gfxValues, ILingoCommandManager commandManager, DirectorGodotStyle godotStyle)
+    public DirGodotScoreLabelsBar(DirScoreGfxValues gfxValues, ILingoCommandManager commandManager, DirectorGodotStyle godotStyle, ILingoFrameworkFactory factory, ILingoMouse mouse)
     {
-        _gfxValues = gfxValues;
-        _commandManager = commandManager;
-        AddChild(_editField);
-        _editField.Visible = false;
-        _editField.Size = new Vector2(120, 16);
-        _editField.TextSubmitted += _ => CommitEdit();
-        _editField.Theme = godotStyle.GetLineEditTheme();
+        _labelsBar = new DirScoreLabelsBar(gfxValues, factory, mouse, commandManager, new LingoPoint(0, 0));
+        _labelsBar.RequestRedraw = () => QueueRedraw();
+        AddChild((Node)_labelsBar.Canvas.FrameworkObj.FrameworkNode);
+        var editNode = (Node)_labelsBar.EditField.FrameworkObj.FrameworkNode;
+        AddChild(editNode);
+        if (editNode is LineEdit le)
+            le.Theme = godotStyle.GetLineEditTheme();
+        MouseFilter = MouseFilterEnum.Ignore;
     }
 
     public bool HeaderCollapsed
     {
-        get => _headerCollapsed;
-        set
-        {
-            _headerCollapsed = value;
-            QueueRedraw();
-        }
+        get => _labelsBar.HeaderCollapsed;
+        set => _labelsBar.HeaderCollapsed = value;
     }
 
-    public void ToggleCollapsed()
+    public event Action<bool>? HeaderCollapseChanged
     {
-        HeaderCollapsed = !HeaderCollapsed;
-        HeaderCollapseChanged?.Invoke(HeaderCollapsed);
+        add => _labelsBar.HeaderCollapseChanged += value;
+        remove => _labelsBar.HeaderCollapseChanged -= value;
     }
 
-    public void SetMovie(LingoMovie? movie)
+    public void ToggleCollapsed() => _labelsBar.ToggleCollapsed();
+
+    public void SetMovie(LingoMovie? movie) => _labelsBar.SetMovie(movie);
+
+    internal void UpdatePosition(Vector2 position)
     {
-        _movie = movie;
-        Size = new Vector2(_gfxValues.LeftMargin + (_movie?.FrameCount ?? 0) * _gfxValues.FrameWidth, _gfxValues.LabelsBarHeight);
-        _editField.Visible = false;
+        _labelsBar.UpdatePosition(position.ToLingoPoint());
     }
 
     public override void _Draw()
     {
-        if (_movie == null) return;
-        int frameCount = _movie.FrameCount;
-        var font = ThemeDB.FallbackFont;
-        Size = new Vector2(_gfxValues.LeftMargin + (frameCount) * _gfxValues.FrameWidth, _gfxValues.LabelsBarHeight);
-        DrawRect(new Rect2(0, 0, Size.X, _gfxValues.LabelsBarHeight), Colors.White);
-        foreach (var kv in _movie.GetScoreLabels())
-        {
-            float x = _gfxValues.LeftMargin + (kv.Value - 1) * _gfxValues.FrameWidth;
-            Vector2[] pts = { new Vector2(x, 5), new Vector2(x + 10, 5), new Vector2(x + 5, 15) };
-            DrawPolygon(pts, new[] { Colors.Black });
-            DrawString(font, new Vector2(x + 12, font.GetAscent() - 5), kv.Key,
-                HorizontalAlignment.Left, -1, 10, Colors.Black);
-        }
-        
+        _labelsBar.Draw();
+        Size = new Vector2(_labelsBar.Width, _labelsBar.Height);
+        CustomMinimumSize = Size;
     }
 
-    public override void _GuiInput(InputEvent @event)
+    protected override void Dispose(bool disposing)
     {
-        if (_movie == null) return;
-
-        if (@event is InputEventMouseButton mb && mb.ButtonIndex == MouseButton.Left)
-        {
-            if (mb.Pressed)
-            {
-                if (mb.Position.X > Size.X - 20)
-                {
-                    ToggleCollapsed();
-                    return;
-                }
-                Vector2 pos = GetLocalMousePosition();
-                foreach (var kv in _movie.GetScoreLabels())
-                {
-                    var font = ThemeDB.FallbackFont;
-                    float x = _gfxValues.LeftMargin + (kv.Value - 1) * _gfxValues.FrameWidth;
-                    float width = font.GetStringSize(kv.Key).X + 20;
-                    if (pos.X >= x && pos.X <= x + width)
-                    {
-                        _activeLabel = kv.Key;
-                        _activeFrame = kv.Value;
-                        _startFrame = kv.Value;
-                        _editField.Text = kv.Key;
-                        if (mb.DoubleClick)
-                        {
-                            // Open the edit field on double click
-                            _dragging = false;
-                            UpdateEditFieldPosition();
-                            _editField.Visible = true;
-                            _editField.GrabFocus();
-                        }
-                        else
-                        {
-                            // Start dragging to reposition the label
-                            _dragging = true;
-                        }
-                        break;
-                    }
-                }
-            }
-            else if (_dragging)
-            {
-                CommitEdit();
-                _dragging = false;
-            }
-        }
-        else if (@event is InputEventMouseMotion && _dragging)
-        {
-            float frameF = (GetLocalMousePosition().X - _gfxValues.LeftMargin) / _gfxValues.FrameWidth;
-            _activeFrame = Math.Clamp(Mathf.RoundToInt(frameF) + 1, 1, _movie.FrameCount);
-            UpdateEditFieldPosition();
-        }
-    }
-
-    private void UpdateEditFieldPosition()
-    {
-        float x = _gfxValues.LeftMargin + (_activeFrame - 1) * _gfxValues.FrameWidth + 12;
-        _editField.Position = new Vector2(x, 2);
-    }
-
-    private void CommitEdit()
-    {
-        if (_activeLabel == null || _movie == null) return;
-        if (_activeFrame != _startFrame || _editField.Text != _activeLabel)
-            _commandManager.Handle(new UpdateFrameLabelCommand(_startFrame, _activeFrame, _editField.Text));
-        _activeLabel = null;
-        _editField.Visible = false;
-        QueueRedraw();
+        if (disposing)
+            _labelsBar.Dispose();
+        base.Dispose(disposing);
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -75,7 +75,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         _LeftTopContainer = new DirGodotScoreLeftTopContainer(_gfxValues, _player.Factory, Mouse,new Vector2(0, _gfxValues.ChannelHeight + 5),_mediator);
         _LeftChannelsContainer = new DirGodotScoreLeftChannelsContainer(_gfxValues,_player.Factory,Mouse, new Vector2(0, _gfxValues.TopStripHeight - _footerMargin), _mediator);
         _framesHeader = new DirGodotFrameHeader(_gfxValues);
-        _labelBar = new DirGodotScoreLabelsBar(_gfxValues, commandManager, godotStyle);
+        _labelBar = new DirGodotScoreLabelsBar(_gfxValues, commandManager, godotStyle, _player.Factory, Mouse);
         _labelBar.HeaderCollapseChanged += OnHeaderCollapseChanged;
 
         _collapseButton = new CollapseButton(_labelBar);
@@ -112,6 +112,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         _marginContainer.AddChild(_LeftTopContainer);
         _topStripContent.AddChild(_labelBar);
         _topStripContent.AddChild(_framesHeader);
+        _labelBar.UpdatePosition(new Vector2(_gfxValues.ChannelInfoWidth, 0));
 
 
 
@@ -156,6 +157,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         _leftHeaderForFrames.Position = new Vector2(0, _framesHeader.Position.Y);
         _lastPosV = -1;
         UpdateScrollSize();
+        _labelBar.UpdatePosition(new Vector2(_gfxValues.ChannelInfoWidth - _masterScroller.ScrollHorizontal, 0));
     }
 
     private float _lastPosV = -1;
@@ -201,6 +203,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         _topStripContent.Position = new Vector2(-_masterScroller.ScrollHorizontal, _topStripContent.Position.Y);
         if (_TopContainer.ScrollX != _masterScroller.ScrollHorizontal)
             _TopContainer.ScrollX = _masterScroller.ScrollHorizontal;
+        _labelBar.UpdatePosition(new Vector2(_gfxValues.ChannelInfoWidth - _masterScroller.ScrollHorizontal, 0));
     }
 
     private void RefreshGrid()


### PR DESCRIPTION
## Summary
- move score labels bar logic to reusable Director.Core layer
- wrap new core implementation for Godot and update window wiring
- fix label bar positioning by updating from window scroll instead of per-frame processing

## Testing
- `dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj`
- `dotnet build src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6892d53de2508332b8a4b9e4057a3800