### PR TITLE
Improve unloading behavior for changing project factory

### DIFF
--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/TetriGroundsGame.cs
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/TetriGroundsGame.cs
@@ -25,11 +25,6 @@ namespace LingoEngine.Demo.TetriGrounds.Core
         }
         public ILingoMovie LoadMovie()
         {
-            _lingoPlayer
-                .LoadCastLibFromCsv("Data", Path.Combine("Medias", "Data", "Members.csv"))
-                .LoadCastLibFromCsv("InternalExt", Path.Combine("Medias", "InternalExt", "Members.csv"))
-                ;
-            //_lingoPlayer.AddCastLib("Data",c => c.Add(LingoMemberType.Bitmap, 1, "MyBG", "/Medias/Data/Game.jpg"));
             _movie = _lingoPlayer.NewMovie(MovieName);
 
             AddLabels();

--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/TetriGroundsProjectFactory.cs
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/TetriGroundsProjectFactory.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using LingoEngine.Casts;
 using LingoEngine.Core;
 using LingoEngine.Projects;
 using LingoEngine.Setup;
@@ -44,5 +46,12 @@ public class TetriGroundsProjectFactory : ILingoProjectFactory
         game.LoadMovie();
         if (autoPlayMovie)
             game.Play();
+    }
+
+    public void LoadCastLibs(ILingoCastLibsContainer castlibContainer, LingoPlayer lingoPlayer)
+    {
+        lingoPlayer
+            .LoadCastLibFromCsv("Data", Path.Combine("Medias", "Data", "Members.csv"))
+            .LoadCastLibFromCsv("InternalExt", Path.Combine("Medias", "InternalExt", "Members.csv"), true);
     }
 }

--- a/src/Director/LingoEngine.Director.Core/Compilers/LingoScriptCompiler.cs
+++ b/src/Director/LingoEngine.Director.Core/Compilers/LingoScriptCompiler.cs
@@ -48,15 +48,8 @@ public class LingoScriptCompiler
     /// </summary>
     public void Compile()
     {
-        var active = _player.ActiveMovie as LingoMovie;
-        var wasPlaying = active?.IsPlaying == true;
-        if (active != null)
-        {
-            active.Halt();
-            _player.CloseMovie(active);
-        }
-
-        RemoveRegistrations();
+        var wasPlaying = (_player.ActiveMovie as LingoMovie)?.IsPlaying == true;
+        _engineRegistration.UnloadMovie("Director");
         UnloadAssembly();
         var assembly = BuildProject();
         if (assembly != null)
@@ -205,11 +198,6 @@ public class LingoScriptCompiler
             return;
         _engineRegistration.SetTheProjectFactory(factoryType);
         _engineRegistration.BuildAndRunProject();
-    }
-
-    private void RemoveRegistrations()
-    {
-        _engineRegistration.ClearDynamicRegistrations();
     }
 
     private void UnloadAssembly()

--- a/src/LingoEngine/Casts/ILingoCast.cs
+++ b/src/LingoEngine/Casts/ILingoCast.cs
@@ -1,6 +1,7 @@
 ﻿using LingoEngine.Core;
 using LingoEngine.Members;
 using LingoEngine.Primitives;
