### PR TITLE
Reset right mouse button after context menu popup

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Windowing/DirContextMenu.cs
+++ b/src/Director/LingoEngine.Director.Core/Windowing/DirContextMenu.cs
@@ -1,5 +1,6 @@
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Gfx;
+using LingoEngine.Inputs;
 
 namespace LingoEngine.Director.Core.Windowing
 {
@@ -13,6 +14,7 @@ namespace LingoEngine.Director.Core.Windowing
         private readonly Func<(float X, float Y)> _positionProvider;
         private readonly Func<bool> _allowOpen;
         private readonly List<Item> _items = new();
+        private readonly LingoMouse? _mouse;
 
         private record Item(LingoGfxMenuItem MenuItem, Func<bool> CanExecute, Action Execute);
 
@@ -20,12 +22,14 @@ namespace LingoEngine.Director.Core.Windowing
             object window,
             ILingoFrameworkFactory factory,
             Func<(float X, float Y)> positionProvider,
-            Func<bool> allowOpen)
+            Func<bool> allowOpen,
+            LingoMouse? mouse)
         {
             _factory = factory;
             _menu = factory.CreateContextMenu(window);
             _positionProvider = positionProvider;
             _allowOpen = allowOpen;
+            _mouse = mouse;
         }
 
         /// <summary>Adds a menu entry.</summary>
@@ -53,6 +57,11 @@ namespace LingoEngine.Director.Core.Windowing
             _menu.X = pos.X;
             _menu.Y = pos.Y;
             _menu.Popup();
+            if (_mouse != null)
+            {
+                _mouse.RightMouseDown = false;
+                _mouse.DoMouseUp();
+            }
         }
 
         public void Dispose()

--- a/src/Director/LingoEngine.Director.Core/Windowing/DirectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Windowing/DirectorWindow.cs
@@ -45,7 +45,7 @@ public class DirectorWindow<TFrameworkWindow> : IDirectorWindow, IDisposable, IL
     public virtual void Dispose()
     {
         LingoKey.Unsubscribe(this);
-       
+
     }
 
     public IDirFrameworkWindow FrameworkObj => _Framework;
@@ -73,9 +73,9 @@ public class DirectorWindow<TFrameworkWindow> : IDirectorWindow, IDisposable, IL
     /// </summary>
     protected DirContextMenu CreateContextMenu(Func<bool>? isllowed = null)
     {
-            if (_Framework == null) throw new Exception("Context menu can only be created once the framework object has been set. Call in it the Init method of the DirectorWindow.");
-            var contextMenu = new DirContextMenu(_Framework, _factory,MouseGetAbolutePosition, isllowed?? AllowContextMenu);
-            return contextMenu;
+        if (_Framework == null) throw new Exception("Context menu can only be created once the framework object has been set. Call in it the Init method of the DirectorWindow.");
+        var contextMenu = new DirContextMenu(_Framework, _factory, MouseGetAbolutePosition, isllowed ?? AllowContextMenu, Mouse as LingoMouse);
+        return contextMenu;
     }
     protected virtual bool AllowContextMenu() => IsActiveWindow;
 }


### PR DESCRIPTION
## Summary
- prevent right mouse button from remaining pressed after opening context menus
- forward window mouse reference to context menu for state reset

## Testing
- `dotnet format src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj --include Windowing/DirContextMenu.cs --include Windowing/DirectorWindow.cs`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689cb162776083328773c0240ec621fa