### PR TITLE
Refactor text edit window toolbar

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Texts/DirectorTextEditWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Texts/DirectorTextEditWindow.cs
@@ -5,6 +5,11 @@ namespace LingoEngine.Director.Core.Texts
 {
     public class DirectorTextEditWindow : DirectorWindow<IDirFrameworkTextEditWindow>
     {
-        public DirectorTextEditWindow(ILingoFrameworkFactory factory) : base(factory) { }
+        public TextEditIconBar IconBar { get; }
+
+        public DirectorTextEditWindow(ILingoFrameworkFactory factory) : base(factory)
+        {
+            IconBar = new TextEditIconBar(factory);
+        }
     }
 }

--- a/src/Director/LingoEngine.Director.Core/Texts/TextEditIconBar.cs
+++ b/src/Director/LingoEngine.Director.Core/Texts/TextEditIconBar.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+using LingoEngine.Texts;
+
+namespace LingoEngine.Director.Core.Texts;
+
+/// <summary>
+/// Reusable toolbar for editing text formatting properties.
+/// Creates all UI elements through the framework factory and
+/// exposes strongly typed events for all value changes.
+/// </summary>
+public class TextEditIconBar
+{
+    private readonly LingoGfxStateButton _alignLeft;
+    private readonly LingoGfxStateButton _alignCenter;
+    private readonly LingoGfxStateButton _alignRight;
+    private readonly LingoGfxStateButton _alignJustified;
+    private readonly LingoGfxStateButton _boldButton;
+    private readonly LingoGfxStateButton _italicButton;
+    private readonly LingoGfxStateButton _underlineButton;
+    private readonly LingoGfxPanel _colorDisplay;
+    private readonly LingoGfxColorPicker _colorPicker;
+    private readonly LingoGfxSpinBox _fontSize;
+    private readonly LingoGfxInputCombobox _fontsCombo;
+
+    /// <summary>Container panel holding the toolbar items.</summary>
+    public LingoGfxPanel Panel { get; }
+
+    /// <summary>Raised when the text alignment changes.</summary>
+    public event Action<LingoTextAlignment>? AlignmentChanged;
+    /// <summary>Raised when bold style is toggled.</summary>
+    public event Action<bool>? BoldChanged;
+    /// <summary>Raised when italic style is toggled.</summary>
+    public event Action<bool>? ItalicChanged;
+    /// <summary>Raised when underline style is toggled.</summary>
+    public event Action<bool>? UnderlineChanged;
+    /// <summary>Raised when font size changes.</summary>
+    public event Action<int>? FontSizeChanged;
+    /// <summary>Raised when a font is selected.</summary>
+    public event Action<string>? FontChanged;
+    /// <summary>Raised when color changes.</summary>
+    public event Action<LingoColor>? ColorChanged;
+
+    /// <summary>Returns whether bold is currently selected.</summary>
+    public bool IsBold => _boldButton.IsOn;
+    /// <summary>Returns whether italic is currently selected.</summary>
+    public bool IsItalic => _italicButton.IsOn;
+    /// <summary>Returns whether underline is currently selected.</summary>
+    public bool IsUnderline => _underlineButton.IsOn;
+    /// <summary>Currently selected font name.</summary>
+    public string SelectedFont => _fontsCombo.SelectedValue ?? string.Empty;
+
+    public TextEditIconBar(ILingoFrameworkFactory factory)
+    {
+        const int actionBarHeight = 22;
+
+        Panel = factory.CreatePanel("TextEditIconBar");
+        Panel.Height = actionBarHeight;
+
+        var container = factory.CreateWrapPanel(LingoOrientation.Horizontal, "TextEditIconBarContainer");
+        Panel.AddItem(container);
+
+        _alignLeft = factory.CreateStateButton("AlignLeft", null, "L", _ => AlignmentChanged?.Invoke(LingoTextAlignment.Left));
+        _alignCenter = factory.CreateStateButton("AlignCenter", null, "C", _ => AlignmentChanged?.Invoke(LingoTextAlignment.Center));
+        _alignRight = factory.CreateStateButton("AlignRight", null, "R", _ => AlignmentChanged?.Invoke(LingoTextAlignment.Right));
+        _alignJustified = factory.CreateStateButton("AlignJustified", null, "J", _ => AlignmentChanged?.Invoke(LingoTextAlignment.Justified));
+        container.AddItem(_alignLeft);
+        container.AddItem(_alignCenter);
+        container.AddItem(_alignRight);
+        container.AddItem(_alignJustified);
+
+        _boldButton = factory.CreateStateButton("Bold", null, "B", v => BoldChanged?.Invoke(v));
+        _italicButton = factory.CreateStateButton("Italic", null, "I", v => ItalicChanged?.Invoke(v));
+        _underlineButton = factory.CreateStateButton("Underline", null, "U", v => UnderlineChanged?.Invoke(v));
+        container.AddItem(_boldButton);
+        container.AddItem(_italicButton);
+        container.AddItem(_underlineButton);
+
+        _fontSize = factory.CreateSpinBox("FontSize", 1, 200, v => FontSizeChanged?.Invoke((int)v));
+        _fontSize.Width = 50;
+        container.AddItem(_fontSize);
+
+        _fontsCombo = factory.CreateInputCombobox("FontsCombo", s => { if (s != null) FontChanged?.Invoke(s); });
+        _fontsCombo.Width = 100;
+        container.AddItem(_fontsCombo);
+
+        _colorDisplay = factory.CreatePanel("ColorDisplay");
+        _colorDisplay.Width = actionBarHeight;
+        _colorDisplay.Height = actionBarHeight;
+        container.AddItem(_colorDisplay);
+
+        _colorPicker = factory.CreateColorPicker("ColorPicker", c =>
+        {
+            _colorDisplay.BackgroundColor = c;
+            ColorChanged?.Invoke(c);
+        });
+        _colorPicker.Width = actionBarHeight;
+        _colorPicker.Height = actionBarHeight;
+        container.AddItem(_colorPicker);
+    }
+
+    /// <summary>Populate fonts available for selection.</summary>
+    public void SetFonts(IEnumerable<string> fonts)
+    {
+        _fontsCombo.ClearItems();
+        foreach (var font in fonts)
+            _fontsCombo.AddItem(font, font);
+    }
+
+    /// <summary>Set the currently selected font.</summary>
+    public void SetFont(string font) => _fontsCombo.SelectedKey = font;
+
+    /// <summary>Set current font size.</summary>
+    public void SetFontSize(int size) => _fontSize.Value = size;
+
+    /// <summary>Set the alignment state.</summary>
+    public void SetAlignment(LingoTextAlignment alignment)
+    {
+        _alignLeft.IsOn = alignment == LingoTextAlignment.Left;
+        _alignCenter.IsOn = alignment == LingoTextAlignment.Center;
+        _alignRight.IsOn = alignment == LingoTextAlignment.Right;
+        _alignJustified.IsOn = alignment == LingoTextAlignment.Justified;
+    }
+
+    public void SetBold(bool on) => _boldButton.IsOn = on;
+    public void SetItalic(bool on) => _italicButton.IsOn = on;
+    public void SetUnderline(bool on) => _underlineButton.IsOn = on;
+
+    /// <summary>Set the current font color.</summary>
+    public void SetColor(LingoColor color)
+    {
+        _colorDisplay.BackgroundColor = color;
+        _colorPicker.Color = color;
+    }
+
+    /// <summary>
+    /// Update all UI controls to reflect the values of the given text member.
+    /// </summary>
+    public void SetMemberValues(ILingoMemberTextBase member)
+    {
+        SetFontSize(member.FontSize);
+        SetFont(member.Font);
+        SetColor(member.TextColor);
+        SetAlignment(member.Alignment);
+        SetBold(member.Bold);
+        SetItalic(member.Italic);
+        SetUnderline(member.Underline);
+    }
+}
+