+using System;
 
 namespace LingoEngine.Casts
 {
@@ -10,7 +11,7 @@ namespace LingoEngine.Casts
     /// A cast library can contain cast members such as sounds, text, graphics, and media.
     /// Lingo equivalent: castLib("LibraryName")
     /// </summary>
-    public interface ILingoCast
+    public interface ILingoCast : IDisposable
     {
         /// <summary>
         /// The name of the cast library.
@@ -36,6 +37,10 @@ namespace LingoEngine.Casts
         /// Cast library property; determines the preload mode of a specified cast library.
         /// </summary>
         PreLoadModeType PreLoadMode { get; set; }
+        /// <summary>
+        /// Indicates whether this cast library belongs to a specific movie (internal) or is shared (external).
+        /// </summary>
+        bool IsInternal { get; }
         /// <summary>
         /// Returns the cast members that are selected in a given Cast window
         /// </summary>

--- a/src/LingoEngine/Casts/LingoCast.cs
+++ b/src/LingoEngine/Casts/LingoCast.cs
@@ -1,6 +1,5 @@
 ﻿using LingoEngine.Bitmaps;
 using LingoEngine.ColorPalettes;
-using LingoEngine.Core;
 using LingoEngine.FilmLoops;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Members;
@@ -10,6 +9,8 @@ using LingoEngine.Shapes;
 using LingoEngine.Sounds;
 using LingoEngine.Texts;
 using LingoEngine.Transitions;
+using System;
+using System.Linq;
 
 namespace LingoEngine.Casts
 {
@@ -35,6 +36,8 @@ namespace LingoEngine.Casts
         /// <inheritdoc/>
         public PreLoadModeType PreLoadMode { get; set; } = PreLoadModeType.WhenNeeded;
         /// <inheritdoc/>
+        public bool IsInternal { get; }
+        /// <inheritdoc/>
         public CastMemberSelection? Selection { get; set; } = null;
 
         public ILingoMembersContainer Member => _MembersContainer;
@@ -44,12 +47,13 @@ namespace LingoEngine.Casts
         public event Action<ILingoMember>? MemberNameChanged;
         
 
-        internal LingoCast(LingoCastLibsContainer castLibsContainer, ILingoFrameworkFactory factory, string name)
+        internal LingoCast(LingoCastLibsContainer castLibsContainer, ILingoFrameworkFactory factory, string name, bool isInternal)
         {
             _castLibsContainer = castLibsContainer;
             _factory = factory;
             Name = name;
             Number = castLibsContainer.GetNextCastNumber();
+            IsInternal = isInternal;
         }
 
         /// <inheritdoc/>
@@ -71,6 +75,8 @@ namespace LingoEngine.Casts
         }
         public ILingoCast Remove(LingoMember member)
         {
+            member.Dispose();
+
             _castLibsContainer.RemoveMember(member);
             _MembersContainer.Remove(member);
             return this;
@@ -152,5 +158,7 @@ namespace LingoEngine.Casts
             _MembersContainer.ChangeNumber(slot2, slot1);
             _MembersContainer.ChangeNumber(tempSlot, slot2);
         }
+
+        public void Dispose() => RemoveAll();
     }
 }

--- a/src/LingoEngine/Casts/LingoCastLibContainer.cs
+++ b/src/LingoEngine/Casts/LingoCastLibContainer.cs
@@ -1,6 +1,5 @@
 ﻿using LingoEngine.FrameworkCommunication;
 using LingoEngine.Members;
-using System.Xml.Linq;
 
 namespace LingoEngine.Casts
 {
@@ -18,7 +17,7 @@ namespace LingoEngine.Casts
         ILingoMember? GetMember(string name, int? castLibNum = null);
         T? GetMember<T>(int number, int? castLibNum = null) where T : class, ILingoMember;
         T? GetMember<T>(string name, int? castLibNum = null) where T : class, ILingoMember;
-        ILingoCast AddCast(string name);
+        ILingoCast AddCast(string name, bool isInternal = false);
         ILingoCast GetCast(int number);
         string GetCastName(int number);
         IEnumerable<ILingoCast> GetAll();
@@ -56,10 +55,10 @@ namespace LingoEngine.Casts
         public string GetCastName(int number) => _casts[number - 1].Name;
         public ILingoCast GetCast(int number) => _casts[number - 1];
 
-        public ILingoCast AddCast(string name)
+        public ILingoCast AddCast(string name, bool isInternal = false)
         {
             var nameL = name.ToLower();
-            var cast = new LingoCast(this, _factory, name);
+            var cast = new LingoCast(this, _factory, name, isInternal);
             _casts.Add(cast);
             _castsByName.Add(nameL, cast);
             if (ActiveCast == null)
@@ -70,13 +69,23 @@ namespace LingoEngine.Casts
         {
             var nameL = cast.Name.ToLower();
             var castTyped = (LingoCast)cast;
-            castTyped.RemoveAll();
+            castTyped.Dispose();
             _casts.Remove(castTyped);
             _castsByName.Remove(nameL);
             if (activeCast == cast && _casts.Count > 0)
                 activeCast = _casts[0];
 
             return cast;
+        }
+
+        public void RemoveInternal()
+        {
+            for (int i = _casts.Count - 1; i >= 0; i--)
+            {
+                var cast = _casts[i];
+                if (cast.IsInternal)
+                    RemoveCast(cast);
+            }
         }
 
         public int GetNextMemberNumber(int castNumber, int numberInCast) => _allMembersContainer.GetNextNumber(castNumber, numberInCast);

--- a/src/LingoEngine/Commands/ILingoCommandManager.cs
+++ b/src/LingoEngine/Commands/ILingoCommandManager.cs
@@ -7,4 +7,5 @@ public interface ILingoCommandManager
         where TCommand : ILingoCommand;
     void Register(Type handlerType);
     bool Handle(ILingoCommand command);
+    void Clear(string? preserveNamespaceFragment = null);
 }

--- a/src/LingoEngine/Commands/LingoCommandManager.cs
+++ b/src/LingoEngine/Commands/LingoCommandManager.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LingoEngine.Commands;
@@ -53,5 +55,23 @@ internal sealed class LingoCommandManager : ILingoCommandManager
             return ok;
         }
         return false;
