### PR TITLE
feat: add reusable slider control

### DIFF
--- a/src/Director/LingoEngine.Director.Core/DirectorSetup.cs
+++ b/src/Director/LingoEngine.Director.Core/DirectorSetup.cs
@@ -56,6 +56,8 @@ namespace LingoEngine.Director.Core
                     .AddSingleton<DirectorTextEditWindow>()
                     .AddSingleton<DirectorBitmapEditWindow>()
                     .AddSingleton<DirectorImportExportWindow>()
+                    .AddSingleton<DirStageManager>()
+                    .AddTransient<IDirStageManager>(p => p.GetRequiredService<DirStageManager>())
                     .AddSingleton<DirScoreManager>()
                     .AddSingleton<DirSpritesManager>()
                     .AddTransient<IDirSpritesManager>(p => p.GetRequiredService<DirSpritesManager>())

--- a/src/Director/LingoEngine.Director.Core/Stages/Commands/StageChangeBackgroundColorCommand.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/Commands/StageChangeBackgroundColorCommand.cs
@@ -1,0 +1,6 @@
+using LingoEngine.Commands;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.Director.Core.Stages.Commands;
+
+public sealed record StageChangeBackgroundColorCommand(LingoColor OldColor, LingoColor NewColor) : ILingoCommand;

--- a/src/Director/LingoEngine.Director.Core/Stages/DirStageManager.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/DirStageManager.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LingoEngine.Director.Core.Sprites;
+using LingoEngine.Primitives;
+using LingoEngine.Sprites;
+using LingoEngine.Core;
+using LingoEngine.Director.Core.Stages.Commands;
+using LingoEngine.Commands;
+using LingoEngine.Director.Core.Tools;
+
+namespace LingoEngine.Director.Core.Stages;
+
+public interface IDirStageManager
+{
+    IReadOnlyList<LingoSprite2D> SelectedSprites { get; }
+    LingoSprite2D? PrimarySelectedSprite { get; }
+    event Action SelectionChanged;
+    event Action SpritesTransformed;
+    bool RecordKeyframes { get; set; }
+    void HandlePointerClick(LingoSprite2D? sprite, bool ctrlHeld);
+    void ClearSelection();
+    LingoPoint ComputeSelectionCenter();
+    LingoRect ComputeSelectionRect();
+    void BeginMove(LingoPoint start);
+    void UpdateMove(LingoPoint current);
+    void EndMove(LingoPoint end);
+    void BeginRotate(LingoPoint start);
+    void UpdateRotate(LingoPoint current);
+    void EndRotate(LingoPoint end);
+    void ChangeBackgroundColor(LingoColor color);
+}
+
+public class DirStageManager : IDirStageManager, IDisposable, ICommandHandler<StageChangeBackgroundColorCommand>
+{
+    private readonly IDirSpritesManager _spritesManager;
+    private readonly ILingoCommandManager _commandManager;
+    private readonly ILingoPlayer _player;
+    private readonly IHistoryManager _historyManager;
+    private readonly IDirectorEventMediator _mediator;
+    private readonly List<LingoSprite2D> _selected = new();
+    private LingoSprite2D? _primary;
+
+    private LingoPoint? _dragStart;
+    private Dictionary<LingoSprite2D, LingoPoint>? _initialPositions;
+    private Dictionary<LingoSprite2D, float>? _initialRotations;
+    private bool _rotating;
+
+    public DirStageManager(IDirSpritesManager spritesManager, ILingoCommandManager commandManager, ILingoPlayer player, IHistoryManager historyManager, IDirectorEventMediator mediator)
+    {
+        _spritesManager = spritesManager;
+        _commandManager = commandManager;
+        _player = player;
+        _historyManager = historyManager;
+        _mediator = mediator;
+        _spritesManager.SpritesSelection.SelectionChanged += SyncSelection;
+        SyncSelection();
+    }
+
+    public IReadOnlyList<LingoSprite2D> SelectedSprites => _selected;
+    public LingoSprite2D? PrimarySelectedSprite => _primary;
+
+    public event Action? SelectionChanged;
+    public event Action? SpritesTransformed;
+
+    private bool _recordKeyframes;
+    public bool RecordKeyframes
+    {
+        get => _recordKeyframes;
+        set => _recordKeyframes = value;
+    }
+
+    private void SyncSelection()
+    {
+        _selected.Clear();
+        foreach (var s in _spritesManager.SpritesSelection.Sprites.OfType<LingoSprite2D>())
+            _selected.Add(s);
+        if (_primary == null || !_selected.Contains(_primary))
+            _primary = _selected.FirstOrDefault();
+        SelectionChanged?.Invoke();
+    }
+
+    public void HandlePointerClick(LingoSprite2D? sprite, bool ctrlHeld)
+    {
+        if (sprite == null) return;
+        if (ctrlHeld)
+        {
+            if (_selected.Contains(sprite))
+                _spritesManager.DeselectSprite(sprite);
+            else
+                _spritesManager.SelectSprite(sprite);
+        }
+        else
+        {
+            _spritesManager.SpritesSelection.Clear();
+            _spritesManager.SelectSprite(sprite);
+        }
+    }
+
+    public void ClearSelection()
+    {
+        if (_selected.Count == 0) return;
+        _spritesManager.SpritesSelection.Clear();
+    }
+
+    public LingoPoint ComputeSelectionCenter()
+    {
+        if (_selected.Count == 0)
+            return new LingoPoint(0, 0);
+        float left = _selected.Min(s => s.Rect.Left);
+        float top = _selected.Min(s => s.Rect.Top);
+        float right = _selected.Max(s => s.Rect.Right);
+        float bottom = _selected.Max(s => s.Rect.Bottom);
+        return new LingoPoint((left + right) / 2f, (top + bottom) / 2f);
+    }
+
+    public LingoRect ComputeSelectionRect()
+    {
+        if (_selected.Count == 0)
+            return new LingoRect();
+        float left = _selected.Min(s => s.Rect.Left);
+        float top = _selected.Min(s => s.Rect.Top);
+        float right = _selected.Max(s => s.Rect.Right);
+        float bottom = _selected.Max(s => s.Rect.Bottom);
+        return new LingoRect(left, top, right, bottom);
+    }
+
+    public void BeginMove(LingoPoint start)
+    {
+        if (_selected.Count == 0) return;
+        _dragStart = start;
+        _initialPositions = _selected.ToDictionary(s => s, s => new LingoPoint(s.LocH, s.LocV));
+        if (RecordKeyframes && _player is LingoPlayer lp)
+            foreach (var s in _selected)
+                lp.Stage.AddKeyFrame(s);
+    }
+
+    public void UpdateMove(LingoPoint current)
+    {
+        if (_dragStart == null || _initialPositions == null) return;
+        float dx = current.X - _dragStart.Value.X;
+        float dy = current.Y - _dragStart.Value.Y;
+        foreach (var s in _selected)
+        {
+            var start = _initialPositions[s];
+            s.LocH = start.X + dx;
+            s.LocV = start.Y + dy;
+            if (RecordKeyframes && _player is LingoPlayer lp)
+                lp.Stage.UpdateKeyFrame(s);
+        }
+        SpritesTransformed?.Invoke();
+    }
+
+    public void EndMove(LingoPoint end)
+    {
+        if (_dragStart == null || _initialPositions == null) return;
+        var endPos = _selected.ToDictionary(s => s, s => new LingoPoint(s.LocH, s.LocV));
+        _commandManager.Handle(new MoveSpritesCommand(_initialPositions, endPos));
+        if (RecordKeyframes && _player is LingoPlayer lp)
+            foreach (var s in _selected)
+                lp.Stage.UpdateKeyFrame(s);
+        _dragStart = null;
+        _initialPositions = null;
+        SpritesTransformed?.Invoke();
+    }
+
+    public void BeginRotate(LingoPoint start)
+    {
+        if (_selected.Count == 0) return;
+        _dragStart = start;
+        _initialRotations = _selected.ToDictionary(s => s, s => s.Rotation);
+        _rotating = true;
+        if (RecordKeyframes && _player is LingoPlayer lp)
+            foreach (var s in _selected)
+                lp.Stage.AddKeyFrame(s);
+    }
+
+    public void UpdateRotate(LingoPoint current)
+    {
+        if (!_rotating || _dragStart == null || _initialRotations == null) return;
+        var center = ComputeSelectionCenter();
+        float startAngle = MathF.Atan2(_dragStart.Value.Y - center.Y, _dragStart.Value.X - center.X);
+        float currentAngle = MathF.Atan2(current.Y - center.Y, current.X - center.X);
+        float delta = (currentAngle - startAngle) * (180f / MathF.PI);
+        foreach (var s in _selected)
+        {
+            s.Rotation = _initialRotations[s] + delta;
+            if (RecordKeyframes && _player is LingoPlayer lp)
+                lp.Stage.UpdateKeyFrame(s);
+        }
+        SpritesTransformed?.Invoke();
+    }
+
+    public void EndRotate(LingoPoint end)
+    {
+        if (!_rotating || _initialRotations == null) return;
+        var endRot = _selected.ToDictionary(s => s, s => s.Rotation);
+        _commandManager.Handle(new RotateSpritesCommand(_initialRotations, endRot));
+        if (RecordKeyframes && _player is LingoPlayer lp)
+            foreach (var s in _selected)
+                lp.Stage.UpdateKeyFrame(s);
+        _rotating = false;
+        _dragStart = null;
+        _initialRotations = null;
+        SpritesTransformed?.Invoke();
+    }
+
+    public void ChangeBackgroundColor(LingoColor color)
+    {
+        if (_player is not LingoPlayer lp) return;
+        var current = lp.Stage.BackgroundColor;
+        if (current.Equals(color)) return;
+        _commandManager.Handle(new StageChangeBackgroundColorCommand(current, color));
+    }
+
+    public bool CanExecute(StageChangeBackgroundColorCommand command) => true;
+
+    public bool Handle(StageChangeBackgroundColorCommand command)
+    {
+        if (_player is not LingoPlayer lp)
+            return false;
+        lp.Stage.BackgroundColor = command.NewColor;
+        _historyManager.Push(
+            () =>
+            {
+                lp.Stage.BackgroundColor = command.OldColor;
+                _mediator.Raise(DirectorEventType.StagePropertiesChanged);
+            },
+            () =>
+            {
+                lp.Stage.BackgroundColor = command.NewColor;
+                _mediator.Raise(DirectorEventType.StagePropertiesChanged);
+            });
+        _mediator.Raise(DirectorEventType.StagePropertiesChanged);
+        return true;
+    }
+
+    public void Dispose()
+    {
+        _spritesManager.SpritesSelection.SelectionChanged -= SyncSelection;
+    }
+}
+