--- a/src/Director/LingoEngine.Director.LGodot/Texts/TextableMemberWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Texts/TextableMemberWindow.cs
@@ -2,23 +2,16 @@
 using LingoEngine.Director.Core.Events;
 using LingoEngine.Texts;
 using LingoEngine.Members;
-using LingoEngine.Director.LGodot.Gfx;
 using LingoEngine.Core;
-using LingoEngine.Movies;
-using System.Linq;
-using LingoEngine.Director.LGodot.Windowing;
-using LingoEngine.Director.LGodot.Icons;
-using LingoEngine.Director.Core.Texts;
-using LingoEngine.Director.Core.Tools;
 using LingoEngine.Director.Core.Icons;
-using LingoEngine.Director.Core.UI;
+using LingoEngine.Director.Core.Texts;
+using LingoEngine.Director.LGodot.Icons;
+using LingoEngine.Director.LGodot.UI;
+using LingoEngine.Director.LGodot.Windowing;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.LGodot.Gfx;
 using LingoEngine.LGodot.Primitives;
 using LingoEngine.Styles;
-using LingoEngine.Director.LGodot.UI;
-using LingoEngine.LGodot.Gfx;
-using LingoEngine.FrameworkCommunication;
-using LingoEngine.Gfx;
-using static Godot.LinkButton;
 
 namespace LingoEngine.Director.LGodot.Casts;
 
