### PR TITLE
Fix film loop bounding box calculations

### DIFF
--- a/src/LingoEngine.LGodot/FilmLoops/LingoGodotFilmLoopMember.cs
+++ b/src/LingoEngine.LGodot/FilmLoops/LingoGodotFilmLoopMember.cs
@@ -4,6 +4,8 @@ using LingoEngine.FilmLoops;
 using LingoEngine.LGodot.Bitmaps;
 using LingoEngine.Primitives;
 using LingoEngine.Sprites;
+using System;
+using System.Linq;
 
 namespace LingoEngine.LGodot.FilmLoops
 {
@@ -17,6 +19,7 @@ namespace LingoEngine.LGodot.FilmLoops
         public byte[]? Media { get; set; }
         public LingoFilmLoopFraming Framing { get; set; } = LingoFilmLoopFraming.Auto;
         public bool Loop { get; set; } = true;
+        public LingoPoint Offset { get; private set; }
 
         public LingoFilmLoopMember Member => _member;
         public LingoGodotFilmLoopMember()
@@ -52,24 +55,23 @@ namespace LingoEngine.LGodot.FilmLoops
 
         public ILingoTexture2D ComposeTexture(LingoSprite2D hostSprite, IReadOnlyList<LingoSprite2DVirtual> layers)
         {
-            //var image = Image.CreateEmpty((int)hostSprite.Width, (int)hostSprite.Height, false, Image.Format.Rgba8);
-            var image = Image.CreateEmpty(300, 300, false, Image.Format.Rgba8);
+            var bounds = _member.GetBoundingBox();
+            Offset = new LingoPoint(-bounds.Left, -bounds.Top);
+            int width = (int)MathF.Ceiling(bounds.Width);
+            int height = (int)MathF.Ceiling(bounds.Height);
+            var image = Image.CreateEmpty(width, height, false, Image.Format.Rgba8);
+            image.Lock();
             foreach (var layer in layers)
             {
                 if (layer.Member is not LingoMemberBitmap pic)
-                    // TODO : add text and in SDL too
                     continue;
-                
+
                 var bmp = pic.Framework<LingoGodotMemberBitmap>();
-                //var srcTex = bmp.TextureGodot;
                 if (bmp.TextureGodot == null) continue;
                 var srcTex = bmp.GetTextureForInk(layer.InkType, layer.BackColor);
                 if (srcTex == null)
                     continue;
                 var srcImg = srcTex.GetImage();
-                //DebugToDisk(srcImg, "Layer_"+layer.SpriteNum);
-                //image.BlitRect(srcImg, new Rect2I(0, 0, srcImg.GetWidth(), srcImg.GetHeight()), new Vector2I(3, 3));
-                //image.BlendRect(srcImg, new Rect2I(0, 0, bmp.Width, bmp.Height), new Vector2I(3, 3));
                 int destW = (int)layer.Width;
                 int destH = (int)layer.Height;
 
@@ -77,9 +79,6 @@ namespace LingoEngine.LGodot.FilmLoops
                 {
                     if (destW != srcImg.GetWidth() || destH != srcImg.GetHeight())
                         srcImg.Resize(destW, destH, Image.Interpolation.Bilinear);
-                    int x = (int)(layer.LocH + hostSprite.Width / 2f - destW / 2f);
-                    int y = (int)(layer.LocV + hostSprite.Height / 2f - destH / 2f);
-                    image.BlendRect(srcImg, new Rect2I(0, 0, destW, destH), new Vector2I(x, y));
                 }
                 else
                 {
@@ -87,25 +86,85 @@ namespace LingoEngine.LGodot.FilmLoops
                     int cropH = Math.Min(destH, srcImg.GetHeight());
                     int cropX = (srcImg.GetWidth() - cropW) / 2;
                     int cropY = (srcImg.GetHeight() - cropH) / 2;
-                    var cropped = srcImg.GetRegion(new Rect2I(cropX, cropY, cropW, cropH));
-                    int x = (int)(layer.LocH + hostSprite.Width / 2f - cropW / 2f);
-                    int y = (int)(layer.LocV + hostSprite.Height / 2f - cropH / 2f);
-                    image.BlendRect(srcImg, new Rect2I(0, 0, cropW, cropH), new Vector2I(x, y));
+                    srcImg = srcImg.GetRegion(new Rect2I(cropX, cropY, cropW, cropH));
+                    destW = cropW;
+                    destH = cropH;
                 }
+
+                var srcCenter = new Vector2(destW / 2f, destH / 2f);
+                var pos = new Vector2(layer.LocH + Offset.X, layer.LocV + Offset.Y);
+                var scale = new Vector2(layer.FlipH ? -1 : 1, layer.FlipV ? -1 : 1);
+                float skewX = Mathf.Tan(Mathf.DegToRad(layer.Skew));
+                var skew = new Transform2D(new Vector2(1, 0), new Vector2(skewX, 1), Vector2.Zero);
+                var transform = Transform2D.Identity;
+                transform = transform.Translated(-srcCenter);
+                transform = transform.Scaled(scale);
+                transform = skew * transform;
+                transform = transform.Rotated(Mathf.DegToRad(layer.Rotation));
+                transform = transform.Translated(pos);
+                BlendImage(image, srcImg, transform, Mathf.Clamp(layer.Blend / 100f, 0f, 1f));
             }
-            //DebugToDisk(image,"Complete");
+            image.Unlock();
             var tex = ImageTexture.CreateFromImage(image);
             var texture = new LingoGodotTexture2D(tex);
             return texture;
         }
+
+        /// <summary>
+        /// Blends <paramref name="src"/> onto <paramref name="dest"/> using the provided
+        /// transform and opacity.
+        /// TODO: consider extracting a shared abstraction for SDL and Godot to avoid
+        /// duplicate pixel code and potentially cache small frames.
+        /// </summary>
+        private static void BlendImage(Image dest, Image src, Transform2D transform, float alpha)
+        {
+            src.Lock();
+            var inv = transform.AffineInverse();
+            Vector2[] pts =
+            {
+                transform * Vector2.Zero,
+                transform * new Vector2(src.GetWidth(), 0),
+                transform * new Vector2(src.GetWidth(), src.GetHeight()),
+                transform * new Vector2(0, src.GetHeight())
+            };
+            int minX = (int)MathF.Floor(pts.Min(p => p.X));
+            int maxX = (int)MathF.Ceiling(pts.Max(p => p.X));
+            int minY = (int)MathF.Floor(pts.Min(p => p.Y));
+            int maxY = (int)MathF.Ceiling(pts.Max(p => p.Y));
+
+            for (int y = minY; y < maxY; y++)
+            {
+                if (y < 0 || y >= dest.GetHeight()) continue;
+                for (int x = minX; x < maxX; x++)
+                {
+                    if (x < 0 || x >= dest.GetWidth()) continue;
+                    var srcPos = inv * new Vector2(x + 0.5f, y + 0.5f);
+                    int sx = (int)MathF.Floor(srcPos.X);
+                    int sy = (int)MathF.Floor(srcPos.Y);
+                    if (sx < 0 || sy < 0 || sx >= src.GetWidth() || sy >= src.GetHeight())
+                        continue;
+                    var c = src.GetPixel(sx, sy);
+                    c.A *= alpha;
+                    if (c.A <= 0f) continue;
+                    var dst = dest.GetPixel(x, y);
+                    float invA = 1f - c.A;
+                    dest.SetPixel(x, y, new Color(
+                        c.R + dst.R * invA,
+                        c.G + dst.G * invA,
+                        c.B + dst.B * invA,
+                        c.A + dst.A * invA));
+                }
+            }
+            src.Unlock();
+        }
 #if DEBUG
         public static void DebugToDisk(Image image, string filName)
         {
-            var fn = "C:/temp/director/"+ filName+".png";
-            if ( File.Exists(fn))
+            var fn = "C:/temp/director/" + filName + ".png";
+            if (File.Exists(fn))
                 File.Delete(fn);
             var tex = ImageTexture.CreateFromImage(image);
-            image.SavePng(fn); 
+            image.SavePng(fn);
         }
 #endif
 

--- a/src/LingoEngine.LGodot/Sprites/LingoGodotSprite2D.cs
+++ b/src/LingoEngine.LGodot/Sprites/LingoGodotSprite2D.cs
@@ -340,7 +340,7 @@ namespace LingoEngine.LGodot.Sprites
             //    case LingoMemberShape shape:
             //        break;
             //    case LingoFilmLoopMember filmloop:
-                    
+
             //        break;
             //}
         }