--- a/src/Director/LingoEngine.Director.Core/Stages/DirectorStageWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/DirectorStageWindow.cs
@@ -3,6 +3,7 @@ using LingoEngine.Director.Core.Stages.Commands;
 using LingoEngine.Director.Core.Tools;
 using LingoEngine.Director.Core.Windowing;
 using LingoEngine.FrameworkCommunication;
+using LingoEngine.Core;
 
 namespace LingoEngine.Director.Core.Stages
 {
@@ -15,10 +16,12 @@ namespace LingoEngine.Director.Core.Stages
 
         public StageTool SelectedTool { get; private set; }
 
+        public StageIconBar IconBar { get; }
 
-        public DirectorStageWindow(IHistoryManager historyManager, ILingoFrameworkFactory factory) : base(factory)
+        public DirectorStageWindow(IHistoryManager historyManager, ILingoFrameworkFactory factory, ILingoCommandManager commandManager, ILingoPlayer player, IDirectorEventMediator mediator, IDirStageManager stageManager) : base(factory)
         {
             _historyManager = historyManager;
+            IconBar = new StageIconBar(factory, commandManager, player, mediator, stageManager);
         }
 
         private void UpdateSelectionBox() => Framework.UpdateSelectionBox();

--- a/src/Director/LingoEngine.Director.Core/Stages/StageIconBar.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/StageIconBar.cs
@@ -1,0 +1,176 @@
+using System;
+using LingoEngine.Commands;
+using LingoEngine.Director.Core.Styles;
+using LingoEngine.Director.Core.Tools;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Gfx;
+using LingoEngine.Movies;
+using LingoEngine.Movies.Commands;
+using LingoEngine.Primitives;
+using LingoEngine.Core;
+
+namespace LingoEngine.Director.Core.Stages;
+
+public class StageIconBar : IDisposable
+{
+    private readonly LingoGfxButton _rewindButton;
+    private readonly LingoGfxButton _playButton;
+    private readonly LingoGfxButton _prevFrameButton;
+    private readonly LingoGfxButton _nextFrameButton;
+    private readonly LingoGfxInputSlider<float> _zoomSlider;
+    private readonly LingoGfxInputCombobox _zoomDropdown;
+    private readonly LingoGfxPanel _colorDisplay;
+    private readonly LingoGfxColorPicker _colorPicker;
+    private readonly LingoGfxStateButton _recordButton;
+    private readonly ILingoPlayer _player;
+    private readonly IDirStageManager _stageManager;
+    private LingoMovie? _movie;
+    private readonly IDirectorEventSubscription _stageChangedSub;
+    private bool _updatingZoom;
+
+    public LingoGfxPanel Panel { get; }
+
+    public event Action<float>? ZoomChanged;
+    public event Action<LingoColor>? ColorChanged;
+
+    public float MinZoom => _zoomSlider.MinValue;
+    public float MaxZoom => _zoomSlider.MaxValue;
+
+    public StageIconBar(ILingoFrameworkFactory factory, ILingoCommandManager commandManager, ILingoPlayer player, IDirectorEventMediator mediator, IDirStageManager stageManager)
+    {
+        const int iconBarHeight = 12;
+        _player = player;
+        _stageManager = stageManager;
+
+        Panel = factory.CreatePanel("StageIconBar");
+        Panel.BackgroundColor = DirectorColors.BG_WhiteMenus;
+        Panel.Height = iconBarHeight;
+
+        var container = factory.CreateWrapPanel(LingoOrientation.Horizontal, "StageIconBarContainer");
+        Panel.AddItem(container);
+
+        _rewindButton = factory.CreateButton("RewindButton", "|<");
+        _rewindButton.Width = 20;
+        _rewindButton.Height = iconBarHeight;
+        _rewindButton.Pressed += () => commandManager.Handle(new RewindMovieCommand());
+        container.AddItem(_rewindButton);
+
+        _playButton = factory.CreateButton("PlayButton", "Play");
+        _playButton.Width = 60;
+        _playButton.Height = iconBarHeight;
+        _playButton.Pressed += () => commandManager.Handle(new PlayMovieCommand());
+        container.AddItem(_playButton);
+
+        _prevFrameButton = factory.CreateButton("PrevFrameButton", "<");
+        _prevFrameButton.Width = 20;
+        _prevFrameButton.Height = iconBarHeight;
+        _prevFrameButton.Pressed += () => commandManager.Handle(new StepFrameCommand(-1));
+        container.AddItem(_prevFrameButton);
+
+        _nextFrameButton = factory.CreateButton("NextFrameButton", ">");
+        _nextFrameButton.Width = 20;
+        _nextFrameButton.Height = iconBarHeight;
+        _nextFrameButton.Pressed += () => commandManager.Handle(new StepFrameCommand(1));
+        container.AddItem(_nextFrameButton);
+
+        _zoomSlider = factory.CreateInputSliderFloat(LingoOrientation.Horizontal, "ZoomSlider", 0.5f, 1.5f, 0.1f);
+        _zoomSlider.Value = 1f;
+        _zoomSlider.Width = 150;
+        _zoomSlider.Height = iconBarHeight;
+        _zoomSlider.ValueChanged += () =>
+        {
+            if (_updatingZoom) return;
+            ZoomChanged?.Invoke(_zoomSlider.Value);
+            SetZoom(_zoomSlider.Value);
+        };
+        container.AddItem(_zoomSlider);
+
+        _zoomDropdown = factory.CreateInputCombobox("ZoomDropdown", null);
+        for (int i = 50; i <= 150; i += 10)
+            _zoomDropdown.AddItem(i.ToString(), $"{i}%");
+        _zoomDropdown.SelectedKey = "100";
+        _zoomDropdown.Width = 60;
+        _zoomDropdown.Height = iconBarHeight;
+        _zoomDropdown.ValueChanged += () =>
+        {
+            if (_updatingZoom) return;
+            if (_zoomDropdown.SelectedKey is string key && int.TryParse(key, out var p))
+            {
+                SetZoom(p / 100f);
+                ZoomChanged?.Invoke(p / 100f);
+            }
+        };
+        container.AddItem(_zoomDropdown);
+
+        _colorDisplay = factory.CreatePanel("ColorDisplay");
+        _colorDisplay.Width = iconBarHeight;
+        _colorDisplay.Height = iconBarHeight;
+        _colorDisplay.BackgroundColor = LingoColorList.Black;
+        container.AddItem(_colorDisplay);
+
+        _colorPicker = factory.CreateColorPicker("ColorPicker", null);
+        _colorPicker.Width = iconBarHeight;
+        _colorPicker.Height = iconBarHeight;
+        _colorPicker.Color = LingoColorList.Black;
+        _colorPicker.ValueChanged += () =>
+        {
+            var c = _colorPicker.Color;
+            _colorDisplay.BackgroundColor = c;
+            ColorChanged?.Invoke(c);
+        };
+        container.AddItem(_colorPicker);
+
+        _recordButton = factory.CreateStateButton("RecordButton", null, "●");
+        _recordButton.Width = iconBarHeight;
+        _recordButton.Height = iconBarHeight;
+        _recordButton.IsOn = _stageManager.RecordKeyframes;
+        _recordButton.ValueChanged += () => { _stageManager.RecordKeyframes = _recordButton.IsOn; };
+        container.AddItem(_recordButton);
+
+        _stageChangedSub = mediator.Subscribe(DirectorEventType.StagePropertiesChanged, OnStagePropertyChanged);
+    }
+
+    private bool OnStagePropertyChanged()
+    {
+        SetColor(_player.Stage.BackgroundColor);
+        return true;
+    }
+
+    private void OnPlayStateChanged(bool playing) => UpdatePlayButton();
+
+    private void UpdatePlayButton()
+    {
+        _playButton.Text = _movie != null && _movie.IsPlaying ? "stop !" : "Play >";
+    }
+
+    public void SetActiveMovie(LingoMovie? movie)
+    {
+        if (_movie != null)
+            _movie.PlayStateChanged -= OnPlayStateChanged;
+        _movie = movie;
+        if (_movie != null)
+            _movie.PlayStateChanged += OnPlayStateChanged;
+        UpdatePlayButton();
+    }
+
+    public void SetZoom(float value)
+    {
+        _updatingZoom = true;
+        _zoomSlider.Value = value;
+        _zoomDropdown.SelectedKey = ((int)MathF.Round(value * 100)).ToString();
+        _updatingZoom = false;
+    }
+
+    public void SetColor(LingoColor color)
+    {
+        _colorDisplay.BackgroundColor = color;
+        _colorPicker.Color = color;
+    }
+
+    public void Dispose()
+    {
+        _stageChangedSub.Release();
+        if (_movie != null)
+            _movie.PlayStateChanged -= OnPlayStateChanged;
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/UI/GfxPanelExtensions.cs
+++ b/src/Director/LingoEngine.Director.Core/UI/GfxPanelExtensions.cs
@@ -103,7 +103,26 @@ namespace LingoEngine.Director.Core.UI
             control.Pressed += onClick;
             ILingoGfxLayoutNode layout = (ILingoGfxLayoutNode)container.AddItem(control, x, y);
             return (control, layout);
-        } 
+        }
+        public static LingoGfxInputSlider<float> SetSliderAt<T>(this LingoGfxPanel container, T element, string name, float x, float y, int width, LingoOrientation orientation, Expression<Func<T, float>> property, float? min = null, float? max = null, float? step = null)
+        {
+            Action<T, float> setter = property.CompileSetter();
+            var slider = container.Factory.CreateInputSliderFloat(orientation, name, min, max, step, v => setter(element, v));
+            slider.Value = property.CompileGetter()(element);
+            slider.Width = width;
+            container.AddItem(slider, x, y);
+            return slider;
+        }
+
+        public static LingoGfxInputSlider<int> SetSliderAt<T>(this LingoGfxPanel container, T element, string name, float x, float y, int width, LingoOrientation orientation, Expression<Func<T, int>> property, int? min = null, int? max = null, int? step = null)
+        {
+            Action<T, int> setter = property.CompileSetter();
+            var slider = container.Factory.CreateInputSliderInt(orientation, name, min, max, step, v => setter(element, v));
+            slider.Value = property.CompileGetter()(element);
+            slider.Width = width;
+            container.AddItem(slider, x, y);
+            return slider;
+        }
         public static LingoGfxStateButton SetStateButtonAt<T>(this LingoGfxPanel container, T element, string name, float x, float y, Expression<Func<T,bool>> property, ILingoImageTexture? texture = null, string? label = null)
         {
             Action<T, bool> setter = property.CompileSetter();

--- a/src/Director/LingoEngine.Director.Core/UI/GfxWrapPanelBuilder.cs
+++ b/src/Director/LingoEngine.Director.Core/UI/GfxWrapPanelBuilder.cs
@@ -132,5 +132,21 @@ namespace LingoEngine.Director.Core.UI
             configure?.Invoke(button);
             return this;
         }
+
+        public GfxWrapPanelBuilder AddSliderFloat(string name, LingoOrientation orientation, Action<float>? onChange = null, float? min = null, float? max = null, float? step = null, Action<LingoGfxInputSlider<float>>? configure = null)
+        {
+            var slider = _factory.CreateInputSliderFloat(orientation, name, min, max, step, onChange);
+            _panel.AddItem(slider);
+            configure?.Invoke(slider);
+            return this;
+        }
+
+        public GfxWrapPanelBuilder AddSliderInt(string name, LingoOrientation orientation, Action<int>? onChange = null, int? min = null, int? max = null, int? step = null, Action<LingoGfxInputSlider<int>>? configure = null)
+        {
+            var slider = _factory.CreateInputSliderInt(orientation, name, min, max, step, onChange);
+            _panel.AddItem(slider);
+            configure?.Invoke(slider);
+            return this;
+        }
     }
 }

