### PR TITLE
Add rectangle selection to score

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Scores/DirScoreRectangleSelection.cs
+++ b/src/Director/LingoEngine.Director.Core/Scores/DirScoreRectangleSelection.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using LingoEngine.Events;
+using LingoEngine.Inputs;
+using LingoEngine.Sprites;
+using LingoEngine.Director.Core.Sprites;
+
+namespace LingoEngine.Director.Core.Scores
+{
+    /// <summary>
+    /// Handles multi-channel rectangle selection logic for the score manager.
+    /// </summary>
+    internal class DirScoreRectangleSelection
+    {
+        private readonly DirScoreManager _manager;
+        private bool _selecting;
+        private int _startChannel;
+        private int _startFrame;
+        private int _prevMinChannel = -1;
+        private int _prevMaxChannel = -1;
+
+        public DirScoreRectangleSelection(DirScoreManager manager)
+        {
+            _manager = manager;
+        }
+
+        public void Begin(int channelNumber, int frameNumber)
+        {
+            var sm = _manager.SpritesManagerNullable;
+            if (sm == null || !sm.Key.ControlDown)
+                _manager.ClearSelection();
+
+            _selecting = true;
+            _startChannel = channelNumber;
+            _startFrame = frameNumber;
+            _prevMinChannel = _prevMaxChannel = -1;
+        }
+
+        public bool Update(int channelNumber, int frameNumber)
+        {
+            if (!_selecting || !_manager.LastMouseLeftDown)
+                return false;
+
+            if (_prevMinChannel != -1)
+            {
+                for (int ch = _prevMinChannel; ch <= _prevMaxChannel; ch++)
+                    if (_manager.Channels.TryGetValue(ch, out var chPrev))
+                        chPrev.ClearSelectionRect();
+            }
+
+            int chDelta = channelNumber - _startChannel;
+            int frDelta = frameNumber - _startFrame;
+            if (Math.Abs(chDelta) < 1 && Math.Abs(frDelta) < 1)
+            {
+                _prevMinChannel = _prevMaxChannel = -1;
+                return true;
+            }
+
+            int minCh = Math.Min(_startChannel, channelNumber);
+            int maxCh = Math.Max(_startChannel, channelNumber);
+            int minFr = Math.Min(_startFrame, frameNumber);
+            int maxFr = Math.Max(_startFrame, frameNumber);
+            for (int ch = minCh; ch <= maxCh; ch++)
+                if (_manager.Channels.TryGetValue(ch, out var chObj))
+                    chObj.SetSelectionRect(minFr, maxFr);
+
+            _prevMinChannel = minCh;
+            _prevMaxChannel = maxCh;
+            return true;
+        }
+
+        public bool Complete(LingoMouseEvent mouseEvent, int channelNumber, int frameNumber)
+        {
+            if (!_selecting)
+                return false;
+
+            if (_prevMinChannel != -1)
+            {
+                for (int ch = _prevMinChannel; ch <= _prevMaxChannel; ch++)
+                    if (_manager.Channels.TryGetValue(ch, out var chPrev))
+                        chPrev.ClearSelectionRect();
+            }
+
+            int chDelta = channelNumber - _startChannel;
+            int frDelta = frameNumber - _startFrame;
+            if (Math.Abs(chDelta) >= 1 || Math.Abs(frDelta) >= 1)
+            {
+                int minCh = Math.Min(_startChannel, channelNumber);
+                int maxCh = Math.Max(_startChannel, channelNumber);
+                int minFr = Math.Min(_startFrame, frameNumber);
+                int maxFr = Math.Max(_startFrame, frameNumber);
+                var toSelect = new List<DirScoreSprite>();
+                for (int ch = minCh; ch <= maxCh; ch++)
+                {
+                    if (_manager.Channels.TryGetValue(ch, out var chObj))
+                    {
+                        foreach (var sp in chObj.GetSprites())
+                        {
+                            if (sp.Sprite.BeginFrame >= minFr && sp.Sprite.EndFrame <= maxFr)
+                                toSelect.Add(sp);
+                        }
+                    }
+                }
+                var sm = _manager.SpritesManagerNullable;
+                if (sm != null)
+                {
+                    if (!sm.Key.ControlDown)
+                        _manager.ClearSelection();
+                    foreach (var sp in toSelect)
+                    {
+                        if (_manager.Selected.Contains(sp))
+                            continue;
+                        _manager.AddSelection(sp, false);
+                        sm.SpritesSelection.Add(sp.Sprite);
+                        sm.Mediator.RaiseSpriteSelected(sp.Sprite);
+                    }
+                }
+            }
+
+            _selecting = false;
+            _prevMinChannel = _prevMaxChannel = -1;
+            _manager.LastMouseLeftDown = false;
+            mouseEvent.Mouse.SetCursor(LingoMouseCursor.Arrow);
+            return true;
+        }
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Scores/DirScoreSprite.cs
+++ b/src/Director/LingoEngine.Director.Core/Scores/DirScoreSprite.cs
@@ -20,9 +20,9 @@ namespace LingoEngine.Director.Core.Scores
         where TSprite : LingoSprite
     {
         public TSprite SpriteT { get; private set; }
-        
 
-#pragma warning disable CS8618 
+
+#pragma warning disable CS8618
         public DirScoreSprite(TSprite sprite, IDirSpritesManager spritesManager) : base(sprite, spritesManager)
 #pragma warning restore CS8618 
         {
@@ -46,17 +46,8 @@ namespace LingoEngine.Director.Core.Scores
         public bool RequireToRedraw { get; private set; } = true;
         public bool IsSelected
         {
-            get => _isSelected; 
-            set
-            {
-                if (_isSelected == value) return;
-                _isSelected = value;
-                if (value)
-                    _spritesManager.SelectSprite(Sprite);
-                else
-                    _spritesManager.DeselectSprite(Sprite);
-                RequireRedraw();
-            }
+            get => _isSelected;
+            set => SetSelected(value);
         }
         public LingoColor ColorCircleBorder { get; set; } = LingoColorList.Black;
         public LingoColor ColorCircle { get; set; } = LingoColorList.White;
@@ -66,7 +57,7 @@ namespace LingoEngine.Director.Core.Scores
         public float Width { get; private set; }
         public float Height { get; private set; }
         public bool ShowLabel { get; set; } = true;
-        public DirScoreSpriteLabelType LabelType { get => labelType; set { labelType = value; RequireRedraw();  } }
+        public DirScoreSpriteLabelType LabelType { get => labelType; set { labelType = value; RequireRedraw(); } }
         public bool IsLocked => Sprite.Lock;
 
         internal int DragStartChannel => _dragStartChannel;
@@ -92,7 +83,7 @@ namespace LingoEngine.Director.Core.Scores
         private void OnSelectionCleared()
         {
             if (IsSelected)
-                IsSelected = false;
+                SetSelected(false, false);
         }
 
         private void OnAnimationChanged() => RequireRedraw();
@@ -102,7 +93,21 @@ namespace LingoEngine.Director.Core.Scores
             //if (Sprite.IsDeleted)
             //    Channel?.RequireFullRedraw();
             //else
-                Channel?.RequireRedraw();
+            Channel?.RequireRedraw();
+        }
+
+        internal void SetSelected(bool value, bool notify = true)
+        {
+            if (_isSelected == value) return;
+            _isSelected = value;
+            if (notify)
+            {
+                if (value)
+                    _spritesManager.SelectSprite(Sprite);
+                else
+                    _spritesManager.DeselectSprite(Sprite);
+            }
+            RequireRedraw();
         }
 
         public void Draw(LingoGfxCanvas canvas, float frameWidth, float channelHeight, float yOffset = 0)
@@ -120,7 +125,7 @@ namespace LingoEngine.Director.Core.Scores
             var labelWidth = Width;
 
             // Draw Background
-            canvas.DrawRect(new LingoRect(X, 0, X+ Width, channelHeight), GetBgColor());
+            canvas.DrawRect(new LingoRect(X, 0, X + Width, channelHeight), GetBgColor());
 
             float radius = 3f;
             string name = Sprite.Name;
@@ -146,10 +151,10 @@ namespace LingoEngine.Director.Core.Scores
         }
 
         public bool IsFrameInSprite(int frame)
-            => Sprite.BeginFrame <= frame && Sprite.EndFrame >= frame; 
+            => Sprite.BeginFrame <= frame && Sprite.EndFrame >= frame;
         public bool IsFrameRangeInSprite(int beginFrame, int endFrame)
-            => 
-            (Sprite.BeginFrame >= beginFrame && beginFrame <= Sprite.EndFrame )
+            =>
+            (Sprite.BeginFrame >= beginFrame && beginFrame <= Sprite.EndFrame)
             || (Sprite.BeginFrame >= endFrame && endFrame <= Sprite.EndFrame)
             ;
 
@@ -230,7 +235,7 @@ namespace LingoEngine.Director.Core.Scores
             {
                 case DirScoreSpriteLabelType.Name: return Sprite2D.Name;
                 case DirScoreSpriteLabelType.Member: return Sprite2D.Member?.Name ?? string.Empty;
-                case DirScoreSpriteLabelType.Behavior: return Sprite2D.Behaviors.Count > 0 ? string.Join(",",Sprite2D.Behaviors.Select(x => x.Name)) : string.Empty;
+                case DirScoreSpriteLabelType.Behavior: return Sprite2D.Behaviors.Count > 0 ? string.Join(",", Sprite2D.Behaviors.Select(x => x.Name)) : string.Empty;
                 case DirScoreSpriteLabelType.Location: return $"{Sprite2D.LocH},{Sprite2D.LocV} ({Sprite2D.LocZ})";
                 case DirScoreSpriteLabelType.Ink: return Sprite2D.InkType.ToString();
                 case DirScoreSpriteLabelType.Blend: return Sprite2D.Blend.ToString();

--- a/src/Director/LingoEngine.Director.Core/Styles/DirectorColors.cs
+++ b/src/Director/LingoEngine.Director.Core/Styles/DirectorColors.cs
@@ -5,6 +5,7 @@ namespace LingoEngine.Director.Core.Styles
     public class DirectorColors
     {
         public static LingoColor BlueSelectColor = new LingoColor(0, 120, 215);
+        public static LingoColor BlueSelectColorSemiTransparent = new LingoColor(0, 120, 215, 80);
         public static LingoColor BlueLightSelectColor = new LingoColor(229,241,251);
         public static LingoColor BG_PropWindowBar = new LingoColor(178, 180, 191);    // Top bar of panels
         public static LingoColor BG_WhiteMenus = new LingoColor(240, 240, 240);       // Common window background


### PR DESCRIPTION
## Summary
- support drawing and applying a selection rectangle across channels
- allow silent selection updates for batch operations
- factor rectangle selection handling into dedicated helper class and use shared semi-transparent selection color

## Testing
- `dotnet format src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj --include src/Director/LingoEngine.Director.Core/Scores/DirScoreChannel.cs,src/Director/LingoEngine.Director.Core/Scores/DirScoreManager.cs,src/Director/LingoEngine.Director.Core/Scores/DirScoreRectangleSelection.cs,src/Director/LingoEngine.Director.Core/Styles/DirectorColors.cs --verbosity diagnostic`
- `dotnet test` *(fails: Could not find file '/workspace/LingoEngine/WillMoveToOwnRepo/ProjectorRays/Test/TestData/TextCast.cst')*

------
https://chatgpt.com/codex/tasks/task_e_689430bf359c8332b10aeb87a7d963aa