+    }
+
+    public void Clear(string? preserveNamespaceFragment = null)
+    {
+        if (string.IsNullOrEmpty(preserveNamespaceFragment))
+        {
+            _handlers.Clear();
+            return;
+        }
+
+        foreach (var cmdType in _handlers.Keys.ToList())
+        {
+            var list = _handlers[cmdType];
+            list.RemoveAll(t => t.Namespace == null ||
+                t.Namespace.IndexOf(preserveNamespaceFragment, StringComparison.OrdinalIgnoreCase) < 0);
+            if (list.Count == 0)
+                _handlers.Remove(cmdType);
+        }
     }
 }

--- a/src/LingoEngine/Core/ILingoPlayer.cs
+++ b/src/LingoEngine/Core/ILingoPlayer.cs
@@ -162,8 +162,8 @@ namespace LingoEngine.Core
 
         ILingoCast CastLib(int number);
         ILingoCast CastLib(string name);
-        ILingoPlayer LoadCastLibFromCsv(string castlibName, string pathAndFilenameToCsv);
-        ILingoPlayer AddCastLib(string name, Action<ILingoCast>? configure = null);
+        ILingoPlayer LoadCastLibFromCsv(string castlibName, string pathAndFilenameToCsv, bool isInternal = false);
+        ILingoPlayer AddCastLib(string name, bool isInternal = false, Action<ILingoCast>? configure = null);
     }
 }
 

--- a/src/LingoEngine/Core/LingoPlayer.cs
+++ b/src/LingoEngine/Core/LingoPlayer.cs
@@ -183,19 +183,24 @@ namespace LingoEngine.Core
         ///     Number,Type,Name,Registration Point,Filename
         ///     1,bitmap,BallB,"(5, 5)",
         /// </summary>
-        public ILingoPlayer LoadCastLibFromCsv(string castlibName, string pathAndFilenameToCsv)
+        public ILingoPlayer LoadCastLibFromCsv(string castlibName, string pathAndFilenameToCsv, bool isInternal = false)
         {
-            var castLib = _castLibsContainer.AddCast(castlibName);
+            var castLib = _castLibsContainer.AddCast(castlibName, isInternal);
             _csvImporter.Value.ImportInCastFromCsvFile(castLib, pathAndFilenameToCsv);
             return this;
         }
 
-        public ILingoPlayer AddCastLib(string name, Action<ILingoCast>? configure = null)
+        public ILingoPlayer AddCastLib(string name, bool isInternal = false, Action<ILingoCast>? configure = null)
         {
-            var castLib = _castLibsContainer.AddCast(name);
+            var castLib = _castLibsContainer.AddCast(name, isInternal);
             if (configure != null)
                 configure(castLib);
             return this;
+        }
+
+        public void UnloadInternalCastLibs()
+        {
+            _castLibsContainer.RemoveInternal();
         }
 
         public void SetActiveMovie(LingoMovie? movie)

