### PR TITLE
Fix ImGui scrolling and compose SDL rendering

### DIFF
--- a/src/LingoEngine.SDL2/Gfx/SdlGfxButton.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxButton.cs
@@ -25,9 +25,8 @@ namespace LingoEngine.SDL2.Gfx
         {
             if (!Visibility) return nint.Zero;
 
-            //ImGui.SetCursorPos(new Vector2(X, Y));
-            var vpPos = context.ImGuiViewPort.WorkPos;
-            var basePos = vpPos + new Vector2(X, Y);
+            var basePos = context.Origin + new Vector2(X, Y);
+            ImGui.SetCursorScreenPos(basePos);
             ImGui.PushID(Name);
             if (!Enabled)
                 ImGui.BeginDisabled();

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxColorPicker.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxColorPicker.cs
@@ -35,7 +35,7 @@ namespace LingoEngine.SDL2.Gfx
         {
             if (!Visibility) return nint.Zero;
 
-            ImGui.SetCursorPos(new Vector2(X, Y));
+            ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
             ImGui.PushID(Name);
             if (!Enabled)
                 ImGui.BeginDisabled();
@@ -49,7 +49,7 @@ namespace LingoEngine.SDL2.Gfx
             if (!Enabled)
                 ImGui.EndDisabled();
             ImGui.PopID();
-            return nint.Zero;
+            return LingoSDLRenderResult.RequireRender();
         }
 
         public override void Dispose() => base.Dispose();

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxInputCheckbox.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxInputCheckbox.cs
@@ -32,7 +32,7 @@ namespace LingoEngine.SDL2.Gfx
         public override LingoSDLRenderResult Render(LingoSDLRenderContext context)
         {
             if (!Visibility) return nint.Zero;
-            ImGui.SetCursorPos(new Vector2(X, Y));
+            ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
             ImGui.PushID(Name);
             if (!Enabled)
                 ImGui.BeginDisabled();
@@ -42,7 +42,7 @@ namespace LingoEngine.SDL2.Gfx
             if (!Enabled)
                 ImGui.EndDisabled();
             ImGui.PopID();
-            return nint.Zero;
+            return LingoSDLRenderResult.RequireRender();
         }
 
         public override void Dispose() => base.Dispose();

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxInputCombobox.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxInputCombobox.cs
@@ -39,7 +39,7 @@ namespace LingoEngine.SDL2.Gfx
         public override LingoSDLRenderResult Render(LingoSDLRenderContext context)
         {
             if (!Visibility) return nint.Zero;
-            ImGui.SetCursorPos(new Vector2(X, Y));
+            ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
             ImGui.PushID(Name);
             if (!Enabled)
                 ImGui.BeginDisabled();
@@ -67,7 +67,7 @@ namespace LingoEngine.SDL2.Gfx
             if (!Enabled)
                 ImGui.EndDisabled();
             ImGui.PopID();
-            return nint.Zero;
+            return LingoSDLRenderResult.RequireRender();
         }
 
         public override void Dispose() => base.Dispose();

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxInputNumber.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxInputNumber.cs
@@ -38,7 +38,7 @@ namespace LingoEngine.SDL2.Gfx
         {
             if (!Visibility) return nint.Zero;
 
-            ImGui.SetCursorPos(new Vector2(X, Y));
+            ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
             ImGui.PushID(Name);
             if (!Enabled)
                 ImGui.BeginDisabled();
@@ -65,7 +65,7 @@ namespace LingoEngine.SDL2.Gfx
             if (!Enabled)
                 ImGui.EndDisabled();
             ImGui.PopID();
-            return nint.Zero;
+            return LingoSDLRenderResult.RequireRender();
         }
 
         public override void Dispose() => base.Dispose();

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxInputSlider.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxInputSlider.cs
@@ -35,7 +35,7 @@ namespace LingoEngine.SDL2.Gfx
         public override LingoSDLRenderResult Render(LingoSDLRenderContext context)
         {
             if (!Visibility) return nint.Zero;
-            ImGui.SetCursorPos(new Vector2(X, Y));
+            ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
             ImGui.PushID(Name);
             if (!Enabled)
                 ImGui.BeginDisabled();
@@ -60,7 +60,7 @@ namespace LingoEngine.SDL2.Gfx
             if (!Enabled)
                 ImGui.EndDisabled();
             ImGui.PopID();
-            return nint.Zero;
+            return LingoSDLRenderResult.RequireRender();
         }
 
         public override void Dispose() => base.Dispose();

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxInputText.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxInputText.cs
@@ -37,9 +37,8 @@ namespace LingoEngine.SDL2.Gfx
         {
             if (!Visibility) return nint.Zero;
 
-            // place relative to overlay screen
-            var basePos = context.ImGuiViewPort.WorkPos;
-            ImGui.SetCursorScreenPos(basePos + new Vector2(X, Y));
+            // place relative to current context origin
+            ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
 
             if (Width > 0) ImGui.SetNextItemWidth(Width);
 

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxItemList.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxItemList.cs
@@ -41,7 +41,7 @@ namespace LingoEngine.SDL2.Gfx
             if (!Visibility)
                 return nint.Zero;
 
-            ImGui.SetCursorPos(new Vector2(X, Y));
+            ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
             ImGui.PushID(Name);
 
             if (!Enabled)
@@ -71,7 +71,7 @@ namespace LingoEngine.SDL2.Gfx
 
             ImGui.PopID();
 
-            return nint.Zero;
+            return LingoSDLRenderResult.RequireRender();
         }
     }
 }

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxMenu.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxMenu.cs
@@ -20,6 +20,6 @@ namespace LingoEngine.SDL2.Gfx
         public void Popup() { }
         public override void Dispose() => base.Dispose();
 
