### PR TITLE
Delegate film loop texture composition to frameworks

### DIFF
--- a/src/LingoEngine.LGodot/Bitmaps/LingoGodotMemberFilmLoop.cs
+++ b/src/LingoEngine.LGodot/Bitmaps/LingoGodotMemberFilmLoop.cs
@@ -2,6 +2,9 @@ using Godot;
 using LingoEngine.Bitmaps;
 using LingoEngine.FilmLoops;
 using LingoEngine.Sprites;
+using System.Collections.Generic;
+using System;
+using LingoEngine.Members;
 
 namespace LingoEngine.LGodot.Bitmaps
 {
@@ -13,6 +16,7 @@ namespace LingoEngine.LGodot.Bitmaps
         private LingoFilmLoopMember _member = null!;
         public bool IsLoaded { get; private set; }
         public byte[]? Media { get; set; }
+        public ILingoTexture2D? Texture { get; set; }
         public LingoFilmLoopFraming Framing { get; set; } = LingoFilmLoopFraming.Auto;
         public bool Loop { get; set; } = true;
 
@@ -48,8 +52,11 @@ namespace LingoEngine.LGodot.Bitmaps
 
         public void CopyToClipboard()
         {
-            if (Media == null) return;
-            var base64 = Convert.ToBase64String(Media);
+            if (Texture is not LingoGodotTexture2D tex)
+                return;
+            var img = tex.Texture.GetImage();
+            var bytes = img.SavePngToBuffer();
+            var base64 = Convert.ToBase64String(bytes);
             DisplayServer.ClipboardSet(base64);
         }
 
@@ -59,12 +66,57 @@ namespace LingoEngine.LGodot.Bitmaps
             if (string.IsNullOrEmpty(data)) return;
             try
             {
-                Media = Convert.FromBase64String(data);
+                var bytes = Convert.FromBase64String(data);
+                var image = new Image();
+                if (image.LoadPngFromBuffer(bytes) != Error.Ok)
+                    return;
+                Media = bytes;
+                Texture = new LingoGodotTexture2D(ImageTexture.CreateFromImage(image));
             }
             catch
             {
                 // ignore malformed clipboard data
             }
+        }
+
+        public void ComposeTexture(LingoSprite2D hostSprite, IReadOnlyList<LingoSprite2DVirtual> layers)
+        {
+            var image = Image.Create((int)hostSprite.Width, (int)hostSprite.Height, false, Image.Format.Rgba8);
+            foreach (var layer in layers)
+            {
+                if (layer.Member is not LingoMemberBitmap pic)
+                    continue;
+                var bmp = pic.Framework<LingoGodotMemberBitmap>();
+                var srcTex = bmp.TextureGodot;
+                if (srcTex == null)
+                    continue;
+
+                var srcImg = srcTex.GetImage();
+                int destW = (int)layer.Width;
+                int destH = (int)layer.Height;
+
+                if (Framing == LingoFilmLoopFraming.Scale)
+                {
+                    if (destW != srcImg.GetWidth() || destH != srcImg.GetHeight())
+                        srcImg.Resize(destW, destH, Image.Interpolation.Bilinear);
+                    int x = (int)(layer.LocH + hostSprite.Width / 2f - destW / 2f);
+                    int y = (int)(layer.LocV + hostSprite.Height / 2f - destH / 2f);
+                    image.BlendRect(srcImg, new Rect2I(0, 0, destW, destH), new Vector2I(x, y));
+                }
+                else
+                {
+                    int cropW = Math.Min(destW, srcImg.GetWidth());
+                    int cropH = Math.Min(destH, srcImg.GetHeight());
+                    int cropX = (srcImg.GetWidth() - cropW) / 2;
+                    int cropY = (srcImg.GetHeight() - cropH) / 2;
+                    var cropped = srcImg.GetRegion(new Rect2I(cropX, cropY, cropW, cropH));
+                    int x = (int)(layer.LocH + hostSprite.Width / 2f - cropW / 2f);
+                    int y = (int)(layer.LocV + hostSprite.Height / 2f - cropH / 2f);
+                    image.BlendRect(cropped, new Rect2I(0, 0, cropW, cropH), new Vector2I(x, y));
+                }
+            }
+            var tex = ImageTexture.CreateFromImage(image);
+            Texture = new LingoGodotTexture2D(tex);
         }
 
         public void Dispose()

