### PR TITLE
Update frame scrubbing to follow mouse drag

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Scores/DirScoreFrameHeader.cs
+++ b/src/Director/LingoEngine.Director.Core/Scores/DirScoreFrameHeader.cs
@@ -52,16 +52,18 @@ public class DirScoreFrameHeader : IDisposable
 
     public void HandleMouseEvent(LingoMouseEvent mouseEvent, int mouseFrame)
     {
-        if (_movie == null) return;
-        if (mouseEvent.Type == LingoMouseEventType.MouseDown && mouseEvent.Mouse.LeftMouseDown)
+        if (_movie == null)
+            return;
+
+        bool isDragging = mouseEvent.Mouse.LeftMouseDown &&
+            (mouseEvent.Type == LingoMouseEventType.MouseDown || mouseEvent.Type == LingoMouseEventType.MouseMove);
+
+        if (isDragging && mouseFrame >= 1 && mouseFrame <= _movie.FrameCount)
         {
-            if (mouseFrame >= 1 && mouseFrame <= _movie.FrameCount)
-            {
-                if (_movie.IsPlaying)
-                    _movie.GoTo(mouseFrame);
-                else
-                    _movie.GoToAndStop(mouseFrame);
-            }
+            if (_movie.IsPlaying)
+                _movie.GoTo(mouseFrame);
+            else
+                _movie.GoToAndStop(mouseFrame);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Update score frame header so dragging with mouse updates current frame continuously

## Testing
- `dotnet format src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj --include src/Director/LingoEngine.Director.Core/Scores/DirScoreFrameHeader.cs -v normal`
- `dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj` *(fails: CSharpCodeProvider/System.CodeDom missing)*

------
https://chatgpt.com/codex/tasks/task_e_689caef5ae9c83328ffd16a8e6984b0a