-        public override LingoSDLRenderResult Render(LingoSDLRenderContext context) => nint.Zero;
+        public override LingoSDLRenderResult Render(LingoSDLRenderContext context) => LingoSDLRenderResult.RequireRender();
     }
 }

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxMenuItem.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxMenuItem.cs
@@ -20,6 +20,6 @@ namespace LingoEngine.SDL2.Gfx
         public void Invoke() => Activated?.Invoke();
         public override void Dispose() => base.Dispose();
 
-        public override LingoSDLRenderResult Render(LingoSDLRenderContext context) => nint.Zero;
+        public override LingoSDLRenderResult Render(LingoSDLRenderContext context) => LingoSDLRenderResult.RequireRender();
     }
 }

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxScrollContainer.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxScrollContainer.cs
@@ -50,12 +50,9 @@ namespace LingoEngine.SDL2.Gfx
 
             ImGui.BeginChild("##scroll", new Vector2(Width, Height), childFlags, winFlags);
 
-            // apply incoming scroll
-            ImGui.SetScrollX(ScrollHorizontal);
-            ImGui.SetScrollY(ScrollVertical);
-
             // child origin for nested components
-            var childOrigin = ImGui.GetCursorScreenPos();
+            var scroll = new Vector2(ImGui.GetScrollX(), ImGui.GetScrollY());
+            var childOrigin = ImGui.GetCursorScreenPos() - scroll;
             var childCtx = new LingoSDLRenderContext(
                 context.Renderer,
                 context.ImGuiViewPort,
@@ -75,10 +72,10 @@ namespace LingoEngine.SDL2.Gfx
             }
 
             // report content size to ImGui so it knows it should scroll
-            ImGui.SetCursorScreenPos(childOrigin);
+            ImGui.SetCursorPos(Vector2.Zero);
             ImGui.Dummy(new Vector2(maxX, maxY)); // <- drives scrollbar visibility
 
-            // read back scroll (after items)
+            // capture user scroll position for external access
             ScrollHorizontal = ImGui.GetScrollX();
             ScrollVertical = ImGui.GetScrollY();
 

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxSpinBox.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxSpinBox.cs
@@ -35,7 +35,7 @@ namespace LingoEngine.SDL2.Gfx
         public override LingoSDLRenderResult Render(LingoSDLRenderContext context)
         {
             if (!Visibility) return nint.Zero;
-            ImGui.SetCursorPos(new Vector2(X, Y));
+            ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
             ImGui.PushID(Name);
             if (!Enabled)
                 ImGui.BeginDisabled();
@@ -48,7 +48,7 @@ namespace LingoEngine.SDL2.Gfx
             if (!Enabled)
                 ImGui.EndDisabled();
             ImGui.PopID();
-            return nint.Zero;
+            return LingoSDLRenderResult.RequireRender();
         }
 
         public override void Dispose() => base.Dispose();

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxTabContainer.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxTabContainer.cs
@@ -60,7 +60,7 @@ namespace LingoEngine.SDL2.Gfx
             if (!Visibility)
                 return nint.Zero;
 