--- a/src/Director/LingoEngine.Director.Core/UI/GfxWrapPanelExtensions.cs
+++ b/src/Director/LingoEngine.Director.Core/UI/GfxWrapPanelExtensions.cs
@@ -40,6 +40,20 @@ namespace LingoEngine.Director.Core.UI
             panel.AddItem(list);
             return list;
         }
+
+        public static LingoGfxInputSlider<float> AddSliderFloat(this LingoGfxWrapPanel panel, ILingoFrameworkFactory factory, string name, LingoOrientation orientation, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null)
+        {
+            var slider = factory.CreateInputSliderFloat(orientation, name, min, max, step, onChange);
+            panel.AddItem(slider);
+            return slider;
+        }
+
+        public static LingoGfxInputSlider<int> AddSliderInt(this LingoGfxWrapPanel panel, ILingoFrameworkFactory factory, string name, LingoOrientation orientation, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null)
+        {
+            var slider = factory.CreateInputSliderInt(orientation, name, min, max, step, onChange);
+            panel.AddItem(slider);
+            return slider;
+        }
        
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/Bitmaps/DirGodotPictureMemberEditorWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Bitmaps/DirGodotPictureMemberEditorWindow.cs
@@ -72,7 +72,7 @@ internal partial class DirGodotPictureMemberEditorWindow : BaseGodotWindow, IHas
     private bool _drawing;
 
     public DirGodotPictureMemberEditorWindow(IDirectorEventMediator mediator, ILingoPlayer player, IDirGodotWindowManager windowManager, DirectorBitmapEditWindow directorPictureEditWindow, IDirectorIconManager iconManager, ILingoCommandManager commandManager, IHistoryManager historyManager, ILingoFrameworkFactory factory)
