### PR TITLE
Fix sprite bounding box for position animation

### DIFF
--- a/Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj
+++ b/Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj
@@ -10,5 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LingoEngine.Lingo.Core\LingoEngine.Lingo.Core.csproj" />
+    <ProjectReference Include="..\..\src\LingoEngine\LingoEngine.csproj" />
   </ItemGroup>
 </Project>

--- a/Test/LingoEngine.Lingo.Core.Tests/LingoSpriteAnimatorPropertiesTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/LingoSpriteAnimatorPropertiesTests.cs
@@ -1,0 +1,19 @@
+using LingoEngine.Animations;
+using LingoEngine.Primitives;
+using Xunit;
+
+namespace LingoEngine.Lingo.Core.Tests;
+
+public class LingoSpriteAnimatorPropertiesTests
+{
+    [Fact]
+    public void BoundingBoxIncludesPositionAnimation()
+    {
+        var props = new LingoSpriteAnimatorProperties();
+        props.AddKeyFrame((10, 100, 0));
+
+        var box = props.GetBoundingBox(new LingoPoint(0, 0), LingoRect.New(0, 0, 10, 10), 10, 10);
+
+        Assert.Equal(new LingoRect(0, 0, 110, 10), box);
+    }
+}

--- a/src/LingoEngine/Animations/LingoSpriteAnimatorProperties.cs
+++ b/src/LingoEngine/Animations/LingoSpriteAnimatorProperties.cs
@@ -5,16 +5,16 @@ namespace LingoEngine.Animations
     public class LingoSpriteAnimatorProperties
     {
         private LingoRect? _calculatedBoundingBox;
-        private Dictionary<int,LingoRect> _calculatedFrameBoundingBoxes = new();
+        private Dictionary<int, LingoRect> _calculatedFrameBoundingBoxes = new();
         private bool _cacheDirty = true;
         public bool CacheIsDirty => _cacheDirty;
         public void CacheApplied() => _cacheDirty = false;
-        public LingoTween<LingoPoint> Position { get; private set;} = new();
-        public LingoTween<LingoPoint> Size { get; private set;} = new();
-        public LingoTween<float> Rotation { get; private set;} = new();
-        public LingoTween<float> Skew { get; private set;} = new();
-        public LingoTween<LingoColor> ForegroundColor { get; private set;} = new();
-        public LingoTween<LingoColor> BackgroundColor { get; private set;} = new();
+        public LingoTween<LingoPoint> Position { get; private set; } = new();
+        public LingoTween<LingoPoint> Size { get; private set; } = new();
+        public LingoTween<float> Rotation { get; private set; } = new();
+        public LingoTween<float> Skew { get; private set; } = new();
+        public LingoTween<LingoColor> ForegroundColor { get; private set; } = new();
+        public LingoTween<LingoColor> BackgroundColor { get; private set; } = new();
         public LingoTween<float> Blend { get; private set; } = new();
 
         public LingoSpriteAnimatorProperties Clone()
@@ -90,7 +90,7 @@ namespace LingoEngine.Animations
 
 
         #region Boundingbox
-        
+
         public LingoRect GetBoundingBox(LingoPoint spriteRegpoint, LingoRect spriteRect, float spriteWidth, float spriteHeight)
         {
             if (_calculatedBoundingBox != null) return _calculatedBoundingBox.Value;
@@ -101,24 +101,20 @@ namespace LingoEngine.Animations
             if (Rotation.HasKeyFrames) frames.AddRange(Rotation.KeyFrames.Select(k => k.Frame));
             if (Skew.HasKeyFrames) frames.AddRange(Skew.KeyFrames.Select(k => k.Frame));
 
-            LingoRect? result = null;
+            var result = spriteRect;
 
-            if (frames.Count == 0)
-            {
-                result = spriteRect;
-            }
-            else
+            if (frames.Count > 0)
             {
                 int start = frames.Min();
                 int end = frames.Max();
                 for (int f = start; f <= end; f++)
                 {
                     var rect = GetBoundingBoxForFrame(f, spriteRegpoint, spriteWidth, spriteHeight);
-                    result = result?.Union(rect) ?? rect;
+                    result = result.Union(rect);
                 }
             }
 
-            _calculatedBoundingBox = result ?? spriteRect;
+            _calculatedBoundingBox = result;
             return _calculatedBoundingBox.Value;
         }
         public LingoRect GetBoundingBoxForFrame(int frame, LingoPoint spriteRegpoint, float spriteWidth, float spriteHeight)


### PR DESCRIPTION
## Summary
- ensure sprite bounding box calculations account for animated positions
- add regression test covering position-based bounding boxes

## Testing
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/Animations/LingoSpriteAnimatorProperties.cs --verbosity diagnostic`
- `dotnet format Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj --include Test/LingoEngine.Lingo.Core.Tests/LingoSpriteAnimatorPropertiesTests.cs Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj --verbosity diagnostic`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689b74fbf6088332b11b8b0a190c73fb