### PR TITLE
Support nested film loops

### DIFF
--- a/src/LingoEngine.LGodot/FilmLoops/LingoGodotFilmLoopMember.cs
+++ b/src/LingoEngine.LGodot/FilmLoops/LingoGodotFilmLoopMember.cs
@@ -85,7 +85,54 @@ namespace LingoEngine.LGodot.FilmLoops
                 BlendImage(image, srcImg, transform, info.Alpha);
                 i++;
             }
-            
+
+            foreach (var layer in layers)
+            {
+                if (layer.Member is not LingoFilmLoopMember)
+                    continue;
+                var nestedPlayer = layer.GetFilmLoopPlayer();
+                if (nestedPlayer?.Texture is not LingoGodotTexture2D nestedTex)
+                    continue;
+                var srcTex = nestedTex.Texture;
+                var srcImg = srcTex.GetImage();
+                int srcW = srcTex.GetWidth();
+                int srcH = srcTex.GetHeight();
+                int destW = (int)layer.Width;
+                int destH = (int)layer.Height;
+                int srcX = 0;
+                int srcY = 0;
+                if (Framing != LingoFilmLoopFraming.Scale)
+                {
+                    int cropW = Math.Min(destW, srcW);
+                    int cropH = Math.Min(destH, srcH);
+                    srcX = (srcW - cropW) / 2;
+                    srcY = (srcH - cropH) / 2;
+                    srcW = cropW;
+                    srcH = cropH;
+                    destW = cropW;
+                    destH = cropH;
+                }
+                srcImg = srcImg.GetRegion(new Rect2I(srcX, srcY, srcW, srcH));
+                if (destW != srcW || destH != srcH)
+                    srcImg.Resize(destW, destH, Image.Interpolation.Bilinear);
+
+                var srcCenter = new LingoPoint(destW / 2f, destH / 2f);
+                var pos = new LingoPoint(layer.LocH + Offset.X, layer.LocV + Offset.Y);
+                var scale = new LingoPoint(layer.FlipH ? -1 : 1, layer.FlipV ? -1 : 1);
+                var tform = LingoTransform2D.Identity
+                    .Translated(-srcCenter.X, -srcCenter.Y)
+                    .Scaled(scale.X, scale.Y)
+                    .Skewed(layer.Skew)
+                    .Rotated(layer.Rotation)
+                    .Translated(pos.X, pos.Y);
+                var m2 = tform.Matrix;
+                var transform2D = new Transform2D(
+                    new Vector2(m2.M11, m2.M12),
+                    new Vector2(m2.M21, m2.M22),
+                    new Vector2(m2.M31, m2.M32));
+                BlendImage(image, srcImg, transform2D, Math.Clamp(layer.Blend / 100f, 0f, 1f));
+            }
+
             //DebugToDisk(image, $"filmloop_{_member.Name}_{hostSprite.Name}");
             var tex = ImageTexture.CreateFromImage(image);
             var texture = new LingoGodotTexture2D(tex);

--- a/src/LingoEngine/FilmLoops/LingoFilmLoopPlayer.cs
+++ b/src/LingoEngine/FilmLoops/LingoFilmLoopPlayer.cs
@@ -34,7 +34,7 @@ namespace LingoEngine.FilmLoops
             _sprite = sprite;
             _castLibs = castLibs;
             _mediator = eventMediator;
-            
+
         }
         private void SetupLayers()
         {
@@ -50,7 +50,7 @@ namespace LingoEngine.FilmLoops
                 var rt = new LingoSprite2DVirtual(_mediator, this, entry, _castLibs);
                 var properties = entry.AnimatorProperties.Clone();
                 if (!properties.Position.HasFirstKeyFrame())
-                // insert the initial sprite properties as keyframe
+                    // insert the initial sprite properties as keyframe
                     properties.AddKeyFrame(new LingoKeyFrameSetting(1, new LingoPoint(entry.LocH, entry.LocV), new LingoPoint(entry.Width, entry.Height), entry.Rotation, entry.Blend, entry.Skew, entry.ForeColor, entry.BackColor));
                 rt.GetAnimator(properties);
                 ApplyFraming(fl, entry, rt);
@@ -161,6 +161,22 @@ namespace LingoEngine.FilmLoops
                 runtime.ForeColor = foreColor;
                 runtime.BackColor = backColor;
                 runtime.Blend = blend;
+
+                if (template.Member is LingoFilmLoopMember)
+                {
+                    var nestedPlayer = runtime.GetFilmLoopPlayer();
+                    if (nestedPlayer == null)
+                    {
+                        nestedPlayer = new LingoFilmLoopPlayer(runtime, _mediator, _castLibs);
+                        runtime.AddActor(nestedPlayer);
+                        nestedPlayer.BeginSprite();
+                    }
+                    else
+                    {
+                        nestedPlayer.StepFrame();
+                    }
+                }
+
                 _activeLayers.Add(runtime);
             }
 

