### PR TITLE
Fix nested film loop negative offset clipping

### DIFF
--- a/Test/LingoEngine.Lingo.Tests/FilmLoops/NestedFilmLoopBoundingBoxTests.cs
+++ b/Test/LingoEngine.Lingo.Tests/FilmLoops/NestedFilmLoopBoundingBoxTests.cs
@@ -50,4 +50,57 @@ public class NestedFilmLoopBoundingBoxTests
         Assert.Equal(innerBounds.Width + 10, bounds.Width);
         Assert.Equal(innerBounds.Height + 10, bounds.Height);
     }
+
+    [Fact]
+    public void GrandFilmLoopIncludesNegativeParentAnimation()
+    {
+        var factory = new Mock<ILingoFrameworkFactory>();
+        var libs = new LingoCastLibsContainer(factory.Object);
+        var cast = (LingoCast)libs.AddCast("Test");
+
+        // Inner film loop with sprite moving left
+        var innerFramework = new Mock<ILingoFrameworkMemberFilmLoop>();
+        var inner = new LingoFilmLoopMember(innerFramework.Object, cast, 1, "Inner");
+        var innerSprite = new LingoFilmLoopMemberSprite
+        {
+            LocH = 0,
+            LocV = 0,
+            Width = 20,
+            Height = 20,
+            BeginFrame = 1,
+            EndFrame = 2
+        };
+        innerSprite.AddKeyframes((2, -10, 0));
+        inner.AddSprite(innerSprite);
+
+        // Outer film loop referencing inner
+        var outerFramework = new Mock<ILingoFrameworkMemberFilmLoop>();
+        var outer = new LingoFilmLoopMember(outerFramework.Object, cast, 2, "Outer");
+        var outerSprite = new LingoFilmLoopMemberSprite(inner)
+        {
+            LocH = 0,
+            LocV = 0,
+            BeginFrame = 1,
+            EndFrame = 2
+        };
+        outer.AddSprite(outerSprite);
+
+        // Grand film loop animating outer to a negative position
+        var grandFramework = new Mock<ILingoFrameworkMemberFilmLoop>();
+        var grand = new LingoFilmLoopMember(grandFramework.Object, cast, 3, "Grand");
+        var grandSprite = new LingoFilmLoopMemberSprite(outer)
+        {
+            LocH = 0,
+            LocV = 0,
+            BeginFrame = 1,
+            EndFrame = 2
+        };
+        grandSprite.AddKeyframes((2, -10, 0));
+        grand.AddSprite(grandSprite);
+
+        var bounds = grand.GetBoundingBox();
+
+        Assert.Equal(-10, bounds.Left);
+        Assert.Equal(20, bounds.Width);
+    }
 }

--- a/src/LingoEngine/FilmLoops/LingoFilmLoopMember.cs
+++ b/src/LingoEngine/FilmLoops/LingoFilmLoopMember.cs
@@ -5,6 +5,7 @@ using LingoEngine.Members;
 using LingoEngine.Primitives;
 using LingoEngine.Bitmaps;
 using LingoEngine.Events;
+using System;
 
 namespace LingoEngine.FilmLoops
 {
@@ -75,9 +76,12 @@ namespace LingoEngine.FilmLoops
         }
         public void UpdateSize()
         {
-            var size = GetBoundingBox();
-            Width = (int)(size.Width);// + (size.Left <0 ? - size.Left : 0));
-            Height = (int)(size.Height); // + (size.Top < 0 ? -size.Top : 0));
+            var bounds = GetBoundingBox();
+            Width = (int)MathF.Ceiling(bounds.Width);
+            Height = (int)MathF.Ceiling(bounds.Height);
+            float regX = bounds.Left < 0 ? -bounds.Left : 0;
+            float regY = bounds.Top < 0 ? -bounds.Top : 0;
+            RegPoint = new LingoPoint(regX, regY);
         }
 
         public override void Unload() => _frameworkFilmLoop.Unload();


### PR DESCRIPTION
## Summary
- adjust film loop members to shift registration point when bounding boxes extend into negative space
- add regression test for nested film loops with negative parent animation

## Testing
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj -v normal`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj -v normal`


------
https://chatgpt.com/codex/tasks/task_e_689c845f68848332a63c2a39b9360efb