### PR TITLE
Display empty cast slots

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Casts/DirCastItem.cs
+++ b/src/Director/LingoEngine.Director.Core/Casts/DirCastItem.cs
@@ -12,27 +12,35 @@ namespace LingoEngine.Director.Core.Casts;
 /// preview is delegated to <see cref="DirectorMemberThumbnail"/> so the logic
 /// can be shared across frameworks.
 /// </summary>
-public class DirCastItem 
+public class DirCastItem
 {
     public const int Width = 58;
     public const int Height = 54;
     private const int LabelHeight = 12;
 
-    private readonly ILingoMember _member;
+    private ILingoMember? _member;
+    private readonly int _slotNumber;
     private bool _selected;
     private bool _hovered;
     private readonly LingoGfxCanvas _canvas;
     private DirectorMemberThumbnail _thumb;
 
-    public ILingoMember Member => _member;
+    public ILingoMember? Member => _member;
     public LingoGfxCanvas Canvas => _canvas;
 
-    public DirCastItem(ILingoFrameworkFactory factory, ILingoMember member, int index, IDirectorIconManager? iconManager)
+    public DirCastItem(ILingoFrameworkFactory factory, ILingoMember? member, int slotNumber, IDirectorIconManager? iconManager)
     {
         _member = member;
-        _canvas = factory.CreateGfxCanvas($"CastMemberCanvas_{index}", Width, Height);
-        
-        _thumb = new DirectorMemberThumbnail(Width - 2, Height - LabelHeight-1, factory, iconManager, _canvas, 1, 1);
+        _slotNumber = slotNumber;
+        _canvas = factory.CreateGfxCanvas($"CastMemberCanvas_{slotNumber}", Width, Height);
+
+        _thumb = new DirectorMemberThumbnail(Width - 2, Height - LabelHeight - 1, factory, iconManager, _canvas, 1, 1);
+        Draw();
+    }
+
+    public void SetMember(ILingoMember? member)
+    {
+        _member = member;
         Draw();
     }
 
@@ -70,14 +78,25 @@ public class DirCastItem
             _canvas.DrawLine(new LingoPoint(0, Height), new LingoPoint(Width, Height), DirectorColors.LineLight); // bottom
             _canvas.DrawLine(new LingoPoint(Width, 0), new LingoPoint(Width, Height), DirectorColors.LineLight); // right
         }
-        
-        // draw member preview
-        _thumb.SetMember(_member);
+
+        // draw member preview or empty slot
+        if (_member != null)
+        {
+            _thumb.SetMember(_member);
+        }
+        else
+        {
+            _thumb.SetEmpty();
+        }
 
         // label text
-        string label = $"{_member.NumberInCast}. {_member.Name}";
-        _canvas.DrawText(new LingoPoint(2, Height - LabelHeight + 10), label, null, _selected?LingoColorList.White : LingoColorList.Black, 8, Width - 4);
-        
+        string label;
+        if (_member != null)
+            label = $"{_member.NumberInCast}. {_member.Name}";
+        else
+            label = _slotNumber.ToString();
+        _canvas.DrawText(new LingoPoint(2, Height - LabelHeight + 10), label, null, _selected ? LingoColorList.White : LingoColorList.Black, 8, Width - 4);
+
 
 
     }

--- a/src/Director/LingoEngine.Director.Core/Casts/DirectorMemberThumbnail.cs
+++ b/src/Director/LingoEngine.Director.Core/Casts/DirectorMemberThumbnail.cs
@@ -46,10 +46,10 @@ public class DirectorMemberThumbnail : IDisposable
         _isCustomCanvas = canvas != null;
         ThumbWidth = width;
         ThumbHeight = height;
-       
-        Canvas = canvas?? factory.CreateGfxCanvas("MemberThumbnailCanvas", width, height);
+
+        Canvas = canvas ?? factory.CreateGfxCanvas("MemberThumbnailCanvas", width, height);
         _iconManager = iconManager;
-        
+
     }
 
     /// <summary>
