### PR TITLE
Fix FilmLoop rendering after sprite refactor

### DIFF
--- a/src/LingoEngine.IO.Data/DTO/LingoFilmLoopMemberSpriteDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoFilmLoopMemberSpriteDTO.cs
@@ -28,9 +28,11 @@ public class LingoFilmLoopMemberSpriteDTO
     public bool FlipV { get; set; }
 
     public LingoPointDTO RegPoint { get; set; }
-    public LingoColorDTO ForeColor { get; set; } 
-    public LingoColorDTO BackColor { get; set; } 
+    public LingoColorDTO ForeColor { get; set; }
+    public LingoColorDTO BackColor { get; set; }
     public float Width { get; set; }
     public float Height { get; set; }
+
+    public LingoSpriteAnimatorDTO Animator { get; set; } = new();
 
 }

--- a/src/LingoEngine/FilmLoops/LingoFilmLoopMemberSprite.cs
+++ b/src/LingoEngine/FilmLoops/LingoFilmLoopMemberSprite.cs
@@ -6,7 +6,7 @@ using LingoEngine.Sprites;
 
 namespace LingoEngine.FilmLoops
 {
-    
+
     /// <summary>
     /// Declares a sprite from a filmloop inside a member, not instanciated as sprite yet.
     /// </summary>
@@ -22,8 +22,8 @@ namespace LingoEngine.FilmLoops
         public int DisplayMember { get; set; }
         public int SpriteNum { get; set; }
 
-        public int Channel{ get; set; }
-        public int BeginFrame{ get; set; }
+        public int Channel { get; set; }
+        public int BeginFrame { get; set; }
         public int EndFrame { get; set; }
 
         public LingoInkType InkType { get => (LingoInkType)_ink; set => Ink = (int)value; }
@@ -73,14 +73,14 @@ namespace LingoEngine.FilmLoops
             _animatorProperties = new LingoSpriteAnimatorProperties();
         }
 
-        public LingoFilmLoopMemberSprite(ILingoMember? member = null):this()
+        public LingoFilmLoopMemberSprite(ILingoMember? member = null) : this()
         {
             if (member != null)
                 SetMember(member);
         }
 
-        public LingoFilmLoopMemberSprite(LingoSprite2D sp, int channel, int begin, int end) 
-            :this(sp)
+        public LingoFilmLoopMemberSprite(LingoSprite2D sp, int channel, int begin, int end)
+            : this(sp)
         {
             BeginFrame = begin;
             EndFrame = end;
@@ -127,12 +127,19 @@ namespace LingoEngine.FilmLoops
             {
                 var cast = castLibs.GetCast(CastNum);
                 if (cast != null)
+                {
                     Member = cast.Member[MemberNumberInCast];
+                    if (Member != null && (Width == 0 || Height == 0))
+                    {
+                        Width = Member.Width;
+                        Height = Member.Height;
+                    }
+                }
             }
         }
 
-        public LingoRect GetBoundingBox() => _animatorProperties.GetBoundingBox(RegPoint,Rect,Width,Height);
-        public LingoRect GetBoundingBoxForFrame(int frame)=> _animatorProperties.GetBoundingBoxForFrame(frame,RegPoint,Width,Height);
+        public LingoRect GetBoundingBox() => _animatorProperties.GetBoundingBox(RegPoint, Rect, Width, Height);
+        public LingoRect GetBoundingBoxForFrame(int frame) => _animatorProperties.GetBoundingBoxForFrame(frame, RegPoint, Width, Height);
 
 
         private LingoPoint GetRegPointOffset()


### PR DESCRIPTION
## Summary
- Ensure film loop member sprites link to their members and default size when missing
- Correct channel deserialization for film loop member sprites
- Serialize and deserialize keyframes for film loop member sprites

## Testing
- `dotnet format LingoEngine.sln --include src/LingoEngine.IO/JsonStateRepository.cs --include src/LingoEngine.IO.Data/DTO/LingoFilmLoopMemberSpriteDTO.cs`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6899e2f10d80833294df61c1fff57955