### PR TITLE
refactor project settings window to core

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Projects/DirectorProjectSettingsWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Projects/DirectorProjectSettingsWindow.cs
@@ -1,10 +1,195 @@
+using LingoEngine.Director.Core.FileSystems;
+using LingoEngine.Director.Core.UI;
 using LingoEngine.Director.Core.Windowing;
-using LingoEngine.FrameworkCommunication;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
 
-namespace LingoEngine.Director.Core.Projects
+namespace LingoEngine.Director.Core.Projects;
+
+/// <summary>
+/// Framework independent implementation of the project settings window.
+/// </summary>
+public class DirectorProjectSettingsWindow : DirectorWindow<IDirFrameworkProjectSettingsWindow>
 {
-    public class DirectorProjectSettingsWindow : DirectorWindow<IDirFrameworkProjectSettingsWindow>
+    private readonly ProjectSettingsEditorState _state;
+    private readonly IIdePathResolver _resolver;
+    private readonly IExecutableFilePicker _picker;
+    private readonly IDirectorWindowManager _windowManager;
+
+    private readonly LingoGfxWrapPanel _root;
+    private readonly LingoGfxInputText _nameEdit;
+    private readonly LingoGfxInputText _folderEdit;
+    private readonly LingoGfxInputCombobox _ideSelect;
+    private readonly LingoGfxWrapPanel _vsPathRow;
+    private readonly LingoGfxInputText _vsPathEdit;
+    private readonly LingoGfxWrapPanel _vsCodePathRow;
+    private readonly LingoGfxInputText _vsCodePathEdit;
+    private readonly LingoGfxLabel _slnPreviewLabel;
+
+    public LingoGfxWrapPanel RootPanel => _root;
+
+    public DirectorProjectSettingsWindow(
+        ProjectSettingsEditorState state,
+        IIdePathResolver resolver,
+        IExecutableFilePicker picker,
+        IDirectorWindowManager windowManager,
+        ILingoFrameworkFactory factory) : base(factory)
     {
-        public DirectorProjectSettingsWindow(ILingoFrameworkFactory factory) : base(factory) { }
+        _state = state;
+        _resolver = resolver;
+        _picker = picker;
+        _windowManager = windowManager;
+
+        _root = factory.CreateWrapPanel(LingoOrientation.Vertical, "ProjectSettingsRoot");
+        _root.ItemMargin = new LingoPoint(0, 4);
+
+        // Project name
+        var nameRow = factory.CreateWrapPanel(LingoOrientation.Horizontal, "NameRow");
+        var nameLabel = factory.CreateLabel("NameLabel", "Project Name");
+        nameLabel.Width = 100;
+        _nameEdit = factory.CreateInputText("NameEdit");
+        _nameEdit.Text = state.ProjectName;
+        _nameEdit.ValueChanged += () => _slnPreviewLabel.Text = GetSlnPreview();
+        nameRow.AddItem(nameLabel);
+        nameRow.AddItem(_nameEdit);
+        _root.AddItem(nameRow);
+
+        // Project folder
+        var folderRow = factory.CreateWrapPanel(LingoOrientation.Horizontal, "FolderRow");
+        var folderLabel = factory.CreateLabel("FolderLabel", "Project Folder");
+        folderLabel.Width = 100;
+        _folderEdit = factory.CreateInputText("FolderEdit");
+        _folderEdit.Text = state.ProjectFolder;
+        _folderEdit.ValueChanged += () => _slnPreviewLabel.Text = GetSlnPreview();
+        folderRow.AddItem(folderLabel);
+        folderRow.AddItem(_folderEdit);
+        _root.AddItem(folderRow);
+
+        _slnPreviewLabel = factory.CreateLabel("SlnPreview", GetSlnPreview());
+        _root.AddItem(_slnPreviewLabel);
+
+        // IDE selection
+        var ideRow = factory.CreateWrapPanel(LingoOrientation.Horizontal, "IdeRow");
+        var ideLabel = factory.CreateLabel("IdeLabel", "IDE");
+        ideLabel.Width = 100;
+        _ideSelect = factory.CreateInputCombobox("IdeSelect");
+        _ideSelect.AddItem(((int)DirectorIdeType.VisualStudio).ToString(), "Visual Studio");
+        _ideSelect.AddItem(((int)DirectorIdeType.VisualStudioCode).ToString(), "Visual Studio Code");
+        _ideSelect.SelectedKey = ((int)state.SelectedIde).ToString();
+        _ideSelect.ValueChanged += UpdateIdePathVisibility;
+        ideRow.AddItem(ideLabel);
+        ideRow.AddItem(_ideSelect);
+        _root.AddItem(ideRow);
+
+        // Visual Studio path
+        _vsPathRow = factory.CreateWrapPanel(LingoOrientation.Horizontal, "VsPathRow");
+        var vsLabel = factory.CreateLabel("VsPathLabel", "VS Path");
+        vsLabel.Width = 100;
+        _vsPathEdit = factory.CreateInputText("VsPathEdit");
+        _vsPathEdit.Text = state.VisualStudioPath;
+        var vsBrowse = factory.CreateButton("VsBrowse", "...");
+        vsBrowse.Pressed += () => _picker.PickExecutable(path => _vsPathEdit.Text = path);
+        var vsAuto = factory.CreateButton("VsAuto", "Auto");
+        vsAuto.Pressed += () => _vsPathEdit.Text = _resolver.AutoDetectVisualStudioPath() ?? string.Empty;
+        _vsPathRow.AddItem(vsLabel);
+        _vsPathRow.AddItem(_vsPathEdit);
+        _vsPathRow.AddItem(vsBrowse);
+        _vsPathRow.AddItem(vsAuto);
+        _root.AddItem(_vsPathRow);
+
+        // VS Code path
+        _vsCodePathRow = factory.CreateWrapPanel(LingoOrientation.Horizontal, "VSCodePathRow");
+        var codeLabel = factory.CreateLabel("VSCodePathLabel", "VS Code Path");
+        codeLabel.Width = 100;
+        _vsCodePathEdit = factory.CreateInputText("VSCodePathEdit");
+        _vsCodePathEdit.Text = state.VisualStudioCodePath;
+        var codeBrowse = factory.CreateButton("CodeBrowse", "...");
+        codeBrowse.Pressed += () => _picker.PickExecutable(path => _vsCodePathEdit.Text = path);
+        var codeAuto = factory.CreateButton("CodeAuto", "Auto");
+        codeAuto.Pressed += () => _vsCodePathEdit.Text = _resolver.AutoDetectVSCodePath() ?? string.Empty;
+        _vsCodePathRow.AddItem(codeLabel);
+        _vsCodePathRow.AddItem(_vsCodePathEdit);
+        _vsCodePathRow.AddItem(codeBrowse);
+        _vsCodePathRow.AddItem(codeAuto);
+        _root.AddItem(_vsCodePathRow);
+
+        // Save & Apply buttons
+        _root.Compose(factory)
+            .AddButton("SaveButton", "Save", OnSavePressed)
+            .AddButton("ApplyButton", "Apply", () =>
+            {
+                if (ValidateSettings())
+                    SaveState();
+            })
+            .Finalize();
+
+        UpdateIdePathVisibility();
+    }
+
+    private DirectorIdeType SelectedIde
+        => (DirectorIdeType)int.Parse(_ideSelect.SelectedKey ?? "0");
+
+    private string GetSlnPreview()
+    {
+        var name = _nameEdit.Text.Trim();
+        var folder = _folderEdit.Text.Trim();
+        return string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(folder)
+            ? "(Solution path preview unavailable)"
+            : $"Solution: {System.IO.Path.Combine(folder, $"{name}.sln")}";
+    }
+
+    private void OnSavePressed()
+    {
+        if (!ValidateSettings())
+            return;
+
+        SaveState();
+        CloseWindow();
+    }
+
+    private void SaveState()
+    {
+        _state.ProjectName = _nameEdit.Text.Trim();
+        _state.ProjectFolder = _folderEdit.Text.Trim();
+        _state.SelectedIde = SelectedIde;
+        _state.VisualStudioPath = _vsPathEdit.Text.Trim();
+        _state.VisualStudioCodePath = _vsCodePathEdit.Text.Trim();
+    }
+
+    private void UpdateIdePathVisibility()
+    {
+        var showVs = SelectedIde == DirectorIdeType.VisualStudio;
+        _vsPathRow.Visibility = showVs;
+        _vsCodePathRow.Visibility = !showVs;
+    }
+
+    private bool ValidateSettings()
+    {
+        if (string.IsNullOrWhiteSpace(_nameEdit.Text))
+        {
+            _windowManager.ShowNotification("Project name is required.", DirUINotificationType.Error);
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(_folderEdit.Text))
+        {
+            _windowManager.ShowNotification("Project folder is required.", DirUINotificationType.Error);
+            return false;
+        }
+
+        if (SelectedIde == DirectorIdeType.VisualStudio && string.IsNullOrWhiteSpace(_vsPathEdit.Text))
+        {
+            _windowManager.ShowNotification("Visual Studio path is required.", DirUINotificationType.Error);
+            return false;
+        }
+
+        if (SelectedIde == DirectorIdeType.VisualStudioCode && string.IsNullOrWhiteSpace(_vsCodePathEdit.Text))
+        {
+            _windowManager.ShowNotification("VS Code path is required.", DirUINotificationType.Error);
+            return false;
+        }
+
+        return true;
     }
 }
