### PR TITLE
Allow dragging score keyframes onto existing frames

### DIFF
--- a/Test/LingoEngine.Lingo.Tests/Animations/LingoSpriteAnimatorPropertiesTests.cs
+++ b/Test/LingoEngine.Lingo.Tests/Animations/LingoSpriteAnimatorPropertiesTests.cs
@@ -45,6 +45,21 @@ public class LingoSpriteAnimatorPropertiesTests
     }
 
     [Fact]
+    public void MoveKeyFrame_OverExisting_ReplacesDestination()
+    {
+        var props = new LingoSpriteAnimatorProperties();
+        props.AddKeyFrame(new LingoKeyFrameSetting(5, position: new LingoPoint(10, 20)));
+        props.AddKeyFrame(new LingoKeyFrameSetting(8, position: new LingoPoint(30, 40)));
+
+        props.MoveKeyFrame(5, 8);
+
+        Assert.Single(props.Position.KeyFrames);
+        Assert.Contains(props.Position.KeyFrames, k => k.Frame == 8 && k.Value.Equals(new LingoPoint(10, 20)));
+        Assert.Single(props.GetKeyFrames()!);
+        Assert.Contains(props.GetKeyFrames()!, k => k.Frame == 8);
+    }
+
+    [Fact]
     public void DeleteKeyFrame_RemovesData()
     {
         var props = new LingoSpriteAnimatorProperties();

--- a/src/Director/LingoEngine.Director.Core/Scores/DirScoreSprite.cs
+++ b/src/Director/LingoEngine.Director.Core/Scores/DirScoreSprite.cs
@@ -281,7 +281,7 @@ namespace LingoEngine.Director.Core.Scores
                 return;
             if (frame <= Sprite.BeginFrame || frame >= Sprite.EndFrame)
                 return;
-            if (_KeyFrames.Contains(frame))
+            if (_dragKeyFramePreview == frame)
                 return;
             _dragKeyFramePreview = frame;
             RequireRedraw();

--- a/src/LingoEngine/Animations/LingoTween.cs
+++ b/src/LingoEngine/Animations/LingoTween.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using LingoEngine.Primitives;
 
 namespace LingoEngine.Animations
@@ -51,18 +52,17 @@ namespace LingoEngine.Animations
         {
             if (from == to)
                 return false;
-            var idx = _keys.FindIndex(k => k.Frame == from);
-            if (idx >= 0)
-            {
-                _keys[idx].Frame = to;
-                _keys.Sort((a, b) => a.Frame.CompareTo(b.Frame));
-                if (from == 1)
-                    _hasFirstKeyFrame = _keys.Any(k => k.Frame == 1);
-                if (to == 1)
-                    _hasFirstKeyFrame = true;
-                return true;
-            }
-            return false;
+
+            var key = _keys.FirstOrDefault(k => k.Frame == from);
+            if (key == null)
+                return false;
+
+            _keys.RemoveAll(k => k.Frame == to);
+            key.Frame = to;
+            _keys.Sort((a, b) => a.Frame.CompareTo(b.Frame));
+
+            _hasFirstKeyFrame = _keys.Any(k => k.Frame == 1);
+            return true;
         }
         public bool HasKeyFrames => _keys.Count > 0;
         public T GetValue(int frame)


### PR DESCRIPTION
## Summary
- permit dragging sprite keyframes over existing frames and back to origin
- replace destination keyframes when moving
- cover keyframe move replacement with tests

## Testing
- `dotnet format --include src/LingoEngine/Animations/LingoTween.cs src/Director/LingoEngine.Director.Core/Scores/DirScoreSprite.cs Test/LingoEngine.Lingo.Tests/Animations/LingoSpriteAnimatorPropertiesTests.cs`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689ca9e6a07883329b4469286c27ca4d