--- a/src/LingoEngine/Events/ILingoEventMediator.cs
+++ b/src/LingoEngine/Events/ILingoEventMediator.cs
@@ -9,5 +9,6 @@
         /// <param name="priority">Optional priority. Lower values are executed first.</param>
         void Subscribe(object listener, int priority = 5000);
         void Unsubscribe(object listener);
+        void Clear(string? preserveNamespaceFragment = null);
     }
 }

--- a/src/LingoEngine/Events/LingoEventMediator.cs
+++ b/src/LingoEngine/Events/LingoEventMediator.cs
@@ -1,4 +1,6 @@
-﻿using LingoEngine.Inputs;
+﻿using System;
+using System.Linq;
+using LingoEngine.Inputs;
 using LingoEngine.Inputs.Events;
 using LingoEngine.Movies;
 using LingoEngine.Movies.Events;
@@ -88,6 +90,35 @@ namespace LingoEngine.Events
             if (ms is IHasKeyDownEvent keyDownEvent) _keyDowns.Remove(keyDownEvent);
 
             _priorities.Remove(ms);
+        }
+
+        public void Clear(string? preserveNamespaceFragment = null)
+        {
+            bool ShouldRemove(object obj) => string.IsNullOrEmpty(preserveNamespaceFragment) ||
+                obj.GetType().Namespace?.IndexOf(preserveNamespaceFragment, StringComparison.OrdinalIgnoreCase) < 0;
+
+            foreach (var key in _priorities.Keys.ToList())
+                if (ShouldRemove(key))
+                    _priorities.Remove(key);
+
+            void FilterList<T>(List<T> list) where T : class => list.RemoveAll(x => ShouldRemove(x!));
+
+            FilterList(_prepareMovies);
+            FilterList(_startMovies);
+            FilterList(_stopMovies);
+            FilterList(_mouseDowns);
+            FilterList(_mouseUps);
+            FilterList(_mouseMoves);
+            FilterList(_mouseEnters);
+            FilterList(_mouseExits);
+            FilterList(_stepFrames);
+            FilterList(_prepareFrames);
+            FilterList(_enterFrames);
+            FilterList(_exitFrames);
+            FilterList(_focuss);
+            FilterList(_blurs);
+            FilterList(_keyUps);
+            FilterList(_keyDowns);
         }
         internal void RaisePrepareMovie() => _prepareMovies.ForEach(x => x.PrepareMovie());
         internal void RaiseStartMovie() => _startMovies.ForEach(x => x.StartMovie());

--- a/src/LingoEngine/Members/IMemberRefUser.cs
+++ b/src/LingoEngine/Members/IMemberRefUser.cs
@@ -1,0 +1,15 @@
+namespace LingoEngine.Members;
+
+/// <summary>
+/// Represents an object that holds a reference to a <see cref="LingoMember"/>.
+/// When the referenced member is removed, <see cref="MemberHasBeenRemoved"/> is invoked
+/// to allow the user to clean up its reference.
+/// </summary>
+public interface IMemberRefUser
+{
+    /// <summary>
+    /// Called when the referenced member has been removed or disposed.
+    /// Implementations should clear their reference to the member.
+    /// </summary>
+    void MemberHasBeenRemoved();
+}

--- a/src/LingoEngine/Projects/ILingoProjectFactory.cs
+++ b/src/LingoEngine/Projects/ILingoProjectFactory.cs
@@ -3,9 +3,11 @@ namespace LingoEngine.Projects;
 using System;
 using LingoEngine.Core;
 using LingoEngine.Setup;
+using LingoEngine.Casts;
 
 public interface ILingoProjectFactory
 {
     void Setup(ILingoEngineRegistration engineRegistration);
     void Run(IServiceProvider serviceProvider, ILingoPlayer player, bool autoPlayMovie);
+    void LoadCastLibs(ILingoCastLibsContainer castlibContainer, LingoPlayer lingoPlayer);
 }