@@ -370,17 +370,19 @@ namespace LingoEngine.LGodot.Sprites
             _DesiredWidth = size.Width;
             Width = size.Width;
             Height = size.Height;
+            var offset = filmLoop.Offset;
+            _Sprite2D.Offset = new Vector2(offset.X - Width / 2f, offset.Y - Height / 2f);
             _filmloopPlayer = _lingoSprite2D.GetFilmLoopPlayer();
             if (_filmloopPlayer == null) return;
             if (_filmloopPlayer.Texture is not LingoGodotTexture2D tex)
                 return;
 
             _Sprite2D.Texture = tex.Texture;
-           
+
         }
         private ILingoMember? _previousChildElement;
         private Node? _previousChildElementNode;
-        
+
 
         private void UpdateNodeMember(ILingoMember member, Node godotElement) // Clone required to be able to draw multiple times the same member
         {

--- a/src/LingoEngine.SDL2/Bitmaps/SdlMemberFilmLoop.cs
+++ b/src/LingoEngine.SDL2/Bitmaps/SdlMemberFilmLoop.cs
@@ -1,8 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.InteropServices;
 using LingoEngine.Bitmaps;
 using LingoEngine.FilmLoops;
 using LingoEngine.Members;
+using LingoEngine.Primitives;
 using LingoEngine.SDL2.Inputs;
 using LingoEngine.SDL2.SDLL;
 using LingoEngine.SDL2.Sprites;
@@ -15,7 +19,8 @@ public class SdlMemberFilmLoop : ILingoFrameworkMemberFilmLoop, IDisposable
     private LingoFilmLoopMember _member = null!;
     public bool IsLoaded { get; private set; }
     public byte[]? Media { get; set; }
-    public ILingoTexture2D? Texture { get; set; }
+    public ILingoTexture2D? Texture { get; private set; }
+    public LingoPoint Offset { get; private set; }
     public LingoFilmLoopFraming Framing { get; set; } = LingoFilmLoopFraming.Auto;
     public bool Loop { get; set; } = true;
 
@@ -70,16 +75,21 @@ public class SdlMemberFilmLoop : ILingoFrameworkMemberFilmLoop, IDisposable
         }
     }
 
