### PR TITLE
Propagate member registration point to film loop sprites

### DIFF
--- a/Test/LingoEngine.Lingo.Tests/FilmLoops/LingoFilmLoopMemberSpriteTests.cs
+++ b/Test/LingoEngine.Lingo.Tests/FilmLoops/LingoFilmLoopMemberSpriteTests.cs
@@ -1,0 +1,32 @@
+using LingoEngine.Bitmaps;
+using LingoEngine.Casts;
+using LingoEngine.FilmLoops;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Primitives;
+using Moq;
+using Xunit;
+
+namespace LingoEngine.Lingo.Tests.FilmLoops;
+
+public class LingoFilmLoopMemberSpriteTests
+{
+    [Fact]
+    public void MemberSpriteDefaultsToMembersRegPoint()
+    {
+        var factory = new Mock<ILingoFrameworkFactory>();
+        var libs = new LingoCastLibsContainer(factory.Object);
+        var cast = (LingoCast)libs.AddCast("Test");
+
+        var bmpFramework = new Mock<ILingoFrameworkMemberBitmap>();
+        var bitmap = new LingoMemberBitmap(cast, bmpFramework.Object, 1, "Bmp")
+        {
+            Width = 9,
+            Height = 8,
+            RegPoint = new LingoPoint(4, 0)
+        };
+
+        var sprite = new LingoFilmLoopMemberSprite(bitmap);
+
+        Assert.Equal(bitmap.RegPoint, sprite.RegPoint);
+    }
+}

--- a/src/LingoEngine/FilmLoops/LingoFilmLoopMemberSprite.cs
+++ b/src/LingoEngine/FilmLoops/LingoFilmLoopMemberSprite.cs
@@ -122,6 +122,8 @@ namespace LingoEngine.FilmLoops
             MemberNumberInCast = member.NumberInCast;
             CastNum = member.CastLibNum;
             Member = member;
+            if (RegPoint == default)
+                RegPoint = member.RegPoint;
             SetMemberData(member);
         }
         public void LinkMember(ILingoCastLibsContainer castLibs)
@@ -133,8 +135,13 @@ namespace LingoEngine.FilmLoops
                 if (cast != null)
                 {
                     Member = cast.Member[MemberNumberInCast];
-                    if (Member != null && (Width == 0 || Height == 0))
-                        SetMemberData(Member);
+                    if (Member != null)
+                    {
+                        if (RegPoint == default)
+                            RegPoint = Member.RegPoint;
+                        if (Width == 0 || Height == 0)
+                            SetMemberData(Member);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- copy cast member registration point into film loop sprites when linking or assigning
- test that film loop member sprites default to their member's registration point

## Testing
- `dotnet format LingoEngine.sln --include src/LingoEngine/FilmLoops/LingoFilmLoopMemberSprite.cs Test/LingoEngine.Lingo.Tests/FilmLoops/LingoFilmLoopMemberSpriteTests.cs --verbosity diagnostic`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689c95d3fd988332aa39d7f360acc29a