### PR TITLE
Fix film loop regpoint clipping in nested film loops

### DIFF
--- a/Test/LingoEngine.Lingo.Tests/FilmLoops/FilmLoopComposerTests.cs
+++ b/Test/LingoEngine.Lingo.Tests/FilmLoops/FilmLoopComposerTests.cs
@@ -1,0 +1,56 @@
+using LingoEngine.Bitmaps;
+using LingoEngine.Casts;
+using LingoEngine.Events;
+using LingoEngine.FilmLoops;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Primitives;
+using LingoEngine.Sprites;
+using Moq;
+using Xunit;
+
+namespace LingoEngine.Lingo.Tests.FilmLoops;
+
+public class FilmLoopComposerTests
+{
+    [Fact]
+    public void PrepareUsesRegistrationPointForTransform()
+    {
+        var factory = new Mock<ILingoFrameworkFactory>();
+        var libs = new LingoCastLibsContainer(factory.Object);
+        var cast = (LingoCast)libs.AddCast("Test");
+
+        var bmpFramework = new Mock<ILingoFrameworkMemberBitmap>();
+        var bitmap = new LingoMemberBitmap(cast, bmpFramework.Object, 1, "Bmp")
+        {
+            Width = 20,
+            Height = 20,
+            RegPoint = new LingoPoint(0, 0)
+        };
+
+        var filmFramework = new Mock<ILingoFrameworkMemberFilmLoop>();
+        var film = new LingoFilmLoopMember(filmFramework.Object, cast, 2, "Film");
+        var entry = new LingoFilmLoopMemberSprite(bitmap)
+        {
+            LocH = 0,
+            LocV = 0,
+            Width = 20,
+            Height = 20,
+            BeginFrame = 1,
+            EndFrame = 1
+        };
+        film.AddSprite(entry);
+        film.UpdateSize();
+
+        var mediator = new LingoEventMediator();
+        var spritesPlayer = new Mock<ILingoSpritesPlayer>();
+        var runtime = new LingoSprite2DVirtual(mediator, spritesPlayer.Object, entry, libs);
+        var layers = new List<LingoSprite2DVirtual> { runtime };
+
+        var prep = LingoFilmLoopComposer.Prepare(film, LingoFilmLoopFraming.Auto, layers);
+        var layer = prep.Layers[0];
+        var topLeft = layer.Transform.TransformPoint(new LingoPoint(0, 0));
+
+        Assert.Equal(0, topLeft.X);
+        Assert.Equal(0, topLeft.Y);
+    }
+}

--- a/src/LingoEngine/FilmLoops/LingoFilmLoopComposer.cs
+++ b/src/LingoEngine/FilmLoops/LingoFilmLoopComposer.cs
@@ -82,11 +82,22 @@ public static class LingoFilmLoopComposer
                 destH = cropH;
             }
 
-            var srcCenter = new LingoPoint(destW / 2f, destH / 2f);
+            var reg = layer.RegPoint;
+            if (layer.Member is { Width: > 0, Height: > 0 } m)
+            {
+                float scaleRegX = destW / (float)m.Width;
+                float scaleRegY = destH / (float)m.Height;
+                reg = new LingoPoint(reg.X * scaleRegX, reg.Y * scaleRegY);
+            }
+            else
+            {
+                reg = new LingoPoint(destW / 2f, destH / 2f);
+            }
+
             var pos = new LingoPoint(layer.LocH + offset.X, layer.LocV + offset.Y);
             var scale = new LingoPoint(layer.FlipH ? -1 : 1, layer.FlipV ? -1 : 1);
             var transform = LingoTransform2D.Identity
-                .Translated(-srcCenter.X, -srcCenter.Y)
+                .Translated(-reg.X, -reg.Y)
                 .Scaled(scale.X, scale.Y)
                 .Skewed(layer.Skew)
                 .Rotated(layer.Rotation)


### PR DESCRIPTION
## Summary
- use registration point to position layers when composing film loop textures
- add regression test ensuring registration point controls transform offset

## Testing
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689c8e00971883329f284abbccc3fd2a