### PR TITLE
Add proxy service provider to allow renewal

### DIFF
--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/TetriGroundsProjectFactory.cs
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/TetriGroundsProjectFactory.cs
@@ -30,11 +30,11 @@ public class TetriGroundsProjectFactory : ILingoProjectFactory
                 .ForMovie(TetriGroundsGame.MovieName, s => s
                     .AddScriptsFromAssembly()
 
-                    // As an example, you can add them manually too:
+                // As an example, you can add them manually too:
 
-                    // .AddMovieScript<StartMoviesScript>() => MovieScript
-                    // .AddBehavior<MouseDownNavigateBehavior>()  -> Behavior
-                    // .AddParentScript<BlockParentScript>() -> Parent script
+                // .AddMovieScript<StartMoviesScript>() => MovieScript
+                // .AddBehavior<MouseDownNavigateBehavior>()  -> Behavior
+                // .AddParentScript<BlockParentScript>() -> Parent script
                 )
                 .ServicesLingo(s => s
                     .AddSingleton<IArkCore, TetriGroundsCore>()
@@ -43,7 +43,7 @@ public class TetriGroundsProjectFactory : ILingoProjectFactory
                 );
     }
 
-    
+
 
     public void LoadCastLibs(ILingoCastLibsContainer castlibContainer, LingoPlayer lingoPlayer)
     {
@@ -51,7 +51,7 @@ public class TetriGroundsProjectFactory : ILingoProjectFactory
             .LoadCastLibFromCsv("Data", Path.Combine("Medias", "Data", "Members.csv"))
             .LoadCastLibFromCsv("InternalExt", Path.Combine("Medias", "InternalExt", "Members.csv"), true);
     }
