### PR TITLE
Decouple SDL GFX factory for standalone tests

### DIFF
--- a/LingoEngine.sln
+++ b/LingoEngine.sln
@@ -37,8 +37,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.Demo.TetriGroun
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{D004920B-E200-4F03-AA99-48FB4D54F50E}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Experimental", "Experimental", "{9C77EB5C-778D-4D98-AE2B-F80137E5D27C}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ToMakePackage", "ToMakePackage", "{134E8198-015E-4E1F-8B31-6DF91C4D80EE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectorRays.Console", "WillMoveToOwnRepo\ProjectorRays\src\ProjectorRays.Console\ProjectorRays.Console.csproj", "{1C1986AE-577A-4A90-8EA9-76F9CDB3540D}"
@@ -46,6 +44,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectorRays.DotNet", "WillMoveToOwnRepo\ProjectorRays\src\ProjectorRays.DotNet\ProjectorRays.DotNet.csproj", "{C9F6D15A-DFD0-4F4C-BBE5-8CBCF8315355}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectorRays.DotNet.Test", "WillMoveToOwnRepo\ProjectorRays\Test\ProjectorRays.DotNet.Test\ProjectorRays.DotNet.Test.csproj", "{08A845C8-FC7C-4C31-BB64-DDFA90F0A10C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.SDL2.GfxVisualTest", "Test\LingoEngine.SDL2.GfxVisualTest\LingoEngine.SDL2.GfxVisualTest.csproj", "{E8BD81BB-813E-4268-A798-3AFC2C5164EF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -365,6 +365,24 @@ Global
 		{08A845C8-FC7C-4C31-BB64-DDFA90F0A10C}.ExportRelease|x64.Build.0 = Release|Any CPU
 		{08A845C8-FC7C-4C31-BB64-DDFA90F0A10C}.ExportRelease|x86.ActiveCfg = Release|Any CPU
 		{08A845C8-FC7C-4C31-BB64-DDFA90F0A10C}.ExportRelease|x86.Build.0 = Release|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.Debug|x64.Build.0 = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.Debug|x86.Build.0 = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.ExportDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.ExportDebug|Any CPU.Build.0 = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.ExportDebug|x64.ActiveCfg = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.ExportDebug|x64.Build.0 = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.ExportDebug|x86.ActiveCfg = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.ExportDebug|x86.Build.0 = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.ExportRelease|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.ExportRelease|Any CPU.Build.0 = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.ExportRelease|x64.ActiveCfg = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.ExportRelease|x64.Build.0 = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.ExportRelease|x86.ActiveCfg = Debug|Any CPU
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF}.ExportRelease|x86.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -386,5 +404,6 @@ Global
 		{1C1986AE-577A-4A90-8EA9-76F9CDB3540D} = {134E8198-015E-4E1F-8B31-6DF91C4D80EE}
 		{C9F6D15A-DFD0-4F4C-BBE5-8CBCF8315355} = {134E8198-015E-4E1F-8B31-6DF91C4D80EE}
 		{08A845C8-FC7C-4C31-BB64-DDFA90F0A10C} = {134E8198-015E-4E1F-8B31-6DF91C4D80EE}
+		{E8BD81BB-813E-4268-A798-3AFC2C5164EF} = {D004920B-E200-4F03-AA99-48FB4D54F50E}
 	EndGlobalSection
 EndGlobal

--- a/Test/LingoEngine.SDL2.GfxVisualTest/GfxTestScene.cs
+++ b/Test/LingoEngine.SDL2.GfxVisualTest/GfxTestScene.cs
@@ -1,0 +1,101 @@
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.SDL2.GfxVisualTest;
+
+public static class GfxTestScene
+{
+    public static LingoGfxScrollContainer Build(ILingoGfxFactory factory)
+    {
+        var scroll = factory.CreateScrollContainer("scroll");
+        scroll.X = 20;
+        scroll.Y = 20;
+        scroll.Width = 760;
+        scroll.Height = 560;
+
+        var panel = factory.CreatePanel("rootPanel");
+        panel.Width = 720;
+        panel.Height = 1400;
+
+        float y = 10f;
+
+        void Add(ILingoGfxNode node, float height = 40)
+        {
+            panel.AddItem(node, 10, y);
+            y += height;
+        }
+
+        Add(factory.CreateLabel("label", "Label"));
+
+        Add(factory.CreateButton("button", "Button"));
+
+        Add(factory.CreateStateButton("stateButton", null, "State"));
+
+        Add(factory.CreateInputText("inputText"));
+
+        Add(factory.CreateInputNumberInt("inputNumber", 0, 100));
+
+        Add(factory.CreateSpinBox("spinBox", 0, 10));
+
+        Add(factory.CreateInputCheckbox("checkbox"));
+
+        var combo = factory.CreateInputCombobox("combobox", null);
+        combo.AddItem("1", "One");
+        combo.AddItem("2", "Two");
+        combo.AddItem("3", "Three");
+        Add(combo);
+
+        var slider = factory.CreateInputSliderFloat(LingoOrientation.Horizontal, "slider", 0, 1, 0.1f);
+        slider.Width = 200;
+        Add(slider, 50);
+
+        var colorPicker = factory.CreateColorPicker("colorPicker");
+        Add(colorPicker, 80);
+
+        var canvas = factory.CreateGfxCanvas("canvas", 100, 50);
+        canvas.Clear(new LingoColor(100, 100, 100, 255));
+        canvas.DrawRect(new LingoRect(10, 10, 80, 30), new LingoColor(200, 0, 0, 255));
+        Add(canvas, 60);
+
+        var list = factory.CreateItemList("itemList");
+        list.Width = 120;
+        list.Height = 60;
+        list.AddItem("a", "Item A");
+        list.AddItem("b", "Item B");
+        list.AddItem("c", "Item C");
+        Add(list, 80);
+
+        var wrap = factory.CreateWrapPanel(LingoOrientation.Horizontal, "wrapPanel");
+        wrap.Width = 300;
+        wrap.Height = 60;
+        wrap.AddItem(factory.CreateButton("wrapBtn1", "One"));
+        wrap.AddItem(factory.CreateButton("wrapBtn2", "Two"));
+        wrap.AddItem(factory.CreateButton("wrapBtn3", "Three"));
+        Add(wrap, 70);
+
+        var tabs = factory.CreateTabContainer("tabContainer");
+        tabs.Width = 300;
+        tabs.Height = 120;
+        var tab1 = factory.CreateTabItem("tab1", "First");
+        tab1.Content = factory.CreateLabel("tab1Label", "Tab 1");
+        tabs.AddTab(tab1);
+        var tab2 = factory.CreateTabItem("tab2", "Second");
+        tab2.Content = factory.CreateLabel("tab2Label", "Tab 2");
+        tabs.AddTab(tab2);
+        Add(tabs, 130);
+
+        var menu = factory.CreateMenu("menu");
+        menu.AddItem(factory.CreateMenuItem("menuItem"));
+        var menuBtn = factory.CreateButton("menuBtn", "Menu (not rendered)");
+        menuBtn.Pressed += () =>
+        {
+            menu.PositionPopup(menuBtn);
+            menu.Popup();
+        };
+        Add(menuBtn);
+
+        scroll.AddItem(panel);
+
+        return scroll;
+    }
+}

--- a/Test/LingoEngine.SDL2.GfxVisualTest/LingoEngine.SDL2.GfxVisualTest.csproj
+++ b/Test/LingoEngine.SDL2.GfxVisualTest/LingoEngine.SDL2.GfxVisualTest.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\LingoEngine.SDL2\LingoEngine.SDL2.csproj" />
+  </ItemGroup>
+</Project>

--- a/Test/LingoEngine.SDL2.GfxVisualTest/Program.cs
+++ b/Test/LingoEngine.SDL2.GfxVisualTest/Program.cs
@@ -1,0 +1,13 @@
+using LingoEngine.SDL2.Gfx;
+using LingoEngine.SDL2.GfxVisualTest;
+using LingoEngine.SDL2.Styles;
+
+using var rootContext = new TestSdlRootComponentContext();
+var fontManager = new SdlFontManager();
+fontManager.LoadAll();
+var factory = new SdlGfxFactory(rootContext, fontManager);
+
+var scroll = GfxTestScene.Build(factory);
+rootContext.ComponentContainer.Activate(((dynamic)scroll.FrameworkObj).ComponentContext);
+
+rootContext.Run();

--- a/Test/LingoEngine.SDL2.GfxVisualTest/TestSdlRootComponentContext.cs
+++ b/Test/LingoEngine.SDL2.GfxVisualTest/TestSdlRootComponentContext.cs
@@ -1,0 +1,53 @@
+using LingoEngine.SDL2;
+using LingoEngine.SDL2.SDLL;
+
+namespace LingoEngine.SDL2.GfxVisualTest;
+
+public class TestSdlRootComponentContext : ISdlRootComponentContext, IDisposable
+{
+    private readonly nint _window;
+    public LingoSDLComponentContainer ComponentContainer { get; } = new();
+    public nint Renderer { get; }
+
+    public TestSdlRootComponentContext()
+    {
+        SDL.SDL_Init(SDL.SDL_INIT_VIDEO | SDL.SDL_INIT_EVENTS | SDL.SDL_INIT_GAMECONTROLLER | SDL.SDL_INIT_AUDIO);
+        SDL_ttf.TTF_Init();
+        SDL_image.IMG_Init(SDL_image.IMG_InitFlags.IMG_INIT_PNG);
+
+        _window = SDL.SDL_CreateWindow("SDL Gfx Visual Test", SDL.SDL_WINDOWPOS_CENTERED, SDL.SDL_WINDOWPOS_CENTERED, 800, 600,
+            SDL.SDL_WindowFlags.SDL_WINDOW_SHOWN | SDL.SDL_WindowFlags.SDL_WINDOW_RESIZABLE);
+        Renderer = SDL.SDL_CreateRenderer(_window, -1,
+            SDL.SDL_RendererFlags.SDL_RENDERER_ACCELERATED | SDL.SDL_RendererFlags.SDL_RENDERER_PRESENTVSYNC);
+        SDL.SDL_RenderSetLogicalSize(Renderer, 800, 600);
+    }
+
+    public void Run()
+    {
+        bool running = true;
+        while (running)
+        {
+            while (SDL.SDL_PollEvent(out var e) == 1)
+            {
+                if (e.type == SDL.SDL_EventType.SDL_QUIT)
+                    running = false;
+            }
+
+            SDL.SDL_SetRenderDrawColor(Renderer, 0, 0, 0, 255);
+            SDL.SDL_RenderClear(Renderer);
+
+            ComponentContainer.Render(new LingoSDLRenderContext(Renderer));
+
+            SDL.SDL_RenderPresent(Renderer);
+        }
+    }
+
+    public void Dispose()
+    {
+        SDL.SDL_DestroyRenderer(Renderer);
+        SDL.SDL_DestroyWindow(_window);
+        SDL_ttf.TTF_Quit();
+        SDL_image.IMG_Quit();
+        SDL.SDL_Quit();
+    }
+}

--- a/src/LingoEngine.LGodot/Gfx/GodotGfxFactory.cs
+++ b/src/LingoEngine.LGodot/Gfx/GodotGfxFactory.cs
@@ -1,0 +1,270 @@
+using System;
+using LingoEngine.Bitmaps;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+using LingoEngine.Styles;
+using LingoEngine.LGodot.Styles;
+
+namespace LingoEngine.LGodot.Gfx
+{
+    /// <summary>
+    /// Factory responsible for creating Godot specific GFX components.
+    /// </summary>
+    public class GodotGfxFactory : ILingoGfxFactory
+    {
+        private readonly ILingoFontManager _fontManager;
+        private readonly ILingoGodotStyleManager _styleManager;
+
+        public GodotGfxFactory(ILingoFontManager fontManager, ILingoGodotStyleManager styleManager)
+        {
+            _fontManager = fontManager;
+            _styleManager = styleManager;
+        }
+
+        public LingoGfxCanvas CreateGfxCanvas(string name, int width, int height)
+        {
+            var canvas = new LingoGfxCanvas();
+            var impl = new LingoGodotGfxCanvas(canvas, _fontManager, width, height);
+            canvas.Width = width;
+            canvas.Height = height;
+            canvas.Name = name;
+            return canvas;
+        }
+
+        public LingoGfxWrapPanel CreateWrapPanel(LingoOrientation orientation, string name)
+        {
+            var panel = new LingoGfxWrapPanel(this);
+            var impl = new LingoGodotWrapPanel(panel, orientation);
+            panel.Name = name;
+            panel.Orientation = orientation;
+            return panel;
+        }
+
+        public LingoGfxPanel CreatePanel(string name)
+        {
+            var panel = new LingoGfxPanel(this);
+            var impl = new LingoGodotPanel(panel);
+            panel.Name = name;
+            return panel;
+        }
+
+        public LingoGfxLayoutWrapper CreateLayoutWrapper(ILingoGfxNode content, float? x, float? y)
+        {
+            if (content is ILingoGfxLayoutNode)
+                throw new InvalidOperationException($"Content {content.Name} already supports layout — wrapping is unnecessary.");
+            var panel = new LingoGfxLayoutWrapper(content);
+            var impl = new LingoGodotLayoutWrapper(panel);
+            if (x != null) panel.X = x.Value;
+            if (y != null) panel.Y = y.Value;
+            return panel;
+        }
+
+        public LingoGfxTabContainer CreateTabContainer(string name)
+        {
+            var tab = new LingoGfxTabContainer();
+            var impl = new LingoGodotTabContainer(tab, _styleManager);
+            tab.Name = name;
+            return tab;
+        }
+
+        public LingoGfxTabItem CreateTabItem(string name, string title)
+        {
+            var tab = new LingoGfxTabItem();
+            var impl = new LingoGodotTabItem(tab);
+            tab.Title = title;
+            tab.Name = name;
+            return tab;
+        }
+
+        public LingoGfxScrollContainer CreateScrollContainer(string name)
+        {
+            var scroll = new LingoGfxScrollContainer();
+            var impl = new LingoGodotScrollContainer(scroll);
+            scroll.Name = name;
+            return scroll;
+        }
+
+        public LingoGfxInputSlider<float> CreateInputSliderFloat(LingoOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null)
+        {
+            var minNum = min.HasValue ? new NullableNum<float>(min.Value) : new NullableNum<float>();
+            var maxNum = max.HasValue ? new NullableNum<float>(max.Value) : new NullableNum<float>();
+            var stepNum = step.HasValue ? new NullableNum<float>(step.Value) : new NullableNum<float>();
+            return CreateInputSlider(name, orientation, minNum, maxNum, stepNum, onChange);
+        }
+
+        public LingoGfxInputSlider<int> CreateInputSliderInt(LingoOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null)
+        {
+            var minNum = min.HasValue ? new NullableNum<int>(min.Value) : new NullableNum<int>();
+            var maxNum = max.HasValue ? new NullableNum<int>(max.Value) : new NullableNum<int>();
+            var stepNum = step.HasValue ? new NullableNum<int>(step.Value) : new NullableNum<int>();
+            return CreateInputSlider(name, orientation, minNum, maxNum, stepNum, onChange);
+        }
+
+        public LingoGfxInputSlider<TValue> CreateInputSlider<TValue>(string name, LingoOrientation orientation, NullableNum<TValue> min, NullableNum<TValue> max, NullableNum<TValue> step, Action<TValue>? onChange = null)
+            where TValue : struct, System.Numerics.INumber<TValue>, IConvertible
+        {
+            var slider = new LingoGfxInputSlider<TValue>();
+            var impl = new LingoGodotInputSlider<TValue>(slider, orientation, onChange);
+            if (min.HasValue) slider.MinValue = min.Value!;
+            if (max.HasValue) slider.MaxValue = max.Value!;
+            if (step.HasValue) slider.Step = step.Value!;
+            slider.Name = name;
+            return slider;
+        }
+
+        public LingoGfxInputText CreateInputText(string name, int maxLength = 0, Action<string>? onChange = null)
+        {
+            var input = new LingoGfxInputText();
+            var impl = new LingoGodotInputText(input, _fontManager, onChange);
+            input.MaxLength = maxLength;
+            input.Name = name;
+            return input;
+        }
+
+        public LingoGfxInputNumber<float> CreateInputNumberFloat(string name, float? min = null, float? max = null, Action<float>? onChange = null)
+        {
+            var minNullableNum = min.HasValue ? new NullableNum<float>(min.Value) : new NullableNum<float>();
+            var maxNullableNum = max.HasValue ? new NullableNum<float>(max.Value) : new NullableNum<float>();
+            return CreateInputNumber(name, minNullableNum, maxNullableNum, onChange);
+        }
+
+        public LingoGfxInputNumber<int> CreateInputNumberInt(string name, int? min = null, int? max = null, Action<int>? onChange = null)
+        {
+            var minNullableNum = min.HasValue ? new NullableNum<int>(min.Value) : new NullableNum<int>();
+            var maxNullableNum = max.HasValue ? new NullableNum<int>(max.Value) : new NullableNum<int>();
+            return CreateInputNumber(name, minNullableNum, maxNullableNum, onChange);
+        }
+
+        public LingoGfxInputNumber<TValue> CreateInputNumber<TValue>(string name, NullableNum<TValue> min, NullableNum<TValue> max, Action<TValue>? onChange = null)
+             where TValue : System.Numerics.INumber<TValue>
+        {
+            var input = new LingoGfxInputNumber<TValue>();
+            var impl = new LingoGodotInputNumber<TValue>(input, _fontManager, onChange);
+            if (min.HasValue) input.Min = min.Value!;
+            if (max.HasValue) input.Max = max.Value!;
+            input.Name = name;
+            return input;
+        }
+
+        public LingoGfxSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null)
+        {
+            var spin = new LingoGfxSpinBox();
+            var impl = new LingoGodotSpinBox(spin, _fontManager, onChange);
+            spin.Name = name;
+            if (min.HasValue) spin.Min = min.Value;
+            if (max.HasValue) spin.Max = max.Value;
+            return spin;
+        }
+
+        public LingoGfxInputCheckbox CreateInputCheckbox(string name, Action<bool>? onChange = null)
+        {
+            var input = new LingoGfxInputCheckbox();
+            var impl = new LingoGodotInputCheckbox(input, onChange);
+            input.Name = name;
+            return input;
+        }
+
+        public LingoGfxInputCombobox CreateInputCombobox(string name, Action<string?>? onChange = null)
+        {
+            var input = new LingoGfxInputCombobox();
+            var impl = new LingoGodotInputCombobox(input, _fontManager, onChange);
+            input.Name = name;
+            return input;
+        }
+
+        public LingoGfxItemList CreateItemList(string name, Action<string?>? onChange = null)
+        {
+            var list = new LingoGfxItemList();
+            var impl = new LingoGodotItemList(list, onChange);
+            list.Name = name;
+            return list;
+        }
+
+        public LingoGfxColorPicker CreateColorPicker(string name, Action<LingoColor>? onChange = null)
+        {
+            var picker = new LingoGfxColorPicker();
+            var impl = new LingoGodotColorPicker(picker, onChange);
+            picker.Name = name;
+            return picker;
+        }
+
+        public LingoGfxLabel CreateLabel(string name, string text = "")
+        {
+            var label = new LingoGfxLabel();
+            var impl = new LingoGodotLabel(label, _fontManager);
+            label.Text = text;
+            label.Name = name;
+            return label;
+        }
+
+        public LingoGfxButton CreateButton(string name, string text = "")
+        {
+            var button = new LingoGfxButton();
+            var impl = new LingoGodotButton(button, _fontManager);
+            button.Name = name;
+            if (!string.IsNullOrWhiteSpace(text))
+                button.Text = text;
+            return button;
+        }
+
+        public LingoGfxStateButton CreateStateButton(string name, ILingoImageTexture? texture = null, string text = "", Action<bool>? onChange = null)
+        {
+            var button = new LingoGfxStateButton();
+            var impl = new LingoGodotStateButton(button, onChange);
+            button.Name = name;
+            if (!string.IsNullOrWhiteSpace(text))
+                button.Text = text;
+            if (texture != null)
+                button.TextureOn = texture;
+            return button;
+        }
+
+        public LingoGfxMenu CreateMenu(string name)
+        {
+            var menu = new LingoGfxMenu();
+            var impl = new LingoGodotMenu(menu, name);
+            return menu;
+        }
+
+        public LingoGfxMenuItem CreateMenuItem(string name, string? shortcut = null)
+        {
+            var item = new LingoGfxMenuItem();
+            var impl = new LingoGodotMenuItem(item, name, shortcut);
+            return item;
+        }
+
+        public LingoGfxMenu CreateContextMenu(object window)
+        {
+            var menu = CreateMenu("ContextMenu");
+            if (window is Godot.Node node)
+                node.AddChild(menu.Framework<LingoGodotMenu>());
+            return menu;
+        }
+
+        public LingoGfxHorizontalLineSeparator CreateHorizontalLineSeparator(string name)
+        {
+            var sep = new LingoGfxHorizontalLineSeparator();
+            var impl = new LingoGodotHorizontalLineSeparator(sep);
+            sep.Name = name;
+            return sep;
+        }
+
+        public LingoGfxVerticalLineSeparator CreateVerticalLineSeparator(string name)
+        {
+            var sep = new LingoGfxVerticalLineSeparator();
+            var impl = new LingoGodotVerticalLineSeparator(sep);
+            sep.Name = name;
+            return sep;
+        }
+
+        public LingoGfxWindow CreateWindow(string name, string title = "")
+        {
+            var win = new LingoGfxWindow();
+            var impl = new LingoGodotWindow(win, _styleManager);
+            win.Name = name;
+            if (!string.IsNullOrWhiteSpace(title))
+                win.Title = title;
+            return win;
+        }
+    }
+}

--- a/src/LingoEngine.SDL2/Core/SdlFactory.cs
+++ b/src/LingoEngine.SDL2/Core/SdlFactory.cs
@@ -35,13 +35,17 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
     private readonly List<IDisposable> _disposables = new();
     private readonly ILingoServiceProvider _serviceProvider;
     private readonly SdlRootContext _rootContext;
+    private readonly SdlGfxFactory _gfxFactory;
     /// <inheritdoc/>
     public SdlFactory(ILingoServiceProvider serviceProvider, SdlRootContext rootContext)
     {
         _serviceProvider = serviceProvider;
         _rootContext = rootContext;
         _rootContext.Factory = this;
+        _gfxFactory = new SdlGfxFactory(_rootContext, _serviceProvider.GetRequiredService<ILingoFontManager>());
     }
+
+    public ILingoGfxFactory GfxFactory => _gfxFactory;
     /// <inheritdoc/>
     public T CreateBehavior<T>(LingoMovie movie) where T : LingoSpriteBehavior
         => movie.GetServiceProvider().GetRequiredService<T>();
@@ -190,10 +194,10 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
     public LingoSDLComponentContainer ComponentContainer => _rootContext.ComponentContainer;
 
     public LingoSDLComponentContext CreateContext(ILingoSDLComponent component, LingoSDLComponentContext? parent = null)
-        => new(ComponentContainer, component, parent) { Renderer = _rootContext.Renderer };
+        => _gfxFactory.CreateContext(component, parent);
 
     public LingoSDLRenderContext CreateRenderContext(ILingoSDLComponent? component = null)
-        => new(_rootContext.Renderer);
+        => _gfxFactory.CreateRenderContext(component);
     /// <inheritdoc/>
     public LingoStageMouse CreateMouse(LingoStage stage)
     {
@@ -215,278 +219,86 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
     #region Gfx elements
     /// <inheritdoc/>
     public LingoGfxCanvas CreateGfxCanvas(string name, int width, int height)
-    {
-        var canvas = new LingoGfxCanvas();
-        var impl = new SdlGfxCanvas(this, _serviceProvider.GetRequiredService<ILingoFontManager>(), width, height);
-        canvas.Init(impl);
-        canvas.Width = width;
-        canvas.Height = height;
-        canvas.Name = name;
-        return canvas;
-    }
-    /// <inheritdoc/>
+        => _gfxFactory.CreateGfxCanvas(name, width, height);
+
     public LingoGfxWrapPanel CreateWrapPanel(LingoOrientation orientation, string name)
-    {
+        => _gfxFactory.CreateWrapPanel(orientation, name);
 
-        var panel = new LingoGfxWrapPanel(this);
-        var impl = new SdlGfxWrapPanel(this, orientation);
-
-        panel.Init(impl);
-        panel.Name = name;
-        // Keep orientation in sync on creation
-        panel.Orientation = orientation;
-        return panel;
-    }
-    /// <inheritdoc/>
     public LingoGfxPanel CreatePanel(string name)
-    {
-        var panel = new LingoGfxPanel(this);
-        var impl = new SdlGfxPanel(this);
-        panel.Init(impl);
-        panel.Name = name;
-        return panel;
-    }
-    /// <inheritdoc/>
-    public LingoGfxTabContainer CreateTabContainer(string name)
-    {
-        var tab = new LingoGfxTabContainer();
-        var impl = new SdlGfxTabContainer(this);
-        tab.Init(impl);
-        tab.Name = name;
-        return tab;
-    }
-    /// <inheritdoc/>
-    public LingoGfxTabItem CreateTabItem(string name, string title)
-    {
-        var tab = new LingoGfxTabItem();
-        var impl = new SdlGfxTabItem(this, tab);
-        tab.Title = title;
-        tab.Name = name;
-        return tab;
-    }
-    /// <inheritdoc/>
-    public LingoGfxScrollContainer CreateScrollContainer(string name)
-    {
-        var scroll = new LingoGfxScrollContainer();
-        var impl = new SdlGfxScrollContainer(this);
-        scroll.Init(impl);
-        scroll.Name = name;
-        return scroll;
-    }
+        => _gfxFactory.CreatePanel(name);
 
-    /// <inheritdoc/>
+    public LingoGfxTabContainer CreateTabContainer(string name)
+        => _gfxFactory.CreateTabContainer(name);
+
+    public LingoGfxTabItem CreateTabItem(string name, string title)
+        => _gfxFactory.CreateTabItem(name, title);
+
+    public LingoGfxScrollContainer CreateScrollContainer(string name)
+        => _gfxFactory.CreateScrollContainer(name);
+
     public LingoGfxInputSlider<float> CreateInputSliderFloat(LingoOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null)
-    {
-        var slider = new LingoGfxInputSlider<float>();
-        var impl = new SdlGfxInputSlider<float>(this);
-        slider.Init(impl);
-        slider.Name = name;
-        if (min.HasValue) slider.MinValue = min.Value;
-        if (max.HasValue) slider.MaxValue = max.Value;
-        if (step.HasValue) slider.Step = step.Value;
-        if (onChange != null)
-            slider.ValueChanged += () => onChange(slider.Value);
-        return slider;
-    }
+        => _gfxFactory.CreateInputSliderFloat(orientation, name, min, max, step, onChange);
 
     public LingoGfxInputSlider<int> CreateInputSliderInt(LingoOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null)
-    {
-        var slider = new LingoGfxInputSlider<int>();
-        var impl = new SdlGfxInputSlider<int>(this);
-        slider.Init(impl);
-        slider.Name = name;
-        if (min.HasValue) slider.MinValue = min.Value;
-        if (max.HasValue) slider.MaxValue = max.Value;
-        if (step.HasValue) slider.Step = step.Value;
-        if (onChange != null)
-            slider.ValueChanged += () => onChange(slider.Value);
-        return slider;
-    }
-    /// <inheritdoc/>
+        => _gfxFactory.CreateInputSliderInt(orientation, name, min, max, step, onChange);
+
     public LingoGfxInputText CreateInputText(string name, int maxLength = 0, Action<string>? onChange = null)
-    {
-        var input = new LingoGfxInputText { MaxLength = maxLength };
-        var impl = new SdlGfxInputText(this);
-        input.Init(impl);
-        input.Name = name;
-        if (onChange != null)
-            input.ValueChanged += () =>
-            {
-                if (onChange != null)
-                    onChange(input.Text);
-            };
-        return input;
-    }
-    /// <inheritdoc/>
+        => _gfxFactory.CreateInputText(name, maxLength, onChange);
+
     public LingoGfxInputNumber<float> CreateInputNumberFloat(string name, float? min = null, float? max = null, Action<float>? onChange = null)
-    {
-        // Convert nullable float to NullableNum<float> explicitly  
-        var minNullableNum = min.HasValue ? new NullableNum<float>(min.Value) : new NullableNum<float>();
-        var maxNullableNum = max.HasValue ? new NullableNum<float>(max.Value) : new NullableNum<float>();
-        return CreateInputNumber(name, minNullableNum, maxNullableNum, onChange);
-    }
-    /// <inheritdoc/>
+        => _gfxFactory.CreateInputNumberFloat(name, min, max, onChange);
+
     public LingoGfxInputNumber<int> CreateInputNumberInt(string name, int? min = null, int? max = null, Action<int>? onChange = null)
-    {
-        // Convert nullable float to NullableNum<float> explicitly  
-        var minNullableNum = min.HasValue ? new NullableNum<int>(min.Value) : new NullableNum<int>();
-        var maxNullableNum = max.HasValue ? new NullableNum<int>(max.Value) : new NullableNum<int>();
-        return CreateInputNumber(name, minNullableNum, maxNullableNum, onChange);
-    }
-    /// <inheritdoc/>
+        => _gfxFactory.CreateInputNumberInt(name, min, max, onChange);
+
     public LingoGfxInputNumber<TValue> CreateInputNumber<TValue>(string name, NullableNum<TValue> min, NullableNum<TValue> max, Action<TValue>? onChange = null)
-         where TValue : System.Numerics.INumber<TValue>
-    {
-        var input = new LingoGfxInputNumber<TValue>();
-        //var impl = new SdlGfxInputNumber<float>(_rootContext.Renderer);
-        //input.Init(impl);
-        //input.Name = name;
-        //if (min.HasValue) input.Min = min.Value;
-        //if (max.HasValue) input.Max = max.Value;
-        return input;
-    }
-    /// <inheritdoc/>
+        where TValue : System.Numerics.INumber<TValue>
+        => _gfxFactory.CreateInputNumber(name, min, max, onChange);
+
     public LingoGfxSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null)
-    {
-        var spin = new LingoGfxSpinBox();
-        var impl = new SdlGfxSpinBox(this);
-        spin.Init(impl);
-        spin.Name = name;
-        if (min.HasValue) spin.Min = min.Value;
-        if (max.HasValue) spin.Max = max.Value;
-        if (onChange != null)
-            spin.ValueChanged += () => onChange(spin.Value);
-        return spin;
-    }
+        => _gfxFactory.CreateSpinBox(name, min, max, onChange);
 
     public LingoGfxInputCheckbox CreateInputCheckbox(string name, Action<bool>? onChange = null)
-    {
-        var input = new LingoGfxInputCheckbox();
-        var impl = new SdlGfxInputCheckbox(this);
-        input.Init(impl);
-        input.Name = name;
-        input.ValueChanged += () =>
-        {
-            if (onChange != null)
-                onChange(input.Checked);
-        };
-        return input;
-    }
-    /// <inheritdoc/>
+        => _gfxFactory.CreateInputCheckbox(name, onChange);
+
     public LingoGfxInputCombobox CreateInputCombobox(string name, Action<string?>? onChange = null)
-    {
-        var input = new LingoGfxInputCombobox();
-        var impl = new SdlGfxInputCombobox(this);
-        input.Init(impl);
-        input.Name = name;
-        input.ValueChanged += () =>
-        {
-            if (onChange != null)
-                onChange(input.SelectedKey);
-        };
-        return input;
-    }
-    /// <inheritdoc/>
+        => _gfxFactory.CreateInputCombobox(name, onChange);
+
     public LingoGfxItemList CreateItemList(string name, Action<string?>? onChange = null)
-    {
-        var list = new LingoGfxItemList();
-        var impl = new SdlGfxItemList(this);
-        list.Init(impl);
-        list.Name = name;
-        if (onChange != null)
-            list.ValueChanged += () => onChange(list.SelectedKey);
-        return list;
-    }
-    /// <inheritdoc/>
+        => _gfxFactory.CreateItemList(name, onChange);
+
     public LingoGfxColorPicker CreateColorPicker(string name, Action<LingoColor>? onChange = null)
-    {
-        var picker = new LingoGfxColorPicker();
-        var impl = new SdlGfxColorPicker(this);
-        picker.Init(impl);
-        picker.Name = name;
-        if (onChange != null)
-            picker.ValueChanged += () => onChange(picker.Color);
-        return picker;
-    }
-    /// <inheritdoc/>
+        => _gfxFactory.CreateColorPicker(name, onChange);
+
     public LingoGfxLabel CreateLabel(string name, string text = "")
-    {
-        var label = new LingoGfxLabel { Text = text };
-        var impl = new SdlGfxLabel(this);
-        label.Init(impl);
-        label.Name = name;
-        return label;
-    }
-    /// <inheritdoc/>
+        => _gfxFactory.CreateLabel(name, text);
+
     public LingoGfxButton CreateButton(string name, string text = "")
-    {
-        var button = new LingoGfxButton { Text = text };
-        var impl = new SdlGfxButton(this);
-        button.Init(impl);
-        button.Name = name;
-        return button;
-    }
-    /// <inheritdoc/>
+        => _gfxFactory.CreateButton(name, text);
+
     public LingoGfxStateButton CreateStateButton(string name, Bitmaps.ILingoImageTexture? texture = null, string text = "", Action<bool>? onChange = null)
-    {
-        var button = new LingoGfxStateButton { Text = text };
-        var impl = new SdlGfxStateButton(this);
-        if (onChange != null)
-            button.ValueChanged += () => onChange(button.IsOn); // hooking in wrapper since SDL button is dummy
-        button.Init(impl);
-        button.Name = name;
-        if (texture != null)
-            button.TextureOn = texture;
-        return button;
-    }
-    /// <inheritdoc/>
+        => _gfxFactory.CreateStateButton(name, texture, text, onChange);
+
     public LingoGfxMenu CreateMenu(string name)
-    {
-        var menu = new LingoGfxMenu();
-        var impl = new SdlGfxMenu(this, name);
-        menu.Init(impl);
-        return menu;
-    }
-    /// <inheritdoc/>
+        => _gfxFactory.CreateMenu(name);
+
     public LingoGfxMenuItem CreateMenuItem(string name, string? shortcut = null)
-    {
-        var item = new LingoGfxMenuItem();
-        var impl = new SdlGfxMenuItem(this, name, shortcut);
-        item.Init(impl);
-        return item;
-    }
+        => _gfxFactory.CreateMenuItem(name, shortcut);
 
-    /// <inheritdoc/>
     public LingoGfxMenu CreateContextMenu(object window)
-    {
-        // SDL UI is not implemented yet, return a basic menu instance
-        var menu = CreateMenu("ContextMenu");
-        return menu;
-    }
-    /// <inheritdoc/>
+        => _gfxFactory.CreateContextMenu(window);
+
     public LingoGfxLayoutWrapper CreateLayoutWrapper(ILingoGfxNode content, float? x, float? y)
-    {
-        throw new NotImplementedException();
-    }
+        => _gfxFactory.CreateLayoutWrapper(content, x, y);
 
-
-    /// <inheritdoc/>
     public LingoGfxWindow CreateWindow(string name, string title = "")
-    {
-        throw new NotImplementedException();
-    }
+        => _gfxFactory.CreateWindow(name, title);
 
-
-    /// <inheritdoc/>
     public LingoGfxHorizontalLineSeparator CreateHorizontalLineSeparator(string name)
-    {
-        throw new NotImplementedException();
-    }
-    /// <inheritdoc/>
+        => _gfxFactory.CreateHorizontalLineSeparator(name);
+
     public LingoGfxVerticalLineSeparator CreateVerticalLineSeparator(string name)
-    {
-        throw new NotImplementedException();
-    }
+        => _gfxFactory.CreateVerticalLineSeparator(name);
     #endregion
 
 

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxButton.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxButton.cs
@@ -4,14 +4,12 @@ using ImGuiNET;
 using LingoEngine.Bitmaps;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
-using LingoEngine.Bitmaps;
-using LingoEngine.SDL2.Core;
 
 namespace LingoEngine.SDL2.Gfx
 {
     internal class SdlGfxButton : SdlGfxComponent, ILingoFrameworkGfxButton, IDisposable
     {
-        public SdlGfxButton(SdlFactory factory) : base(factory)
+        public SdlGfxButton(SdlGfxFactory factory) : base(factory)
         {
         }
         public LingoMargin Margin { get; set; } = LingoMargin.Zero;
@@ -21,8 +19,6 @@ namespace LingoEngine.SDL2.Gfx
         public ILingoImageTexture? IconTexture { get => _icon; set => _icon = value; }
 
         public object FrameworkNode => this;
-
-        public ILingoImageTexture? IconTexture { get; set; }
 
         public event Action? Pressed;
 

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxCanvas.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxCanvas.cs
@@ -7,7 +7,6 @@ using LingoEngine.Primitives;
 using LingoEngine.SDL2.Primitives;
 using LingoEngine.SDL2.SDLL;
 using LingoEngine.SDL2.Pictures;
-using LingoEngine.SDL2.Core;
 using LingoEngine.Styles;
 using LingoEngine.Texts;
 
@@ -25,7 +24,7 @@ namespace LingoEngine.SDL2.Gfx
 
         public bool Pixilated { get; set; }
 
-        public SdlGfxCanvas(SdlFactory factory, ILingoFontManager fontManager, int width, int height) : base(factory)
+        public SdlGfxCanvas(SdlGfxFactory factory, ILingoFontManager fontManager, int width, int height) : base(factory)
         {
             _fontManager = fontManager;
             _width = width;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxColorPicker.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxColorPicker.cs
@@ -3,13 +3,12 @@ using System.Numerics;
 using ImGuiNET;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
-using LingoEngine.SDL2.Core;
 
 namespace LingoEngine.SDL2.Gfx
 {
     internal class SdlGfxColorPicker : SdlGfxComponent, ILingoFrameworkGfxColorPicker, IDisposable
     {
-        public SdlGfxColorPicker(SdlFactory factory) : base(factory)
+        public SdlGfxColorPicker(SdlGfxFactory factory) : base(factory)
         {
         }
         public bool Enabled { get; set; } = true;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxComponent.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxComponent.cs
@@ -1,5 +1,4 @@
 using System;
-using LingoEngine.SDL2.Core;
 
 namespace LingoEngine.SDL2.Gfx;
 
@@ -9,7 +8,7 @@ namespace LingoEngine.SDL2.Gfx;
 /// </summary>
 public abstract class SdlGfxComponent : ILingoSDLComponent, IDisposable
 {
-    protected SdlGfxComponent(SdlFactory factory)
+    protected SdlGfxComponent(SdlGfxFactory factory)
     {
         ComponentContext = factory.CreateContext(this);
         ComponentContext.Visible = _visibility;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxFactory.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxFactory.cs
@@ -1,0 +1,280 @@
+using System;
+using LingoEngine.Bitmaps;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+using LingoEngine.SDL2;
+using LingoEngine.Styles;
+
+namespace LingoEngine.SDL2.Gfx
+{
+    /// <summary>
+    /// Factory responsible for creating SDL specific GFX components.
+    /// </summary>
+    public class SdlGfxFactory : ILingoGfxFactory
+    {
+        private readonly ISdlRootComponentContext _rootContext;
+        private readonly ILingoFontManager _fontManager;
+
+        public SdlGfxFactory(ISdlRootComponentContext rootContext, ILingoFontManager fontManager)
+        {
+            _rootContext = rootContext;
+            _fontManager = fontManager;
+        }
+
+        internal LingoSDLComponentContext CreateContext(ILingoSDLComponent component, LingoSDLComponentContext? parent = null)
+            => new(_rootContext.ComponentContainer, component, parent) { Renderer = _rootContext.Renderer };
+
+        internal LingoSDLRenderContext CreateRenderContext(ILingoSDLComponent? component = null)
+            => new(_rootContext.Renderer);
+
+        public LingoGfxCanvas CreateGfxCanvas(string name, int width, int height)
+        {
+            var canvas = new LingoGfxCanvas();
+            var impl = new SdlGfxCanvas(this, _fontManager, width, height);
+            canvas.Init(impl);
+            canvas.Width = width;
+            canvas.Height = height;
+            canvas.Name = name;
+            return canvas;
+        }
+
+        public LingoGfxWrapPanel CreateWrapPanel(LingoOrientation orientation, string name)
+        {
+            var panel = new LingoGfxWrapPanel(this);
+            var impl = new SdlGfxWrapPanel(this, orientation);
+            panel.Init(impl);
+            panel.Name = name;
+            panel.Orientation = orientation;
+            return panel;
+        }
+
+        public LingoGfxPanel CreatePanel(string name)
+        {
+            var panel = new LingoGfxPanel(this);
+            var impl = new SdlGfxPanel(this);
+            panel.Init(impl);
+            panel.Name = name;
+            return panel;
+        }
+
+        public LingoGfxLayoutWrapper CreateLayoutWrapper(ILingoGfxNode content, float? x, float? y)
+        {
+            throw new NotImplementedException();
+        }
+
+        public LingoGfxTabContainer CreateTabContainer(string name)
+        {
+            var tab = new LingoGfxTabContainer();
+            var impl = new SdlGfxTabContainer(this);
+            tab.Init(impl);
+            tab.Name = name;
+            return tab;
+        }
+
+        public LingoGfxTabItem CreateTabItem(string name, string title)
+        {
+            var tab = new LingoGfxTabItem();
+            var impl = new SdlGfxTabItem(this, tab);
+            tab.Title = title;
+            tab.Name = name;
+            return tab;
+        }
+
+        public LingoGfxScrollContainer CreateScrollContainer(string name)
+        {
+            var scroll = new LingoGfxScrollContainer();
+            var impl = new SdlGfxScrollContainer(this);
+            scroll.Init(impl);
+            scroll.Name = name;
+            return scroll;
+        }
+
+        public LingoGfxInputSlider<float> CreateInputSliderFloat(LingoOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null)
+        {
+            var slider = new LingoGfxInputSlider<float>();
+            var impl = new SdlGfxInputSlider<float>(this);
+            slider.Init(impl);
+            slider.Name = name;
+            if (min.HasValue) slider.MinValue = min.Value;
+            if (max.HasValue) slider.MaxValue = max.Value;
+            if (step.HasValue) slider.Step = step.Value;
+            if (onChange != null)
+                slider.ValueChanged += () => onChange(slider.Value);
+            return slider;
+        }
+
+        public LingoGfxInputSlider<int> CreateInputSliderInt(LingoOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null)
+        {
+            var slider = new LingoGfxInputSlider<int>();
+            var impl = new SdlGfxInputSlider<int>(this);
+            slider.Init(impl);
+            slider.Name = name;
+            if (min.HasValue) slider.MinValue = min.Value;
+            if (max.HasValue) slider.MaxValue = max.Value;
+            if (step.HasValue) slider.Step = step.Value;
+            if (onChange != null)
+                slider.ValueChanged += () => onChange(slider.Value);
+            return slider;
+        }
+
+        public LingoGfxInputText CreateInputText(string name, int maxLength = 0, Action<string>? onChange = null)
+        {
+            var input = new LingoGfxInputText { MaxLength = maxLength };
+            var impl = new SdlGfxInputText(this);
+            input.Init(impl);
+            input.Name = name;
+            if (onChange != null)
+                input.ValueChanged += () => onChange(input.Text);
+            return input;
+        }
+
+        public LingoGfxInputNumber<float> CreateInputNumberFloat(string name, float? min = null, float? max = null, Action<float>? onChange = null)
+        {
+            var minNullableNum = min.HasValue ? new NullableNum<float>(min.Value) : new NullableNum<float>();
+            var maxNullableNum = max.HasValue ? new NullableNum<float>(max.Value) : new NullableNum<float>();
+            return CreateInputNumber(name, minNullableNum, maxNullableNum, onChange);
+        }
+
+        public LingoGfxInputNumber<int> CreateInputNumberInt(string name, int? min = null, int? max = null, Action<int>? onChange = null)
+        {
+            var minNullableNum = min.HasValue ? new NullableNum<int>(min.Value) : new NullableNum<int>();
+            var maxNullableNum = max.HasValue ? new NullableNum<int>(max.Value) : new NullableNum<int>();
+            return CreateInputNumber(name, minNullableNum, maxNullableNum, onChange);
+        }
+
+        public LingoGfxInputNumber<TValue> CreateInputNumber<TValue>(string name, NullableNum<TValue> min, NullableNum<TValue> max, Action<TValue>? onChange = null)
+            where TValue : System.Numerics.INumber<TValue>
+        {
+            var input = new LingoGfxInputNumber<TValue>();
+            //var impl = new SdlGfxInputNumber<float>(_rootContext.Renderer);
+            //input.Init(impl);
+            //input.Name = name;
+            //if (min.HasValue) input.Min = min.Value;
+            //if (max.HasValue) input.Max = max.Value;
+            return input;
+        }
+
+        public LingoGfxSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null)
+        {
+            var spin = new LingoGfxSpinBox();
+            var impl = new SdlGfxSpinBox(this);
+            spin.Init(impl);
+            spin.Name = name;
+            if (min.HasValue) spin.Min = min.Value;
+            if (max.HasValue) spin.Max = max.Value;
+            if (onChange != null)
+                spin.ValueChanged += () => onChange(spin.Value);
+            return spin;
+        }
+
+        public LingoGfxInputCheckbox CreateInputCheckbox(string name, Action<bool>? onChange = null)
+        {
+            var input = new LingoGfxInputCheckbox();
+            var impl = new SdlGfxInputCheckbox(this);
+            input.Init(impl);
+            input.Name = name;
+            input.ValueChanged += () => onChange?.Invoke(input.Checked);
+            return input;
+        }
+
+        public LingoGfxInputCombobox CreateInputCombobox(string name, Action<string?>? onChange = null)
+        {
+            var input = new LingoGfxInputCombobox();
+            var impl = new SdlGfxInputCombobox(this);
+            input.Init(impl);
+            input.Name = name;
+            input.ValueChanged += () => onChange?.Invoke(input.SelectedKey);
+            return input;
+        }
+
+        public LingoGfxItemList CreateItemList(string name, Action<string?>? onChange = null)
+        {
+            var list = new LingoGfxItemList();
+            var impl = new SdlGfxItemList(this);
+            list.Init(impl);
+            list.Name = name;
+            if (onChange != null)
+                list.ValueChanged += () => onChange(list.SelectedKey);
+            return list;
+        }
+
+        public LingoGfxColorPicker CreateColorPicker(string name, Action<LingoColor>? onChange = null)
+        {
+            var picker = new LingoGfxColorPicker();
+            var impl = new SdlGfxColorPicker(this);
+            picker.Init(impl);
+            picker.Name = name;
+            if (onChange != null)
+                picker.ValueChanged += () => onChange(picker.Color);
+            return picker;
+        }
+
+        public LingoGfxLabel CreateLabel(string name, string text = "")
+        {
+            var label = new LingoGfxLabel { Text = text };
+            var impl = new SdlGfxLabel(this);
+            label.Init(impl);
+            label.Name = name;
+            return label;
+        }
+
+        public LingoGfxButton CreateButton(string name, string text = "")
+        {
+            var button = new LingoGfxButton { Text = text };
+            var impl = new SdlGfxButton(this);
+            button.Init(impl);
+            button.Name = name;
+            return button;
+        }
+
+        public LingoGfxStateButton CreateStateButton(string name, ILingoImageTexture? texture = null, string text = "", Action<bool>? onChange = null)
+        {
+            var button = new LingoGfxStateButton { Text = text };
+            var impl = new SdlGfxStateButton(this);
+            if (onChange != null)
+                button.ValueChanged += () => onChange(button.IsOn);
+            button.Init(impl);
+            button.Name = name;
+            if (texture != null)
+                button.TextureOn = texture;
+            return button;
+        }
+
+        public LingoGfxMenu CreateMenu(string name)
+        {
+            var menu = new LingoGfxMenu();
+            var impl = new SdlGfxMenu(this, name);
+            menu.Init(impl);
+            return menu;
+        }
+
+        public LingoGfxMenuItem CreateMenuItem(string name, string? shortcut = null)
+        {
+            var item = new LingoGfxMenuItem();
+            var impl = new SdlGfxMenuItem(this, name, shortcut);
+            item.Init(impl);
+            return item;
+        }
+
+        public LingoGfxMenu CreateContextMenu(object window)
+        {
+            var menu = CreateMenu("ContextMenu");
+            return menu;
+        }
+
+        public LingoGfxHorizontalLineSeparator CreateHorizontalLineSeparator(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public LingoGfxVerticalLineSeparator CreateVerticalLineSeparator(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public LingoGfxWindow CreateWindow(string name, string title = "")
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxInputCheckbox.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxInputCheckbox.cs
@@ -3,13 +3,12 @@ using System.Numerics;
 using ImGuiNET;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
-using LingoEngine.SDL2.Core;
 
 namespace LingoEngine.SDL2.Gfx
 {
     internal class SdlGfxInputCheckbox : SdlGfxComponent, ILingoFrameworkGfxInputCheckbox, IDisposable
     {
-        public SdlGfxInputCheckbox(SdlFactory factory) : base(factory)
+        public SdlGfxInputCheckbox(SdlGfxFactory factory) : base(factory)
         {
         }
         public bool Enabled { get; set; } = true;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxInputCombobox.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxInputCombobox.cs
@@ -4,13 +4,12 @@ using System.Numerics;
 using ImGuiNET;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
-using LingoEngine.SDL2.Core;
 
 namespace LingoEngine.SDL2.Gfx
 {
     internal class SdlGfxInputCombobox : SdlGfxComponent, ILingoFrameworkGfxInputCombobox, IDisposable
     {
-        public SdlGfxInputCombobox(SdlFactory factory) : base(factory)
+        public SdlGfxInputCombobox(SdlGfxFactory factory) : base(factory)
         {
         }
         public bool Enabled { get; set; } = true;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxInputNumber.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxInputNumber.cs
@@ -3,13 +3,12 @@ using System.Numerics;
 using ImGuiNET;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
-using LingoEngine.SDL2.Core;
 
 namespace LingoEngine.SDL2.Gfx
 {
     internal class SdlGfxInputNumber : SdlGfxComponent, ILingoFrameworkGfxInputNumber<float>, IDisposable
     {
-        public SdlGfxInputNumber(SdlFactory factory) : base(factory)
+        public SdlGfxInputNumber(SdlGfxFactory factory) : base(factory)
         {
         }
         public bool Enabled { get; set; } = true;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxInputSlider.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxInputSlider.cs
@@ -3,13 +3,12 @@ using System.Numerics;
 using ImGuiNET;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
-using LingoEngine.SDL2.Core;
 
 namespace LingoEngine.SDL2.Gfx
 {
     internal class SdlGfxInputSlider<TValue> : SdlGfxComponent, ILingoFrameworkGfxInputSlider<TValue>, IDisposable where TValue : struct
     {
-        public SdlGfxInputSlider(SdlFactory factory) : base(factory)
+        public SdlGfxInputSlider(SdlGfxFactory factory) : base(factory)
         {
         }
         public LingoMargin Margin { get; set; } = LingoMargin.Zero;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxInputText.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxInputText.cs
@@ -3,13 +3,12 @@ using System.Numerics;
 using ImGuiNET;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
-using LingoEngine.SDL2.Core;
 
 namespace LingoEngine.SDL2.Gfx
 {
     internal class SdlGfxInputText : SdlGfxComponent, ILingoFrameworkGfxInputText, IDisposable
     {
-        public SdlGfxInputText(SdlFactory factory) : base(factory)
+        public SdlGfxInputText(SdlGfxFactory factory) : base(factory)
         {
         }
         public bool Enabled { get; set; } = true;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxItemList.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxItemList.cs
@@ -4,13 +4,12 @@ using System.Numerics;
 using ImGuiNET;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
-using LingoEngine.SDL2.Core;
 
 namespace LingoEngine.SDL2.Gfx
 {
     internal class SdlGfxItemList : SdlGfxComponent, ILingoFrameworkGfxItemList, IDisposable
     {
-        public SdlGfxItemList(SdlFactory factory) : base(factory)
+        public SdlGfxItemList(SdlGfxFactory factory) : base(factory)
         {
         }
         public bool Enabled { get; set; } = true;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxLabel.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxLabel.cs
@@ -3,7 +3,6 @@ using System.Numerics;
 using ImGuiNET;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
-using LingoEngine.SDL2.Core;
 using LingoEngine.SDL2.Primitives;
 using LingoEngine.Texts;
 
@@ -11,7 +10,7 @@ namespace LingoEngine.SDL2.Gfx
 {
     internal class SdlGfxLabel : SdlGfxComponent, ILingoFrameworkGfxLabel, IDisposable
     {
-        public SdlGfxLabel(SdlFactory factory) : base(factory)
+        public SdlGfxLabel(SdlGfxFactory factory) : base(factory)
         {
         }
         public LingoMargin Margin { get; set; } = LingoMargin.Zero;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxMenu.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxMenu.cs
@@ -1,7 +1,6 @@
 using System;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
-using LingoEngine.SDL2.Core;
 
 namespace LingoEngine.SDL2.Gfx
 {
@@ -10,7 +9,7 @@ namespace LingoEngine.SDL2.Gfx
         public LingoMargin Margin { get; set; } = LingoMargin.Zero;
         public object FrameworkNode => this;
 
-        public SdlGfxMenu(SdlFactory factory, string name) : base(factory)
+        public SdlGfxMenu(SdlGfxFactory factory, string name) : base(factory)
         {
             Name = name;
         }

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxMenuItem.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxMenuItem.cs
@@ -1,6 +1,5 @@
 using System;
 using LingoEngine.Gfx;
-using LingoEngine.SDL2.Core;
 
 namespace LingoEngine.SDL2.Gfx
 {
@@ -12,7 +11,7 @@ namespace LingoEngine.SDL2.Gfx
         public event Action? Activated;
         public object FrameworkNode => this;
 
-        public SdlGfxMenuItem(SdlFactory factory, string name, string? shortcut) : base(factory)
+        public SdlGfxMenuItem(SdlGfxFactory factory, string name, string? shortcut) : base(factory)
         {
             Name = name;
             Shortcut = shortcut;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxPanel.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxPanel.cs
@@ -2,14 +2,13 @@ using System;
 using System.Collections.Generic;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
-using LingoEngine.SDL2.Core;
 using LingoEngine.SDL2.SDLL;
 
 namespace LingoEngine.SDL2.Gfx
 {
     internal class SdlGfxPanel : SdlGfxComponent, ILingoFrameworkGfxPanel, IDisposable
     {
-        public SdlGfxPanel(SdlFactory factory) : base(factory)
+        public SdlGfxPanel(SdlGfxFactory factory) : base(factory)
         {
         }
         public LingoMargin Margin { get; set; } = LingoMargin.Zero;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxScrollContainer.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxScrollContainer.cs
@@ -4,13 +4,12 @@ using System.Numerics;
 using ImGuiNET;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
-using LingoEngine.SDL2.Core;
 
 namespace LingoEngine.SDL2.Gfx
 {
     internal class SdlGfxScrollContainer : SdlGfxComponent, ILingoFrameworkGfxScrollContainer, IDisposable
     {
-        public SdlGfxScrollContainer(SdlFactory factory) : base(factory)
+        public SdlGfxScrollContainer(SdlGfxFactory factory) : base(factory)
         {
         }
         public LingoMargin Margin { get; set; } = LingoMargin.Zero;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxSpinBox.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxSpinBox.cs
@@ -3,13 +3,12 @@ using System.Numerics;
 using ImGuiNET;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
-using LingoEngine.SDL2.Core;
 
 namespace LingoEngine.SDL2.Gfx
 {
     internal class SdlGfxSpinBox : SdlGfxComponent, ILingoFrameworkGfxSpinBox, IDisposable
     {
-        public SdlGfxSpinBox(SdlFactory factory) : base(factory)
+        public SdlGfxSpinBox(SdlGfxFactory factory) : base(factory)
         {
         }
         public bool Enabled { get; set; } = true;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxStateButton.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxStateButton.cs
@@ -6,7 +6,6 @@ using LingoEngine.Primitives;
 using LingoEngine.Bitmaps;
 using LingoEngine.SDL2.Pictures;
 using LingoEngine.SDL2.SDLL;
-using LingoEngine.SDL2.Core;
 
 namespace LingoEngine.SDL2.Gfx
 {
@@ -17,7 +16,7 @@ namespace LingoEngine.SDL2.Gfx
         private nint _textureOffPtr;
         private ILingoImageTexture? _textureOff;
 
-        public SdlGfxStateButton(SdlFactory factory) : base(factory)
+        public SdlGfxStateButton(SdlGfxFactory factory) : base(factory)
         {
         }
         public bool Enabled { get; set; } = true;

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxTabContainer.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxTabContainer.cs
@@ -4,7 +4,6 @@ using System.Numerics;
 using ImGuiNET;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
-using LingoEngine.SDL2.Core;
 
 namespace LingoEngine.SDL2.Gfx
 {
@@ -16,7 +15,7 @@ namespace LingoEngine.SDL2.Gfx
         public LingoMargin Margin { get; set; } = LingoMargin.Zero;
         public object FrameworkNode => this;
 
-        public SdlGfxTabContainer(SdlFactory factory) : base(factory)
+        public SdlGfxTabContainer(SdlGfxFactory factory) : base(factory)
         {
         }
 
@@ -96,7 +95,7 @@ namespace LingoEngine.SDL2.Gfx
 
     public class SdlGfxTabItem : SdlGfxComponent, ILingoFrameworkGfxTabItem
     {
-        public SdlGfxTabItem(SdlFactory factory, LingoGfxTabItem tab) : base(factory)
+        public SdlGfxTabItem(SdlGfxFactory factory, LingoGfxTabItem tab) : base(factory)
         {
             tab.Init(this);
         }

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxWrapPanel.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxWrapPanel.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
-using LingoEngine.SDL2.Core;
 using LingoEngine.SDL2.SDLL;
 
 namespace LingoEngine.SDL2.Gfx
@@ -16,7 +15,7 @@ namespace LingoEngine.SDL2.Gfx
 
         private readonly List<ILingoFrameworkGfxLayoutNode> _children = new();
 
-        public SdlGfxWrapPanel(SdlFactory factory, LingoOrientation orientation) : base(factory)
+        public SdlGfxWrapPanel(SdlGfxFactory factory, LingoOrientation orientation) : base(factory)
         {
             Orientation = orientation;
             ItemMargin = new LingoPoint(0, 0);

--- a/src/LingoEngine.SDL2/ISdlRootComponentContext.cs
+++ b/src/LingoEngine.SDL2/ISdlRootComponentContext.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.SDL2;
+
+public interface ISdlRootComponentContext
+{
+    LingoSDLComponentContainer ComponentContainer { get; }
+    nint Renderer { get; }
+}

--- a/src/LingoEngine.SDL2/SdlRootContext.cs
+++ b/src/LingoEngine.SDL2/SdlRootContext.cs
@@ -7,7 +7,7 @@ using LingoEngine.SDL2.Inputs;
 using LingoEngine.SDL2.Stages;
 using LingoEngine.SDL2;
 
-public class SdlRootContext : IDisposable
+public class SdlRootContext : IDisposable, ISdlRootComponentContext
 {
     public nint Window { get; }
     public nint Renderer { get; }

--- a/src/LingoEngine.SDL2/Styles/SdlFontManager.cs
+++ b/src/LingoEngine.SDL2/Styles/SdlFontManager.cs
@@ -2,7 +2,7 @@ using LingoEngine.Styles;
 
 namespace LingoEngine.SDL2.Styles;
 
-internal class SdlFontManager : ILingoFontManager
+public class SdlFontManager : ILingoFontManager
 {
     private readonly List<(string Name, string FileName)> _fontsToLoad = new();
     private readonly Dictionary<string, object> _loadedFonts = new();

--- a/src/LingoEngine/Gfx/ILingoGfxFactory.cs
+++ b/src/LingoEngine/Gfx/ILingoGfxFactory.cs
@@ -1,0 +1,39 @@
+using System;
+using LingoEngine.Bitmaps;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.Gfx
+{
+    /// <summary>
+    /// Factory interface for creating engine-level GFX components.
+    /// </summary>
+    public interface ILingoGfxFactory
+    {
+        LingoGfxCanvas CreateGfxCanvas(string name, int width, int height);
+        LingoGfxWrapPanel CreateWrapPanel(LingoOrientation orientation, string name);
+        LingoGfxPanel CreatePanel(string name);
+        LingoGfxLayoutWrapper CreateLayoutWrapper(ILingoGfxNode content, float? x, float? y);
+        LingoGfxTabContainer CreateTabContainer(string name);
+        LingoGfxTabItem CreateTabItem(string name, string title);
+        LingoGfxScrollContainer CreateScrollContainer(string name);
+        LingoGfxInputSlider<float> CreateInputSliderFloat(LingoOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null);
+        LingoGfxInputSlider<int> CreateInputSliderInt(LingoOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null);
+        LingoGfxInputText CreateInputText(string name, int maxLength = 0, Action<string>? onChange = null);
+        LingoGfxInputNumber<float> CreateInputNumberFloat(string name, float? min = null, float? max = null, Action<float>? onChange = null);
+        LingoGfxInputNumber<int> CreateInputNumberInt(string name, int? min = null, int? max = null, Action<int>? onChange = null);
+        LingoGfxSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null);
+        LingoGfxInputCheckbox CreateInputCheckbox(string name, Action<bool>? onChange = null);
+        LingoGfxInputCombobox CreateInputCombobox(string name, Action<string?>? onChange = null);
+        LingoGfxItemList CreateItemList(string name, Action<string?>? onChange = null);
+        LingoGfxColorPicker CreateColorPicker(string name, Action<LingoColor>? onChange = null);
+        LingoGfxLabel CreateLabel(string name, string text = "");
+        LingoGfxButton CreateButton(string name, string text = "");
+        LingoGfxStateButton CreateStateButton(string name, ILingoImageTexture? texture = null, string text = "", Action<bool>? onChange = null);
+        LingoGfxMenu CreateMenu(string name);
+        LingoGfxMenuItem CreateMenuItem(string name, string? shortcut = null);
+        LingoGfxMenu CreateContextMenu(object window);
+        LingoGfxHorizontalLineSeparator CreateHorizontalLineSeparator(string name);
+        LingoGfxVerticalLineSeparator CreateVerticalLineSeparator(string name);
+        LingoGfxWindow CreateWindow(string name, string title = "");
+    }
+}

--- a/src/LingoEngine/Gfx/LingoGfxPanel.cs
+++ b/src/LingoEngine/Gfx/LingoGfxPanel.cs
@@ -1,4 +1,3 @@
-using LingoEngine.FrameworkCommunication;
 using LingoEngine.Primitives;
 
 namespace LingoEngine.Gfx
@@ -8,16 +7,16 @@ namespace LingoEngine.Gfx
     /// </summary>
     public class LingoGfxPanel : LingoGfxNodeLayoutBase<ILingoFrameworkGfxPanel>
     {
-        private readonly ILingoFrameworkFactory _factory;
-        public ILingoFrameworkFactory Factory => _factory;
-        public LingoGfxPanel(ILingoFrameworkFactory factory)
+        private readonly ILingoGfxFactory _factory;
+        public ILingoGfxFactory Factory => _factory;
+        public LingoGfxPanel(ILingoGfxFactory factory)
         {
             _factory = factory;
         }
 
 
         /// <summary>Adds a child to the panel and sets its position.</summary>
-        public ILingoGfxNode AddItem(ILingoGfxNode node, float? x= null, float? y = null)
+        public ILingoGfxNode AddItem(ILingoGfxNode node, float? x = null, float? y = null)
         {
             if (node is ILingoGfxLayoutNode layoutNode)
             {
@@ -28,14 +27,14 @@ namespace LingoEngine.Gfx
             }
             else
             {
-                LingoGfxLayoutWrapper item = _factory.CreateLayoutWrapper(node ,x, y);
+                LingoGfxLayoutWrapper item = _factory.CreateLayoutWrapper(node, x, y);
 
                 _framework.AddItem(item.FrameworkWrapper<ILingoFrameworkGfxLayoutWrapper>());
                 return item;
             }
 
         }
-      
+
         public void RemoveItem(ILingoGfxNode node) => _framework.RemoveItem(node.Framework<ILingoFrameworkGfxLayoutNode>());
         public void RemoveItem(ILingoFrameworkGfxLayoutNode node) => _framework.RemoveItem(node);
         public IEnumerable<ILingoFrameworkGfxLayoutNode> GetChildren() => _framework.GetItems();
@@ -79,9 +78,9 @@ namespace LingoEngine.Gfx
         public LingoGfxLayoutWrapper(ILingoGfxNode content)
         {
             Content = content;
-            
+
         }
-    
+
 
 
 

--- a/src/LingoEngine/Gfx/LingoGfxWrapPanel.cs
+++ b/src/LingoEngine/Gfx/LingoGfxWrapPanel.cs
@@ -1,4 +1,3 @@
-using LingoEngine.FrameworkCommunication;
 using LingoEngine.Primitives;
 
 namespace LingoEngine.Gfx
@@ -20,9 +19,9 @@ namespace LingoEngine.Gfx
             get => _framework.ItemMargin;
             set => _framework.ItemMargin = value;
         }
-        public ILingoFrameworkFactory Factory { get; }
+        public ILingoGfxFactory Factory { get; }
 
-        public LingoGfxWrapPanel(ILingoFrameworkFactory factory)
+        public LingoGfxWrapPanel(ILingoGfxFactory factory)
         {
             Factory = factory;
         }


### PR DESCRIPTION
## Summary
- Introduce `ISdlRootComponentContext` and update SDL GFX factory and root context to use it
- Expose `SdlFontManager` publicly so tests can instantiate fonts
- Extract UI construction into `GfxTestScene` and add `TestSdlRootComponentContext` for lightweight SDL visual tests
- Move SDL initialization into `TestSdlRootComponentContext` to simplify SDL visual test setup

## Testing
- `dotnet format Test/LingoEngine.SDL2.GfxVisualTest/LingoEngine.SDL2.GfxVisualTest.csproj --include Test/LingoEngine.SDL2.GfxVisualTest/Program.cs Test/LingoEngine.SDL2.GfxVisualTest/TestSdlRootComponentContext.cs -v diag`
- `dotnet build Test/LingoEngine.SDL2.GfxVisualTest/LingoEngine.SDL2.GfxVisualTest.csproj`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689aafce4c348332801e9e19246278e2