-    public void ComposeTexture(LingoSprite2D hostSprite, IReadOnlyList<LingoSprite2DVirtual> layers)
+    public ILingoTexture2D ComposeTexture(LingoSprite2D hostSprite, IReadOnlyList<LingoSprite2DVirtual> layers)
     {
         var sdlSprite = hostSprite.FrameworkObj as SdlSprite;
         if (sdlSprite == null)
-            return;
-        int width = (int)hostSprite.Width;
-        int height = (int)hostSprite.Height;
+            return Texture ?? new SdlTexture2D(nint.Zero, 0, 0);
+
+        var bounds = _member.GetBoundingBox();
+        Offset = new LingoPoint(-bounds.Left, -bounds.Top);
+        int width = (int)MathF.Ceiling(bounds.Width);
+        int height = (int)MathF.Ceiling(bounds.Height);
+
         nint surface = SDL.SDL_CreateRGBSurfaceWithFormat(0, width, height, 32, SDL.SDL_PIXELFORMAT_RGBA32);
         if (surface == nint.Zero)
-            return;
+            return Texture ?? new SdlTexture2D(nint.Zero, width, height);
+
         foreach (var layer in layers)
         {
             if (layer.Member is not LingoMemberBitmap pic)
@@ -93,19 +103,21 @@ public class SdlMemberFilmLoop : ILingoFrameworkMemberFilmLoop, IDisposable
             int destH = (int)layer.Height;
             int srcW = bmp.Width;
             int srcH = bmp.Height;
-            SDL.SDL_Rect srcRect;
-            SDL.SDL_Rect dstRect;
 
+            nint srcSurf = src;
+            bool freeSrc = false;
             if (Framing == LingoFilmLoopFraming.Scale)
             {
-                srcRect = new SDL.SDL_Rect { x = 0, y = 0, w = srcW, h = srcH };
-                int x = (int)(layer.LocH + hostSprite.Width / 2f - destW / 2f);
-                int y = (int)(layer.LocV + hostSprite.Height / 2f - destH / 2f);
-                dstRect = new SDL.SDL_Rect { x = x, y = y, w = destW, h = destH };
                 if (destW != srcW || destH != srcH)
-                    SDL.SDL_BlitScaled(src, ref srcRect, surface, ref dstRect);
-                else
-                    SDL.SDL_BlitSurface(src, ref srcRect, surface, ref dstRect);
+                {
+                    srcSurf = SDL.SDL_CreateRGBSurfaceWithFormat(0, destW, destH, 32, SDL.SDL_PIXELFORMAT_RGBA32);
+                    if (srcSurf == nint.Zero)
+                        continue;
+                    SDL.SDL_Rect srect = new SDL.SDL_Rect { x = 0, y = 0, w = srcW, h = srcH };
+                    SDL.SDL_Rect drect = new SDL.SDL_Rect { x = 0, y = 0, w = destW, h = destH };
+                    SDL.SDL_BlitScaled(src, ref srect, srcSurf, ref drect);
+                    freeSrc = true;
+                }
             }
             else
             {
@@ -113,21 +125,96 @@ public class SdlMemberFilmLoop : ILingoFrameworkMemberFilmLoop, IDisposable
                 int cropH = Math.Min(destH, srcH);
                 int cropX = (srcW - cropW) / 2;
                 int cropY = (srcH - cropH) / 2;
-                srcRect = new SDL.SDL_Rect { x = cropX, y = cropY, w = cropW, h = cropH };
-                int x = (int)(layer.LocH + hostSprite.Width / 2f - cropW / 2f);
-                int y = (int)(layer.LocV + hostSprite.Height / 2f - cropH / 2f);
-                dstRect = new SDL.SDL_Rect { x = x, y = y, w = cropW, h = cropH };
-                SDL.SDL_BlitSurface(src, ref srcRect, surface, ref dstRect);
+                srcSurf = SDL.SDL_CreateRGBSurfaceWithFormat(0, cropW, cropH, 32, SDL.SDL_PIXELFORMAT_RGBA32);
+                if (srcSurf == nint.Zero)
+                    continue;
+                SDL.SDL_Rect srect = new SDL.SDL_Rect { x = cropX, y = cropY, w = cropW, h = cropH };
+                SDL.SDL_Rect drect = new SDL.SDL_Rect { x = 0, y = 0, w = cropW, h = cropH };
+                SDL.SDL_BlitSurface(src, ref srect, srcSurf, ref drect);
+                destW = cropW;
+                destH = cropH;
+                freeSrc = true;
             }
+
+            var srcCenter = new Vector2(destW / 2f, destH / 2f);
+            var pos = new Vector2(layer.LocH + Offset.X, layer.LocV + Offset.Y);
+            var scale = new Vector2(layer.FlipH ? -1 : 1, layer.FlipV ? -1 : 1);
+            float skewX = (float)Math.Tan(layer.Skew * Math.PI / 180f);
+            var transform = Matrix3x2.Identity;
+            transform *= Matrix3x2.CreateTranslation(-srcCenter);
+            transform *= Matrix3x2.CreateScale(scale);
+            transform *= Matrix3x2.CreateSkew(skewX, 0);
+            transform *= Matrix3x2.CreateRotation((float)(layer.Rotation * Math.PI / 180f));
+            transform *= Matrix3x2.CreateTranslation(pos);
+
+            BlendSurface(surface, srcSurf, transform, Math.Clamp(layer.Blend / 100f, 0f, 1f));
+
+            if (freeSrc)
+                SDL.SDL_FreeSurface(srcSurf);
         }
-        if (Texture is SdlTexture2D tex && tex.Texture != nint.Zero)
-        {
-            SDL.SDL_DestroyTexture(tex.Texture);
-        }
+
+        if (Texture is SdlTexture2D oldTex && oldTex.Texture != nint.Zero)
+            SDL.SDL_DestroyTexture(oldTex.Texture);
+
         nint texture = SDL.SDL_CreateTextureFromSurface(sdlSprite.Renderer, surface);
         SDL.SDL_FreeSurface(surface);
-        if (texture != nint.Zero)
-            Texture = new SdlTexture2D(texture, width, height);
+        Texture = new SdlTexture2D(texture, width, height);
+        return Texture;
+    }
+
+    /// <summary>
+    /// Blends <paramref name="src"/> onto <paramref name="dest"/> using an affine transform.
+    /// TODO: share logic with Godot implementation and investigate caching small frames.
+    /// </summary>
+    private static unsafe void BlendSurface(nint dest, nint src, Matrix3x2 transform, float alpha)
+    {
+        SDL.SDL_LockSurface(dest);
+        SDL.SDL_LockSurface(src);
+        var dSurf = Marshal.PtrToStructure<SDL.SDL_Surface>(dest);
+        var sSurf = Marshal.PtrToStructure<SDL.SDL_Surface>(src);
+
+        Matrix3x2.Invert(transform, out var inv);
+
+        Vector2[] pts =
+        {
+            Vector2.Transform(Vector2.Zero, transform),
+            Vector2.Transform(new Vector2(sSurf.w, 0), transform),
+            Vector2.Transform(new Vector2(sSurf.w, sSurf.h), transform),
+            Vector2.Transform(new Vector2(0, sSurf.h), transform)
+        };
+        int minX = (int)MathF.Floor(pts.Min(p => p.X));
+        int maxX = (int)MathF.Ceiling(pts.Max(p => p.X));
+        int minY = (int)MathF.Floor(pts.Min(p => p.Y));
+        int maxY = (int)MathF.Ceiling(pts.Max(p => p.Y));
+
+        byte* dpix = (byte*)dSurf.pixels;
+        byte* spix = (byte*)sSurf.pixels;
+
+        for (int y = minY; y < maxY; y++)
+        {
+            if (y < 0 || y >= dSurf.h) continue;
+            for (int x = minX; x < maxX; x++)
+            {
+                if (x < 0 || x >= dSurf.w) continue;
+                var srcPos = Vector2.Transform(new Vector2(x + 0.5f, y + 0.5f), inv);
+                int sx = (int)MathF.Floor(srcPos.X);
+                int sy = (int)MathF.Floor(srcPos.Y);
+                if (sx < 0 || sy < 0 || sx >= sSurf.w || sy >= sSurf.h)
+                    continue;
+                byte* sp = spix + sy * sSurf.pitch + sx * 4;
+                float a = sp[3] / 255f * alpha;
+                if (a <= 0f) continue;
+                byte* dp = dpix + y * dSurf.pitch + x * 4;
+                float invA = 1f - a;
+                dp[0] = (byte)(sp[0] * a + dp[0] * invA);
+                dp[1] = (byte)(sp[1] * a + dp[1] * invA);
+                dp[2] = (byte)(sp[2] * a + dp[2] * invA);
+                dp[3] = (byte)(sp[3] * a + dp[3] * invA);
+            }
+        }
+
+        SDL.SDL_UnlockSurface(src);
+        SDL.SDL_UnlockSurface(dest);
     }
 
     public void Dispose() { Unload(); }