--- a/src/LingoEngine/Scripts/LingoFrameScriptSprite.cs
+++ b/src/LingoEngine/Scripts/LingoFrameScriptSprite.cs
@@ -34,11 +34,13 @@ public class LingoFrameScriptSprite : LingoSprite, ILingoSpriteWithMember
         BeginFrame = beginFrame;
         EndFrame = endFrame;
         Member = frameScript;
+        Member.UsedBy(this);
         Name = frameScript.Name ?? string.Empty;
     }
 
     public override void OnRemoveMe()
     {
+        Member?.ReleaseFromRefUser(this);
         if (Behavior != null)
             _environment.Events.Unsubscribe(Behavior);
         _onRemoveMe(this);
@@ -82,7 +84,8 @@ public class LingoFrameScriptSprite : LingoSprite, ILingoSpriteWithMember
         {
             baseAction(s);
             var sprite = (LingoFrameScriptSprite)s;
-            sprite.Member = Member;
+            sprite.Member = member;
+            member.UsedBy(sprite);
             if (behaviorType != null)
             {
                 var method = typeof(LingoFrameScriptSprite).GetMethod(nameof(SetBehavior), BindingFlags.Instance | BindingFlags.NonPublic);
@@ -90,7 +93,7 @@ public class LingoFrameScriptSprite : LingoSprite, ILingoSpriteWithMember
                 var behaviorNew = (LingoSpriteBehavior)generic.Invoke(sprite, null)!;
                 if (userProperties != null)
                     behaviorNew.SetUserProperties(userProperties);
-                
+
             }
         };
 
@@ -99,8 +102,15 @@ public class LingoFrameScriptSprite : LingoSprite, ILingoSpriteWithMember
 
     public void SetMember(LingoMemberScript lingoMemberScript)
     {
+        Member?.ReleaseFromRefUser(this);
         Member = lingoMemberScript;
+        Member.UsedBy(this);
     }
 
     public ILingoMember? GetMember() => Member;
+
+    public void MemberHasBeenRemoved()
+    {
+        Member = null!;
+    }
 }

--- a/src/LingoEngine/Setup/LingoProxyServiceCollection.cs
+++ b/src/LingoEngine/Setup/LingoProxyServiceCollection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
@@ -72,10 +73,28 @@ internal class LingoProxyServiceCollection : IServiceCollection
 
     IEnumerator IEnumerable.GetEnumerator() => _inner.GetEnumerator();
 
-    public void UnregisterLingo()
+    public void UnregisterMovie(string? preserveNamespaceFragment = null)
     {
-        foreach (var d in _registrations)
+        for (int i = _registrations.Count - 1; i >= 0; i--)
+        {
+            var d = _registrations[i];
+            if (preserveNamespaceFragment != null && HasNamespace(d, preserveNamespaceFragment))
+                continue;
             _inner.Remove(d);
-        _registrations.Clear();
+            _registrations.RemoveAt(i);
+        }
+    }
+
+    private static bool HasNamespace(ServiceDescriptor descriptor, string fragment)
+    {
+        var ns = descriptor.ServiceType?.Namespace;
+        if (ns != null && ns.IndexOf(fragment, StringComparison.OrdinalIgnoreCase) >= 0)
+            return true;
+        ns = descriptor.ImplementationType?.Namespace;
+        if (ns != null && ns.IndexOf(fragment, StringComparison.OrdinalIgnoreCase) >= 0)
+            return true;
+        var instType = descriptor.ImplementationInstance?.GetType();
+        ns = instType?.Namespace;
+        return ns != null && ns.IndexOf(fragment, StringComparison.OrdinalIgnoreCase) >= 0;
     }
 }

--- a/src/LingoEngine/Sounds/LingoSpriteSound.cs
+++ b/src/LingoEngine/Sounds/LingoSpriteSound.cs
@@ -31,6 +31,7 @@ public class LingoSpriteSound : LingoSprite, ILingoSpriteWithMember
         BeginFrame = beginFrame;
         EndFrame = endFrame;
         Sound = sound;
