### PR TITLE
feat: handle mouse wheel events

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Stages/StageBoundingBoxesOverlay.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/StageBoundingBoxesOverlay.cs
@@ -166,6 +166,7 @@ public class StageBoundingBoxesOverlay : IHasSpriteSelectedEvent, ILingoMouseEve
     }
 
     void ILingoMouseEventHandler.RaiseMouseMove(LingoMouseEvent mouse) => OnMouseMove(mouse);
+    void ILingoMouseEventHandler.RaiseMouseWheel(LingoMouseEvent mouse) { }
 
     private Anchor HitTest(float x, float y)
     {

--- a/src/Director/LingoEngine.Director.LGodot/Bitmaps/DirGodotPictureMemberEditorWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Bitmaps/DirGodotPictureMemberEditorWindow.cs
@@ -1,6 +1,7 @@
 ﻿using Godot;
 using LingoEngine.Director.LGodot.Gfx;
 using LingoEngine.Director.Core.Events;
+using LingoEngine.Events;
 using LingoEngine.Members;
 using LingoEngine.Core;
 using LingoEngine.Primitives;
@@ -57,6 +58,7 @@ internal partial class DirGodotPictureMemberEditorWindow : BaseGodotWindow, IHas
     private int _brushSize = 1;
     private readonly LingoBitmapSelection _selection = new();
     private Vector2I _selectStart;
+    private Vector2 _lastMousePos;
 
 
     private readonly float[] _zoomLevels = new float[]
@@ -248,6 +250,11 @@ internal partial class DirGodotPictureMemberEditorWindow : BaseGodotWindow, IHas
 
         _scaleDropdown.ItemSelected += id => OnScaleSelected(id);
         _bottomBar.AddChild(_scaleDropdown);
+
+        Mouse.OnMouseDown(OnMouseDown);
+        Mouse.OnMouseUp(OnMouseUp);
+        Mouse.OnMouseMove(OnMouseMove);
+        Mouse.OnMouseEvent(OnMouseEvent);
     }
     private void StyleIconButton(Button button, DirectorIcon icon)
     {
@@ -507,108 +514,125 @@ internal partial class DirGodotPictureMemberEditorWindow : BaseGodotWindow, IHas
     {
         base._Input(@event);
 
-        if (base._dragging) return;
-        if (!Visible) return;
-        Rect2 bounds = new Rect2(_scrollContainer.GlobalPosition, _scrollContainer.Size);
-        Vector2 mousePos = GetGlobalMousePosition();
-        if (!bounds.HasPoint(mousePos)) return;
-        if (@event is InputEventKey keyEvent)
-        {
-            if (keyEvent.Keycode == Key.Space)
-                SpaceBarPress(keyEvent);
+        if (base._dragging || !Visible)
             return;
-        }
 
-        if (@event is InputEventMouseButton mb)
+        if (@event is InputEventKey keyEvent && keyEvent.Keycode == Key.Space)
         {
-            if (mb.ButtonIndex == MouseButton.Left)
-            {
-                if (mb.Pressed && _spaceHeld)
-                {
-                    _panning = true;
-                    GetViewport().SetInputAsHandled();
-                    return;
-                }
-
-                if (mb.Pressed && !@_spaceHeld)
-                {
-                    if (_paintToolbar.SelectedTool == PainterToolType.SelectRectangle)
-                        StartRectangleSelection();
-                    else if (_paintToolbar.SelectedTool == PainterToolType.SelectLasso)
-                        StartLassoSelection();
-                    else if (_painter != null && _imageRect.Texture != null)
-                    {
-                        _drawing = true;
-                        DrawingPixels();
-                    }
-                    GetViewport().SetInputAsHandled();
-                    return;
-                }
-
-                if (!mb.Pressed)
-                {
-                    if (_selection.IsDragSelecting && _paintToolbar.SelectedTool == PainterToolType.SelectRectangle)
-                        FinishRectangleSelection(mb);
-                    else if (_selection.IsLassoSelecting && _paintToolbar.SelectedTool == PainterToolType.SelectLasso)
-                        FinishLassoSelection(mb);
-                    else
-                        _panning = false;
-                    _drawing = false;
-                    GetViewport().SetInputAsHandled();
-                    return;
-                }
-            }
-            else if (!mb.Pressed && (mb.ButtonIndex == MouseButton.WheelUp || mb.ButtonIndex == MouseButton.WheelDown))
-            {
-                ZoomingWithMouseScroll(mb);
-                return;
-            }
-
-        }
-        else if (@event is InputEventMouseMotion motion)
-        {
-            if (_selection.IsDragSelecting && _paintToolbar.SelectedTool == PainterToolType.SelectRectangle)
-            {
-                var local = _imageRect.GetLocalMousePosition();
-                var end = new Vector2I((int)local.X, (int)local.Y);
-                _selection.UpdateRectSelection(
-                    new LingoPoint(_selectStart.X, _selectStart.Y),
-                    new LingoPoint(end.X, end.Y));
-                RedrawSelectionCanvas();
-                GetViewport().SetInputAsHandled();
-                return;
-            }
-            else if (_selection.IsLassoSelecting && _paintToolbar.SelectedTool == PainterToolType.SelectLasso)
-            {
-                var local = _imageRect.GetLocalMousePosition();
-                var point = new Vector2I((int)local.X, (int)local.Y);
-                _selection.AddLassoPoint(point.X, point.Y);
-                RedrawSelectionCanvas();
-                GetViewport().SetInputAsHandled();
-                return;
-            }
-            if (_panning)
-            {
-                _scrollContainer.ScrollHorizontal -= (int)motion.Relative.X;
-                _scrollContainer.ScrollVertical -= (int)motion.Relative.Y;
-
-                GetViewport().SetInputAsHandled();
-                return;
-            }
-            if (_drawing)
-            {
-                DrawingPixels();
-                GetViewport().SetInputAsHandled();
-                return;
-            }
+            SpaceBarPress(keyEvent);
         }
     }
 
-    private void ZoomingWithMouseScroll(InputEventMouseButton mb)
+    private void OnMouseDown(LingoMouseEvent e)
+    {
+        if (!IsEventInScrollArea() || !e.Mouse.LeftMouseDown)
+            return;
+
+        if (_spaceHeld)
+        {
+            _panning = true;
+            _lastMousePos = new Vector2(e.Mouse.MouseH, e.Mouse.MouseV);
+            GetViewport().SetInputAsHandled();
+            return;
+        }
+
+        if (_paintToolbar.SelectedTool == PainterToolType.SelectRectangle)
+            StartRectangleSelection();
+        else if (_paintToolbar.SelectedTool == PainterToolType.SelectLasso)
+            StartLassoSelection();
+        else if (_painter != null && _imageRect.Texture != null)
+        {
+            _drawing = true;
+            DrawingPixels();
+        }
+
+        GetViewport().SetInputAsHandled();
+    }
+
+    private void OnMouseUp(LingoMouseEvent e)
+    {
+        if (!IsEventInScrollArea())
+            return;
+
+        bool ctrl = Input.IsKeyPressed(Key.Ctrl);
+        bool shift = Input.IsKeyPressed(Key.Shift);
+
+        if (_selection.IsDragSelecting && _paintToolbar.SelectedTool == PainterToolType.SelectRectangle)
+            FinishRectangleSelection(ctrl, shift);
+        else if (_selection.IsLassoSelecting && _paintToolbar.SelectedTool == PainterToolType.SelectLasso)
+            FinishLassoSelection(ctrl, shift);
+        else
+            _panning = false;
+
+        _drawing = false;
+        GetViewport().SetInputAsHandled();
+    }
+
+    private void OnMouseMove(LingoMouseEvent e)
+    {
+        if (!IsEventInScrollArea())
+            return;
+
+        var current = new Vector2(e.Mouse.MouseH, e.Mouse.MouseV);
+
+        if (_selection.IsDragSelecting && _paintToolbar.SelectedTool == PainterToolType.SelectRectangle)
+        {
+            var local = _imageRect.GetLocalMousePosition();
+            var end = new Vector2I((int)local.X, (int)local.Y);
+            _selection.UpdateRectSelection(
+                new LingoPoint(_selectStart.X, _selectStart.Y),
+                new LingoPoint(end.X, end.Y));
+            RedrawSelectionCanvas();
+            GetViewport().SetInputAsHandled();
+            return;
+        }
+        else if (_selection.IsLassoSelecting && _paintToolbar.SelectedTool == PainterToolType.SelectLasso)
+        {
+            var local = _imageRect.GetLocalMousePosition();
+            var point = new Vector2I((int)local.X, (int)local.Y);
+            _selection.AddLassoPoint(point.X, point.Y);
+            RedrawSelectionCanvas();
+            GetViewport().SetInputAsHandled();
+            return;
+        }
+
+        if (_panning)
+        {
+            var rel = current - _lastMousePos;
+            _scrollContainer.ScrollHorizontal -= (int)rel.X;
+            _scrollContainer.ScrollVertical -= (int)rel.Y;
+            _lastMousePos = current;
+            GetViewport().SetInputAsHandled();
+            return;
+        }
+
+        if (_drawing)
+        {
+            DrawingPixels();
+            GetViewport().SetInputAsHandled();
+        }
+    }
+
+    private void OnMouseEvent(LingoMouseEvent e)
+    {
+        if (e.Type == LingoMouseEventType.MouseWheel && IsEventInScrollArea())
+        {
+            ZoomingWithMouseScroll(e.WheelDelta);
+        }
+    }
+
+    private bool IsEventInScrollArea()
+    {
+        Rect2 bounds = new Rect2(_scrollContainer.GlobalPosition, _scrollContainer.Size);
+        Vector2 mousePos = GetGlobalMousePosition();
+        return bounds.HasPoint(mousePos);
+    }
+
+    private void ZoomingWithMouseScroll(float delta)
     {
         // Apply zoom factor per scroll step (e.g. 25% per notch)
         const float zoomStep = 1.25f;
-        float factor = mb.ButtonIndex == MouseButton.WheelUp ? zoomStep : 1f / zoomStep;
+        float factor = delta > 0 ? zoomStep : 1f / zoomStep;
 
         float rawScale = _scale * factor;
 
@@ -623,14 +647,14 @@ internal partial class DirGodotPictureMemberEditorWindow : BaseGodotWindow, IHas
         GetViewport().SetInputAsHandled();
     }
 
-    private void FinishRectangleSelection(InputEventMouseButton mb)
+    private void FinishRectangleSelection(bool ctrlPressed, bool shiftPressed)
     {
         var local = _imageRect.GetLocalMousePosition();
         var end = new Vector2I((int)local.X, (int)local.Y);
         var rect = LingoPoint.RectFromPoints(
             new LingoPoint(_selectStart.X, _selectStart.Y),
             new LingoPoint(end.X, end.Y));
-        _selection.ApplySelection(rect, mb.CtrlPressed, mb.ShiftPressed);
+        _selection.ApplySelection(rect, ctrlPressed, shiftPressed);
         _selection.EndRectSelection();
         RedrawSelectionCanvas();
     }
@@ -662,13 +686,13 @@ internal partial class DirGodotPictureMemberEditorWindow : BaseGodotWindow, IHas
             RedrawSelectionCanvas();
         }
     }
