### PR TITLE
Integrate ImGui rendering for SDL canvas and fix tab tabs

### DIFF
--- a/src/LingoEngine.SDL2/Gfx/SdlGfxCanvas.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxCanvas.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Runtime.InteropServices;
+using ImGuiNET;
 using LingoEngine.Bitmaps;
 using LingoEngine.Gfx;
 using LingoEngine.Primitives;
@@ -260,8 +262,18 @@ namespace LingoEngine.SDL2.Gfx
 
         public override LingoSDLRenderResult Render(LingoSDLRenderContext context)
         {
+            if (!Visibility)
+                return nint.Zero;
+
             ComponentContext.Renderer = context.Renderer;
-            return _texture;
+
+            var screenPos = context.Origin + new Vector2(X, Y);
+            ImGui.SetCursorScreenPos(screenPos);
+            ImGui.PushID(Name);
+            ImGui.Image(_texture, new Vector2(Width, Height));
+            ImGui.PopID();
+
+            return LingoSDLRenderResult.RequireRender();
         }
 
     }

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxTabContainer.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxTabContainer.cs
@@ -69,8 +69,7 @@ namespace LingoEngine.SDL2.Gfx
                 for (int i = 0; i < _children.Count; i++)
                 {
                     var tab = _children[i];
-                    bool open = _selectedIndex == i;
-                    if (ImGui.BeginTabItem(tab.Title, ref open))
+                    if (ImGui.BeginTabItem(tab.Title))
                     {
                         _selectedIndex = i;
                         if (tab.Content?.FrameworkObj is SdlGfxComponent comp)


### PR DESCRIPTION
## Summary
- render SDL canvas textures using ImGui so they appear in scroll containers
- show all tabs by removing incorrect open flag handling

## Testing
- `dotnet format src/LingoEngine.SDL2/LingoEngine.SDL2.csproj --include src/LingoEngine.SDL2/Gfx/SdlGfxCanvas.cs src/LingoEngine.SDL2/Gfx/SdlGfxTabContainer.cs -v diag`
- `dotnet build src/LingoEngine.SDL2/LingoEngine.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689cdf5f7e148332b93ef9e5b492d17a