--- a/src/LingoEngine.LGodot/Sprites/LingoGodotSprite.cs
+++ b/src/LingoEngine.LGodot/Sprites/LingoGodotSprite.cs
@@ -12,6 +12,7 @@ using LingoEngine.Texts.FrameworkCommunication;
 using LingoEngine.Shapes;
 using LingoEngine.LGodot.Shapes;
 using LingoEngine.LGodot.Primitives;
+using LingoEngine.FilmLoops;
 
 namespace LingoEngine.LGodot.Sprites
 {
@@ -37,8 +38,11 @@ namespace LingoEngine.LGodot.Sprites
         private float _x;
         private float _y;
         public float X { get => _x; set { _x = value; IsDirty = true; } }
-        public float Y { get => _y; 
-            set { _y = value; IsDirty = true; } }
+        public float Y
+        {
+            get => _y;
+            set { _y = value; IsDirty = true; }
+        }
         private int _zIndex;
         public int ZIndex
         {
@@ -275,10 +279,10 @@ namespace LingoEngine.LGodot.Sprites
             // todo: move this 2 lines in IsDirty if test
             var offset = GetRegPointOffset();
             _Sprite2D.Position = new Vector2(_x - offset.X, _y - offset.Y);
-            
+
         }
 
-       
+
         private void UpdateMember()
         {
             if (!IsDirtyMember) return;
@@ -290,6 +294,14 @@ namespace LingoEngine.LGodot.Sprites
                 case LingoMemberBitmap pictureMember:
                     RemoveLastChildElement();
                     UpdateMemberPicture(pictureMember.Framework<LingoGodotMemberBitmap>());
+                    UpdateSizeFromTexture();
+                    if (_DesiredWidth == 0) _DesiredWidth = Width;
+                    if (_DesiredHeight == 0) _DesiredHeight = Height;
+                    IsDirty = true;
+                    return;
+                case LingoFilmLoopMember flm:
+                    RemoveLastChildElement();
+                    UpdateMemberFilmLoop(flm.Framework<LingoGodotMemberFilmLoop>());
                     UpdateSizeFromTexture();
                     if (_DesiredWidth == 0) _DesiredWidth = Width;
                     if (_DesiredHeight == 0) _DesiredHeight = Height;
@@ -308,7 +320,7 @@ namespace LingoEngine.LGodot.Sprites
                     UpdateNodeMember(_lingoSprite.Member, (Node)shape.Framework<LingoGodotMemberShape>().CloneForSpriteDraw());
                     break;
             }
-            
+
             UpdateSprite2DName();
         }
         public void ApplyMemberChanges()
@@ -329,7 +341,7 @@ namespace LingoEngine.LGodot.Sprites
         }
         private void RemoveLastChildElement()
         {
-            if (_previousChildElementNode != null) 
+            if (_previousChildElementNode != null)
                 _Sprite2D.RemoveChild(_previousChildElementNode);
             _previousChildElementNode = null;
             _previousChildElement = null;
@@ -346,9 +358,17 @@ namespace LingoEngine.LGodot.Sprites
             else
                 _Sprite2D.Texture = godotPicture.TextureGodot;
         }
+        private void UpdateMemberFilmLoop(LingoGodotMemberFilmLoop filmLoop)
+        {
+            if (filmLoop.Texture is not LingoGodotTexture2D tex)
+                return;
+            _Sprite2D.Texture = tex.Texture;
+            Width = tex.Width;
+            Height = tex.Height;
+        }
         private ILingoMember? _previousChildElement;
         private Node? _previousChildElementNode;
-        
+
         private void UpdateNodeMember(ILingoMember member, Node godotElement) // Clone required to be able to draw multiple times the same member
         {
             if (_previousChildElement == member) return;

--- a/src/LingoEngine.SDL2/Bitmaps/SdlImageTexture.cs
+++ b/src/LingoEngine.SDL2/Bitmaps/SdlImageTexture.cs
@@ -21,3 +21,17 @@ public class SdlImageTexture : ILingoImageTexture
         Height = height;
     }
 }
+
+public class SdlTexture2D : ILingoTexture2D
+{
+    public nint Texture { get; }
+    public int Width { get; }
+    public int Height { get; }
+
+    public SdlTexture2D(nint texture, int width, int height)
+    {
+        Texture = texture;
+        Width = width;
+        Height = height;
+    }
+}