-    public ILingoMovie? LoadStartupMovie(IServiceProvider serviceProvider, LingoPlayer lingoPlayer)
+    public ILingoMovie? LoadStartupMovie(ILingoServiceProvider serviceProvider, LingoPlayer lingoPlayer)
     {
         _movie = LoadMovie(lingoPlayer);
         return _movie;

--- a/src/LingoEngine.LGodot/Core/GodotFactory.cs
+++ b/src/LingoEngine.LGodot/Core/GodotFactory.cs
@@ -36,13 +36,13 @@ namespace LingoEngine.LGodot.Core
     public class GodotFactory : ILingoFrameworkFactory, IDisposable
     {
         private readonly List<IDisposable> _disposables = new List<IDisposable>();
-        private readonly IServiceProvider _serviceProvider;
+        private readonly ILingoServiceProvider _serviceProvider;
         private readonly LingoGodotRootNode _lingoRootNode;
         private Node _rootNode;
 
-        public GodotFactory(IServiceProvider serviceProvider, LingoGodotRootNode rootNode)
+        public GodotFactory(ILingoServiceProvider serviceProvider, LingoGodotRootNode rootNode)
         {
-            _lingoRootNode= rootNode;
+            _lingoRootNode = rootNode;
             _rootNode = rootNode.RootNode;
             _serviceProvider = serviceProvider;
         }
@@ -134,7 +134,7 @@ namespace LingoEngine.LGodot.Core
         /// <inheritdoc/>
         public LingoMemberText CreateMemberText(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default)
         {
-            var godotInstance = new LingoGodotMemberText(_serviceProvider.GetRequiredService<ILingoFontManager>(),_serviceProvider.GetRequiredService<ILogger<LingoGodotMemberText>>());
+            var godotInstance = new LingoGodotMemberText(_serviceProvider.GetRequiredService<ILingoFontManager>(), _serviceProvider.GetRequiredService<ILogger<LingoGodotMemberText>>());
             var lingoInstance = new LingoMemberText((LingoCast)cast, godotInstance, numberInCast, name, fileName ?? "", regPoint);
             godotInstance.Init(lingoInstance);
             _disposables.Add(godotInstance);
@@ -454,7 +454,7 @@ namespace LingoEngine.LGodot.Core
         public LingoGfxMenuItem CreateMenuItem(string name, string? shortcut = null)
         {
             var item = new LingoGfxMenuItem();
-            var impl = new LingoGodotMenuItem(item,name, shortcut);
+            var impl = new LingoGodotMenuItem(item, name, shortcut);
             return item;
         }
 

--- a/src/LingoEngine.SDL2/Core/SdlFactory.cs
+++ b/src/LingoEngine.SDL2/Core/SdlFactory.cs
@@ -32,10 +32,10 @@ namespace LingoEngine.SDL2.Core;
 public class SdlFactory : ILingoFrameworkFactory, IDisposable
 {
     private readonly List<IDisposable> _disposables = new();
-    private readonly IServiceProvider _serviceProvider;
+    private readonly ILingoServiceProvider _serviceProvider;
     private readonly SdlRootContext _rootContext;
     /// <inheritdoc/>
-    public SdlFactory(IServiceProvider serviceProvider, SdlRootContext rootContext)
+    public SdlFactory(ILingoServiceProvider serviceProvider, SdlRootContext rootContext)
     {
         _serviceProvider = serviceProvider;
         _rootContext = rootContext;
@@ -458,15 +458,15 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
     {
         throw new NotImplementedException();
     }
-  
-   
+
+
     /// <inheritdoc/>
     public LingoGfxWindow CreateWindow(string name, string title = "")
     {
         throw new NotImplementedException();
     }
-  
-  
+
+
     /// <inheritdoc/>
     public LingoGfxHorizontalLineSeparator CreateHorizontalLineSeparator(string name)
     {

--- a/src/LingoEngine/Commands/CommandManagerExtensions.cs
+++ b/src/LingoEngine/Commands/CommandManagerExtensions.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Linq;
-using Microsoft.Extensions.DependencyInjection;
+using LingoEngine.Core;
 
 namespace LingoEngine.Commands;
 
 internal static class CommandManagerExtensions
 {
-    public static void DiscoverAndSubscribe(this ILingoCommandManager manager, IServiceProvider provider)
+    public static void DiscoverAndSubscribe(this ILingoCommandManager manager, ILingoServiceProvider provider)
     {
         var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(x =>
         {

--- a/src/LingoEngine/Commands/LingoCommandManager.cs
+++ b/src/LingoEngine/Commands/LingoCommandManager.cs
@@ -1,15 +1,16 @@
 using System;
 using System.Linq;
+using LingoEngine.Core;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LingoEngine.Commands;
 
 internal sealed class LingoCommandManager : ILingoCommandManager
 {
-    private readonly IServiceProvider _provider;
+    private readonly ILingoServiceProvider _provider;
     private readonly Dictionary<Type, List<Type>> _handlers = new();
 
-    public LingoCommandManager(IServiceProvider provider) => _provider = provider;
+    public LingoCommandManager(ILingoServiceProvider provider) => _provider = provider;
 
     public void Register<THandler, TCommand>()
         where THandler : ICommandHandler<TCommand>

--- a/src/LingoEngine/Core/LingoPlayer.cs
+++ b/src/LingoEngine/Core/LingoPlayer.cs
@@ -25,7 +25,7 @@ namespace LingoEngine.Core
         private readonly LingoCastLibsContainer _castLibsContainer;
         private readonly LingoSound _sound;
         private readonly ILingoWindow _window;
-        private readonly IServiceProvider _serviceProvider;
+        private readonly ILingoServiceProvider _serviceProvider;
         private Action<LingoMovie> _actionOnNewMovie;
         private Dictionary<string, LingoMovieEnvironment> _moviesByName = new();
         private List<LingoMovieEnvironment> _movies = new();
@@ -43,7 +43,7 @@ namespace LingoEngine.Core
         public ILingoStage Stage => _Stage;
         /// <inheritdoc/>
         public ILingoCast ActiveCastLib => _castLibsContainer.ActiveCast;
-        
+
         /// <inheritdoc/>
         public ILingoSound Sound => _sound;
         public ILingoStageMouse Mouse => _Mouse;
@@ -80,9 +80,9 @@ namespace LingoEngine.Core
         public ILingoMovie? ActiveMovie { get; private set; }
         public event Action<ILingoMovie?>? ActiveMovieChanged;
 
-        public LingoPlayer(IServiceProvider serviceProvider, ILingoFrameworkFactory factory, ILingoCastLibsContainer castLibsContainer, ILingoWindow window, ILingoClock lingoClock, ILingoSystem lingoSystem)
+        public LingoPlayer(ILingoServiceProvider serviceProvider, ILingoFrameworkFactory factory, ILingoCastLibsContainer castLibsContainer, ILingoWindow window, ILingoClock lingoClock, ILingoSystem lingoSystem)
         {
-            _actionOnNewMovie= m => { };
+            _actionOnNewMovie = m => { };
             _serviceProvider = serviceProvider;
             Factory = factory;
             _castLibsContainer = (LingoCastLibsContainer)castLibsContainer;
@@ -114,7 +114,7 @@ namespace LingoEngine.Core
         /// <inheritdoc/>
         public void Cursor(int cursorNum)
         {
-            
+
         }
         /// <inheritdoc/>
         public void Halt()
@@ -140,7 +140,7 @@ namespace LingoEngine.Core
         public ILingoMovie NewMovie(string name, bool andActivate = true)
         {
             // Create the default cast
-            if (_castLibsContainer.Count == 0) 
+            if (_castLibsContainer.Count == 0)
                 _castLibsContainer.AddCast("Internal");
 
             // Create a new movies scope, needed for behaviours.
@@ -148,7 +148,7 @@ namespace LingoEngine.Core
 
             // Create the movie.
             var movieEnv = (LingoMovieEnvironment)scope.ServiceProvider.GetRequiredService<ILingoMovieEnvironment>();
-            movieEnv.Init(name, _movies.Count + 1, this, _LingoKey, _sound, _Mouse, _Stage, _System, Clock, _castLibsContainer, scope,m =>
+            movieEnv.Init(name, _movies.Count + 1, this, _LingoKey, _sound, _Mouse, _Stage, _System, Clock, _castLibsContainer, scope, m =>
             {
                 // On remove movie
                 var movieEnvironment = m.GetEnvironment();

--- a/src/LingoEngine/Core/LingoServiceProvider.cs
+++ b/src/LingoEngine/Core/LingoServiceProvider.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace LingoEngine.Core
+{
+    public interface ILingoServiceProvider : IServiceProvider
+    {
+        void SetServiceProvider(IServiceProvider serviceProvider);
+    }
+
+    public class LingoServiceProvider : ILingoServiceProvider
+    {
+        private IServiceProvider? _serviceProvider;
+
+        public void SetServiceProvider(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public object? GetService(Type serviceType)
+        {
+            if (_serviceProvider == null)
+                throw new InvalidOperationException("Service provider is not set.");
+            return _serviceProvider.GetService(serviceType);
+        }
+    }
+}

--- a/src/LingoEngine/Movies/LingoMovie.cs
+++ b/src/LingoEngine/Movies/LingoMovie.cs
@@ -11,6 +11,7 @@ using LingoEngine.Transitions;
 using LingoEngine.Tempos;
 using LingoEngine.ColorPalettes;
 using LingoEngine.Scripts;
+using LingoEngine.Core;
 
 namespace LingoEngine.Movies
 {
@@ -28,13 +29,13 @@ namespace LingoEngine.Movies
         private int _NextFrame = -1;
         private int _lastFrame = 0;
         private bool _isPlaying = false;
-        
+
         private bool _needToRaiseStartMovie = false;
         private LingoCastLibsContainer _castLibContainer;
         private readonly LingoFrameLabelManager _frameLabelManager;
         private readonly LingoSprite2DManager _sprite2DManager;
         private bool _IsManualUpdateStage;
-        public event Action<int>? Sprite2DListChanged { add => _sprite2DManager.SpriteListChanged+=value;remove => _sprite2DManager.SpriteListChanged-=value; }
+        public event Action<int>? Sprite2DListChanged { add => _sprite2DManager.SpriteListChanged += value; remove => _sprite2DManager.SpriteListChanged -= value; }
 
         private readonly LingoSpriteAudioManager _audioManager;
         private readonly LingoSpriteTransitionManager _transitionManager;
@@ -75,7 +76,7 @@ namespace LingoEngine.Movies
 
         public int Frame => _currentFrame;
         public int CurrentFrame => _currentFrame;
-        public int FrameCount => 620; 
+        public int FrameCount => 620;
         public int Timer { get; private set; }
         public int SpriteTotalCount => _sprite2DManager.SpriteTotalCount;
         public int SpriteMaxNumber => _sprite2DManager.SpriteMaxNumber;
@@ -88,7 +89,7 @@ namespace LingoEngine.Movies
         {
             get => _tempoManager.Tempo;
             set => _tempoManager.ChangeTempo(value);
-        } 
+        }
         public int MaxSpriteChannelCount
         {
             get => _sprite2DManager.MaxSpriteChannelCount;
@@ -160,8 +161,8 @@ namespace LingoEngine.Movies
         }
 
 
-       
-        
+
+
 
 
         #region Sprites
@@ -172,7 +173,7 @@ namespace LingoEngine.Movies
         public LingoSprite2D AddSprite(int num, Action<LingoSprite2D>? configure = null) => _sprite2DManager.AddSprite(num, configure);
         public LingoFrameScriptSprite AddFrameBehavior<TBehaviour>(int frameNumber, Action<TBehaviour>? configureBehaviour = null, Action<LingoFrameScriptSprite>? configure = null) where TBehaviour : LingoSpriteBehavior
             => _frameScriptManager.Add(frameNumber, configureBehaviour, configure);
-        public LingoSprite2D AddSprite(int num,string name, Action<LingoSprite2D>? configure = null) => _sprite2DManager.AddSprite(num,name, configure);
+        public LingoSprite2D AddSprite(int num, string name, Action<LingoSprite2D>? configure = null) => _sprite2DManager.AddSprite(num, name, configure);
         public LingoSprite? AddSpriteByChannelNum(int spriteNumWithChannel, int begin, int end, ILingoMember? member)
         {
             if (spriteNumWithChannel < _spriteManagers.Count)
@@ -244,7 +245,7 @@ namespace LingoEngine.Movies
                     _delayTicks--;
                     return;
                 }
-                if(_IsManualUpdateStage)
+                if (_IsManualUpdateStage)
                     OnUpdateStage();
                 else
                     AdvanceFrame();
@@ -308,10 +309,10 @@ namespace LingoEngine.Movies
                 //_spriteManagers.ForEach(x => x.EndSprites());
                 _isAdvancing = false;
             }
-            
+
         }
 
-     
+
 
         // Play the movie
         public void Play()
@@ -326,7 +327,7 @@ namespace LingoEngine.Movies
             PlayStateChanged?.Invoke(true);
             OnTick();
             _needToRaiseStartMovie = false;
-           
+
         }
 
         private void OnStop()
@@ -445,12 +446,12 @@ namespace LingoEngine.Movies
         }
         private void OnUpdateStage()
         {
-            
+
             Timer++;
             _actorList.Invoke();
             _FrameworkMovie.UpdateStage();
             _IsManualUpdateStage = false;
-        } 
+        }
         #endregion
 
 
@@ -465,23 +466,23 @@ namespace LingoEngine.Movies
         #region CastLibs
         public ILingoCastLibsContainer CastLib => _castLibContainer;
         public ILingoMembersContainer Member => _castLibContainer.Member;
-        public T? GetMember<T>(int number) where T : class,ILingoMember => _castLibContainer.GetMember<T>(number);
+        public T? GetMember<T>(int number) where T : class, ILingoMember => _castLibContainer.GetMember<T>(number);
         public T? GetMember<T>(string name) where T : class, ILingoMember => _castLibContainer.GetMember<T>(name);
         #endregion
 
 
         #region MovieScripts
         public ILingoMovie AddMovieScript<T>()
-            where T: LingoMovieScript
+            where T : LingoMovieScript
         {
             _MovieScripts.Add<T>();
             return this;
-        } 
+        }
         public void CallMovieScript<T>(Action<T> action) where T : LingoMovieScript
             => _MovieScripts.Call(action);
         public TResult? CallMovieScript<T, TResult>(Func<T, TResult> action) where T : LingoMovieScript
             => _MovieScripts.Call(action);
-           
+
         private void CallOnAllMovieScripts(Action<LingoMovieScript> actionOnAll)
             => _MovieScripts.CallAll(actionOnAll);
 
@@ -490,7 +491,7 @@ namespace LingoEngine.Movies
 
 
         public LingoMovieEnvironment GetEnvironment() => _environment;
-        public IServiceProvider GetServiceProvider() => _environment.GetServiceProvider();
+        public ILingoServiceProvider GetServiceProvider() => _environment.GetServiceProvider();
 
         public void StartTimer() => Timer = 0;
 
@@ -503,7 +504,7 @@ namespace LingoEngine.Movies
         public int GetPrevSpriteEnd(int channel, int frame)
             => _sprite2DManager.GetPrevSpriteEnd(channel, frame);
 
-       
+
         public int GetMaxLocZ() => _sprite2DManager.GetMaxLocZ();
 
         public ILingoMemberFactory New => _memberFactory;
@@ -511,6 +512,6 @@ namespace LingoEngine.Movies
         public LingoMember? MouseMemberUnderMouse() // todo : implement
             => null;
 
-        
+
     }
 }

--- a/src/LingoEngine/Projects/ILingoProjectFactory.cs
+++ b/src/LingoEngine/Projects/ILingoProjectFactory.cs
@@ -10,6 +10,6 @@ public interface ILingoProjectFactory
 {
     void Setup(ILingoEngineRegistration engineRegistration);
     void LoadCastLibs(ILingoCastLibsContainer castlibContainer, LingoPlayer lingoPlayer);
-    ILingoMovie? LoadStartupMovie(IServiceProvider serviceProvider, LingoPlayer lingoPlayer);
+    ILingoMovie? LoadStartupMovie(ILingoServiceProvider serviceProvider, LingoPlayer lingoPlayer);
     void Run(ILingoMovie movie, bool autoPlayMovie);
 }


### PR DESCRIPTION
## Summary
- introduce ILingoServiceProvider proxy for resetting the underlying IServiceProvider
- register and reuse the proxy in LingoEngineRegistration, rebuilding it on project changes
- replace IServiceProvider dependencies with ILingoServiceProvider across engine components and factories
- ensure project factory is created before rebuilding the service provider so new services are registered

## Testing
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/Setup/LingoEngineRegistration.cs --verbosity diag --no-restore`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689aa4662114833293421356e7b9fccd