+        Sound.UsedBy(this);
         Name = sound.Name ?? string.Empty;
         _soundChannel = _environment.Sound.Channel(channel);
     }
@@ -47,10 +48,11 @@ public class LingoSpriteSound : LingoSprite, ILingoSpriteWithMember
         base.EndSprite();
     }
 
-    public override void OnRemoveMe()
-    {
-        _onRemoveMe(this);
-    }
+        public override void OnRemoveMe()
+        {
+            Sound?.ReleaseFromRefUser(this);
+            _onRemoveMe(this);
+        }
 
     public override Action<LingoSprite> GetCloneAction()
     {
@@ -61,11 +63,17 @@ public class LingoSpriteSound : LingoSprite, ILingoSpriteWithMember
         {
             baseAction(s);
             var sprite = (LingoSpriteSound)s;
-            sprite.Sound = Sound;
+            sprite.Sound = member;
+            member?.UsedBy(sprite);
         };
 
         return action;
     }
 
     public ILingoMember? GetMember() => Sound;
+
+    public void MemberHasBeenRemoved()
+    {
+        Sound = null;
+    }
 }

--- a/src/LingoEngine/Sprites/ILingoSpriteWithMember.cs
+++ b/src/LingoEngine/Sprites/ILingoSpriteWithMember.cs
@@ -5,7 +5,7 @@ namespace LingoEngine.Sprites
     /// <summary>
     /// Sprite that exposes its underlying member.
     /// </summary>
-    public interface ILingoSpriteWithMember : ILingoSpriteBase
+    public interface ILingoSpriteWithMember : ILingoSpriteBase, IMemberRefUser
     {
         ILingoMember? GetMember();
     }

--- a/src/LingoEngine/Sprites/LingoSprite2D.cs
+++ b/src/LingoEngine/Sprites/LingoSprite2D.cs
@@ -320,7 +320,7 @@ When a movie stops, events occur in the following order:
             });
             FrameworkObj.Hide();
             // Release the old member link with this sprite
-            _Member?.ReleaseFromSprite(this);
+            _Member?.ReleaseFromRefUser(this);
             base.DoEndSprite();
         }
 
@@ -357,10 +357,13 @@ When a movie stops, events occur in the following order:
                 return this;
             // Release the old member link with this sprite
             if (member != _Member)
-                _Member?.ReleaseFromSprite(this);
+            {
+                _Member?.ReleaseFromRefUser(this);
+            }
             _Member = member as LingoMember;
             if (_Member != null)
             {
+                _Member.UsedBy(this);
                 RegPoint = _Member.RegPoint;
             }
             if (member is LingoFilmLoopMember filmLoop)
@@ -598,9 +601,15 @@ When a movie stops, events occur in the following order:
 
         public override void OnRemoveMe()
         {
+            _Member?.ReleaseFromRefUser(this);
             _frameworkSprite.RemoveMe();
             if (_onRemoveMe != null)
                 _onRemoveMe(this);
+        }
+
+        public void MemberHasBeenRemoved()
+        {
+            _Member = null;
         }
 
         public void SetOnRemoveMe(Action<LingoSprite2D> onRemoveMe) => _onRemoveMe = onRemoveMe;