--- a/src/LingoEngine.SDL2/Bitmaps/SdlMemberFilmLoop.cs
+++ b/src/LingoEngine.SDL2/Bitmaps/SdlMemberFilmLoop.cs
@@ -1,7 +1,11 @@
 using System;
+using System.Collections.Generic;
 using LingoEngine.Bitmaps;
 using LingoEngine.FilmLoops;
+using LingoEngine.Members;
 using LingoEngine.SDL2.Inputs;
+using LingoEngine.SDL2.SDLL;
+using LingoEngine.SDL2.Sprites;
 using LingoEngine.Sprites;
 
 namespace LingoEngine.SDL2.Pictures;
@@ -11,6 +15,7 @@ public class SdlMemberFilmLoop : ILingoFrameworkMemberFilmLoop, IDisposable
     private LingoFilmLoopMember _member = null!;
     public bool IsLoaded { get; private set; }
     public byte[]? Media { get; set; }
+    public ILingoTexture2D? Texture { get; set; }
     public LingoFilmLoopFraming Framing { get; set; } = LingoFilmLoopFraming.Auto;
     public bool Loop { get; set; } = true;
 
@@ -26,6 +31,11 @@ public class SdlMemberFilmLoop : ILingoFrameworkMemberFilmLoop, IDisposable
 
     public void Unload()
     {
+        if (Texture is SdlTexture2D tex && tex.Texture != nint.Zero)
+        {
+            SDL.SDL_DestroyTexture(tex.Texture);
+            Texture = null;
+        }
         IsLoaded = false;
     }
 
@@ -58,6 +68,66 @@ public class SdlMemberFilmLoop : ILingoFrameworkMemberFilmLoop, IDisposable
         catch
         {
         }
+    }
+
+    public void ComposeTexture(LingoSprite2D hostSprite, IReadOnlyList<LingoSprite2DVirtual> layers)
+    {
+        var sdlSprite = hostSprite.FrameworkObj as SdlSprite;
+        if (sdlSprite == null)
+            return;
+        int width = (int)hostSprite.Width;
+        int height = (int)hostSprite.Height;
+        nint surface = SDL.SDL_CreateRGBSurfaceWithFormat(0, width, height, 32, SDL.SDL_PIXELFORMAT_RGBA32);
+        if (surface == nint.Zero)
+            return;
+        foreach (var layer in layers)
+        {
+            if (layer.Member is not LingoMemberBitmap pic)
+                continue;
+            var bmp = pic.Framework<SdlMemberBitmap>();
+            var src = bmp.Surface;
+            if (src == nint.Zero)
+                continue;
+
+            int destW = (int)layer.Width;
+            int destH = (int)layer.Height;
+            int srcW = bmp.Width;
+            int srcH = bmp.Height;
+            SDL.SDL_Rect srcRect;
+            SDL.SDL_Rect dstRect;
+
+            if (Framing == LingoFilmLoopFraming.Scale)
+            {
+                srcRect = new SDL.SDL_Rect { x = 0, y = 0, w = srcW, h = srcH };
+                int x = (int)(layer.LocH + hostSprite.Width / 2f - destW / 2f);
+                int y = (int)(layer.LocV + hostSprite.Height / 2f - destH / 2f);
+                dstRect = new SDL.SDL_Rect { x = x, y = y, w = destW, h = destH };
+                if (destW != srcW || destH != srcH)
+                    SDL.SDL_BlitScaled(src, ref srcRect, surface, ref dstRect);
+                else
+                    SDL.SDL_BlitSurface(src, ref srcRect, surface, ref dstRect);
+            }
+            else
+            {
+                int cropW = Math.Min(destW, srcW);
+                int cropH = Math.Min(destH, srcH);
+                int cropX = (srcW - cropW) / 2;
+                int cropY = (srcH - cropH) / 2;
+                srcRect = new SDL.SDL_Rect { x = cropX, y = cropY, w = cropW, h = cropH };
+                int x = (int)(layer.LocH + hostSprite.Width / 2f - cropW / 2f);
+                int y = (int)(layer.LocV + hostSprite.Height / 2f - cropH / 2f);
+                dstRect = new SDL.SDL_Rect { x = x, y = y, w = cropW, h = cropH };
+                SDL.SDL_BlitSurface(src, ref srcRect, surface, ref dstRect);
+            }
+        }
+        if (Texture is SdlTexture2D tex && tex.Texture != nint.Zero)
+        {
+            SDL.SDL_DestroyTexture(tex.Texture);
+        }
+        nint texture = SDL.SDL_CreateTextureFromSurface(sdlSprite.Renderer, surface);
+        SDL.SDL_FreeSurface(surface);
+        if (texture != nint.Zero)
+            Texture = new SdlTexture2D(texture, width, height);
     }
 
     public void Dispose() { Unload(); }