-        : base(DirectorMenuCodes.PictureEditWindow, "Picture Editor", windowManager)
+        : base(DirectorMenuCodes.PictureEditWindow, "Picture Editor", windowManager, historyManager)
     {
         _mediator = mediator;
         _player = player;

--- a/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Casts/DirGodotCastWindow.cs
@@ -35,7 +35,7 @@ namespace LingoEngine.Director.LGodot.Casts
         internal ILingoMember? SelectedMember => _selectedItem?.LingoMember;
 
         public DirGodotCastWindow(IDirectorEventMediator mediator, DirectorGodotStyle style, DirectorCastWindow directorCastWindow, ILingoPlayer player, IDirGodotWindowManager windowManager, ILingoCommandManager commandManager, IHistoryManager historyManager, IDirectorIconManager iconManager)
-            : base(DirectorMenuCodes.CastWindow, "Cast", windowManager)
+            : base(DirectorMenuCodes.CastWindow, "Cast", windowManager, historyManager)
         {
             _mediator = mediator;
             _style = style;

--- a/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs
@@ -2,7 +2,6 @@ using Godot;
 using LingoEngine.Movies;
 using LingoEngine.LGodot.Stages;
 using LingoEngine.Core;
-using LingoEngine.Commands;
 using LingoEngine.Director.Core.Stages;
 using System.Linq;
 using System.Collections.Generic;
@@ -10,12 +9,9 @@ using LingoEngine.LGodot.Primitives;
 using LingoEngine.Texts;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Director.LGodot.Windowing;
-using LingoEngine.Director.Core.Stages.Commands;
 using LingoEngine.Director.Core.Tools;
 using LingoEngine.Sprites;
-using LingoEngine.Movies.Commands;
 using LingoEngine.Stages;
-using LingoEngine.Director.Core.Sprites;
 using LingoEngine.Director.Core.UI;
 using LingoEngine.LGodot.Gfx;
 using LingoEngine.Inputs;
@@ -26,26 +22,14 @@ using LingoEngine.Director.LGodot.UI;
 
 namespace LingoEngine.Director.LGodot.Movies;
 
-internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelectedEvent, IDirFrameworkStageWindow
+internal partial class DirGodotStageWindow : BaseGodotWindow, IDirFrameworkStageWindow
 {
     private const int IconBarHeight = 12;
     private readonly LingoGodotStageContainer _stageContainer;
     private readonly IDirectorEventMediator _mediator;
     private readonly ILingoPlayer _player;
-    private readonly ILingoCommandManager _commandManager;
-    private readonly IHistoryManager _historyManager;
-    private readonly IconBarContainer _iconBar = new IconBarContainer();
-    private readonly HSlider _zoomSlider = new HSlider();
-    private readonly OptionButton _zoomDropdown = new OptionButton();
-    private readonly Button _rewindButton = new Button();
-    private readonly Button _playButton = new Button();
-    private readonly Button _prevFrameButton = new Button();
-    private readonly Button _nextFrameButton = new Button();
-    private readonly Button _recordButton = new Button();
     private readonly ColorRect _stageBgRect = new ColorRect();
     private readonly ColorRect _stageWindowBgRect = new ColorRect();
-    private readonly ColorRect _colorDisplay = new ColorRect();
-    private readonly ColorPickerButton _colorPicker = new ColorPickerButton();
     private readonly ScrollContainer _scrollContainer = new ScrollContainer();
     private readonly SelectionBox _selectionBox = new SelectionBox();
     private readonly StageBoundingBoxesOverlay _boundingBoxes;
@@ -55,20 +39,16 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
 
     private LingoMovie? _movie;
     private ILingoFrameworkStage? _stage;
-    private readonly List<LingoSprite2D> _selectedSprites = new();
+    private readonly DirStageManager _stageManager;
     private readonly DirectorStageWindow _directorStageWindow;
+    private readonly StageIconBar _iconBar;
     private readonly Node2D _stageLayer;
-    private LingoSprite2D? _primarySelectedSprite;
-    private Vector2? _dragStart;
-    private Dictionary<LingoSprite2D, Primitives.LingoPoint>? _initialPositions;
-    private Dictionary<LingoSprite2D, float>? _initialRotations;
-    private bool _rotating;
     private bool _spaceHeld;
     private bool _panning;
     private float _scale = 1f;
 
-    public DirGodotStageWindow(ILingoFrameworkStageContainer stageContainer, IDirectorEventMediator directorEventMediator, ILingoCommandManager commandManager, IHistoryManager historyManager, ILingoPlayer player, DirectorStageWindow directorStageWindow, DirectorStageGuides guides, IDirGodotWindowManager windowManager, IDirectorIconManager iconManager)
-        : base(DirectorMenuCodes.StageWindow, "Stage", windowManager)
+    public DirGodotStageWindow(ILingoFrameworkStageContainer stageContainer, IDirectorEventMediator directorEventMediator, IHistoryManager historyManager, ILingoPlayer player, DirectorStageWindow directorStageWindow, DirectorStageGuides guides, DirStageManager stageManager, IDirGodotWindowManager windowManager, IDirectorIconManager iconManager)
+        : base(DirectorMenuCodes.StageWindow, "Stage", windowManager, historyManager)
     {
         // TempFix
         //base.DontUseInputInsteadOfGuiInput();
@@ -78,12 +58,15 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         _mediator = directorEventMediator;
         _player = player;
         _player.ActiveMovieChanged += OnActiveMovieChanged;
-        _commandManager = commandManager;
-        _historyManager = historyManager;
         directorStageWindow.Init(this);
         _directorStageWindow = directorStageWindow;
+        _iconBar = directorStageWindow.IconBar;
+        _iconBar.ZoomChanged += SetScale;
+        _iconBar.ColorChanged += OnColorChanged;
         BackgroundColor = LingoColorList.Transparent;
-        _mediator.Subscribe(this);
+        _stageManager = stageManager;
+        _stageManager.SelectionChanged += OnStageSelectionChanged;
+        _stageManager.SpritesTransformed += OnStageSpritesTransformed;
         _stageChangedSubscription = _mediator.Subscribe(DirectorEventType.StagePropertiesChanged, StagePropertyChanged);
 
         var lp = (LingoPlayer)_player;
@@ -103,16 +86,6 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         _stageBgRect.Name = "StageBackgroundRect";
         _stageWindowBgRect.Name = "StageWindowBackgroundRect";
         _stageContainer.Container.Name = "StageContainer";
-        _iconBar.Name = "IconBar";
-        _zoomSlider.Name = "ZoomSlider";
-        _zoomDropdown.Name = "ZoomDropdown";
-        _rewindButton.Name = "RewindButton";
-        _playButton.Name = "PlayButton";
-        _prevFrameButton.Name = "PrevFrameButton";
-        _nextFrameButton.Name = "NextFrameButton";
-        _recordButton.Name = "RecordButton";
-        _colorDisplay.Name = "ColorDisplay";
-        _colorPicker.Name = "ColorPicker";
 
         const int zIndexStageStart = DirGodotWindowManager.ZIndexInactiveWindow + 1000;
 
@@ -165,10 +138,10 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         AddChild(_scrollContainer);
 
         // bottom icon bar
-        AddChild(_iconBar);
-        CreateBottomIconBar();
+        var iconBarPanel = _iconBar.Panel.Framework<LingoGodotPanel>();
+        AddChild(iconBarPanel);
+        CreateBottomIconBar(iconBarPanel);
 
-        UpdatePlayButton();
 
         
     }
@@ -194,72 +167,16 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         _scrollContainer.ZIndex = 500;
     }
 
-    private void CreateBottomIconBar()
+    private void CreateBottomIconBar(LingoGodotPanel iconBarPanel)
     {
-        _iconBar.AnchorLeft = 0;
-        _iconBar.AnchorRight = 1;
-        _iconBar.AnchorTop = 1;
-        _iconBar.AnchorBottom = 1;
-        _iconBar.OffsetLeft = 0;
-        _iconBar.OffsetRight = 0;
-        _iconBar.OffsetTop = - TitleBarHeight;
-        _iconBar.OffsetBottom = 0;
-
-
-        _rewindButton.Text = "|<";
-        _rewindButton.CustomMinimumSize = new Vector2(20, IconBarHeight);
-        _rewindButton.Pressed += () => _commandManager.Handle(new RewindMovieCommand());
-        _iconBar.AddChild(_rewindButton);
-
-        _playButton.CustomMinimumSize = new Vector2(60, IconBarHeight);
-        _playButton.AddThemeFontSizeOverride("font_size", 8);
-        _playButton.Pressed += () => _commandManager.Handle(new PlayMovieCommand());
-        _iconBar.AddChild(_playButton);
-
-        _prevFrameButton.Text = "<";
-        _prevFrameButton.CustomMinimumSize = new Vector2(20, IconBarHeight);
-        _prevFrameButton.Pressed += () => _commandManager.Handle(new StepFrameCommand(-1));
-        _iconBar.AddChild(_prevFrameButton);
-
-        _nextFrameButton.Text = ">";
-        _nextFrameButton.CustomMinimumSize = new Vector2(20, IconBarHeight);
-        _nextFrameButton.Pressed += () => _commandManager.Handle(new StepFrameCommand(1));
-        _iconBar.AddChild(_nextFrameButton);
-
-        _zoomSlider.MinValue = 0.5f;
-        _zoomSlider.MaxValue = 1.5f;
-        _zoomSlider.Step = 0.1f;
-        _zoomSlider.Value = 1f;
-        _zoomSlider.CustomMinimumSize = new Vector2(150, IconBarHeight);
-        _zoomSlider.ValueChanged += value => SetScale((float)value);
-        _iconBar.AddChild(_zoomSlider);
-
-        for (int i = 50; i <= 150; i += 10)
-            _zoomDropdown.AddItem($"{i}%");
-        _zoomDropdown.Select(5); // 100%
-        _zoomDropdown.CustomMinimumSize = new Vector2(60, IconBarHeight);
-        _zoomDropdown.ItemSelected += id => SetScale((50 + id * 10) / 100f);
-        _iconBar.AddChild(_zoomDropdown);
-
-        _colorDisplay.Color = Colors.Black;
-        _colorDisplay.CustomMinimumSize = new Vector2(IconBarHeight, IconBarHeight);
-        _iconBar.AddChild(_colorDisplay);
-
-        _colorPicker.CustomMinimumSize = new Vector2(IconBarHeight, IconBarHeight);
-        _colorPicker.Color = Colors.Black;
-        _colorPicker.ColorChanged += c => OnColorChanged(c);
-        _iconBar.AddChild(_colorPicker);
-
-        _recordButton.Text = "●";
-        _recordButton.ToggleMode = true;
-        _recordButton.CustomMinimumSize = new Vector2(IconBarHeight, IconBarHeight);
-        _recordButton.AddThemeColorOverride("font_color", Colors.Red);
-        _recordButton.Toggled += pressed =>
-        {
-            if (_player is LingoPlayer lp)
-                lp.Stage.RecordKeyframes = pressed;
-        };
-        _iconBar.AddChild(_recordButton);
+        iconBarPanel.AnchorLeft = 0;
+        iconBarPanel.AnchorRight = 1;
+        iconBarPanel.AnchorTop = 1;
+        iconBarPanel.AnchorBottom = 1;
+        iconBarPanel.OffsetLeft = 0;
+        iconBarPanel.OffsetRight = 0;
+        iconBarPanel.OffsetTop = -TitleBarHeight;
+        iconBarPanel.OffsetBottom = 0;
     }
 
     protected override void OnResizing(Vector2 size)
@@ -294,8 +211,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
 
         _stage?.SetActiveMovie(movie);
         _movie = movie;
-        _selectedSprites.Clear();
-        _primarySelectedSprite = null;
+        _stageManager.ClearSelection();
         _selectionBox.Visible = false;
 
         if (_movie != null)
@@ -306,7 +222,7 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
             _boundingBoxes.SetInput(env.Mouse, env.Key);
         }
 
-        UpdatePlayButton();
+        _iconBar.SetActiveMovie(movie);
         UpdateBoundingBoxes();
     }
 