--- a/src/LingoEngine/Sprites/LingoSprite2DVirtual.cs
+++ b/src/LingoEngine/Sprites/LingoSprite2DVirtual.cs
@@ -5,7 +5,7 @@ using LingoEngine.Primitives;
 
 namespace LingoEngine.Sprites
 {
-    public class LingoSprite2DVirtual : LingoSprite ,ILingoSprite2DLight
+    public class LingoSprite2DVirtual : LingoSprite, ILingoSprite2DLight, ILingoSpriteWithMember
     {
         public const int SpriteNumOffset = 6;
         private int _ink;
@@ -225,11 +225,14 @@ namespace LingoEngine.Sprites
             if (_Member != null && (_Member.Type == LingoMemberType.Script || _Member.Type == LingoMemberType.Sound || _Member.Type == LingoMemberType.Transition || _Member.Type == LingoMemberType.Unknown || _Member.Type == LingoMemberType.Palette || _Member.Type == LingoMemberType.Movie || _Member.Type == LingoMemberType.Font || _Member.Type == LingoMemberType.Cursor))
                 return;
             // Release the old member link with this sprite
-            //if (member != _Member)
-            //    _Member?.ReleaseFromSprite(this);
+            if (member != _Member)
+            {
+                _Member?.ReleaseFromRefUser(this);
+            }
             _Member = member as LingoMember;
             if (_Member != null)
             {
+                _Member.UsedBy(this);
                 RegPoint = _Member.RegPoint;
                 _Member.Preload();
                 Width = _Member.Width;
@@ -303,8 +306,14 @@ namespace LingoEngine.Sprites
 
         public override void OnRemoveMe()
         {
+            _Member?.ReleaseFromRefUser(this);
             if (_onRemoveMe != null)
                 _onRemoveMe(this);
+        }
+
+        public void MemberHasBeenRemoved()
+        {
+            _Member = null;
         }
 
         public void SetOnRemoveMe(Action<LingoSprite2DVirtual> onRemoveMe) => _onRemoveMe = onRemoveMe;

--- a/src/LingoEngine/Transitions/LingoTransitionSprite.cs
+++ b/src/LingoEngine/Transitions/LingoTransitionSprite.cs
@@ -24,12 +24,16 @@ public class LingoTransitionSprite : LingoSprite, ILingoSpriteWithMember
 
     public override void OnRemoveMe()
     {
+        Member?.ReleaseFromRefUser(this);
         _removeMe(this);
     }
     public void SetSettings(LingoTransitionFrameSettings settings)
     {
         if (Member == null)
+        {
             Member = _environment.CastLibsContainer.ActiveCast.Add<LingoTransitionMember>(0, "");
+            Member.UsedBy(this);
+        }
         Member.SetSettings(settings);
     }
 
@@ -49,7 +53,8 @@ public class LingoTransitionSprite : LingoSprite, ILingoSpriteWithMember
         {
             baseAction(s);
             var sprite = (LingoTransitionSprite)s;
-            sprite.Member = Member;
+            sprite.Member = member;
+            member?.UsedBy(sprite);
             if (settings != null)
                 sprite.SetSettings(settings);
         };
@@ -59,9 +64,16 @@ public class LingoTransitionSprite : LingoSprite, ILingoSpriteWithMember
 
     public void SetMember(LingoTransitionMember transitionMember)
     {
+        Member?.ReleaseFromRefUser(this);
         Member = transitionMember;
-        SetSettings(transitionMember.GetSettings());
+       Member.UsedBy(this);
+       SetSettings(transitionMember.GetSettings());
     }
 
     public ILingoMember? GetMember() => Member;
+
+    public void MemberHasBeenRemoved()
+    {
+        Member = null;
+    }
 }


### PR DESCRIPTION
## Summary
- Ensure cloned sprites register their cast member usage so members can track referencing sprites
- Remove the unused base `MemberHasBeenRemoved` hook; only member-bearing sprites implement it

## Testing
- `dotnet format --include src/LingoEngine/Sprites/LingoSprite.cs,src/LingoEngine/Sprites/LingoSprite2D.cs,src/LingoEngine/Sprites/LingoSprite2DVirtual.cs,src/LingoEngine/Sounds/LingoSpriteSound.cs,src/LingoEngine/Transitions/LingoTransitionSprite.cs,src/LingoEngine/ColorPalettes/LingoColorPaletteSprite.cs,src/LingoEngine/Scripts/LingoFrameScriptSprite.cs --verbosity normal`
- `dotnet test --no-restore --verbosity normal` *(fails: Failed: 6, Passed: 2)*

------
https://chatgpt.com/codex/tasks/task_e_6896c183a8b48332b0f74f98f1bfc7f1