--- a/src/LingoEngine.SDL2/Sprites/SdlSprite.cs
+++ b/src/LingoEngine.SDL2/Sprites/SdlSprite.cs
@@ -1,5 +1,6 @@
 using LingoEngine.Bitmaps;
 using LingoEngine.Members;
+using LingoEngine.FilmLoops;
 using LingoEngine.Primitives;
 using LingoEngine.SDL2.Pictures;
 using LingoEngine.SDL2.SDLL;
@@ -20,6 +21,7 @@ public class SdlSprite : ILingoFrameworkSprite, IDisposable
 
     private readonly nint _renderer;
     private nint _texture = nint.Zero;
+    internal nint Renderer => _renderer;
 
     public SdlSprite(LingoSprite2D sprite, nint renderer, Action<SdlSprite> show, Action<SdlSprite> hide, Action<SdlSprite> remove)
     {
@@ -189,6 +191,19 @@ public class SdlSprite : ILingoFrameworkSprite, IDisposable
                             Height = p.Height;
                         }
                     }
+                }
+                break;
+            case LingoFilmLoopMember flm:
+                var fl = flm.Framework<SdlMemberFilmLoop>();
+                if (fl.Texture is SdlTexture2D tex && tex.Texture != nint.Zero)
+                {
+                    if (_texture != nint.Zero && _texture != tex.Texture)
+                    {
+                        SDL.SDL_DestroyTexture(_texture);
+                    }
+                    _texture = tex.Texture;
+                    Width = tex.Width;
+                    Height = tex.Height;
                 }
                 break;
             case LingoMemberText text:

--- a/src/LingoEngine/Bitmaps/ILingoFrameworkMemberFilmLoop.cs
+++ b/src/LingoEngine/Bitmaps/ILingoFrameworkMemberFilmLoop.cs
@@ -1,5 +1,7 @@
 using LingoEngine.FilmLoops;
 using LingoEngine.Members;
+using LingoEngine.Sprites;
+using System.Collections.Generic;
 
 namespace LingoEngine.Bitmaps
 {
@@ -14,6 +16,11 @@ namespace LingoEngine.Bitmaps
         byte[]? Media { get; set; }
 
         /// <summary>
+        /// Composed texture for the current film loop frame.
+        /// </summary>
+        ILingoTexture2D? Texture { get; set; }
+
+        /// <summary>
         /// Determines how the film loop should be framed within its sprite rectangle.
         /// Mirrors the Lingo <c>framing</c> property with values <c>#crop</c>, <c>#scale</c>, or <c>#auto</c>.
         /// </summary>
@@ -24,5 +31,12 @@ namespace LingoEngine.Bitmaps
         /// Corresponds to the Lingo <c>loop</c> property used with film loop sprites.
         /// </summary>
         bool Loop { get; set; }
+
+        /// <summary>
+        /// Composes the active film loop layers into a single texture.
+        /// </summary>
+        /// <param name="hostSprite">The sprite hosting the film loop.</param>
+        /// <param name="layers">Currently active layers for this frame.</param>
+        void ComposeTexture(LingoSprite2D hostSprite, IReadOnlyList<LingoSprite2DVirtual> layers);
     }
 }


### PR DESCRIPTION
## Summary
- Fix film loop runtime layer positioning to be relative to the host sprite
- Add crop and scale handling to Godot and SDL film loop compositors

## Testing
- `dotnet format LingoEngine.sln --include src/LingoEngine/FilmLoops/LingoFilmLoopPlayer.cs src/LingoEngine.SDL2/Bitmaps/SdlMemberFilmLoop.cs src/LingoEngine.LGodot/Bitmaps/LingoGodotMemberFilmLoop.cs -v diag`
- `dotnet test LingoEngine.sln --no-build` (fails: 6, passes: 2)


------
https://chatgpt.com/codex/tasks/task_e_6895861df0f88332bf98fe8671bf6155