@@ -318,31 +234,40 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
 
     private void OnPlayStateChanged(bool isPlaying)
     {
-        UpdatePlayButton();
         UpdateBoundingBoxes();
         if (isPlaying)
         {
             _selectionBox.Visible = false;
         }
-        else if (_selectedSprites.Count > 0)
+        else if (_stageManager.SelectedSprites.Count > 0)
             UpdateSelectionBox();
     }
 
-    private void UpdatePlayButton()
+    private void OnStageSelectionChanged()
     {
-        _playButton.Text = _movie != null && _movie.IsPlaying ? "stop !" : "Play >";
+        if (_movie != null && !_movie.IsPlaying && _stageManager.SelectedSprites.Count > 0)
+            UpdateSelectionBox();
+        else
+            _selectionBox.Visible = false;
+        UpdateBoundingBoxes();
+    }
+
+    private void OnStageSpritesTransformed()
+    {
+        UpdateSelectionBox();
+        UpdateBoundingBoxes();
     }
 
 
-    private void OnColorChanged(Color color)
+
+    private void OnColorChanged(LingoColor color)
     {
-        _stageBgRect.Color = color;
-        _colorDisplay.Color = color;
-        _player.Stage.BackgroundColor = color.ToLingoColor();
+        _stageManager.ChangeBackgroundColor(color);
     }
     private bool StagePropertyChanged()
     {
-        _stageBgRect.Color = _player.Stage.BackgroundColor.ToGodotColor();
+        var color = _player.Stage.BackgroundColor;
+        _stageBgRect.Color = color.ToGodotColor();
         _stageBgRect.CustomMinimumSize = new Vector2(_player.Stage.Width, _player.Stage.Height);
         UpdateStagePosition();
         return true;
@@ -355,16 +280,9 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
     }
     private void SetScale(float scale)
     {
-        _zoomSlider.Value = scale;
+        _iconBar.SetZoom(scale);
         _scale = scale;
         _stageLayer.SetScale(new Vector2(scale, scale));
-    }
-    private void UpdateScaleDropdown(float value)
-    {
-        int percent = (int)Mathf.Round(value * 100);
-        int index = (percent - 50) / 10;
-        if (index >= 0 && index < _zoomDropdown.ItemCount)
-            _zoomDropdown.Select(index);
     }
 
     private void OnToolChanged(StageTool tool)
@@ -383,29 +301,14 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         }
     }
 
-    public void SpriteSelected(ILingoSpriteBase sprite)
-    {
-        _selectedSprites.Clear();
-        if (!(sprite is LingoSprite2D ls))
-            return;
-        _selectedSprites.Add(ls);
-        _primarySelectedSprite = ls;
-        if (_movie != null && !_movie.IsPlaying && ls != null)
-            UpdateSelectionBox();
-    }
-
     public void UpdateSelectionBox()
     {
-        if (_selectedSprites.Count == 0)
+        if (_stageManager.SelectedSprites.Count == 0)
         {
             _selectionBox.Visible = false;
             return;
         }
-        float left = _selectedSprites.Min(s => s.Rect.Left);
-        float top = _selectedSprites.Min(s => s.Rect.Top);
-        float right = _selectedSprites.Max(s => s.Rect.Right);
-        float bottom = _selectedSprites.Max(s => s.Rect.Bottom);
-        var rect = new Rect2(left, top, right - left, bottom - top);
+        var rect = _stageManager.ComputeSelectionRect().ToRect2();
         _selectionBox.UpdateRect(rect);
         _selectionBox.Visible = true;
     }
@@ -420,9 +323,9 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
             return;
         }
 
-        if (_selectedSprites.Count > 0)
+        if (_stageManager.SelectedSprites.Count > 0)
         {
-            _boundingBoxes.SetSprites(_selectedSprites);
+            _boundingBoxes.SetSprites(_stageManager.SelectedSprites);
             _boundingBoxes.Visible = true;
             _spriteSummary.Visible = true;
         }
