### PR TITLE
feat(director): add delete keyframe menu option

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Scores/DirScoreSprite.cs
+++ b/src/Director/LingoEngine.Director.Core/Scores/DirScoreSprite.cs
@@ -298,6 +298,15 @@ namespace LingoEngine.Director.Core.Scores
             RequireRedraw();
         }
 
+        internal void DeleteKeyFrame(int frame)
+        {
+            if (Sprite2D == null)
+                return;
+            Sprite2D.DeleteKeyFrame(frame - Sprite.BeginFrame);
+            _KeyFrames = null;
+            RequireRedraw();
+        }
+
 
         private string GetName()
         {


### PR DESCRIPTION
## Summary
- add Delete Keyframe option to score context menu
- enable removal of sprite keyframes from Director score

## Testing
- `dotnet format src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj --include src/Director/LingoEngine.Director.Core/Scores/DirScoreSprite.cs src/Director/LingoEngine.Director.Core/Scores/DirectorScoreWindow.cs -v diag`
- `dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj` *(fails: type names 'CSharpCodeProvider', 'CompilerParameters', 'CompilerError' could not be found)*
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689cae0eb9548332b8b31e85da82c66e