### PR TITLE
Fix film loop clipping for negative positions

### DIFF
--- a/Test/LingoEngine.Lingo.Tests/FilmLoops/NestedFilmLoopBoundingBoxTests.cs
+++ b/Test/LingoEngine.Lingo.Tests/FilmLoops/NestedFilmLoopBoundingBoxTests.cs
@@ -103,4 +103,30 @@ public class NestedFilmLoopBoundingBoxTests
         Assert.Equal(-10, bounds.Left);
         Assert.Equal(20, bounds.Width);
     }
+
+    [Fact]
+    public void UpdateSizeAccountsForSpritesLeftOfOrigin()
+    {
+        var factory = new Mock<ILingoFrameworkFactory>();
+        var libs = new LingoCastLibsContainer(factory.Object);
+        var cast = (LingoCast)libs.AddCast("Test");
+
+        var framework = new Mock<ILingoFrameworkMemberFilmLoop>();
+        var film = new LingoFilmLoopMember(framework.Object, cast, 1, "Film");
+        var sprite = new LingoFilmLoopMemberSprite
+        {
+            LocH = -20,
+            LocV = 0,
+            Width = 10,
+            Height = 10,
+            BeginFrame = 1,
+            EndFrame = 1
+        };
+        film.AddSprite(sprite);
+
+        film.UpdateSize();
+
+        Assert.Equal(25, film.Width);
+        Assert.Equal(25, film.RegPoint.X);
+    }
 }

--- a/src/LingoEngine.SDL2/Sprites/SdlSprite.cs
+++ b/src/LingoEngine.SDL2/Sprites/SdlSprite.cs
@@ -216,21 +216,19 @@ public class SdlSprite : ILingoFrameworkSprite, ILingoSDLComponent, IDisposable
         if (_lingoSprite.Member is { } member)
         {
             var baseOffset = member.CenterOffsetFromRegPoint();
+            float scaleX = 1f;
+            float scaleY = 1f;
             if (member.Width != 0 && member.Height != 0)
             {
-                float scaleX = Width / member.Width;
-                float scaleY = Height / member.Height;
-                offset = new LingoPoint(baseOffset.X * scaleX, baseOffset.Y * scaleY);
+                scaleX = Width / member.Width;
+                scaleY = Height / member.Height;
             }
-            else
-            {
-                offset = baseOffset;
-            }
+            offset = new LingoPoint(baseOffset.X * scaleX, baseOffset.Y * scaleY);
 
             if (_lingoSprite.Member is LingoFilmLoopMember flm)
             {
                 var fl = flm.Framework<SdlMemberFilmLoop>();
-                offset = new LingoPoint(offset.X - fl.Offset.X, offset.Y - fl.Offset.Y);
+                offset = new LingoPoint(offset.X - fl.Offset.X * scaleX, offset.Y - fl.Offset.Y * scaleY);
             }
         }
 
@@ -378,5 +376,5 @@ public class SdlSprite : ILingoFrameworkSprite, ILingoSDLComponent, IDisposable
 
     }
 
-   
+
 }

--- a/src/LingoEngine/Bitmaps/ILingoFrameworkMemberFilmLoop.cs
+++ b/src/LingoEngine/Bitmaps/ILingoFrameworkMemberFilmLoop.cs
@@ -1,5 +1,6 @@
 using LingoEngine.FilmLoops;
 using LingoEngine.Members;
+using LingoEngine.Primitives;
 using LingoEngine.Sprites;
 
 namespace LingoEngine.Bitmaps
@@ -25,6 +26,11 @@ namespace LingoEngine.Bitmaps
         /// Corresponds to the Lingo <c>loop</c> property used with film loop sprites.
         /// </summary>
         bool Loop { get; set; }
+
+        /// <summary>
+        /// Offset from the film loop's registration point to the top-left corner of its composed texture.
+        /// </summary>
+        LingoPoint Offset { get; }
 
         /// <summary>
         /// Composes the active film loop layers into a single texture.

--- a/src/LingoEngine/FilmLoops/LingoFilmLoopComposer.cs
+++ b/src/LingoEngine/FilmLoops/LingoFilmLoopComposer.cs
@@ -95,6 +95,12 @@ public static class LingoFilmLoopComposer
             }
 
             var pos = new LingoPoint(layer.LocH + offset.X, layer.LocV + offset.Y);
+            if (layer.Member is LingoFilmLoopMember nested)
+            {
+                var fl = nested.Framework<ILingoFrameworkMemberFilmLoop>();
+                pos.X -= fl.Offset.X;
+                pos.Y -= fl.Offset.Y;
+            }
             var scale = new LingoPoint(layer.FlipH ? -1 : 1, layer.FlipV ? -1 : 1);
             var transform = LingoTransform2D.Identity
                 .Translated(-reg.X, -reg.Y)

--- a/src/LingoEngine/FilmLoops/LingoFilmLoopMember.cs
+++ b/src/LingoEngine/FilmLoops/LingoFilmLoopMember.cs
@@ -77,11 +77,16 @@ namespace LingoEngine.FilmLoops
         public void UpdateSize()
         {
             var bounds = GetBoundingBox();
-            Width = (int)MathF.Ceiling(bounds.Width);
-            Height = (int)MathF.Ceiling(bounds.Height);
-            float regX = bounds.Left < 0 ? -bounds.Left : 0;
-            float regY = bounds.Top < 0 ? -bounds.Top : 0;
-            RegPoint = new LingoPoint(regX, regY);
+
+            // Expand dimensions to include areas positioned left or above the origin.
+            float left = MathF.Min(bounds.Left, 0);
+            float top = MathF.Min(bounds.Top, 0);
+            float right = MathF.Max(bounds.Right, 0);
+            float bottom = MathF.Max(bounds.Bottom, 0);
+
+            Width = (int)MathF.Ceiling(right - left);
+            Height = (int)MathF.Ceiling(bottom - top);
+            RegPoint = new LingoPoint(-left, -top);
         }
 
         public override void Unload() => _frameworkFilmLoop.Unload();


### PR DESCRIPTION
## Summary
- expose composed texture offset on `ILingoFrameworkMemberFilmLoop`
- subtract nested film loop offsets when composing textures
- scale SDL film loop offsets by sprite scaling for correct positioning

## Testing
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj`
- `dotnet test Test/LingoEngine.SDL2.GfxVisualTest/LingoEngine.SDL2.GfxVisualTest.csproj` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689c997cc4ac83328f27d6c3dc04005a