### PR TITLE
Optimize film loop player frame handling

### DIFF
--- a/src/LingoEngine/FilmLoops/LingoFilmLoopMember.cs
+++ b/src/LingoEngine/FilmLoops/LingoFilmLoopMember.cs
@@ -26,7 +26,7 @@ namespace LingoEngine.FilmLoops
 
         public int FrameCount { get; private set; }
 
-       
+
 
         /// <summary>
         /// Gets the framework specific implementation for this film loop.
@@ -71,7 +71,7 @@ namespace LingoEngine.FilmLoops
             if (_isLoaded) return;
             _frameworkFilmLoop.Preload();
             UpdateSize();
-             _isLoaded = true;
+            _isLoaded = true;
         }
         public void UpdateSize()
         {
@@ -141,36 +141,8 @@ namespace LingoEngine.FilmLoops
             }
         }
 
-        public LingoRect GetBoundingBoxForFrame(int frame)
-        {
-            var boxes = SpriteEntries
-                   .Select(e => e.GetBoundingBoxForFrame(frame))
-                   .ToList();
-
-            if (boxes.Count == 0)
-                return new LingoRect();
-
-            var bounds = boxes[0];
-            for (int i = 1; i < boxes.Count; i++)
-                bounds = bounds.Union(boxes[i]);
-
-            return bounds;
-        }
-        public LingoRect GetBoundingBox()
-        {
-            var boxes = SpriteEntries
-                .Select(e => e.GetBoundingBox())
-                .ToList();
-
-            if (boxes.Count == 0)
-                return new LingoRect();
-
-            var bounds = boxes[0];
-            for (int i = 1; i < boxes.Count; i++)
-                bounds = bounds.Union(boxes[i]);
-
-            return bounds;
-        }
+        public LingoRect GetBoundingBoxForFrame(int frame) => SpriteEntries.GetBoundingBoxForFrame(frame);
+        public LingoRect GetBoundingBox() => SpriteEntries.GetBoundingBox();
 
 
     }

--- a/src/LingoEngine/FilmLoops/LingoFilmLoopMemberSpriteExtensions.cs
+++ b/src/LingoEngine/FilmLoops/LingoFilmLoopMemberSpriteExtensions.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Linq;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.FilmLoops
+{
+    public static class LingoFilmLoopMemberSpriteExtensions
+    {
+        public static LingoRect GetBoundingBoxForFrame(this IEnumerable<LingoFilmLoopMemberSprite> sprites, int frame)
+        {
+            var boxes = sprites
+                .Select(e => e.GetBoundingBoxForFrame(frame))
+                .ToList();
+
+            if (boxes.Count == 0)
+                return new LingoRect();
+
+            var bounds = boxes[0];
+            for (int i = 1; i < boxes.Count; i++)
+                bounds = bounds.Union(boxes[i]);
+
+            return bounds;
+        }
+
+        public static LingoRect GetBoundingBox(this IEnumerable<LingoFilmLoopMemberSprite> sprites)
+        {
+            var boxes = sprites
+                .Select(e => e.GetBoundingBox())
+                .ToList();
+
+            if (boxes.Count == 0)
+                return new LingoRect();
+
+            var bounds = boxes[0];
+            for (int i = 1; i < boxes.Count; i++)
+                bounds = bounds.Union(boxes[i]);
+
+            return bounds;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- precompute frame count during film loop setup
- reuse list when composing active film loop layers
- centralize film loop bounding box calculations in extension methods

## Testing
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/FilmLoops/LingoFilmLoopMember.cs src/LingoEngine/FilmLoops/LingoFilmLoopPlayer.cs src/LingoEngine/FilmLoops/LingoFilmLoopMemberSpriteExtensions.cs --verbosity diagnostic`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689aa669eea883329e8f9f6298c3a5ab