### PR TITLE
Draw sprite motion paths on stage

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Stages/DirStageManager.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/DirStageManager.cs
@@ -8,6 +8,7 @@ using LingoEngine.Core;
 using LingoEngine.Director.Core.Stages.Commands;
 using LingoEngine.Commands;
 using LingoEngine.Director.Core.Tools;
+using LingoEngine.Animations;
 
 namespace LingoEngine.Director.Core.Stages;
 
@@ -29,6 +30,7 @@ public interface IDirStageManager
     void UpdateRotate(LingoPoint current);
     void EndRotate(LingoPoint end);
     void ChangeBackgroundColor(LingoColor color);
+    LingoSpriteMotionPath? GetMotionPath(LingoSprite2D sprite);
 }
 
 public class DirStageManager : IDirStageManager, IDisposable, ICommandHandler<StageChangeBackgroundColorCommand>
@@ -203,6 +205,11 @@ public class DirStageManager : IDirStageManager, IDisposable, ICommandHandler<St
         _dragStart = null;
         _initialRotations = null;
         SpritesTransformed?.Invoke();
+    }
+
+    public LingoSpriteMotionPath? GetMotionPath(LingoSprite2D sprite)
+    {
+        return _player.Stage.GetSpriteMotionPath(sprite);
     }
 
     public void ChangeBackgroundColor(LingoColor color)

--- a/src/Director/LingoEngine.Director.Core/Stages/StageMotionPathOverlay.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/StageMotionPathOverlay.cs
@@ -1,0 +1,70 @@
+using System;
+using LingoEngine.Animations;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Gfx;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.Director.Core.Stages;
+
+/// <summary>
+/// Overlay that draws the motion path for a sprite.
+/// </summary>
+public class StageMotionPathOverlay : IDisposable
+{
+    private readonly LingoGfxCanvas _canvas;
+
+    public LingoGfxCanvas Canvas => _canvas;
+
+    public bool Visible { get => _canvas.Visibility; set => _canvas.Visibility = value; }
+
+    public StageMotionPathOverlay(ILingoFrameworkFactory factory)
+    {
+        _canvas = factory.CreateGfxCanvas("MotionPathCanvas", 3000, 2000);
+        _canvas.Visibility = false;
+    }
+
+    public void Draw(LingoSpriteMotionPath? path)
+    {
+        _canvas.Clear(LingoColorList.Transparent);
+        if (path == null || path.Frames.Count == 0)
+        {
+            _canvas.Visibility = false;
+            return;
+        }
+
+        for (int i = 1; i < path.Frames.Count; i++)
+        {
+            var prev = path.Frames[i - 1].Position;
+            var curr = path.Frames[i].Position;
+            _canvas.DrawLine(prev, curr, LingoColorList.Yellow);
+        }
+
+        var first = path.Frames[0];
+        var last = path.Frames[^1];
+        DrawCircle(first.Position, LingoColorList.Green, true, 2.5f);
+        DrawCircle(last.Position, LingoColorList.Red, true, 2.5f);
+
+        for (int i = 1; i < path.Frames.Count - 1; i++)
+        {
+            var f = path.Frames[i];
+            if (f.IsKeyFrame)
+                DrawCircle(f.Position, LingoColorList.Yellow, true, 2.5f);
+            else
+                DrawCircle(f.Position, LingoColorList.Yellow, false, 1.5f);
+        }
+
+        _canvas.Visibility = true;
+    }
+
+    private void DrawCircle(LingoPoint position, LingoColor fillColor, bool keyframe, float radius)
+    {
+        _canvas.DrawCircle(position, radius, fillColor, true);
+        if (keyframe)
+            _canvas.DrawCircle(position, radius, LingoColorList.Black, false, 1);
+    }
+
+    public void Dispose()
+    {
+        _canvas.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- expose sprite motion paths through `DirStageManager`
- render motion paths with colored keyframe markers via `StageMotionPathOverlay`
- update Godot stage window to display the motion path of the selected sprite

## Testing
- `dotnet format src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj --include src/Director/LingoEngine.Director.Core/Stages/DirStageManager.cs src/Director/LingoEngine.Director.Core/Stages/StageMotionPathOverlay.cs -v diag`
- `dotnet format src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj --include src/Director/LingoEngine.Director.LGodot/Stages/DirGodotStageWindow.cs -v diag`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689ca77e384083328006c5abc049841c