--- a/src/LingoEngine.SDL2/Sprites/SdlSprite.cs
+++ b/src/LingoEngine.SDL2/Sprites/SdlSprite.cs
@@ -142,6 +142,12 @@ public class SdlSprite : ILingoFrameworkSprite, IDisposable
             {
                 offset = baseOffset;
             }
+
+            if (_lingoSprite.Member is LingoFilmLoopMember flm)
+            {
+                var fl = flm.Framework<SdlMemberFilmLoop>();
+                offset = new LingoPoint(offset.X - fl.Offset.X, offset.Y - fl.Offset.Y);
+            }
         }
 
         SDL.SDL_Rect dst = new SDL.SDL_Rect


### PR DESCRIPTION
## Summary
- add per-layer transform blending and offset computation for SDL film loops to match Godot behavior
- apply film loop offset during SDL sprite rendering
- note TODO to refactor shared pixel-blend logic

## Testing
- `dotnet format --include src/LingoEngine.LGodot/FilmLoops/LingoGodotFilmLoopMember.cs src/LingoEngine.SDL2/Bitmaps/SdlMemberFilmLoop.cs src/LingoEngine.SDL2/Sprites/SdlSprite.cs`
- `dotnet test` *(fails: Could not find file '/workspace/LingoEngine/WillMoveToOwnRepo/ProjectorRays/Test/TestData/TextCast.cst')*


------
https://chatgpt.com/codex/tasks/task_e_6895de19def0833294717af966988315