### PR TITLE
Ensure install script updates PATH

### DIFF
--- a/scripts/install-dotnet.sh
+++ b/scripts/install-dotnet.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+# Ensure $HOME/.dotnet is on PATH
+if [[ ":$PATH:" != *":$HOME/.dotnet:"* ]]; then
+  export PATH="$HOME/.dotnet:$PATH"
+fi
+
 if command -v dotnet >/dev/null 2>&1; then
   echo ".NET SDK already installed: $(dotnet --version)"
   exit 0
@@ -12,4 +17,4 @@ chmod +x dotnet-install.sh
 ./dotnet-install.sh --channel LTS
 rm dotnet-install.sh
 
-echo "Installation complete. Add \$HOME/.dotnet to your PATH if needed."
+echo "Installation complete. \$HOME/.dotnet has been added to your PATH."


### PR DESCRIPTION
## Summary
- Ensure install script adds `$HOME/.dotnet` to PATH
- Clarify completion message after installing .NET SDK

## Testing
- `bash -n scripts/install-dotnet.sh`
- `./scripts/install-dotnet.sh`

------
https://chatgpt.com/codex/tasks/task_e_68998c255d9c8332a1f2907ea73cd8b9