@@ -59,10 +59,8 @@ public class DirectorMemberThumbnail : IDisposable
     {
         if (!_isCustomCanvas)
             Canvas.Clear(DirectorColors.BG_WhiteMenus);
-       
-        Canvas.DrawRect(LingoRect.New(_xOffset, _yOffset, _rectWidth, ThumbHeight ), LingoColorList.White, true);
-        Canvas.DrawRect(LingoRect.New(_xOffset, _yOffset, _rectWidth, ThumbHeight ), LingoColorList.Gray, false);
-        
+        DrawBorder();
+
         switch (member)
         {
             case LingoMemberBitmap pic:
@@ -83,12 +81,25 @@ public class DirectorMemberThumbnail : IDisposable
             {
                 var miniIconSize = 16;
                 var data = _iconManager.Get(icon.Value);
-                var x = ThumbWidth - miniIconSize-1;
-                var y = ThumbHeight - miniIconSize-1+ _iconYOffset;
-                Canvas.DrawRect(LingoRect.New(_xOffset+x, _yOffset + y, miniIconSize, miniIconSize), LingoColorList.White,true);
-                Canvas.DrawPicture(data, miniIconSize -2, miniIconSize-2, new LingoPoint(_xOffset+x + 1, _yOffset + y +1));
+                var x = ThumbWidth - miniIconSize - 1;
+                var y = ThumbHeight - miniIconSize - 1 + _iconYOffset;
+                Canvas.DrawRect(LingoRect.New(_xOffset + x, _yOffset + y, miniIconSize, miniIconSize), LingoColorList.White, true);
+                Canvas.DrawPicture(data, miniIconSize - 2, miniIconSize - 2, new LingoPoint(_xOffset + x + 1, _yOffset + y + 1));
             }
         }
+    }
+
+    public void SetEmpty()
+    {
+        if (!_isCustomCanvas)
+            Canvas.Clear(DirectorColors.BG_WhiteMenus);
+        DrawBorder();
+    }
+
+    private void DrawBorder()
+    {
+        Canvas.DrawRect(LingoRect.New(_xOffset, _yOffset, _rectWidth, ThumbHeight), LingoColorList.White, true);
+        Canvas.DrawRect(LingoRect.New(_xOffset, _yOffset, _rectWidth, ThumbHeight), LingoColorList.Gray, false);
     }
 
     private void DrawPicture(LingoMemberBitmap picture)
@@ -99,8 +110,8 @@ public class DirectorMemberThumbnail : IDisposable
             return;
         var w = impl.Width;
         var h = impl.Height;
-       
-        Canvas.DrawPicture(impl.Texture, ThumbWidth-2, ThumbHeight-2, new LingoPoint(_xOffset+1, _yOffset + 2));
+
+        Canvas.DrawPicture(impl.Texture, ThumbWidth - 2, ThumbHeight - 2, new LingoPoint(_xOffset + 1, _yOffset + 2));
     }
 
     private void DrawText(string text)
@@ -113,7 +124,7 @@ public class DirectorMemberThumbnail : IDisposable
         var startY = _yOffset + (int)Math.Max((ThumbHeight - textHeight) / 2f, 0);
 
         int maxWidth = ThumbWidth - 4;
-        Canvas.DrawText(new LingoPoint(_xOffset+2, startY), text, null, new LingoColor(0, 0, 0), fontSize, maxWidth);
+        Canvas.DrawText(new LingoPoint(_xOffset + 2, startY), text, null, new LingoColor(0, 0, 0), fontSize, maxWidth);
     }
 
     private static string GetPreviewText(ILingoMemberTextBase text)


### PR DESCRIPTION
## Summary
- Show 999 slots in cast tab
- Render placeholder slots for missing members
- Guard cast item drag logic against empty slots

## Testing
- `dotnet format LingoEngine.sln --include src/Director/LingoEngine.Director.Core/Casts/DirCastItem.cs src/Director/LingoEngine.Director.Core/Casts/DirCastTab.cs src/Director/LingoEngine.Director.Core/Casts/DirectorMemberThumbnail.cs -v diag --verify-no-changes`
- `dotnet test` *(fails: Could not find file 'Test/TestData/TextCast.cst')*

------
https://chatgpt.com/codex/tasks/task_e_689455613b888332a721ecb5c35463f8