### PR TITLE
feat: enable keyframe editing

### DIFF
--- a/Test/LingoEngine.Lingo.Tests/Animations/LingoSpriteAnimatorPropertiesTests.cs
+++ b/Test/LingoEngine.Lingo.Tests/Animations/LingoSpriteAnimatorPropertiesTests.cs
@@ -16,4 +16,44 @@ public class LingoSpriteAnimatorPropertiesTests
 
         Assert.Equal(new LingoRect(0, 0, 110, 10), box);
     }
+
+    [Fact]
+    public void MoveKeyFrame_MovesDataToNewFrame()
+    {
+        var props = new LingoSpriteAnimatorProperties();
+        props.AddKeyFrame(new LingoKeyFrameSetting(5, position: new LingoPoint(10, 20)));
+
+        props.MoveKeyFrame(5, 8);
+
+        Assert.DoesNotContain(props.Position.KeyFrames, k => k.Frame == 5);
+        Assert.Contains(props.Position.KeyFrames, k => k.Frame == 8 && k.Value.Equals(new LingoPoint(10, 20)));
+        Assert.DoesNotContain(props.GetKeyFrames()!, k => k.Frame == 5);
+        Assert.Contains(props.GetKeyFrames()!, k => k.Frame == 8);
+    }
+
+    [Fact]
+    public void MoveKeyFrame_ToSameFrame_NoOp()
+    {
+        var props = new LingoSpriteAnimatorProperties();
+        props.AddKeyFrame(new LingoKeyFrameSetting(5, position: new LingoPoint(10, 20)));
+
+        props.MoveKeyFrame(5, 5);
+
+        Assert.Single(props.Position.KeyFrames);
+        Assert.Contains(props.Position.KeyFrames, k => k.Frame == 5 && k.Value.Equals(new LingoPoint(10, 20)));
+        Assert.Contains(props.GetKeyFrames()!, k => k.Frame == 5);
+    }
+
+    [Fact]
+    public void DeleteKeyFrame_RemovesData()
+    {
+        var props = new LingoSpriteAnimatorProperties();
+        props.AddKeyFrame(new LingoKeyFrameSetting(5, position: new LingoPoint(10, 20)));
+
+        var result = props.DeleteKeyFrame(5);
+
+        Assert.True(result);
+        Assert.Empty(props.Position.KeyFrames);
+        Assert.Empty(props.GetKeyFrames()!);
+    }
 }

--- a/src/LingoEngine/Animations/LingoSpriteAnimatorProperties.cs
+++ b/src/LingoEngine/Animations/LingoSpriteAnimatorProperties.cs
@@ -61,15 +61,45 @@ namespace LingoEngine.Animations
         internal IReadOnlyCollection<LingoKeyFrameSetting>? GetKeyFrames() => _settings.Values;
         internal void MoveKeyFrame(int from, int to)
         {
+            if (from == to)
+                return;
             if (!_settings.TryGetValue(from, out var setting))
                 return;
-            //setting.Frame = to;
-            // todo : move all keyframes in all arrays , or delete and add
+            _settings.Remove(from);
+            setting.Frame = to;
+            _settings[to] = setting;
+
+            Position.MoveKeyFrame(from, to);
+            Size.MoveKeyFrame(from, to);
+            Rotation.MoveKeyFrame(from, to);
+            Skew.MoveKeyFrame(from, to);
+            ForegroundColor.MoveKeyFrame(from, to);
+            BackgroundColor.MoveKeyFrame(from, to);
+            Blend.MoveKeyFrame(from, to);
+
+            _cacheDirty = true;
         }
         public bool DeleteKeyFrame(int frame)
         {
-            // TODO : remove keyframe
-            return false;
+            bool removed = false;
+            removed |= Position.DeleteKeyFrame(frame);
+            removed |= Size.DeleteKeyFrame(frame);
+            removed |= Rotation.DeleteKeyFrame(frame);
+            removed |= Skew.DeleteKeyFrame(frame);
+            removed |= ForegroundColor.DeleteKeyFrame(frame);
+            removed |= BackgroundColor.DeleteKeyFrame(frame);
+            removed |= Blend.DeleteKeyFrame(frame);
+
+            if (_settings.ContainsKey(frame))
+            {
+                _settings.Remove(frame);
+                removed = true;
+            }
+
+            if (removed)
+                _cacheDirty = true;
+
+            return removed;
         }
         public void AddKeyframes(params LingoKeyFrameSetting[] keyframes)
         {
@@ -209,7 +239,7 @@ namespace LingoEngine.Animations
             _calculatedFrameBoundingBoxes.Clear();
         }
 
-        
+
         #endregion
     }
 }

--- a/src/LingoEngine/Animations/LingoTween.cs
+++ b/src/LingoEngine/Animations/LingoTween.cs
@@ -33,6 +33,37 @@ namespace LingoEngine.Animations
                 AddKeyFrame(frame, value, ease);
             }
         }
+
+        public bool DeleteKeyFrame(int frame)
+        {
+            var idx = _keys.FindIndex(k => k.Frame == frame);
+            if (idx >= 0)
+            {
+                _keys.RemoveAt(idx);
+                if (frame == 1)
+                    _hasFirstKeyFrame = _keys.Any(k => k.Frame == 1);
+                return true;
+            }
+            return false;
+        }
+
+        public bool MoveKeyFrame(int from, int to)
+        {
+            if (from == to)
+                return false;
+            var idx = _keys.FindIndex(k => k.Frame == from);
+            if (idx >= 0)
+            {
+                _keys[idx].Frame = to;
+                _keys.Sort((a, b) => a.Frame.CompareTo(b.Frame));
+                if (from == 1)
+                    _hasFirstKeyFrame = _keys.Any(k => k.Frame == 1);
+                if (to == 1)
+                    _hasFirstKeyFrame = true;
+                return true;
+            }
+            return false;
+        }
         public bool HasKeyFrames => _keys.Count > 0;
         public T GetValue(int frame)
         {
@@ -102,7 +133,7 @@ namespace LingoEngine.Animations
             var clone = new LingoTween<T>();
             foreach (var key in _keys)
                 clone.AddKeyFrame(key.Frame, key.Value, key.Ease);
-            
+
             clone.Options = Options;
             return clone;
 


### PR DESCRIPTION
## Summary
- add move and delete operations for animation keyframes
- allow dragging keyframes on the score with preview and overlap checks
- prevent redundant moves when a keyframe is released at its original frame
- test keyframe move and delete behaviors, including no-op moves

## Testing
- `dotnet format LingoEngine.sln --include src/LingoEngine/Animations/LingoSpriteAnimatorProperties.cs --include src/LingoEngine/Animations/LingoTween.cs --include Test/LingoEngine.Lingo.Tests/Animations/LingoSpriteAnimatorPropertiesTests.cs`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689c8b1eebfc83328061a8e5472d62b1