@@ -28,26 +21,15 @@ internal partial class DirGodotTextableMemberWindow : BaseGodotWindow, IHasMembe
     private const int ActionBarHeight = 22;
     private readonly TextEdit _textEdit = new TextEdit();
     private readonly MemberNavigationBar<ILingoMemberTextBase> _navBar;
-    private readonly LingoGfxStateButton _alignLeft;
-    private readonly LingoGfxStateButton _alignCenter;
-    private readonly LingoGfxStateButton _alignRight;
-    private readonly LingoGfxStateButton _alignJustified;
-    private readonly LingoGfxStateButton _boldButton;
-    private readonly LingoGfxStateButton _italicButton;
-    private readonly LingoGfxStateButton _underlineButton;
-    private readonly ColorRect _colorDisplay = new ColorRect();
-    private readonly ColorPickerButton _colorPicker = new ColorPickerButton();
-    private readonly SpinBox _fontSize = new SpinBox();
-    private readonly OptionButton _fontsCombo = new OptionButton();
-    private readonly IconBarContainer _topBar = new IconBarContainer();
+    private readonly TextEditIconBar _iconBar;
+    private readonly LingoGodotPanel _topBar;
 
     private readonly ILingoPlayer _player;
     private readonly IDirectorIconManager _iconManager;
     private readonly ILingoFontManager _lingoFontManager;
     private ILingoMemberTextBase? _member;
-    private List<string> _allFonts;
     private const int _topOffset = 4;