-    private void FinishLassoSelection(InputEventMouseButton mb)
+    private void FinishLassoSelection(bool ctrlPressed, bool shiftPressed)
     {
         var polygon = _selection.EndLassoSelection();
         if (polygon.Count > 2)
         {
             var pixels = LingoPoint.PointsInsidePolygon(polygon);
-            _selection.ApplySelection(pixels, mb.CtrlPressed, mb.ShiftPressed);
+            _selection.ApplySelection(pixels, ctrlPressed, shiftPressed);
         }
         RedrawSelectionCanvas();
     }

--- a/src/LingoEngine.LGodot/Inputs/LingoGodotMouse.cs
+++ b/src/LingoEngine.LGodot/Inputs/LingoGodotMouse.cs
@@ -20,11 +20,11 @@ namespace LingoEngine.LGodot
         }
         public void ReplaceMouseObj(LingoMouse lingoMouse)
         {
-            _lingoMouse = new Lazy<LingoMouse>(()=>  lingoMouse);
+            _lingoMouse = new Lazy<LingoMouse>(() => lingoMouse);
         }
         public void Release()
         {
-            
+
         }
         public void HandleMouseMoveEvent(InputEventMouseMotion mouseMotionEvent, bool isInsideRect, float x, float y)
         {
@@ -41,12 +41,18 @@ namespace LingoEngine.LGodot
         {
             _lingoMouse.Value.MouseH = x;
             _lingoMouse.Value.MouseV = y;
+            if (mouseButtonEvent.ButtonIndex == MouseButton.WheelUp || mouseButtonEvent.ButtonIndex == MouseButton.WheelDown)
+            {
+                var delta = mouseButtonEvent.ButtonIndex == MouseButton.WheelUp ? 1f : -1f;
+                _lingoMouse.Value.DoMouseWheel(delta);
+                return;
+            }
             //Console.WriteLine(Name + ":" + mouseButtonEvent.Position.X + "x" + mouseButtonEvent.Position.Y + ":" + isInsideRect);
             // Handle Mouse Down event
             if (mouseButtonEvent.Pressed)
             {
                 // mouse down must be inside rect, mouse up may not
-                if (isInsideRect && x > 0 && y> 0)
+                if (isInsideRect && x > 0 && y > 0)
                 {
                     wasPressed = true;
                     if (mouseButtonEvent.ButtonIndex == MouseButton.Left)
@@ -54,7 +60,7 @@ namespace LingoEngine.LGodot
                         // Handle Left Button Down
                         _lingoMouse.Value.MouseDown = true;
                         _lingoMouse.Value.LeftMouseDown = true;
-                         DetectDoubleClick();
+                        DetectDoubleClick();
                         _lingoMouse.Value.DoMouseDown();
                     }
                     else if (mouseButtonEvent.ButtonIndex == MouseButton.Right)
@@ -158,7 +164,7 @@ namespace LingoEngine.LGodot
             };
         }
 
-        
+
     }
 
 }

