### PR TITLE
Fix nested film loop bounding boxes

### DIFF
--- a/Test/LingoEngine.Lingo.Tests/FilmLoops/NestedFilmLoopBoundingBoxTests.cs
+++ b/Test/LingoEngine.Lingo.Tests/FilmLoops/NestedFilmLoopBoundingBoxTests.cs
@@ -1,0 +1,53 @@
+using LingoEngine.Bitmaps;
+using LingoEngine.Casts;
+using LingoEngine.FilmLoops;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Primitives;
+using Moq;
+using Xunit;
+
+namespace LingoEngine.Lingo.Tests.FilmLoops;
+
+public class NestedFilmLoopBoundingBoxTests
+{
+    [Fact]
+    public void OuterFilmLoopUsesInnerBoundsWhenChildSizeIsZero()
+    {
+        var factory = new Mock<ILingoFrameworkFactory>();
+        var libs = new LingoCastLibsContainer(factory.Object);
+        var cast = (LingoCast)libs.AddCast("Test");
+
+        var innerFramework = new Mock<ILingoFrameworkMemberFilmLoop>();
+        var inner = new LingoFilmLoopMember(innerFramework.Object, cast, 1, "Inner");
+        var innerSprite = new LingoFilmLoopMemberSprite
+        {
+            LocH = 10,
+            LocV = 10,
+            Width = 20,
+            Height = 20,
+            BeginFrame = 1,
+            EndFrame = 2
+        };
+        innerSprite.AddKeyframes((2, 20, 20));
+        inner.AddSprite(innerSprite);
+
+        var innerBounds = inner.GetBoundingBox();
+
+        var outerFramework = new Mock<ILingoFrameworkMemberFilmLoop>();
+        var outer = new LingoFilmLoopMember(outerFramework.Object, cast, 2, "Outer");
+        var outerSprite = new LingoFilmLoopMemberSprite(inner)
+        {
+            LocH = 0,
+            LocV = 0,
+            BeginFrame = 1,
+            EndFrame = 2
+        };
+        outerSprite.AddKeyframes((2, 10, 10));
+        outer.AddSprite(outerSprite);
+
+        var bounds = outer.GetBoundingBox();
+
+        Assert.Equal(innerBounds.Width + 10, bounds.Width);
+        Assert.Equal(innerBounds.Height + 10, bounds.Height);
+    }
+}

--- a/Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj
+++ b/Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Moq" Version="4.20.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LingoEngine/FilmLoops/LingoFilmLoopMemberSprite.cs
+++ b/src/LingoEngine/FilmLoops/LingoFilmLoopMemberSprite.cs
@@ -139,6 +139,11 @@ namespace LingoEngine.FilmLoops
 
         private void SetMemberData(ILingoMember member)
         {
+            if (member is LingoFilmLoopMember filmLoop)
+            {
+                filmLoop.UpdateSize();
+            }
+
             Width = member.Width;
             Height = member.Height;
             _animatorProperties.RequestRecalculatedBoundingBox();


### PR DESCRIPTION
## Summary
- ensure film loop sprites refresh child dimensions
- test nested film loop bounding boxes using Moq
- cover position keyframes in bounding box regression test

## Testing
- `dotnet format Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689c64a5837c8332986c09427962c0bd