+

--- a/src/Director/LingoEngine.Director.Core/Styles/DirectorColors.cs
+++ b/src/Director/LingoEngine.Director.Core/Styles/DirectorColors.cs
@@ -5,7 +5,7 @@ namespace LingoEngine.Director.Core.Styles
     public class DirectorColors
     {
         public static LingoColor BlueSelectColor = new LingoColor(0, 120, 215);
-        public static LingoColor BlueLightSelectColor = new LingoColor(229,241,251);
+        public static LingoColor BlueLightSelectColor = new LingoColor(229, 241, 251);
         public static LingoColor BG_PropWindowBar = new LingoColor(178, 180, 191);    // Top bar of panels
         public static LingoColor BG_WhiteMenus = new LingoColor(240, 240, 240);       // Common window background
 
@@ -70,6 +70,16 @@ namespace LingoEngine.Director.Core.Styles
 
         public static LingoColor Button_Text_Normal = new LingoColor(0, 0, 0);
         public static LingoColor Button_Text_Disabled = new LingoColor(130, 130, 130);
+
+
+
+        // Notifications
+        public static LingoColor Notification_Warning_Bg = new LingoColor(255, 255, 204);
+        public static LingoColor Notification_Warning_Border = new LingoColor(255, 255, 0);
+        public static LingoColor Notification_Error_Bg = new LingoColor(255, 204, 204);
+        public static LingoColor Notification_Error_Border = new LingoColor(255, 0, 0);
+        public static LingoColor Notification_Info_Bg = new LingoColor(204, 204, 255);
+        public static LingoColor Notification_Info_Border = new LingoColor(0, 0, 255);
 
 
 

--- a/src/Director/LingoEngine.Director.Core/Windowing/DirUINotificationType.cs
+++ b/src/Director/LingoEngine.Director.Core/Windowing/DirUINotificationType.cs
@@ -1,0 +1,9 @@
+namespace LingoEngine.Director.Core.Windowing
+{
+    public enum DirUINotificationType
+    {
+        Warning,
+        Error,
+        Information,
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Windowing/DirectorWindowManager.cs
+++ b/src/Director/LingoEngine.Director.Core/Windowing/DirectorWindowManager.cs
@@ -12,7 +12,7 @@ namespace LingoEngine.Director.Core.Windowing
         void SetActiveWindow(IDirectorWindowRegistration window);
         IDirectorWindowDialogReference? ShowConfirmDialog(string title, string message, Action<bool> onResult);
         IDirectorWindowDialogReference? ShowCustomDialog(string title, ILingoFrameworkGfxPanel panel);
-        IDirectorWindowDialogReference? ShowNotification(string message);
+        IDirectorWindowDialogReference? ShowNotification(string message, DirUINotificationType type);
     }
     public interface IDirectorWindowRegistration
     {
@@ -30,7 +30,7 @@ namespace LingoEngine.Director.Core.Windowing
         void SetActiveWindow(string windowCode);
         IDirectorWindowDialogReference? ShowConfirmDialog(string title, string message, Action<bool> onResult);
         IDirectorWindowDialogReference? ShowCustomDialog(string title, ILingoFrameworkGfxPanel panel);
-        IDirectorWindowDialogReference? ShowNotification(string message);
+        IDirectorWindowDialogReference? ShowNotification(string message, DirUINotificationType type);
     }
     public class DirectorWindowManager : IDirectorWindowManager,
         ICommandHandler<OpenWindowCommand>,
@@ -102,8 +102,8 @@ namespace LingoEngine.Director.Core.Windowing
         public IDirectorWindowDialogReference? ShowCustomDialog(string title, ILingoFrameworkGfxPanel panel)
             => _frameworkWindowManager.ShowCustomDialog(title, panel);
 
-        public IDirectorWindowDialogReference? ShowNotification(string message)
-            => _frameworkWindowManager.ShowNotification(message);
+        public IDirectorWindowDialogReference? ShowNotification(string message, DirUINotificationType type)
+            => _frameworkWindowManager.ShowNotification(message, type);
 
 
         public bool OpenWindow(string windowCode)

--- a/src/Director/LingoEngine.Director.LGodot/Projects/DirGodotProjectSettingsWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Projects/DirGodotProjectSettingsWindow.cs
@@ -1,194 +1,28 @@
 using Godot;
-using LingoEngine.Director.Core;
-using LingoEngine.Director.Core.FileSystems;
 using LingoEngine.Director.Core.Projects;
 using LingoEngine.Director.Core.UI;
+using LingoEngine.Director.LGodot.Gfx;
 using LingoEngine.Director.LGodot.Windowing;
 
-namespace LingoEngine.Director.LGodot.Gfx;
+namespace LingoEngine.Director.LGodot.Projects;
 
+/// <summary>
+/// Godot wrapper for <see cref="DirectorProjectSettingsWindow"/>.
+/// </summary>
 internal partial class DirGodotProjectSettingsWindow : BaseGodotWindow, IDirFrameworkProjectSettingsWindow
 {
-    private readonly ProjectSettingsEditorState _state;
-    private readonly IIdePathResolver _resolver;
-    private readonly IExecutableFilePicker _picker;
-    private readonly HBoxContainer _vsPathRow;
-    private readonly HBoxContainer _vsCodePathRow;
-
-    private readonly LineEdit _nameEdit = new LineEdit();
-    private readonly LineEdit _folderEdit = new LineEdit();
-    private readonly OptionButton _ideSelect = new OptionButton();
-    private readonly LineEdit _vsPathEdit = new LineEdit();
-    private readonly LineEdit _vscodePathEdit = new LineEdit();
-    private readonly Label _slnPreviewLabel = new Label();
-
-
-
-
     public DirGodotProjectSettingsWindow(
-        ProjectSettingsEditorState state,
-        IIdePathResolver resolver,
-        IExecutableFilePicker picker,
-        IDirGodotWindowManager windowManager,
-        DirectorProjectSettingsWindow directorProjectSettingsWindow)
+        DirectorProjectSettingsWindow directorWindow,
+        IDirGodotWindowManager windowManager)
         : base(DirectorMenuCodes.ProjectSettingsWindow, "Project Settings", windowManager)
     {
-        _state = state;
-        _resolver = resolver;
-        _picker = picker;
-        directorProjectSettingsWindow.Init(this);
+        directorWindow.Init(this);
         Size = new Vector2(420, 200);
         CustomMinimumSize = Size;
 
-        var vbox = new VBoxContainer();
-        vbox.Position = new Vector2(5, TitleBarHeight + 5);
-        AddChild(vbox);
-
-        // Project name
-        var h1 = new HBoxContainer();
-        h1.AddChild(new Label { Text = "Project Name", CustomMinimumSize = new Vector2(100, 16) });
-        _nameEdit.Text = state.ProjectName;
-        h1.AddChild(_nameEdit);
-        vbox.AddChild(h1);
-        _nameEdit.TextChanged += (_) => _slnPreviewLabel.Text = GetSlnPreview();
-        _folderEdit.TextChanged += (_) => _slnPreviewLabel.Text = GetSlnPreview();
-
-
-        // Project folder
-        var h2 = new HBoxContainer();
-        h2.AddChild(new Label { Text = "Project Folder", CustomMinimumSize = new Vector2(100, 16) });
-        _folderEdit.Text = state.ProjectFolder;
-        h2.AddChild(_folderEdit);
-        vbox.AddChild(h2);
-
-        _slnPreviewLabel.Text = GetSlnPreview();
-        vbox.AddChild(_slnPreviewLabel);
-
-
-        // IDE selection
-        var h3 = new HBoxContainer();
-        h3.AddChild(new Label { Text = "IDE", CustomMinimumSize = new Vector2(100, 16) });
-        _ideSelect.AddItem("Visual Studio", (int)DirectorIdeType.VisualStudio);
-        _ideSelect.AddItem("Visual Studio Code", (int)DirectorIdeType.VisualStudioCode);
-        _ideSelect.Selected = (int)state.SelectedIde;
-        _ideSelect.ItemSelected += OnIdeSelected;
-        h3.AddChild(_ideSelect);
-        vbox.AddChild(h3);
-
-        // Visual Studio path row
-        _vsPathRow = new HBoxContainer();
-        _vsPathRow.AddChild(new Label { Text = "VS Path", CustomMinimumSize = new Vector2(100, 16) });
-        _vsPathEdit.Text = state.VisualStudioPath;
-        _vsPathRow.AddChild(_vsPathEdit);
-        var vsBrowse = new Button { Text = "..." };
-        vsBrowse.Pressed += () => _picker.PickExecutable(path => _vsPathEdit.Text = path);
-        _vsPathRow.AddChild(vsBrowse);
-        var vsAuto = new Button { Text = "Auto" };
-        vsAuto.Pressed += () => _vsPathEdit.Text = _resolver.AutoDetectVisualStudioPath() ?? "";
-        _vsPathRow.AddChild(vsAuto);
-        vbox.AddChild(_vsPathRow);
-
-        // VS Code path row
-        _vsCodePathRow = new HBoxContainer();
-        _vsCodePathRow.AddChild(new Label { Text = "VS Code Path", CustomMinimumSize = new Vector2(100, 16) });
-        _vscodePathEdit.Text = state.VisualStudioCodePath;
-        _vsCodePathRow.AddChild(_vscodePathEdit);
-        var codeBrowse = new Button { Text = "..." };
-        codeBrowse.Pressed += () => _picker.PickExecutable(path => _vscodePathEdit.Text = path);
-        _vsCodePathRow.AddChild(codeBrowse);
-        var codeAuto = new Button { Text = "Auto" };
-        codeAuto.Pressed += () => _vscodePathEdit.Text = _resolver.AutoDetectVSCodePath() ?? "";
-        _vsCodePathRow.AddChild(codeAuto);
-        vbox.AddChild(_vsCodePathRow);
-
-        // Save button
-        var save = new Button { Text = "Save" };
-        save.Pressed += OnSavePressed;
-        vbox.AddChild(save);
-
-
-        var apply = new Button { Text = "Apply" };
-        apply.Pressed += () =>
-        {
-            if (ValidateSettings())
-                SaveState();
-        };
-        vbox.AddChild(apply);
-
-
-        UpdateIdePathVisibility();
+        var root = directorWindow.RootPanel.Framework<LingoGodotWrapPanel>();
+        root.Position = new Vector2(5, TitleBarHeight + 5);
+        AddChild(root);
     }
-
-    private string GetSlnPreview()
-    {
-        var name = _nameEdit.Text.Trim();
-        var folder = _folderEdit.Text.Trim();
-        return string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(folder)
-            ? "(Solution path preview unavailable)"
-            : $"Solution: {System.IO.Path.Combine(folder, $"{name}.sln")}";
-    }
-
-
-    private void OnIdeSelected(long index) => UpdateIdePathVisibility();
-
-    private void UpdateIdePathVisibility()
-    {
-        bool showVs = _ideSelect.Selected == (int)DirectorIdeType.VisualStudio;
-        _vsPathRow.Visible = showVs;
-        _vsCodePathRow.Visible = !showVs;
-    }
-
-    private void OnSavePressed()
-    {
-        if (!ValidateSettings())
-            return;
-
-        SaveState();
-        Visible = false;
-    }
-
-    private void SaveState()
-    {
-        _state.ProjectName = _nameEdit.Text.Trim();
-        _state.ProjectFolder = _folderEdit.Text.Trim();
-        _state.SelectedIde = (DirectorIdeType)_ideSelect.Selected;
-        _state.VisualStudioPath = _vsPathEdit.Text.Trim();
-        _state.VisualStudioCodePath = _vscodePathEdit.Text.Trim();
-    }
-
-
-
-    private bool ValidateSettings()
-    {
-        if (string.IsNullOrWhiteSpace(_nameEdit.Text))
-        {
-            GD.PrintErr("Project name is required.");
-            return false;
-        }
-
-        if (string.IsNullOrWhiteSpace(_folderEdit.Text))
-        {
-            GD.PrintErr("Project folder is required.");
-            return false;
-        }
-
-        var ide = (DirectorIdeType)_ideSelect.Selected;
-        if (ide == DirectorIdeType.VisualStudio && string.IsNullOrWhiteSpace(_vsPathEdit.Text))
-        {
-            GD.PrintErr("Visual Studio path is required.");
-            return false;
-        }
-
-        if (ide == DirectorIdeType.VisualStudioCode && string.IsNullOrWhiteSpace(_vscodePathEdit.Text))
-        {
-            GD.PrintErr("VS Code path is required.");
-            return false;
-        }
-
-        return true;
-    }
-
-
-
-
 }
+

--- a/src/Director/LingoEngine.Director.LGodot/Windowing/GodotWindowManager.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Windowing/GodotWindowManager.cs
@@ -44,7 +44,7 @@ internal class DirGodotWindowManager : IDirGodotWindowManager
         SetTheActiveWindow(window);
     }
 
