### PR TITLE
Implement cast drag-and-drop with hover feedback

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Casts/DirCastItem.cs
+++ b/src/Director/LingoEngine.Director.Core/Casts/DirCastItem.cs
@@ -20,6 +20,7 @@ public class DirCastItem
 
     private readonly ILingoMember _member;
     private bool _selected;
+    private bool _hovered;
     private readonly LingoGfxCanvas _canvas;
     private DirectorMemberThumbnail _thumb;
 
@@ -41,12 +42,27 @@ public class DirCastItem
         Draw();
     }
 
+    public void SetHovered(bool hovered)
+    {
+        _hovered = hovered;
+        Draw();
+    }
+
     private void Draw()
     {
         _canvas.Clear(LingoColorList.Transparent);
         // selection highlight
         if (_selected)
+        {
             _canvas.DrawRect(LingoRect.New(0, 0, Width, Height), DirectorColors.BlueSelectColor, true);
+        }
+        else if (_hovered)
+        {
+            _canvas.DrawLine(new LingoPoint(0, 0), new LingoPoint(Width, 0), LingoColorList.Black); // top
+            _canvas.DrawLine(new LingoPoint(0, 0), new LingoPoint(0, Height), LingoColorList.Black); // left
+            _canvas.DrawLine(new LingoPoint(0, Height), new LingoPoint(Width, Height), LingoColorList.Black); // bottom
+            _canvas.DrawLine(new LingoPoint(Width, 0), new LingoPoint(Width, Height), LingoColorList.Black); // right
+        }
         else
         {
             _canvas.DrawLine(new LingoPoint(0, 0), new LingoPoint(Width, 0), DirectorColors.LineDarker); // top

--- a/src/LingoEngine/Casts/ILingoCast.cs
+++ b/src/LingoEngine/Casts/ILingoCast.cs
@@ -55,5 +55,12 @@ namespace LingoEngine.Casts
         T Add<T>(int numberInCast, string name, Action<T>? configure = null) where T: ILingoMember;
 
         IEnumerable<ILingoMember> GetAll();
+
+        /// <summary>
+        /// Swap the positions of two cast members identified by their slot numbers.
+        /// </summary>
+        /// <param name="slot1">First slot number.</param>
+        /// <param name="slot2">Second slot number.</param>
+        void SwapMembers(int slot1, int slot2);
     }
 }

--- a/src/LingoEngine/Casts/LingoCast.cs
+++ b/src/LingoEngine/Casts/LingoCast.cs
@@ -135,5 +135,15 @@ namespace LingoEngine.Casts
             }
         }
         public IEnumerable<ILingoMember> GetAll() => _MembersContainer.All;
+
+        public void SwapMembers(int slot1, int slot2)
+        {
+            if (slot1 == slot2) return;
+
+            var tempSlot = _MembersContainer.FindEmpty();
+            _MembersContainer.ChangeNumber(slot1, tempSlot);
+            _MembersContainer.ChangeNumber(slot2, slot1);
+            _MembersContainer.ChangeNumber(tempSlot, slot2);
+        }
     }
 }

--- a/src/LingoEngine/Members/LingoMembersContainer.cs
+++ b/src/LingoEngine/Members/LingoMembersContainer.cs
@@ -69,6 +69,19 @@
                 _membersByName.Remove(name);
         }
 
+        internal void ChangeNumber(int oldNumber, int newNumber)
+        {
+            if (oldNumber == newNumber || containerForAll)
+                return;
+
+            if (_members.TryGetValue(oldNumber, out var member))
+            {
+                _members.Remove(oldNumber);
+                _members[newNumber] = member;
+                member.NumberInCast = newNumber;
+            }
+        }
+
         internal void MemberNameChanged(string oldName, LingoMember member)
         {
             oldName = oldName.ToLower();


### PR DESCRIPTION
## Summary
- allow swapping cast members by dragging between slots
- add hover state that renders a black border around cast items
- expose cast member swap API
- change member renumbering to avoid removals during swap

## Testing
- `dotnet test` *(fails: System.IO.FileNotFoundException: Could not find file '/workspace/LingoEngine/WillMoveToOwnRepo/ProjectorRays/Test/TestData/TextCast.cst')*

------
https://chatgpt.com/codex/tasks/task_e_689421b0140c83328ef991826c4e3672