-    public DirGodotTextableMemberWindow(IDirectorEventMediator mediator, ILingoPlayer player, DirectorTextEditWindow directorTextEditWindow, IDirGodotWindowManager windowManager, IDirectorIconManager iconManager, ILingoFontManager lingoFontManager, ILingoFrameworkFactory frameworkFactory)
+    public DirGodotTextableMemberWindow(IDirectorEventMediator mediator, ILingoPlayer player, DirectorTextEditWindow directorTextEditWindow, IDirGodotWindowManager windowManager, IDirectorIconManager iconManager, ILingoFontManager lingoFontManager)
         : base(DirectorMenuCodes.TextEditWindow, "Edit Text", windowManager)
     {
         _player = player;
@@ -64,43 +46,20 @@ internal partial class DirGodotTextableMemberWindow : BaseGodotWindow, IHasMembe
         _navBar.Position = new Vector2(0, TitleBarHeight);
         _navBar.CustomMinimumSize = new Vector2(Size.X, NavigationBarHeight);
 
-        _topBar.Position = new Vector2(0, TitleBarHeight + NavigationBarHeight+2);
-        AddChild(_topBar);
-
-        _alignLeft = frameworkFactory.CreateStateButton(Name + "_alignLeft", null,"L", (s) => SetAlignment(LingoTextAlignment.Left));
-        _alignCenter = frameworkFactory.CreateStateButton(Name + "_alignCenter", null, "C", (s) => SetAlignment(LingoTextAlignment.Center));
-        _alignRight = frameworkFactory.CreateStateButton(Name + "_alignRight", null, "R", (s) => SetAlignment(LingoTextAlignment.Right));
-        _alignJustified = frameworkFactory.CreateStateButton(Name + "_alignJustified", null, "J", (s) => SetAlignment(LingoTextAlignment.Justified));
-        _topBar.AddChild(_alignLeft.Framework<LingoGodotStateButton>());
-        _topBar.AddChild(_alignCenter.Framework<LingoGodotStateButton>());
-        _topBar.AddChild(_alignRight.Framework<LingoGodotStateButton>());
-        _topBar.AddChild(_alignJustified.Framework<LingoGodotStateButton>());
-
-        _boldButton = frameworkFactory.CreateStateButton(Name + "_bold", null, "B", v => ToggleStyle(LingoTextStyle.Bold, v));
-        _italicButton = frameworkFactory.CreateStateButton(Name + "_italic", null, "I", v => ToggleStyle(LingoTextStyle.Italic, v));
-        _underlineButton = frameworkFactory.CreateStateButton(Name + "_underline", null, "U", v => ToggleStyle(LingoTextStyle.Underline, v));
-        _topBar.AddChild(_boldButton.Framework<LingoGodotStateButton>());
-        _topBar.AddChild(_italicButton.Framework<LingoGodotStateButton>());
-        _topBar.AddChild(_underlineButton.Framework<LingoGodotStateButton>());
-
-        _fontSize.MinValue = 1;
-        _fontSize.MaxValue = 200;
-        _fontSize.CustomMinimumSize = new Vector2(50, 16);
-        _fontSize.ValueChanged += v =>
+        _iconBar = directorTextEditWindow.IconBar;
+        _iconBar.AlignmentChanged += a => SetAlignment(a);
+        _iconBar.BoldChanged += v => ToggleStyle(LingoTextStyle.Bold, v);
+        _iconBar.ItalicChanged += v => ToggleStyle(LingoTextStyle.Italic, v);
+        _iconBar.UnderlineChanged += v => ToggleStyle(LingoTextStyle.Underline, v);
+        _iconBar.FontSizeChanged += v =>
         {
             if (_member != null)
-                _member.FontSize = (int)v;
-            _textEdit.AddThemeConstantOverride("font_size", (int)v);
+                _member.FontSize = v;
+            _textEdit.AddThemeConstantOverride("font_size", v);
             ApplyStyleToEditor();
         };
-        _topBar.AddChild(_fontSize);
-
-        _allFonts = _lingoFontManager.GetAllNames().ToList();
-        foreach (var font in _allFonts)
-            _fontsCombo.AddItem(font);
-        _fontsCombo.ItemSelected += id =>
+        _iconBar.FontChanged += fontName =>
         {
-            var fontName = _fontsCombo.GetItemText((int)id);
             if (_member != null)
                 _member.Font = fontName;
             var f = _lingoFontManager.Get<Font>(fontName);
@@ -108,15 +67,20 @@ internal partial class DirGodotTextableMemberWindow : BaseGodotWindow, IHasMembe
                 _textEdit.AddThemeFontOverride("font", f);
             ApplyStyleToEditor();
         };
-        _topBar.AddChild(_fontsCombo);
+        _iconBar.ColorChanged += c =>
+        {
+            _textEdit.AddThemeColorOverride("font_color", c.ToGodotColor());
+            if (_member != null)
+                _member.TextColor = c;
+        };
 
-        _colorDisplay.CustomMinimumSize = new Vector2(ActionBarHeight, ActionBarHeight);
-        _topBar.AddChild(_colorDisplay);
-        _colorPicker.CustomMinimumSize = new Vector2(ActionBarHeight, ActionBarHeight);
-        _colorPicker.ColorChanged += c => OnColorChanged(c);
-        _topBar.AddChild(_colorPicker);
+        _iconBar.SetFonts(_lingoFontManager.GetAllNames());
 
-        _textEdit.Position = new Vector2(0, TitleBarHeight + NavigationBarHeight + ActionBarHeight+ _topOffset);
+        _topBar = _iconBar.Panel.Framework<LingoGodotPanel>();
+        _topBar.Position = new Vector2(0, TitleBarHeight + NavigationBarHeight + 2);
+        AddChild(_topBar);
+
+        _textEdit.Position = new Vector2(0, TitleBarHeight + NavigationBarHeight + ActionBarHeight + _topOffset);
         _textEdit.Size = new Vector2(Size.X - 10, Size.Y - (TitleBarHeight + NavigationBarHeight + ActionBarHeight + 5));
         _textEdit.SizeFlagsHorizontal = SizeFlags.ExpandFill;
         _textEdit.SizeFlagsVertical = SizeFlags.ExpandFill;
@@ -131,39 +95,22 @@ internal partial class DirGodotTextableMemberWindow : BaseGodotWindow, IHasMembe
 
     public void MemberSelected(ILingoMember member)
     {
-        if (member is not ILingoMemberTextBase textMember)
-            return;
-        
+        if (member is ILingoMemberTextBase textMember)
+            SetMemberValues(textMember);
+    }
+
+    private void SetMemberValues(ILingoMemberTextBase textMember)
+    {
         _member = textMember;
         _textEdit.Text = textMember.Text.Replace("\r", "\r\n");
         _textEdit.AddThemeColorOverride("font_color", textMember.TextColor.ToGodotColor());
         _textEdit.AddThemeConstantOverride("font_size", textMember.FontSize);
         var font = _lingoFontManager.Get<Font>(textMember.Font);
         if (font != null)
-        {
             _textEdit.AddThemeFontOverride("font", font);
-            _fontsCombo.Selected = _allFonts.IndexOf(textMember.Font);
-        }
-        _colorDisplay.Color = textMember.TextColor.ToGodotColor();
-        _colorPicker.Color = textMember.TextColor.ToGodotColor();
-        _fontSize.Value = textMember.FontSize;
+
+        _iconBar.SetMemberValues(textMember);
         _navBar.SetMember(textMember);
-        _alignLeft.IsOn = false;
-        _alignCenter.IsOn = false;
-        _alignRight.IsOn = false;
-        _alignJustified.IsOn = false;
-        _boldButton.IsOn = textMember.Bold;
-        _italicButton.IsOn = textMember.Italic;
-        _underlineButton.IsOn = textMember.Underline;
-        switch (textMember.Alignment)
-        {
-            case LingoTextAlignment.Left:_alignLeft.IsOn = true;break;
-            case LingoTextAlignment.Center: _alignCenter.IsOn = true; break;
-            case LingoTextAlignment.Right: _alignRight.IsOn = true; break;
-            case LingoTextAlignment.Justified: _alignJustified.IsOn = true; break;
-            default:
-                break;
-        }
         ApplyStyleToEditor();
     }
 
@@ -171,7 +118,8 @@ internal partial class DirGodotTextableMemberWindow : BaseGodotWindow, IHasMembe
     {
         base.OnResizing(size);
         _navBar.CustomMinimumSize = new Vector2(size.X, NavigationBarHeight);
-        _textEdit.Size = new Vector2(size.X - 10, size.Y - (TitleBarHeight + NavigationBarHeight + ActionBarHeight + 5+ _topOffset));
+        _iconBar.Panel.Width = size.X;
+        _textEdit.Size = new Vector2(size.X - 10, size.Y - (TitleBarHeight + NavigationBarHeight + ActionBarHeight + 5 + _topOffset));
     }
 
     private bool SetAlignment(LingoTextAlignment alignment)
@@ -188,14 +136,6 @@ internal partial class DirGodotTextableMemberWindow : BaseGodotWindow, IHasMembe
         };
         _textEdit.Set("alignment", val);
         return true;