@@ -467,9 +370,8 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
             else if (!mb.Pressed && (mb.ButtonIndex == MouseButton.WheelUp || mb.ButtonIndex == MouseButton.WheelDown) && bounds.HasPoint(mousePos))
             {
                 float delta = mb.ButtonIndex == MouseButton.WheelUp ? 0.1f : -0.1f;
-                float newScale = Mathf.Clamp(_scale + delta, (float)_zoomSlider.MinValue, (float)_zoomSlider.MaxValue);
+                float newScale = Mathf.Clamp(_scale + delta, _iconBar.MinZoom, _iconBar.MaxZoom);
                 SetScale(newScale);
-                UpdateScaleDropdown(newScale);
                 //_stageContainer.SetScale(newScale);
                 GetViewport().SetInputAsHandled();
                 return;
@@ -480,17 +382,6 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
             _scrollContainer.ScrollHorizontal -= (int)motion.Relative.X;
             _scrollContainer.ScrollVertical -= (int)motion.Relative.Y;
             GetViewport().SetInputAsHandled();
-            return;
-        }
-
-        if (@event is InputEventKey key && key.Pressed && key.Keycode == Key.Z && key.CtrlPressed)
-        {
-            _historyManager.Undo();
-            return;
-        }
-        if (@event is InputEventKey key2 && key2.Pressed && key2.Keycode == Key.Y && key2.CtrlPressed)
-        {
-            _historyManager.Redo();
             return;
         }
 
@@ -515,28 +406,9 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
             Vector2 localPos = _stageContainer.Container.ToLocal(mb.Position);
             if (_movie == null) return;
             var sprite = _movie.GetSpriteAtPoint(localPos.X, localPos.Y, skipLockedSprites: true) as LingoSprite2D;
-            if (mb.Pressed)
+            if (mb.Pressed && sprite != null)
             {
-                if (sprite != null)
-                {
-                    if (Input.IsKeyPressed(Key.Ctrl))
-                    {
-                        if (_selectedSprites.Contains(sprite))
-                            _selectedSprites.Remove(sprite);
-                        else
-                            _selectedSprites.Add(sprite);
-                        UpdateSelectionBox();
-                        UpdateBoundingBoxes();
-                    }
-                    else
-                    {
-                        _selectedSprites.Clear();
-                        _selectedSprites.Add(sprite);
-                        _mediator.RaiseSpriteSelected(sprite);
-                        UpdateSelectionBox();
-                        UpdateBoundingBoxes();
-                    }
-                }
+                _stageManager.HandlePointerClick(sprite, Input.IsKeyPressed(Key.Ctrl));
             }
         }
     }
@@ -545,41 +417,16 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
     {
         if (@event is InputEventMouseButton mb && mb.ButtonIndex == MouseButton.Left)
         {
+            var p = new LingoEngine.Primitives.LingoPoint(mb.Position.X, mb.Position.Y);
             if (mb.Pressed)
-            {
-                if (_selectedSprites.Count > 0)
-                {
-                    _dragStart = mb.Position;
-                    _initialPositions = _selectedSprites.ToDictionary(s => s, s => new Primitives.LingoPoint(s.LocH, s.LocV));
-                    if (_player is LingoPlayer lp && lp.Stage.RecordKeyframes)
-                        foreach (var s in _selectedSprites)
-                            lp.Stage.AddKeyFrame(s);
-                }
-            }
-            else if (_dragStart.HasValue && _initialPositions != null)
-            {
-                var end = _selectedSprites.ToDictionary(s => s, s => new Primitives.LingoPoint(s.LocH, s.LocV));
-                _commandManager.Handle(new MoveSpritesCommand(_initialPositions, end));
-                _dragStart = null;
-                _initialPositions = null;
-                if (_player is LingoPlayer lp && lp.Stage.RecordKeyframes)
-                    foreach (var s in _selectedSprites)
-                        lp.Stage.UpdateKeyFrame(s);
-            }
+                _stageManager.BeginMove(p);
+            else
+                _stageManager.EndMove(p);
         }
-        else if (@event is InputEventMouseMotion motion && _dragStart.HasValue && _initialPositions != null)
+        else if (@event is InputEventMouseMotion motion)
         {
-            Vector2 delta = motion.Position - _dragStart.Value;
-            foreach (var s in _selectedSprites)
-            {
-                var start = _initialPositions[s];
-                s.LocH = start.X + delta.X;
-                s.LocV = start.Y + delta.Y;
-                if (_player is LingoPlayer lp && lp.Stage.RecordKeyframes)
-                    lp.Stage.UpdateKeyFrame(s);
-            }
-            UpdateSelectionBox();
-            UpdateBoundingBoxes();
+            var p = new LingoEngine.Primitives.LingoPoint(motion.Position.X, motion.Position.Y);
+            _stageManager.UpdateMove(p);
         }
     }
 
@@ -587,58 +434,18 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
     {
         if (@event is InputEventMouseButton mb && mb.ButtonIndex == MouseButton.Left)
         {
+            var p = new LingoEngine.Primitives.LingoPoint(mb.Position.X, mb.Position.Y);
             if (mb.Pressed)
-            {
-                if (_selectedSprites.Count > 0)
-                {
-                    _dragStart = mb.Position;
-                    _initialRotations = _selectedSprites.ToDictionary(s => s, s => s.Rotation);
-                    _rotating = true;
-                    if (_player is LingoPlayer lp && lp.Stage.RecordKeyframes)
-                        foreach (var s in _selectedSprites)
-                            lp.Stage.AddKeyFrame(s);
-                }
-            }
-            else if (_rotating && _initialRotations != null)
-            {
-                var end = _selectedSprites.ToDictionary(s => s, s => s.Rotation);
-                _commandManager.Handle(new RotateSpritesCommand(_initialRotations, end));
-                _rotating = false;
-                _dragStart = null;
-                _initialRotations = null;
-                if (_player is LingoPlayer lp && lp.Stage.RecordKeyframes)
-                    foreach (var s in _selectedSprites)
-                        lp.Stage.UpdateKeyFrame(s);
-            }
+                _stageManager.BeginRotate(p);
+            else
+                _stageManager.EndRotate(p);
         }
-        else if (@event is InputEventMouseMotion motion && _rotating && _initialRotations != null && _dragStart.HasValue)
+        else if (@event is InputEventMouseMotion motion)
         {
-            Vector2 center = ComputeSelectionCenter();
-            float startAngle = (_dragStart.Value - center).Angle();
-            float currentAngle = (motion.Position - center).Angle();
-            float delta = Mathf.RadToDeg(currentAngle - startAngle);
-            foreach (var s in _selectedSprites)
-            {
-                s.Rotation = _initialRotations[s] + delta;
-                if (_player is LingoPlayer lp && lp.Stage.RecordKeyframes)
-                    lp.Stage.UpdateKeyFrame(s);
-            }
-            UpdateSelectionBox();
-            UpdateBoundingBoxes();
+            var p = new LingoEngine.Primitives.LingoPoint(motion.Position.X, motion.Position.Y);
+            _stageManager.UpdateRotate(p);
         }
     }
-
-    private Vector2 ComputeSelectionCenter()
-    {
-        if (_selectedSprites.Count == 0) return Vector2.Zero;
-        float left = _selectedSprites.Min(s => s.Rect.Left);
-        float top = _selectedSprites.Min(s => s.Rect.Top);
-        float right = _selectedSprites.Max(s => s.Rect.Right);
-        float bottom = _selectedSprites.Max(s => s.Rect.Bottom);
-        return new Vector2((left + right) / 2f, (top + bottom) / 2f);
-    }
-
-  
 
     protected override void Dispose(bool disposing)
     {
@@ -649,7 +456,8 @@ internal partial class DirGodotStageWindow : BaseGodotWindow, IHasSpriteSelected
         }
         _stageChangedSubscription.Release();
         _player.ActiveMovieChanged -= OnActiveMovieChanged;
-        _mediator.Unsubscribe(this);
+        _stageManager.SelectionChanged -= OnStageSelectionChanged;
+        _stageManager.SpritesTransformed -= OnStageSpritesTransformed;
         _spriteSummary.Dispose();
         base.Dispose(disposing);
     }