--- a/src/LingoEngine/Sprites/LingoSprite2DVirtual.cs
+++ b/src/LingoEngine/Sprites/LingoSprite2DVirtual.cs
@@ -39,7 +39,7 @@ namespace LingoEngine.Sprites
         /// <summary>Channel default cast member.</summary>
         public int DisplayMember { get; set; }
 
-        
+
 
         public LingoInkType InkType { get => (LingoInkType)_ink; set => Ink = (int)value; }
         public int Ink
@@ -50,7 +50,7 @@ namespace LingoEngine.Sprites
                 _ink = value;
             }
         }
-               
+
         public bool Hilite { get; set; }
         public bool Linked { get; private set; }
         public bool Loaded { get; private set; }
@@ -68,8 +68,8 @@ namespace LingoEngine.Sprites
         }
 
         public float Rotation { get; set; }
-        public float Skew  { get; set; }
-        public bool FlipH  { get; set; }
+        public float Skew { get; set; }
+        public bool FlipH { get; set; }
         public bool FlipV { get; set; }
         public int Constraint { get => _constraint; set => _constraint = value; }
 
@@ -93,9 +93,10 @@ namespace LingoEngine.Sprites
         }
 
 
-        public float Width { 
-            get => _width; 
-            set => _width = value; 
+        public float Width
+        {
+            get => _width;
+            set => _width = value;
         }
         public float Height { get => _height; set => _height = value; }
 
@@ -104,7 +105,7 @@ namespace LingoEngine.Sprites
 
         #endregion
 
-      
+
         private LingoPoint GetRegPointOffset()
         {
             if (_Member is { } member)
@@ -129,7 +130,7 @@ namespace LingoEngine.Sprites
         }
 
         public LingoSprite2DVirtual(ILingoEventMediator eventMediator, ILingoSpritesPlayer spritesPlayer, LingoSprite2D sp)
-            :base(eventMediator)
+            : base(eventMediator)
         {
             _spritesPlayer = spritesPlayer;
             Name = sp.Name;
@@ -232,7 +233,7 @@ namespace LingoEngine.Sprites
                 return animator.GetBoundingBox();
 
             return Rect;
-        } 
+        }
         public LingoRect GetBoundingBoxForFrame(int frame)
         {
             var animator = GetActorsOfType<LingoSpriteAnimator>().FirstOrDefault();
@@ -247,7 +248,7 @@ namespace LingoEngine.Sprites
         {
             return Rect.Contains(point);
         }
-       
+
 
         public void SetMember(ILingoMember? member)
         {
@@ -270,7 +271,7 @@ namespace LingoEngine.Sprites
             }
         }
 
-       
+
 
         #region ZIndex/locZ
         public void SendToBack()
@@ -294,7 +295,7 @@ namespace LingoEngine.Sprites
             LocZ++;
         }
         #endregion
-       
+
 
 
         #region Math methods
@@ -331,7 +332,7 @@ namespace LingoEngine.Sprites
         public bool IsPointInsideBoundingBox(float x, float y)
             => Rect.Contains((x, y));
 
-       
+
 
 
         public override void OnRemoveMe()
@@ -346,10 +347,12 @@ namespace LingoEngine.Sprites
             _Member = null;
         }
 
+        public LingoFilmLoopPlayer? GetFilmLoopPlayer() => GetActorsOfType<LingoFilmLoopPlayer>().FirstOrDefault();
+
         public void SetOnRemoveMe(Action<LingoSprite2DVirtual> onRemoveMe) => _onRemoveMe = onRemoveMe;
 
         public override string GetFullName() => $"{SpriteNum}.{Name}.{Member?.Name}";
 
-       
+
     }
 }


### PR DESCRIPTION
## Summary
- allow film loop members to host and play nested film loops
- play nested film loops when a film loop member runs as a sprite
- render nested film loops inside Godot film loop compositions

## Testing
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/FilmLoops/LingoFilmLoopPlayer.cs src/LingoEngine/Sprites/LingoSprite2DVirtual.cs`
- `dotnet format src/LingoEngine.LGodot/LingoEngine.LGodot.csproj --include src/LingoEngine.LGodot/FilmLoops/LingoGodotFilmLoopMember.cs`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689b76862bb883329433b1b48e226456