-    }
-
-    private void OnColorChanged(Color color)
-    {
-        _colorDisplay.Color = color;
-        _textEdit.AddThemeColorOverride("font_color", color);
-        if (_member != null)
-            _member.TextColor = color.ToLingoColor();
     }
 
     private void ToggleStyle(LingoTextStyle style, bool on)
@@ -215,22 +155,22 @@ internal partial class DirGodotTextableMemberWindow : BaseGodotWindow, IHasMembe
 
     private void ApplyStyleToEditor()
     {
-        var fontName = _fontsCombo.GetItemText(_fontsCombo.Selected);
+        var fontName = _iconBar.SelectedFont;
         var font = _lingoFontManager.Get<Font>(fontName);
         if (font != null)
         {
             var variation = new FontVariation { BaseFont = font };
             TextServer.FontStyle fs = 0;
-            if (_boldButton.IsOn)
+            if (_iconBar.IsBold)
                 fs |= TextServer.FontStyle.Bold;
-            if (_italicButton.IsOn)
+            if (_iconBar.IsItalic)
                 fs |= TextServer.FontStyle.Italic;
-           // variation.FontStyle = fs;
+            // variation.FontStyle = fs;
             //_textEdit.AddThemeFontOverride("font", variation);
         }
-        //_textEdit.UnderlineMode = _underlineButton.IsOn ? UnderlineMode.Always : UnderlineMode.Disabled;
+        //_textEdit.UnderlineMode = _iconBar.IsUnderline ? UnderlineMode.Always : UnderlineMode.Disabled;
     }
 
 
-   
+
 }


### PR DESCRIPTION
## Summary
- extract reusable `TextEditIconBar` with alignment, style, font, size and color events
- expose icon bar from `DirectorTextEditWindow`
- simplify Godot text member window to use new icon bar and raised events
- centralize icon bar state updates through `SetMemberValues`

## Testing
- `~/.dotnet/dotnet format LingoEngine.sln --verbosity diagnostic --include src/Director/LingoEngine.Director.Core/Texts/TextEditIconBar.cs src/Director/LingoEngine.Director.LGodot/Texts/TextableMemberWindow.cs`
- `~/.dotnet/dotnet test --no-build` *(fails: Could not find file '/workspace/LingoEngine/WillMoveToOwnRepo/ProjectorRays/Test/TestData/TextCast.cst')*


------
https://chatgpt.com/codex/tasks/task_e_689445c274b48332908b2cba4147b0e7