--- a/src/Director/LingoEngine.Director.LGodot/Windowing/BaseGodotWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Windowing/BaseGodotWindow.cs
@@ -5,6 +5,7 @@ using LingoEngine.LGodot;
 using LingoEngine.LGodot.Primitives;
 using LingoEngine.Primitives;
 using LingoEngine.Inputs;
+using LingoEngine.Director.Core.Tools;
 
 namespace LingoEngine.Director.LGodot
 {
@@ -12,6 +13,7 @@ namespace LingoEngine.Director.LGodot
     {
         public ILingoMouse Mouse { get; private set; }
         private readonly IDirGodotWindowManager _windowManager;
+        private readonly IHistoryManager? _historyManager;
         protected readonly LingoGodotMouse _MouseFrameworkObj;
         protected bool _dragging;
         protected bool _resizing;
@@ -34,12 +36,13 @@ namespace LingoEngine.Director.LGodot
         public string WindowCode { get; private set; }
         public string WindowName { get; private set; }
 
-        public BaseGodotWindow(string windowCode,string name, IDirGodotWindowManager windowManager)
+        public BaseGodotWindow(string windowCode,string name, IDirGodotWindowManager windowManager, IHistoryManager? historyManager = null)
         {
             Name = $"Window {name}";
             WindowName = name;
             WindowCode = windowCode;
             _windowManager = windowManager;
+            _historyManager = historyManager;
             _MouseFrameworkObj = new LingoGodotMouse(new Lazy<LingoMouse>(() => (LingoMouse)Mouse!));
             Mouse = new LingoMouse(_MouseFrameworkObj);
             
@@ -112,6 +115,20 @@ namespace LingoEngine.Director.LGodot
         }
         protected virtual void OnHandleTheEvent(InputEvent @event)
         {
+            if (@event is InputEventKey key && key.Pressed && _historyManager != null)
+            {
+                if (key.Keycode == Key.Z && key.CtrlPressed)
+                {
+                    _historyManager.Undo();
+                    return;
+                }
+                if (key.Keycode == Key.Y && key.CtrlPressed)
+                {
+                    _historyManager.Redo();
+                    return;
+                }
+            }
+
             var isInsideRect = GetGlobalRect().HasPoint(GetGlobalMousePosition());
             var mousePos = GetLocalMousePosition();
             // Handle mouse button events (MouseDown and MouseUp)

--- a/src/LingoEngine.LGodot/Core/GodotFactory.cs
+++ b/src/LingoEngine.LGodot/Core/GodotFactory.cs
@@ -1,4 +1,6 @@
 ﻿using Godot;
+using System;
+using System.Numerics;
 using LingoEngine.Core;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.LGodot.Movies;
@@ -287,6 +289,35 @@ namespace LingoEngine.LGodot.Core
             var impl = new LingoGodotScrollContainer(scroll);
             scroll.Name = name;
             return scroll;
+        }
+
+        /// <inheritdoc/>
+        public LingoGfxInputSlider<float> CreateInputSliderFloat(LingoOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null)
+        {
+            var minNum = min.HasValue ? new NullableNum<float>(min.Value) : new NullableNum<float>();
+            var maxNum = max.HasValue ? new NullableNum<float>(max.Value) : new NullableNum<float>();
+            var stepNum = step.HasValue ? new NullableNum<float>(step.Value) : new NullableNum<float>();
+            return CreateInputSlider(name, orientation, minNum, maxNum, stepNum, onChange);
+        }
+
+        public LingoGfxInputSlider<int> CreateInputSliderInt(LingoOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null)
+        {
+            var minNum = min.HasValue ? new NullableNum<int>(min.Value) : new NullableNum<int>();
+            var maxNum = max.HasValue ? new NullableNum<int>(max.Value) : new NullableNum<int>();
+            var stepNum = step.HasValue ? new NullableNum<int>(step.Value) : new NullableNum<int>();
+            return CreateInputSlider(name, orientation, minNum, maxNum, stepNum, onChange);
+        }
+
+        public LingoGfxInputSlider<TValue> CreateInputSlider<TValue>(string name, LingoOrientation orientation, NullableNum<TValue> min, NullableNum<TValue> max, NullableNum<TValue> step, Action<TValue>? onChange = null)
+            where TValue : struct, System.Numerics.INumber<TValue>, System.IConvertible
+        {
+            var slider = new LingoGfxInputSlider<TValue>();
+            var impl = new LingoGodotInputSlider<TValue>(slider, orientation, onChange);
+            if (min.HasValue) slider.MinValue = min.Value!;
+            if (max.HasValue) slider.MaxValue = max.Value!;
+            if (step.HasValue) slider.Step = step.Value!;
+            slider.Name = name;
+            return slider;
         }
         /// <inheritdoc/>
 

--- a/src/LingoEngine.LGodot/Gfx/LingoGodotInputSlider.cs
+++ b/src/LingoEngine.LGodot/Gfx/LingoGodotInputSlider.cs
@@ -1,0 +1,88 @@
+using Godot;
+using System;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.LGodot.Gfx
+{
+    /// Godot implementation of <see cref="ILingoFrameworkGfxInputSlider{TValue}"/>.
+    /// </summary>
+    public partial class LingoGodotInputSlider<TValue> : Control, ILingoFrameworkGfxInputSlider<TValue>, System.IDisposable
+        where TValue : struct, System.IConvertible
+    {
+        private readonly Slider _slider;
+        private readonly System.Action<TValue>? _onChange;
+        private LingoMargin _margin = LingoMargin.Zero;
+        private event System.Action? _onValueChanged;
+
+        public LingoGodotInputSlider(LingoGfxInputSlider<TValue> slider, LingoOrientation orientation, System.Action<TValue>? onChange)
+        {
+            _onChange = onChange;
+            _slider = orientation == LingoOrientation.Horizontal ? new HSlider() : new VSlider();
+            _slider.AnchorLeft = 0; _slider.AnchorRight = 1; _slider.AnchorTop = 0; _slider.AnchorBottom = 1;
+            _slider.OffsetLeft = 0; _slider.OffsetRight = 0; _slider.OffsetTop = 0; _slider.OffsetBottom = 0;
+            AddChild(_slider);
+            slider.Init(this);
+            _slider.ValueChanged += OnSliderValueChanged;
+            CustomMinimumSize = new Vector2(2,2);
+            SizeFlagsHorizontal = 0;
+            SizeFlagsVertical = 0;
+        }
+
+        private void OnSliderValueChanged(double v)
+        {
+            _onValueChanged?.Invoke();
+            _onChange?.Invoke((TValue)Convert.ChangeType(v, typeof(TValue)));
+        }
+
+        public float X { get => Position.X; set => Position = new Vector2(value, Position.Y); }
+        public float Y { get => Position.Y; set => Position = new Vector2(Position.X, value); }
+
+        public new float Width
+        {
+            get => CustomMinimumSize.X;
+            set { CustomMinimumSize = new Vector2(value, CustomMinimumSize.Y); }
+        }
+        public new float Height
+        {
+            get => CustomMinimumSize.Y;
+            set { CustomMinimumSize = new Vector2(CustomMinimumSize.X, value); }
+        }
+
+        public bool Visibility { get => Visible; set => Visible = value; }
+        string ILingoFrameworkGfxNode.Name { get => Name; set => Name = value; }
+
+        public LingoMargin Margin
+        {
+            get => _margin;
+            set
+            {
+                _margin = value;
+                AddThemeConstantOverride("margin_left", (int)_margin.Left);
+                AddThemeConstantOverride("margin_right", (int)_margin.Right);
+                AddThemeConstantOverride("margin_top", (int)_margin.Top);
+                AddThemeConstantOverride("margin_bottom", (int)_margin.Bottom);
+            }
+        }
+
+        public bool Enabled { get => _slider.Editable; set => _slider.Editable = value; }
+        public object FrameworkNode => this;
+
+        event System.Action? ILingoFrameworkGfxNodeInput.ValueChanged
+        {
+            add => _onValueChanged += value;
+            remove => _onValueChanged -= value;
+        }
+
+        public TValue Value { get => (TValue)Convert.ChangeType(_slider.Value, typeof(TValue)); set => _slider.Value = Convert.ToDouble(value); }
+        public TValue MinValue { get => (TValue)Convert.ChangeType(_slider.MinValue, typeof(TValue)); set => _slider.MinValue = Convert.ToDouble(value); }
+        public TValue MaxValue { get => (TValue)Convert.ChangeType(_slider.MaxValue, typeof(TValue)); set => _slider.MaxValue = Convert.ToDouble(value); }
+        public TValue Step { get => (TValue)Convert.ChangeType(_slider.Step, typeof(TValue)); set => _slider.Step = Convert.ToDouble(value); }
+
+        public new void Dispose()
+        {
+            _slider.ValueChanged -= OnSliderValueChanged;
+            QueueFree();
+        }
+    }
+}

--- a/src/LingoEngine.SDL2/Core/SdlFactory.cs
+++ b/src/LingoEngine.SDL2/Core/SdlFactory.cs
@@ -260,6 +260,35 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
         scroll.Name = name;
         return scroll;
     }
+
+    /// <inheritdoc/>
+    public LingoGfxInputSlider<float> CreateInputSliderFloat(LingoOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null)
+    {
+        var slider = new LingoGfxInputSlider<float>();
+        var impl = new SdlGfxInputSlider<float>();
+        slider.Init(impl);
+        slider.Name = name;
+        if (min.HasValue) slider.MinValue = min.Value;
+        if (max.HasValue) slider.MaxValue = max.Value;
+        if (step.HasValue) slider.Step = step.Value;
+        if (onChange != null)
+            slider.ValueChanged += () => onChange(slider.Value);
+        return slider;
+    }
+
+    public LingoGfxInputSlider<int> CreateInputSliderInt(LingoOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null)
+    {
+        var slider = new LingoGfxInputSlider<int>();
+        var impl = new SdlGfxInputSlider<int>();
+        slider.Init(impl);
+        slider.Name = name;
+        if (min.HasValue) slider.MinValue = min.Value;
+        if (max.HasValue) slider.MaxValue = max.Value;
+        if (step.HasValue) slider.Step = step.Value;
+        if (onChange != null)
+            slider.ValueChanged += () => onChange(slider.Value);
+        return slider;
+    }
     /// <inheritdoc/>
     public LingoGfxInputText CreateInputText(string name, int maxLength = 0)
     {

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxInputSlider.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxInputSlider.cs
@@ -1,0 +1,37 @@
+using System;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.SDL2.Gfx
+{
+    internal class SdlGfxInputSlider<TValue> : ILingoFrameworkGfxInputSlider<TValue>, IDisposable where TValue : struct
+    {
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Width { get; set; }
+        public float Height { get; set; }
+        public bool Visibility { get; set; } = true;
+        public string Name { get; set; } = string.Empty;
+        public LingoMargin Margin { get; set; } = LingoMargin.Zero;
+        public bool Enabled { get; set; } = true;
+        private TValue _value = default!;
+        public TValue Value
+        {
+            get => _value;
+            set
+            {
+                if (!Equals(_value, value))
+                {
+                    _value = value;
+                    ValueChanged?.Invoke();
+                }
+            }
+        }
+        public TValue MinValue { get; set; } = default!;
+        public TValue MaxValue { get; set; } = default!;
+        public TValue Step { get; set; } = default!;
+        public event Action? ValueChanged;
+        public object FrameworkNode => this;
+        public void Dispose() { }
+    }
+}

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
@@ -1,4 +1,5 @@
-﻿using LingoEngine.Casts;
+﻿using System;
+using LingoEngine.Casts;
 using LingoEngine.Core;
 using LingoEngine.Inputs;
 using LingoEngine.Members;
@@ -88,6 +89,11 @@ namespace LingoEngine.FrameworkCommunication
 
         /// <summary>Creates a scroll container.</summary>
         LingoGfxScrollContainer CreateScrollContainer(string name);
+
+        /// <summary>Creates a slider input control for floating point values.</summary>
+        LingoGfxInputSlider<float> CreateInputSliderFloat(LingoOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null);
+        /// <summary>Creates a slider input control for integer values.</summary>
+        LingoGfxInputSlider<int> CreateInputSliderInt(LingoOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null);
 
         /// <summary>Creates a single line text input.</summary>
         LingoGfxInputText CreateInputText(string name, int maxLength = 0, Action<string>? onChange = null);

--- a/src/LingoEngine/Gfx/ILingoFrameworkGfxInputSlider.cs
+++ b/src/LingoEngine/Gfx/ILingoFrameworkGfxInputSlider.cs
@@ -1,0 +1,13 @@
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Framework specific implementation of a slider input control.
+    /// </summary>
+    public interface ILingoFrameworkGfxInputSlider<TValue> : ILingoFrameworkGfxNodeInput
+    {
+        TValue Value { get; set; }
+        TValue MinValue { get; set; }
+        TValue MaxValue { get; set; }
+        TValue Step { get; set; }
+    }
+}

--- a/src/LingoEngine/Gfx/LingoGfxInputSlider.cs
+++ b/src/LingoEngine/Gfx/LingoGfxInputSlider.cs
@@ -1,0 +1,17 @@
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Engine level wrapper for a slider input control.
+    /// </summary>
+    public class LingoGfxInputSlider<TValue> : LingoGfxInputBase<ILingoFrameworkGfxInputSlider<TValue>>
+    {
+        /// <summary>Current value of the slider.</summary>
+        public TValue Value { get => _framework.Value; set => _framework.Value = value; }
+        /// <summary>Minimum allowed value.</summary>
+        public TValue MinValue { get => _framework.MinValue; set => _framework.MinValue = value; }
+        /// <summary>Maximum allowed value.</summary>
+        public TValue MaxValue { get => _framework.MaxValue; set => _framework.MaxValue = value; }
+        /// <summary>Step size when moving the slider.</summary>
+        public TValue Step { get => _framework.Step; set => _framework.Step = value; }
+    }
+}

