### PR TITLE
docs: clarify project-specific testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,10 @@ These instructions apply to the entire repository.
 - The project targets **.NET 8**. If the `dotnet` CLI isn't available, install it with `./scripts/install-dotnet.sh` and ensure `$HOME/.dotnet` is on your `PATH`.
 
 ## Testing
-- Run `dotnet test` from the repository root before committing any change.
+- Run tests only for the projects affected by your changes; do not run the entire solution.
+- For changes in core engine code (e.g., under `src` or `Test/LingoEngine.Lingo.Core.Tests`), run `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`.
+- For changes in the ProjectorRays area (`WillMoveToOwnRepo/ProjectorRays`), run `dotnet test WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/ProjectorRays.DotNet.Test.csproj`.
+- Apply the same approach for other components: run `dotnet test <path-to-test-project>` for each modified project.
 
 ## Code Style
 - Use `dotnet format` to fix style issues when needed.


### PR DESCRIPTION
## Summary
- specify project-level test commands instead of running the whole solution
- document when to run ProjectorRays tests vs. core engine tests

## Testing
- `dotnet test` *(fails: Could not find file '/workspace/LingoEngine/WillMoveToOwnRepo/ProjectorRays/Test/TestData/TextCast.cst')*

------
https://chatgpt.com/codex/tasks/task_e_6896bee621bc83329af915b8ff123f6a