-   
+
 
     public void SetActiveWindow(IDirectorWindowRegistration windowRegistration)
     {
@@ -112,7 +112,7 @@ internal class DirGodotWindowManager : IDirGodotWindowManager
         return new DirectorWindowDialogReference(dialog.QueueFree);
     }
 
-    private static void ReplaceIconColor(Window dialog,string name,Color colorNew)
+    private static void ReplaceIconColor(Window dialog, string name, Color colorNew)
     {
         var closeButton = dialog.GetThemeIcon(name);
         ImageTexture tinted = CreateTintedIcon(closeButton, colorNew);
@@ -135,11 +135,11 @@ internal class DirGodotWindowManager : IDirGodotWindowManager
         }
 
         var tinted = ImageTexture.CreateFromImage(image);
-        
+
         return tinted;
     }
 
-    public IDirectorWindowDialogReference? ShowNotification(string message)
+    public IDirectorWindowDialogReference? ShowNotification(string message, DirUINotificationType type)
     {
         var root = ActiveWindow?.GetTree().Root;
         if (root == null)
@@ -149,7 +149,27 @@ internal class DirGodotWindowManager : IDirGodotWindowManager
         {
             CustomMinimumSize = new Vector2(200, 40)
         };
-        var style = new StyleBoxFlat { BgColor = new Color(1f, 1f, 0.8f) };
+        var (bg, border) = type switch
+        {
+            DirUINotificationType.Error => (
+                DirectorColors.Notification_Error_Bg.ToGodotColor(),
+                DirectorColors.Notification_Error_Border.ToGodotColor()
+            ),
+            DirUINotificationType.Information => (
+                DirectorColors.Notification_Info_Bg.ToGodotColor(),
+                DirectorColors.Notification_Info_Border.ToGodotColor()
+            ),
+            _ => (
+                DirectorColors.Notification_Warning_Bg.ToGodotColor(),
+                DirectorColors.Notification_Warning_Border.ToGodotColor()
+            ),
+        };
+        var style = new StyleBoxFlat
+        {
+            BgColor = bg,
+            BorderColor = border,
+            BorderWidthAll = 2
+        };
         panel.AddThemeStyleboxOverride("panel", style);
 
         var label = new Label { Text = message };


### PR DESCRIPTION
## Summary
- refactor project settings window into framework-agnostic implementation using Gfx elements
- add Godot wrapper for the new project settings window
- validate project settings using notification support in window manager
- introduce DirUINotificationType and color-coded notifications
- centralize notification colors in `DirectorColors` and adopt wrap panel builder helpers

## Testing
- `dotnet format --no-restore --include src/Director/LingoEngine.Director.Core/Styles/DirectorColors.cs src/Director/LingoEngine.Director.LGodot/Windowing/GodotWindowManager.cs src/Director/LingoEngine.Director.Core/Projects/DirectorProjectSettingsWindow.cs -v diag`
- `dotnet test` *(fails: Could not find file '/workspace/LingoEngine/WillMoveToOwnRepo/ProjectorRays/Test/TestData/TextCast.cst')*


------
https://chatgpt.com/codex/tasks/task_e_6894332ca87083329497ba71191159b3