--- a/src/LingoEngine.SDL2/Core/SdlFactory.cs
+++ b/src/LingoEngine.SDL2/Core/SdlFactory.cs
@@ -187,7 +187,7 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
     /// <inheritdoc/>
     public LingoStageMouse CreateMouse(LingoStage stage)
     {
-        var mouseImpl = new SdlMouse(new Lazy<LingoMouse>(() => null!));
+        var mouseImpl = _rootContext.Mouse;
         var mouse = new LingoStageMouse(stage, mouseImpl);
         mouseImpl.SetLingoMouse(mouse);
         return mouse;

--- a/src/LingoEngine.SDL2/Inputs/SdlMouse.cs
+++ b/src/LingoEngine.SDL2/Inputs/SdlMouse.cs
@@ -3,6 +3,7 @@ using LingoEngine.FrameworkCommunication;
 using LingoEngine.Inputs;
 using LingoEngine.SDL2.Pictures;
 using LingoEngine.SDL2.SDLL;
+using System;
 using System.Runtime.InteropServices;
 
 namespace LingoEngine.SDL2.Inputs;
@@ -95,6 +96,61 @@ public class SdlMouse : ILingoFrameworkMouse
     public void ReplaceMouseObj(LingoMouse lingoMouse)
     {
         _lingoMouse = new Lazy<LingoMouse>(() => lingoMouse);
+    }
+
+    public void ProcessEvent(SDL.SDL_Event e)
+    {
+        switch (e.type)
+        {
+            case SDL.SDL_EventType.SDL_MOUSEMOTION:
+                _lingoMouse.Value.MouseH = e.motion.x;
+                _lingoMouse.Value.MouseV = e.motion.y;
+                _lingoMouse.Value.DoMouseMove();
+                break;
+            case SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN:
+                _lingoMouse.Value.MouseH = e.button.x;
+                _lingoMouse.Value.MouseV = e.button.y;
+                if (e.button.button == SDL.SDL_BUTTON_LEFT)
+                {
+                    _lingoMouse.Value.MouseDown = true;
+                    _lingoMouse.Value.LeftMouseDown = true;
+                    _lingoMouse.Value.DoubleClick = e.button.clicks > 1;
+                }
+                else if (e.button.button == SDL.SDL_BUTTON_RIGHT)
+                {
+                    _lingoMouse.Value.RightMouseDown = true;
+                }
+                else if (e.button.button == SDL.SDL_BUTTON_MIDDLE)
+                {
+                    _lingoMouse.Value.MiddleMouseDown = true;
+                }
+                _lingoMouse.Value.DoMouseDown();
+                break;
+            case SDL.SDL_EventType.SDL_MOUSEBUTTONUP:
+                _lingoMouse.Value.MouseH = e.button.x;
+                _lingoMouse.Value.MouseV = e.button.y;
+                if (e.button.button == SDL.SDL_BUTTON_LEFT)
+                {
+                    _lingoMouse.Value.MouseDown = false;
+                    _lingoMouse.Value.LeftMouseDown = false;
+                }
+                else if (e.button.button == SDL.SDL_BUTTON_RIGHT)
+                {
+                    _lingoMouse.Value.RightMouseDown = false;
+                }
+                else if (e.button.button == SDL.SDL_BUTTON_MIDDLE)
+                {
+                    _lingoMouse.Value.MiddleMouseDown = false;
+                }
+                _lingoMouse.Value.DoMouseUp();
+                break;
+            case SDL.SDL_EventType.SDL_MOUSEWHEEL:
+                SDL.SDL_GetMouseState(out var x, out var y);
+                _lingoMouse.Value.MouseH = x;
+                _lingoMouse.Value.MouseV = y;
+                _lingoMouse.Value.DoMouseWheel(e.wheel.y);
+                break;
+        }
     }
 
     ~SdlMouse()

--- a/src/LingoEngine.SDL2/SdlRootContext.cs
+++ b/src/LingoEngine.SDL2/SdlRootContext.cs
@@ -1,8 +1,10 @@
 namespace LingoEngine.SDL2;
+using System;
 using LingoEngine.Core;
 using LingoEngine.SDL2.SDLL;
 using LingoEngine.SDL2.Core;
 using LingoEngine.Movies;
+using LingoEngine.Inputs;
 using LingoEngine.SDL2.Inputs;
 using LingoEngine.SDL2.Stages;
 
@@ -15,13 +17,14 @@ public class SdlRootContext : IDisposable
 
     public LingoDebugOverlay DebugOverlay { get; set; }
     internal SdlKey Key { get; } = new();
+    internal SdlMouse Mouse { get; } = new SdlMouse(new Lazy<LingoMouse>(() => null!));
     private bool _f1Pressed;
 
     public SdlRootContext(nint window, nint renderer)
     {
         Window = window;
         Renderer = renderer;
-        
+
     }
     public void Init(ILingoPlayer player)
     {
@@ -31,7 +34,7 @@ public class SdlRootContext : IDisposable
     public void Run()
     {
         var clock = (LingoClock)_lPlayer.Clock;
-       
+
         bool running = true;
         uint last = SDL.SDL_GetTicks();
         while (running)
@@ -41,13 +44,14 @@ public class SdlRootContext : IDisposable
                 if (e.type == SDL.SDL_EventType.SDL_QUIT)
                     running = false;
                 Key.ProcessEvent(e);
+                Mouse.ProcessEvent(e);
             }
             uint now = SDL.SDL_GetTicks();
             float delta = (now - last) / 1000f;
             last = now;
             DebugOverlay.Update(delta);
             bool f1 = _lPlayer.Key.KeyPressed((int)SDL.SDL_Keycode.SDLK_F1);
-            if ( f1 && !_f1Pressed)
+            if (f1 && !_f1Pressed)
                 DebugOverlay.Toggle();
             _f1Pressed = f1;
             clock.Tick(delta);

--- a/src/LingoEngine/Events/LingoEventMediator.cs
+++ b/src/LingoEngine/Events/LingoEventMediator.cs
@@ -21,6 +21,7 @@ namespace LingoEngine.Events
         private readonly List<IHasMouseDownEvent> _mouseDowns = new();
         private readonly List<IHasMouseUpEvent> _mouseUps = new();
         private readonly List<IHasMouseMoveEvent> _mouseMoves = new();
+        private readonly List<IHasMouseWheelEvent> _mouseWheels = new();
         private readonly List<IHasMouseEnterEvent> _mouseEnters = new();
         private readonly List<IHasMouseExitEvent> _mouseExits = new();
         //private readonly List<IHasBeginSpriteEvent> _beginSprites = new();
@@ -55,6 +56,7 @@ namespace LingoEngine.Events
             if (ms is IHasMouseDownEvent mouseDownEvent) Insert(_mouseDowns, mouseDownEvent);
             if (ms is IHasMouseUpEvent mouseUpEvent) Insert(_mouseUps, mouseUpEvent);
             if (ms is IHasMouseMoveEvent mouseMoveEvent) Insert(_mouseMoves, mouseMoveEvent);
+            if (ms is IHasMouseWheelEvent mouseWheelEvent) Insert(_mouseWheels, mouseWheelEvent);
             if (ms is IHasMouseEnterEvent mouseEnterEvent) Insert(_mouseEnters, mouseEnterEvent);
             if (ms is IHasMouseExitEvent mouseExitEvent) Insert(_mouseExits, mouseExitEvent);
             //if (ms is IHasBeginSpriteEvent beginSpriteEvent) Insert(_beginSprites, beginSpriteEvent);
@@ -76,6 +78,7 @@ namespace LingoEngine.Events
             if (ms is IHasMouseDownEvent mouseDownEvent) _mouseDowns.Remove(mouseDownEvent);
             if (ms is IHasMouseUpEvent mouseUpEvent) _mouseUps.Remove(mouseUpEvent);
             if (ms is IHasMouseMoveEvent mouseMoveEvent) _mouseMoves.Remove(mouseMoveEvent);
+            if (ms is IHasMouseWheelEvent mouseWheelEvent) _mouseWheels.Remove(mouseWheelEvent);
             if (ms is IHasMouseEnterEvent mouseEnterEvent) _mouseEnters.Remove(mouseEnterEvent);
             if (ms is IHasMouseExitEvent mouseExitEvent) _mouseExits.Remove(mouseExitEvent);
             //if (ms is IHasBeginSpriteEvent beginSpriteEvent) _beginSprites.Remove(beginSpriteEvent);
@@ -109,6 +112,7 @@ namespace LingoEngine.Events
             FilterList(_mouseDowns);
             FilterList(_mouseUps);
             FilterList(_mouseMoves);
+            FilterList(_mouseWheels);
             FilterList(_mouseEnters);
             FilterList(_mouseExits);
             FilterList(_stepFrames);
@@ -126,6 +130,7 @@ namespace LingoEngine.Events
         public void RaiseMouseDown(LingoMouseEvent mouse) => _mouseDowns.ForEach(x => x.MouseDown(mouse));
         public void RaiseMouseUp(LingoMouseEvent mouse) => _mouseUps.ForEach(x => x.MouseUp(mouse));
         public void RaiseMouseMove(LingoMouseEvent mouse) => _mouseMoves.ForEach(x => x.MouseMove(mouse));
+        public void RaiseMouseWheel(LingoMouseEvent mouse) => _mouseWheels.ForEach(x => x.MouseWheel(mouse));
         internal void RaiseMouseEnter(LingoMouseEvent mouse) => _mouseEnters.ForEach(x => x.MouseEnter(mouse));
         internal void RaiseMouseExit(LingoMouseEvent mouse) => _mouseExits.ForEach(x => x.MouseExit(mouse));
         //internal void RaiseBeginSprite() => _beginSprites.ForEach(x => x.BeginSprite());

--- a/src/LingoEngine/Events/LingoMouseEventSubscription.cs
+++ b/src/LingoEngine/Events/LingoMouseEventSubscription.cs
@@ -4,7 +4,10 @@ namespace LingoEngine.Events
 {
     public enum LingoMouseEventType
     {
-        MouseUp,MouseDown, MouseMove
+        MouseUp,
+        MouseDown,
+        MouseMove,
+        MouseWheel
     }
     public class LingoMouseEvent
     {
@@ -13,6 +16,7 @@ namespace LingoEngine.Events
         public bool ContinuePropation { get; set; } = true;
         public float MouseH => Mouse.MouseH;
         public float MouseV => Mouse.MouseV;
+        public float WheelDelta => Mouse.WheelDelta;
 
         public LingoMouseEvent(LingoMouse lingoMouse, LingoMouseEventType type)
         {
@@ -26,6 +30,7 @@ namespace LingoEngine.Events
         void RaiseMouseDown(LingoMouseEvent mouse);
         void RaiseMouseUp(LingoMouseEvent mouse);
         void RaiseMouseMove(LingoMouseEvent mouse);
+        void RaiseMouseWheel(LingoMouseEvent mouse);
     }
     public interface ILingoMouseEventSubscription
     {
@@ -46,6 +51,7 @@ namespace LingoEngine.Events
         public void DoMouseDown(LingoMouseEvent mouse) => _target.RaiseMouseDown(mouse);
         public void DoMouseUp(LingoMouseEvent mouse) => _target.RaiseMouseUp(mouse);
         public void DoMouseMove(LingoMouseEvent mouse) => _target.RaiseMouseMove(mouse);
+        public void DoMouseWheel(LingoMouseEvent mouse) => _target.RaiseMouseWheel(mouse);
 
         public void Release()
         {

--- a/src/LingoEngine/Events/LingoMovieScriptMediator.cs
+++ b/src/LingoEngine/Events/LingoMovieScriptMediator.cs
@@ -48,6 +48,7 @@ namespace LingoEngine.Events
         new void DoMouseDown(LingoStageMouse mouse);
         new void DoMouseUp(LingoStageMouse mouse);
         new void DoMouseMove(LingoStageMouse mouse);
+        new void DoMouseWheel(LingoStageMouse mouse);
 
         // Movie Script Frame events
         void DoEnterFrame();
@@ -81,6 +82,7 @@ namespace LingoEngine.Events
 
         // Dispatch MouseMove event to all subscribers
         public void MouseMove(LingoStageMouse mouse) => _subscriptions.ForEach(s => s.MouseMove(mouse));
+        public void MouseWheel(LingoStageMouse mouse) => _subscriptions.ForEach(s => s.MouseWheel(mouse));
 
         // Dispatch EnterFrame event to all subscribers
         public void EnterFrame() => _subscriptions.ForEach(s => s.EnterFrame());
@@ -102,6 +104,7 @@ namespace LingoEngine.Events
             public void MouseDown(LingoStageMouse mouse) => _target.DoMouseDown(mouse);
             public void MouseUp(LingoStageMouse mouse) => _target.DoMouseUp(mouse);
             public void MouseMove(LingoStageMouse mouse) => _target.DoMouseMove(mouse);
+            public void MouseWheel(LingoStageMouse mouse) => _target.DoMouseWheel(mouse);
             public void EnterFrame() => _target.DoEnterFrame();
             public void ExitFrame() => _target.DoExitFrame();
 

--- a/src/LingoEngine/Inputs/Events/IMouseEvents.cs
+++ b/src/LingoEngine/Inputs/Events/IMouseEvents.cs
@@ -1,4 +1,3 @@
-﻿
 using LingoEngine.Events;
 
 namespace LingoEngine.Inputs.Events
@@ -26,6 +25,10 @@ namespace LingoEngine.Inputs.Events
         void MouseMove(LingoMouseEvent mouse);
     }
 
+    public interface IHasMouseWheelEvent
+    {
+        void MouseWheel(LingoMouseEvent mouse);
+    }
 
     public interface IHasMouseEnterEvent
     {

--- a/src/LingoEngine/Sprites/LingoSprite2D.cs
+++ b/src/LingoEngine/Sprites/LingoSprite2D.cs
@@ -231,7 +231,7 @@ namespace LingoEngine.Sprites
         }
 
         #region Animation / keyframes
-        
+
         /// <summary>
         /// Adds animation keyframes for this sprite. When invoked for the first time
         /// it lazily creates a <see cref="LingoSpriteAnimator"/> actor and stores it
@@ -253,7 +253,7 @@ namespace LingoEngine.Sprites
             animator.RecalculateCache();
         }
 
-        
+
 
         public void SetSpriteTweenOptions(bool positionEnabled, bool sizeEnabled, bool rotationEnabled, bool skewEnabled,
             bool foregroundColorEnabled, bool backgroundColorEnabled, bool blendEnabled,
@@ -400,7 +400,7 @@ When a movie stops, events occur in the following order:
             {
                 if (existingPlayer == null)
                 {
-                    existingPlayer = new LingoFilmLoopPlayer(this, _eventMediator,_environment.CastLibsContainer);
+                    existingPlayer = new LingoFilmLoopPlayer(this, _eventMediator, _environment.CastLibsContainer);
                     AddActor(existingPlayer);
                 }
                 if (IsActive)
@@ -555,6 +555,7 @@ When a movie stops, events occur in the following order:
             _eventMediator.RaiseMouseUp(mouse);
         }
         protected virtual void MouseUp(LingoMouseEvent mouse) { }
+        void ILingoMouseEventHandler.RaiseMouseWheel(LingoMouseEvent mouse) => _eventMediator.RaiseMouseWheel(mouse);
         private void DoMouseDrag(LingoMouseEvent mouse)
         {
             LocH = mouse.MouseH;
@@ -686,6 +687,6 @@ When a movie stops, events occur in the following order:
             return action;
         }
 
-       
+
     }
 }


### PR DESCRIPTION
## Summary
- add IHasMouseWheelEvent interface and track wheel handlers in event mediator
- wire SDL backend: root context and SdlMouse now dispatch movement, button, and wheel events
- create mouse from root context so SDL polling can update LingoMouse

## Testing
- `dotnet format LingoEngine.sln --include src/LingoEngine/Inputs/Events/IMouseEvents.cs src/LingoEngine/Events/LingoEventMediator.cs src/LingoEngine.SDL2/Core/SdlFactory.cs src/LingoEngine.SDL2/SdlRootContext.cs src/LingoEngine.SDL2/Inputs/SdlMouse.cs --verbosity diagnostic`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689aa830019c833298d5d132d79d5b73