--- a/src/LingoEngine/Stages/ILingoStage.cs
+++ b/src/LingoEngine/Stages/ILingoStage.cs
@@ -12,7 +12,6 @@ namespace LingoEngine.Stages
         LingoColor BackgroundColor { get; set; }
         int Height { get; set; }
         LingoMember? MouseMemberUnderMouse { get; }
-        bool RecordKeyframes { get; set; }
         int Width { get; set; }
 
         void AddKeyFrame(LingoSprite2D sprite);

--- a/src/LingoEngine/Stages/LingoStage.cs
+++ b/src/LingoEngine/Stages/LingoStage.cs
@@ -15,7 +15,6 @@ namespace LingoEngine.Stages
         public int Width { get; set; } = 640;
         public int Height { get; set; } = 480;
         public LingoColor BackgroundColor { get; set; }
-        public bool RecordKeyframes { get; set; }
 
         public LingoMovie? ActiveMovie { get; private set; }
         public LingoMember? MouseMemberUnderMouse
@@ -39,7 +38,7 @@ namespace LingoEngine.Stages
        
         public void AddKeyFrame(LingoSprite2D sprite)
         {
-            if (!RecordKeyframes || ActiveMovie == null)
+            if (ActiveMovie == null)
                 return;
             int frame = ActiveMovie.CurrentFrame;
             sprite.AddKeyframes((frame, sprite.LocH, sprite.LocV, sprite.Rotation, sprite.Skew));
@@ -47,7 +46,7 @@ namespace LingoEngine.Stages
 
         public void UpdateKeyFrame(LingoSprite2D sprite)
         {
-            if (!RecordKeyframes || ActiveMovie == null)
+            if (ActiveMovie == null)
                 return;
             int frame = ActiveMovie.CurrentFrame;
             sprite.UpdateKeyframe(frame, sprite.LocH, sprite.LocV, sprite.Rotation, sprite.Skew);


### PR DESCRIPTION
## Summary
- move recording state and selection rect logic into DirStageManager with background color command and undo/redo support
- delegate color changes and selection box updates in DirGodotStageWindow to DirStageManager
- centralize undo/redo shortcuts in BaseGodotWindow and drop RecordKeyframes flag from LingoStage

## Testing
- `dotnet build src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj`
- `dotnet test src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68937a2aac548332a061f3f65962de0c