-            ImGui.SetCursorPos(new Vector2(X, Y));
+            ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
             ImGui.PushID(Name);
             ImGui.BeginChild("##tabs", new Vector2(Width, Height), ImGuiChildFlags.None);
 
@@ -74,7 +74,11 @@ namespace LingoEngine.SDL2.Gfx
                     {
                         _selectedIndex = i;
                         if (tab.Content?.FrameworkObj is SdlGfxComponent comp)
-                            comp.Render(context);
+                        {
+                            var origin = ImGui.GetCursorScreenPos();
+                            var childCtx = new LingoSDLRenderContext(context.Renderer, context.ImGuiViewPort, ImGui.GetWindowDrawList(), origin);
+                            comp.Render(childCtx);
+                        }
                         ImGui.EndTabItem();
                     }
                 }
@@ -83,7 +87,7 @@ namespace LingoEngine.SDL2.Gfx
 
             ImGui.EndChild();
             ImGui.PopID();
-            return nint.Zero;
+            return LingoSDLRenderResult.RequireRender();
         }
 
         public override void Dispose()
@@ -108,6 +112,6 @@ namespace LingoEngine.SDL2.Gfx
 
         public override void Dispose() => base.Dispose();
 
-        public override LingoSDLRenderResult Render(LingoSDLRenderContext context) => nint.Zero;
+        public override LingoSDLRenderResult Render(LingoSDLRenderContext context) => LingoSDLRenderResult.RequireRender();
     }
 }

--- a/src/LingoEngine.SDL2/ImGuiSdlBackend.cs
+++ b/src/LingoEngine.SDL2/ImGuiSdlBackend.cs
@@ -47,7 +47,7 @@ namespace LingoEngine.SDL2
         {
             NewFrame();
             var imGuiViewPort = ImGui.GetMainViewport();
-            
+
             ImGui.SetNextWindowPos(imGuiViewPort.WorkPos);
             ImGui.SetNextWindowSize(imGuiViewPort.WorkSize);
             const ImGuiWindowFlags overlayFlags =
@@ -152,7 +152,8 @@ namespace LingoEngine.SDL2
         {
             ImGui.End();
             ImGui.PopStyleVar();
-            Render();           
+            Render();
+            SDL_RenderPresent(_renderer);
         }
 
         public void Render()
@@ -278,6 +279,6 @@ namespace LingoEngine.SDL2
             if (scan == ev) io.AddKeyEvent(imguiKey, down);
         }
 
-       
+
     }
 }

--- a/src/LingoEngine.SDL2/Movies/SdlMovie.cs
+++ b/src/LingoEngine.SDL2/Movies/SdlMovie.cs
@@ -48,8 +48,6 @@ public class SdlMovie : ILingoFrameworkMovie, IDisposable
         {
             s.ComponentContext.RenderToTexture(context);
         }
-
-        SDL.SDL_RenderPresent(context.Renderer);
     }
 
     internal void CreateSprite<T>(T lingoSprite) where T : LingoSprite2D

--- a/src/LingoEngine.SDL2/SdlRootContext.cs
+++ b/src/LingoEngine.SDL2/SdlRootContext.cs
@@ -74,7 +74,7 @@ public class SdlRootContext : IDisposable, ISdlRootComponentContext
             float delta = (now - last) / 1000f;
             last = now;
             ImGuiViewPort = _imgui.BeginFrame();
-            ImDrawList = ImGui.GetForegroundDrawList();
+            ImDrawList = ImGui.GetWindowDrawList();
 
             DebugOverlay.Update(delta);
             bool f1 = _lPlayer.Key.KeyPressed((int)SDL.SDL_Keycode.SDLK_F1);
@@ -87,7 +87,7 @@ public class SdlRootContext : IDisposable, ISdlRootComponentContext
         Dispose();
     }
 
-    
+
 
     public void Dispose()
     {


### PR DESCRIPTION
## Summary
- offset scroll container children by current scroll and report content size using local coordinates
- present SDL renderer after ImGui draws to overlay and remove per-movie Present call
- fetch overlay draw list from ImGui root window for consistent rendering
- capture ImGui scroll offsets in scroll container without forcing positions

## Testing
- `dotnet format src/LingoEngine.SDL2/LingoEngine.SDL2.csproj --include src/LingoEngine.SDL2/Gfx/SdlGfxScrollContainer.cs -v diag`
- `dotnet build src/LingoEngine.SDL2/LingoEngine.SDL2.csproj`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689cce37920883329cd3ce28499451e2