### PR TITLE
Add joystick-controlled on-screen keyboard

### DIFF
--- a/src/LingoEngine.LGodot/Gfx/LingoGodotWindow.cs
+++ b/src/LingoEngine.LGodot/Gfx/LingoGodotWindow.cs
@@ -3,6 +3,8 @@ using LingoEngine.Gfx;
 using LingoEngine.LGodot.Primitives;
 using LingoEngine.LGodot.Styles;
 using LingoEngine.Primitives;
+using LingoEngine.Inputs;
+using LingoEngine.LGodot;
 using System;
 using static Godot.Control;
 
@@ -23,7 +25,16 @@ namespace LingoEngine.LGodot.Gfx
         private bool _isPopup;
         public LingoGodotWindow(LingoGfxWindow window, ILingoGodotStyleManager lingoGodotStyleManager)
         {
-            window.Init(this);
+            LingoMouse? mouse = null;
+            var mouseImpl = new LingoGodotMouseArea(this, new Lazy<LingoMouse>(() => mouse!));
+            mouse = new LingoMouse(mouseImpl);
+
+            LingoKey? key = null;
+            var keyImpl = new LingoGodotKey(this, new Lazy<LingoKey>(() => key!));
+            key = new LingoKey(keyImpl);
+            keyImpl.SetLingoKey(key);
+
+            window.Init(this, mouse, key);
             //Borderless = true;
             //ExtendToTitle = true;
             Theme = lingoGodotStyleManager.GetTheme(LingoGodotThemeElementType.PopupWindow);
@@ -50,15 +61,18 @@ namespace LingoEngine.LGodot.Gfx
 
         public float X { get => Position.X; set => Position = new Vector2I((int)value, Position.Y); }
         public float Y { get => Position.Y; set => Position = new Vector2I(Position.X, (int)value); }
-        public float Width { get => Size.X; 
-            set { 
+        public float Width
+        {
+            get => Size.X;
+            set
+            {
                 Size = new Vector2I((int)value, Size.Y);
                 _panel.Size = Size;
-            } 
+            }
         }
         public float Height
         {
-            get => Size.Y; 
+            get => Size.Y;
             set
             {
                 Size = new Vector2I(Size.X, (int)value);
@@ -70,7 +84,7 @@ namespace LingoEngine.LGodot.Gfx
         public new string Title { get => base.Title; set => base.Title = value; }
         public bool IsPopup
         {
-            get => _isPopup; 
+            get => _isPopup;
             set
             {
                 _isPopup = value;
@@ -78,6 +92,7 @@ namespace LingoEngine.LGodot.Gfx
                 Exclusive = value;
             }
         }
+        public bool Borderless { get => base.Borderless; set => base.Borderless = value; }
         public LingoColor BackgroundColor
         {
             get => _panelStyle.BgColor.ToLingoColor();

--- a/src/LingoEngine.SDL2/Core/SdlFactory.cs
+++ b/src/LingoEngine.SDL2/Core/SdlFactory.cs
@@ -187,6 +187,8 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
             d.Dispose();
     }
 
+    internal SdlRootContext RootContext => _rootContext;
+
     public LingoSDLComponentContainer ComponentContainer => _rootContext.ComponentContainer;
 
     public LingoSDLComponentContext CreateContext(ILingoSDLComponent component, LingoSDLComponentContext? parent = null)
@@ -202,7 +204,6 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
         mouseImpl.SetLingoMouse(mouse);
         return mouse;
     }
-    /// <inheritdoc/>
     public LingoKey CreateKey()
     {
         var impl = _rootContext.Key;
@@ -473,7 +474,11 @@ public class SdlFactory : ILingoFrameworkFactory, IDisposable
     /// <inheritdoc/>
     public LingoGfxWindow CreateWindow(string name, string title = "")
     {
-        throw new NotImplementedException();
+        var win = new LingoGfxWindow();
+        var impl = new SdlGfxWindow(win, this);
+        win.Name = name;
+        win.Title = title;
+        return win;
     }
 
 

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxWindow.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxWindow.cs
@@ -1,0 +1,136 @@
+using System;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+using LingoEngine.SDL2.Core;
+using LingoEngine.SDL2.SDLL;
+using LingoEngine.Inputs;
+using LingoEngine.SDL2.Inputs;
+
+namespace LingoEngine.SDL2.Gfx;
+
+internal class SdlGfxWindow : SdlGfxPanel, ILingoFrameworkGfxWindow, IDisposable
+{
+    private readonly SdlFactory _factory;
+    private readonly SdlMouse _mouseImpl;
+    private readonly SdlKey _keyImpl;
+    private event Action? _onOpen;
+    private event Action? _onClose;
+    private event Action<float, float>? _onResize;
+    private string _title = string.Empty;
+    private bool _isPopup;
+    private bool _borderless;
+
+    public SdlGfxWindow(LingoGfxWindow window, SdlFactory factory) : base(factory)
+    {
+        _factory = factory;
+
+        LingoMouse? mouse = null;
+        _mouseImpl = new SdlMouse(new Lazy<LingoMouse>(() => mouse!));
+        _factory.RootContext.Mice.Add(_mouseImpl);
+        mouse = new LingoMouse(_mouseImpl);
+
+        _keyImpl = new SdlKey();
+        _factory.RootContext.Keys.Add(_keyImpl);
+        var key = new LingoKey(_keyImpl);
+        _keyImpl.SetLingoKey(key);
+
+        window.Init(this, mouse, key);
+        Visibility = false;
+    }
+
+    public void Dispose()
+    {
+        _factory.RootContext.Mice.Remove(_mouseImpl);
+        _factory.RootContext.Keys.Remove(_keyImpl);
+    }
+
+    public string Title
+    {
+        get => _title;
+        set => _title = value;
+    }
+
+    public new float Width
+    {
+        get => base.Width;
+        set
+        {
+            if (Math.Abs(base.Width - value) > float.Epsilon)
+            {
+                base.Width = value;
+                _onResize?.Invoke(base.Width, base.Height);
+            }
+        }
+    }
+
+    public new float Height
+    {
+        get => base.Height;
+        set
+        {
+            if (Math.Abs(base.Height - value) > float.Epsilon)
+            {
+                base.Height = value;
+                _onResize?.Invoke(base.Width, base.Height);
+            }
+        }
+    }
+
+    public bool IsPopup
+    {
+        get => _isPopup;
+        set => _isPopup = value;
+    }
+
+    public bool Borderless
+    {
+        get => _borderless;
+        set => _borderless = value;
+    }
+
+    public new LingoColor BackgroundColor
+    {
+        get => base.BackgroundColor ?? LingoColorList.White;
+        set => base.BackgroundColor = value;
+    }
+
+    event Action? ILingoFrameworkGfxWindow.OnOpen
+    {
+        add => _onOpen += value;
+        remove => _onOpen -= value;
+    }
+
+    event Action? ILingoFrameworkGfxWindow.OnClose
+    {
+        add => _onClose += value;
+        remove => _onClose -= value;
+    }
+
+    event Action<float, float>? ILingoFrameworkGfxWindow.OnResize
+    {
+        add => _onResize += value;
+        remove => _onResize -= value;
+    }
+
+    public void Popup()
+    {
+        _factory.ComponentContainer.Activate(ComponentContext);
+        Visibility = true;
+        _onOpen?.Invoke();
+    }
+
+    public void PopupCentered()
+    {
+        SDL.SDL_GetWindowSize(_factory.RootContext.Window, out var w, out var h);
+        X = (w - Width) / 2f;
+        Y = (h - Height) / 2f;
+        Popup();
+    }
+
+    public void Hide()
+    {
+        Visibility = false;
+        _factory.ComponentContainer.Deactivate(ComponentContext);
+        _onClose?.Invoke();
+    }
+}

--- a/src/LingoEngine.SDL2/SdlRootContext.cs
+++ b/src/LingoEngine.SDL2/SdlRootContext.cs
@@ -1,5 +1,6 @@
 namespace LingoEngine.SDL2;
 using System;
+using System.Collections.Generic;
 using LingoEngine.Core;
 using LingoEngine.SDL2.SDLL;
 using LingoEngine.SDL2.Core;
@@ -17,8 +18,10 @@ public class SdlRootContext : IDisposable
     private LingoPlayer _lPlayer;
 
     public LingoDebugOverlay DebugOverlay { get; set; }
-    internal SdlKey Key { get; } = new();
-    internal SdlMouse Mouse { get; } = new SdlMouse(new Lazy<LingoMouse>(() => null!));
+    internal List<SdlKey> Keys { get; } = new() { new SdlKey() };
+    internal List<SdlMouse> Mice { get; } = new() { new SdlMouse(new Lazy<LingoMouse>(() => null!)) };
+    internal SdlKey Key => Keys[0];
+    internal SdlMouse Mouse => Mice[0];
     private bool _f1Pressed;
     public LingoSDLComponentContainer ComponentContainer { get; } = new();
     internal SdlFactory Factory { get; set; } = null!;
@@ -48,8 +51,10 @@ public class SdlRootContext : IDisposable
             {
                 if (e.type == SDL.SDL_EventType.SDL_QUIT)
                     running = false;
-                Key.ProcessEvent(e);
-                Mouse.ProcessEvent(e);
+                foreach (var k in Keys)
+                    k.ProcessEvent(e);
+                foreach (var m in Mice)
+                    m.ProcessEvent(e);
             }
             uint now = SDL.SDL_GetTicks();
             float delta = (now - last) / 1000f;

--- a/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
+++ b/src/LingoEngine/FrameworkCommunication/ILingoFrameworkFactory.cs
@@ -38,7 +38,7 @@ namespace LingoEngine.FrameworkCommunication
         /// <summary>Creates a new cast member instance.</summary>
         T CreateMember<T>(ILingoCast cast, int numberInCast, string name = "") where T : LingoMember;
         /// <summary>Creates a picture member.</summary>
-        LingoMemberBitmap CreateMemberBitmap(ILingoCast cast,int numberInCast, string name = "", string? fileName = null,
+        LingoMemberBitmap CreateMemberBitmap(ILingoCast cast, int numberInCast, string name = "", string? fileName = null,
             LingoPoint regPoint = default);
         /// <summary>Creates a sound member.</summary>
         LingoMemberSound CreateMemberSound(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, LingoPoint regPoint = default);
@@ -154,6 +154,6 @@ namespace LingoEngine.FrameworkCommunication
         T CreateBehavior<T>(LingoMovie lingoMovie) where T : LingoSpriteBehavior;
         /// <summary>Creates a movie script.</summary>
         T CreateMovieScript<T>(LingoMovie lingoMovie) where T : LingoMovieScript;
-        
+
     }
 }

--- a/src/LingoEngine/Gfx/ILingoFrameworkGfxWindow.cs
+++ b/src/LingoEngine/Gfx/ILingoFrameworkGfxWindow.cs
@@ -12,6 +12,8 @@ namespace LingoEngine.Gfx
         string Title { get; set; }
         LingoColor BackgroundColor { get; set; }
         bool IsPopup { get; set; }
+        /// <summary>Whether the window is borderless (no title bar).</summary>
+        bool Borderless { get; set; }
 
         /// <summary>Raised when the window is opened.</summary>
         event Action? OnOpen;

--- a/src/LingoEngine/Gfx/LingoGfxWindow.cs
+++ b/src/LingoEngine/Gfx/LingoGfxWindow.cs
@@ -1,3 +1,5 @@
+using LingoEngine.Events;
+using LingoEngine.Inputs;
 using LingoEngine.Primitives;
 using System;
 
@@ -6,27 +8,68 @@ namespace LingoEngine.Gfx
     /// <summary>
     /// Engine level wrapper for a window element.
     /// </summary>
-    public class LingoGfxWindow : LingoGfxNodeLayoutBase<ILingoFrameworkGfxWindow>
+    public class LingoGfxWindow : LingoGfxNodeLayoutBase<ILingoFrameworkGfxWindow>, ILingoMouseRectProvider
     {
+        private LingoMouse _mouse = null!;
+        private LingoKey _key = null!;
+        private ILingoMouseSubscription? _mouseDownSub;
+        private ILingoMouseSubscription? _mouseUpSub;
+        private ILingoMouseSubscription? _mouseMoveSub;
+        private readonly KeyHandler _keyHandler;
+
+        private event Action? _onOpen;
+        private event Action? _onClose;
+
+        public LingoGfxWindow() => _keyHandler = new KeyHandler(this);
+
+        public void Init(ILingoFrameworkGfxWindow framework, LingoMouse mouse, LingoKey key)
+        {
+            base.Init(framework);
+            _mouse = mouse.CreateNewInstance(this);
+            _key = key.CreateNewInstance(this);
+
+            _mouseDownSub = _mouse.OnMouseDown(e => OnMouseDown?.Invoke(e));
+            _mouseUpSub = _mouse.OnMouseUp(e => OnMouseUp?.Invoke(e));
+            _mouseMoveSub = _mouse.OnMouseMove(e => OnMouseMove?.Invoke(e));
+            _key.Subscribe(_keyHandler);
+
+            _framework.OnOpen += () => _onOpen?.Invoke();
+            _framework.OnClose += () => _onClose?.Invoke();
+        }
+
         public string Title { get => _framework.Title; set => _framework.Title = value; }
         public LingoColor BackgroundColor { get => _framework.BackgroundColor; set => _framework.BackgroundColor = value; }
         public bool IsPopup { get => _framework.IsPopup; set => _framework.IsPopup = value; }
+        public bool Borderless { get => _framework.Borderless; set => _framework.Borderless = value; }
+
+        public LingoMouse Mouse => _mouse;
+
+        public LingoKey Key => _key;
 
         public event Action? OnOpen
         {
-            add { _framework.OnOpen += value; }
-            remove { _framework.OnOpen -= value; }
+            add { _onOpen += value; }
+            remove { _onOpen -= value; }
         }
+
         public event Action? OnClose
         {
-            add { _framework.OnClose += value; }
-            remove { _framework.OnClose -= value; }
+            add { _onClose += value; }
+            remove { _onClose -= value; }
         }
+
         public event Action<float, float>? OnResize
         {
             add { _framework.OnResize += value; }
             remove { _framework.OnResize -= value; }
         }
+
+        public event Action<LingoMouseEvent>? OnMouseDown;
+        public event Action<LingoMouseEvent>? OnMouseUp;
+        public event Action<LingoMouseEvent>? OnMouseMove;
+
+        public event Action<LingoKey>? OnKeyDown;
+        public event Action<LingoKey>? OnKeyUp;
 
         public LingoGfxWindow AddItem(ILingoGfxNode node)
         {
@@ -45,7 +88,33 @@ namespace LingoEngine.Gfx
         public IEnumerable<ILingoFrameworkGfxLayoutNode> GetItems() => _framework.GetItems();
 
         public void Popup() => _framework.Popup();
+
         public void PopupCentered() => _framework.PopupCentered();
+
         public void Hide() => _framework.Hide();
+
+        LingoRect ILingoMouseRectProvider.MouseOffset => new LingoRect(X, Y, Width, Height);
+        bool ILingoActivationProvider.IsActivated => Visibility;
+
+        private class KeyHandler : ILingoKeyEventHandler
+        {
+            private readonly LingoGfxWindow _owner;
+            public KeyHandler(LingoGfxWindow owner) => _owner = owner;
+            public void RaiseKeyDown(LingoKey lingoKey)
+                => _owner.OnKeyDown?.Invoke(lingoKey);
+            public void RaiseKeyUp(LingoKey lingoKey)
+                => _owner.OnKeyUp?.Invoke(lingoKey);
+        }
+
+        public override void Dispose()
+        {
+            _mouseDownSub?.Release();
+            _mouseUpSub?.Release();
+            _mouseMoveSub?.Release();
+            (_mouse as IDisposable)?.Dispose();
+            _key.Unsubscribe(_keyHandler);
+            (_key as IDisposable)?.Dispose();
+            base.Dispose();
+        }
     }
 }

--- a/src/LingoEngine/Inputs/ILingoActivationProvider.cs
+++ b/src/LingoEngine/Inputs/ILingoActivationProvider.cs
@@ -1,0 +1,14 @@
+namespace LingoEngine.Inputs
+{
+    /// <summary>
+    /// Provides activation state for input proxies.
+    /// </summary>
+    public interface ILingoActivationProvider
+    {
+        /// <summary>
+        /// Indicates whether the proxy should emit input events.
+        /// </summary>
+        bool IsActivated { get; }
+    }
+}
+

--- a/src/LingoEngine/Inputs/ILingoMouseRectProvider.cs
+++ b/src/LingoEngine/Inputs/ILingoMouseRectProvider.cs
@@ -1,0 +1,16 @@
+using LingoEngine.Primitives;
+
+namespace LingoEngine.Inputs
+{
+    /// <summary>
+    /// Supplies the mouse region and activation state for a proxy mouse.
+    /// </summary>
+    public interface ILingoMouseRectProvider : ILingoActivationProvider
+    {
+        /// <summary>
+        /// Rectangle describing the area in which mouse events are valid.
+        /// </summary>
+        LingoRect MouseOffset { get; }
+    }
+}
+

--- a/src/LingoEngine/Inputs/LingoJoystickKeyboard.cs
+++ b/src/LingoEngine/Inputs/LingoJoystickKeyboard.cs
@@ -1,0 +1,352 @@
+using LingoEngine.Events;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+using LingoEngine.Texts;
+using System;
+using System.Linq;
+
+namespace LingoEngine.Inputs
+{
+    /// <summary>
+    /// On-screen keyboard navigated via joystick.
+    /// Supports letters, digits, space and backspace.
+    /// </summary>
+    public class LingoJoystickKeyboard : IDisposable
+    {
+        private readonly ILingoFrameworkFactory _factory;
+        private readonly string[][] _layout;
+        private readonly int _cellWidth = 32;
+        private readonly int _cellHeight = 32;
+        private readonly LingoGfxWindow _window;
+        private readonly LingoGfxCanvas _canvas;
+        private readonly Action _onWindowClosed;
+        private int _selectedRow;
+        private int _selectedCol;
+        private bool _enableMouse;
+        private bool _enableKeyNumbers;
+        private bool _enableKeyLetters;
+        private bool _enableKeySpecial;
+
+        /// <summary>Color used for the border of the selected key.</summary>
+        public LingoColor SelectedColor { get; set; } = LingoColorList.Black;
+
+        /// <summary>Optional fill color for the selected key.</summary>
+        public LingoColor? SelectedBackgroundColor { get; set; }
+
+        /// <summary>Background color of the keyboard.</summary>
+        public LingoColor BackgroundColor { get; set; } = LingoColorList.White;
+
+        /// <summary>Font name used for key labels.</summary>
+        public string? FontName { get; set; }
+
+        private string _title = "Keyboard";
+
+        /// <summary>Window title.</summary>
+        public string Title
+        {
+            get => _title;
+            set
+            {
+                _title = value;
+                ApplyWindowChrome();
+            }
+        }
+
+        private bool _showTitleBar = true;
+
+        /// <summary>Whether to show the window title bar and close button.</summary>
+        public bool ShowTitleBar
+        {
+            get => _showTitleBar;
+            set
+            {
+                _showTitleBar = value;
+                ApplyWindowChrome();
+            }
+        }
+
+        /// <summary>Current text entered through the keyboard.</summary>
+        public string Text { get; private set; } = string.Empty;
+
+        /// <summary>Maximum allowed length of <see cref="Text"/>.</summary>
+        public int MaxLength { get; set; } = int.MaxValue;
+
+        /// <summary>Raised when the keyboard window is closed.</summary>
+        public event Action? Closed;
+
+        /// <summary>Raised when a key is selected.</summary>
+        public event Action<string>? KeySelected;
+
+        /// <summary>Supported keyboard layouts.</summary>
+        public enum LingoKeyboardLayoutType
+        {
+            Azerty,
+            Qwerty
+        }
+
+        public LingoJoystickKeyboard(ILingoFrameworkFactory factory, LingoKeyboardLayoutType layoutType = LingoKeyboardLayoutType.Qwerty, bool showEscapeKey = false)
+        {
+            _factory = factory;
+            _layout = layoutType == LingoKeyboardLayoutType.Azerty ? BuildAzertyLayout(showEscapeKey) : BuildQwertyLayout(showEscapeKey);
+            var cols = _layout.Max(r => r.Length);
+            var width = cols * _cellWidth;
+            var height = _layout.Length * _cellHeight;
+            _window = _factory.CreateWindow("LingoJoystickKeyboard", _title);
+            _window.IsPopup = true;
+            _onWindowClosed = () => Closed?.Invoke();
+            _window.OnClose += _onWindowClosed;
+            _window.OnMouseDown += OnMouseDown;
+            _window.OnMouseMove += OnMouseMove;
+            _window.OnKeyDown += HandleKeyInput;
+            _canvas = _factory.CreateGfxCanvas("LingoJoystickKeyboardCanvas", width, height);
+            _window.AddItem(_canvas);
+            ApplyWindowChrome();
+            DrawKeyboard();
+        }
+
+        /// <summary>Enables hardware keyboard input.</summary>
+        public void EnableKey(bool enableNumbers, bool enableLetters, bool enableSpecialKeys)
+        {
+            _enableKeyNumbers = enableNumbers;
+            _enableKeyLetters = enableLetters;
+            _enableKeySpecial = enableSpecialKeys;
+        }
+
+        /// <summary>Enables hardware mouse input.</summary>
+        public void EnableMouse(bool state) => _enableMouse = state;
+
+        private static string[][] BuildQwertyLayout(bool showEsc)
+        {
+            var layout = new[]
+            {
+                new[] { "1","2","3","4","5","6","7","8","9","0" },
+                new[] { "Q","W","E","R","T","Y","U","I","O","P" },
+                new[] { "A","S","D","F","G","H","J","K","L" },
+                new[] { "Z","X","C","V","B","N","M","SPACE","BACKSPACE" }
+            };
+            if (showEsc)
+                layout[^1] = layout[^1].Concat(new[] { "ESC" }).ToArray();
+            return layout;
+        }
+
+        private static string[][] BuildAzertyLayout(bool showEsc)
+        {
+            var layout = new[]
+            {
+                new[] { "1","2","3","4","5","6","7","8","9","0" },
+                new[] { "A","Z","E","R","T","Y","U","I","O","P" },
+                new[] { "Q","S","D","F","G","H","J","K","L","M" },
+                new[] { "W","X","C","V","B","N","SPACE","BACKSPACE" }
+            };
+            if (showEsc)
+                layout[^1] = layout[^1].Concat(new[] { "ESC" }).ToArray();
+            return layout;
+        }
+
+        private void ApplyWindowChrome()
+        {
+            if (ShowTitleBar)
+                _window.Title = _title;
+            else
+                _window.Title = string.Empty;
+            _window.Borderless = !ShowTitleBar;
+        }
+
+        private void DrawKeyboard()
+        {
+            _canvas.Clear(BackgroundColor);
+            for (int r = 0; r < _layout.Length; r++)
+            {
+                for (int c = 0; c < _layout[r].Length; c++)
+                {
+                    var x = c * _cellWidth;
+                    var y = r * _cellHeight;
+                    var key = _layout[r][c];
+                    var selected = r == _selectedRow && c == _selectedCol;
+                    if (selected && SelectedBackgroundColor.HasValue)
+                        _canvas.DrawRect(new LingoRect(x, y, _cellWidth, _cellHeight), SelectedBackgroundColor.Value, true);
+                    var border = selected ? SelectedColor : LingoColorList.DarkGray;
+                    _canvas.DrawRect(new LingoRect(x, y, _cellWidth, _cellHeight), border, false, 1);
+                    var label = key switch { "SPACE" => "Space", "BACKSPACE" => "Bksp", "ESC" => "Esc", _ => key };
+                    _canvas.DrawText(new LingoPoint(x + 2, y + 2), label, FontName, LingoColorList.Black, 12, _cellWidth - 4, LingoTextAlignment.Center);
+                }
+            }
+        }
+
+        /// <summary>Moves selection one cell up.</summary>
+        public void MoveUp()
+        {
+            _selectedRow = (_selectedRow - 1 + _layout.Length) % _layout.Length;
+            _selectedCol = Math.Min(_selectedCol, _layout[_selectedRow].Length - 1);
+            DrawKeyboard();
+        }
+
+        /// <summary>Moves selection one cell down.</summary>
+        public void MoveDown()
+        {
+            _selectedRow = (_selectedRow + 1) % _layout.Length;
+            _selectedCol = Math.Min(_selectedCol, _layout[_selectedRow].Length - 1);
+            DrawKeyboard();
+        }
+
+        /// <summary>Moves selection one cell left.</summary>
+        public void MoveLeft()
+        {
+            var len = _layout[_selectedRow].Length;
+            _selectedCol = (_selectedCol - 1 + len) % len;
+            DrawKeyboard();
+        }
+
+        /// <summary>Moves selection one cell right.</summary>
+        public void MoveRight()
+        {
+            var len = _layout[_selectedRow].Length;
+            _selectedCol = (_selectedCol + 1) % len;
+            DrawKeyboard();
+        }
+
+        /// <summary>Gets the string value of the currently selected key without executing it.</summary>
+        public string GetSelectedKey()
+        {
+            var key = _layout[_selectedRow][_selectedCol];
+            return key switch
+            {
+                "SPACE" => " ",
+                "BACKSPACE" => "\b",
+                "ESC" => string.Empty,
+                _ => key
+            };
+        }
+
+        /// <summary>Executes the currently selected key and updates <see cref="Text"/>.</summary>
+        public string ExecuteSelectedKey()
+        {
+            var key = _layout[_selectedRow][_selectedCol];
+            var result = GetSelectedKey();
+            if (key == "ESC")
+            {
+                Close();
+            }
+            else
+            {
+                ProcessInput(result);
+            }
+            return result;
+        }
+
+        private void ProcessInput(string value)
+        {
+            if (value == "\b")
+            {
+                if (Text.Length > 0)
+                    Text = Text[..^1];
+            }
+            else
+            {
+                if (Text.Length + value.Length <= MaxLength)
+                    Text += value;
+            }
+            KeySelected?.Invoke(value);
+            DrawKeyboard();
+        }
+
+        private void HandleKeyInput(LingoKey key)
+        {
+            if (!_window.Visibility) return;
+            if (!(_enableKeyNumbers || _enableKeyLetters || _enableKeySpecial)) return;
+            var name = key.Key.ToUpperInvariant();
+            bool isDigit = name.Length == 1 && char.IsDigit(name[0]);
+            bool isLetter = name.Length == 1 && char.IsLetter(name[0]);
+            bool isSpecial = !isDigit && !isLetter;
+            if ((isDigit && !_enableKeyNumbers) || (isLetter && !_enableKeyLetters) || (isSpecial && !_enableKeySpecial))
+                return;
+            switch (name)
+            {
+                case "UP":
+                    MoveUp();
+                    break;
+                case "DOWN":
+                    MoveDown();
+                    break;
+                case "LEFT":
+                    MoveLeft();
+                    break;
+                case "RIGHT":
+                    MoveRight();
+                    break;
+                case "ENTER":
+                case "RETURN":
+                    ExecuteSelectedKey();
+                    break;
+                case "SPACE":
+                    ProcessInput(" ");
+                    break;
+                case "BACKSPACE":
+                    ProcessInput("\b");
+                    break;
+                case "ESC":
+                case "ESCAPE":
+                    Close();
+                    break;
+                default:
+                    if (name.Length == 1 && char.IsLetterOrDigit(name[0]))
+                        ProcessInput(name);
+                    break;
+            }
+        }
+
+        private void OnMouseMove(LingoMouseEvent e)
+        {
+            if (!_window.Visibility) return;
+            if (!_enableMouse) return;
+            var localX = e.MouseH - _window.X;
+            var localY = e.MouseV - _window.Y;
+            if (localX < 0 || localY < 0 || localX >= _canvas.Width || localY >= _canvas.Height) return;
+            var row = (int)(localY / _cellHeight);
+            var col = (int)(localX / _cellWidth);
+            if (row < 0 || row >= _layout.Length || col < 0 || col >= _layout[row].Length) return;
+            _selectedRow = row;
+            _selectedCol = col;
+            DrawKeyboard();
+        }
+
+        private void OnMouseDown(LingoMouseEvent e)
+        {
+            if (!_window.Visibility) return;
+            if (!_enableMouse) return;
+            OnMouseMove(e);
+            ExecuteSelectedKey();
+            e.ContinuePropation = false;
+        }
+
+        /// <summary>Opens the keyboard popup window at the given position or centered if none.</summary>
+        public void Open(LingoPoint? position = null)
+        {
+            ApplyWindowChrome();
+            if (position.HasValue)
+            {
+                _window.X = position.Value.X;
+                _window.Y = position.Value.Y;
+                _window.Popup();
+            }
+            else
+            {
+                _window.PopupCentered();
+            }
+        }
+
+        /// <summary>Closes the keyboard popup window.</summary>
+        public void Close() => _window.Hide();
+
+        public void Dispose()
+        {
+            _window.OnClose -= _onWindowClosed;
+            _window.OnMouseDown -= OnMouseDown;
+            _window.OnMouseMove -= OnMouseMove;
+            _window.OnKeyDown -= HandleKeyInput;
+            _window.Dispose();
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce `ILingoMouseRectProvider` and `ILingoActivationProvider` for rect-based input proxies
- add `CreateNewInstance` helpers to `LingoMouse` and `LingoKey` to generate disposable, activation-aware proxies
- update `LingoGfxWindow` to implement the rect provider and use proxy mice and keys instead of manual subscriptions

## Testing
- `/root/.dotnet/dotnet format src/LingoEngine/LingoEngine.csproj --no-restore --verbosity diagnostic --include src/LingoEngine/Gfx/LingoGfxWindow.cs src/LingoEngine/Inputs/LingoKey.cs src/LingoEngine/Inputs/LingoMouse.cs src/LingoEngine/Inputs/ILingoActivationProvider.cs src/LingoEngine/Inputs/ILingoMouseRectProvider.cs`
- `/root/.dotnet/dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_689ad2e093cc8332b9c932cb7cf21ac6