### PR TITLE
Refactor SDL canvas to queue draw actions

### DIFF
--- a/Test/LingoEngine.SDL2.GfxVisualTest/GfxTestScene.cs
+++ b/Test/LingoEngine.SDL2.GfxVisualTest/GfxTestScene.cs
@@ -106,7 +106,7 @@ public static class GfxTestScene
 
     private static LingoGfxLabel CreateLabel(ILingoGfxFactory factory, string text)
     {
-        var label = factory.CreateLabel(text.Replace(" ","_"), text);
+        var label = factory.CreateLabel(text.Replace(" ", "_"), text);
         label.FontColor = LingoColorList.LightGray;
         return label;
 

--- a/Test/LingoEngine.SDL2.GfxVisualTest/TestSdlRootComponentContext.cs
+++ b/Test/LingoEngine.SDL2.GfxVisualTest/TestSdlRootComponentContext.cs
@@ -14,10 +14,10 @@ public class TestSdlRootComponentContext : ISdlRootComponentContext, IDisposable
 {
 
 
-// add fields
-private bool _imguiReady;
+    // add fields
+    private bool _imguiReady;
 
-private readonly nint _window;
+    private readonly nint _window;
     public LingoSDLComponentContainer ComponentContainer { get; } = new();
     public nint Renderer { get; }
 
@@ -32,9 +32,10 @@ private readonly nint _window;
     public ImGuiViewportPtr ImGuiViewPort { get; private set; }
     public ImDrawListPtr ImDrawList { get; private set; }
 
+    public nint RegisterTexture(nint sdlTexture) => _imgui.RegisterTexture(sdlTexture);
+
     public TestSdlRootComponentContext()
     {
-        
         SDL.SDL_Init(SDL.SDL_INIT_VIDEO | SDL.SDL_INIT_EVENTS | SDL.SDL_INIT_GAMECONTROLLER | SDL.SDL_INIT_AUDIO);
         SDL_ttf.TTF_Init();
         SDL_image.IMG_Init(SDL_image.IMG_InitFlags.IMG_INIT_PNG);
@@ -81,8 +82,7 @@ private readonly nint _window;
 
             SDL.SDL_SetRenderDrawColor(Renderer, 50, 0, 50, 255);
             SDL.SDL_RenderClear(Renderer);
-
-            ComponentContainer.Render(new LingoSDLRenderContext(Renderer,ImGuiViewPort,ImDrawList, ImGuiViewPort.WorkPos));
+            ComponentContainer.Render(new LingoSDLRenderContext(Renderer, ImGuiViewPort, ImDrawList, ImGuiViewPort.WorkPos));
 
             _imgui.EndFrame();  // draws ImGui on top
 

--- a/src/LingoEngine.SDL2/ISdlRootComponentContext.cs
+++ b/src/LingoEngine.SDL2/ISdlRootComponentContext.cs
@@ -13,5 +13,7 @@ public interface ISdlRootComponentContext
     LingoMouse LingoMouse { get; }
     LingoKey LingoKey { get; }
 
+    nint RegisterTexture(nint sdlTexture);
+
     LingoPoint GetWindowSize();
 }

--- a/src/LingoEngine.SDL2/SdlRootContext.cs
+++ b/src/LingoEngine.SDL2/SdlRootContext.cs
@@ -34,6 +34,8 @@ public class SdlRootContext : IDisposable, ISdlRootComponentContext
     public ImGuiViewportPtr ImGuiViewPort { get; private set; }
     public ImDrawListPtr ImDrawList { get; private set; }
 
+    public nint RegisterTexture(nint sdlTexture) => _imgui.RegisterTexture(sdlTexture);
+
     public SdlRootContext(nint window, nint renderer)
     {
         Window = window;


### PR DESCRIPTION
## Summary
- Queue SDL canvas drawing commands and mark dirty state for re-rendering
- Render queued actions to texture and display via ImGui for ScrollContainer support
- Register SDL canvas textures with ImGui backend and use returned handle when drawing

## Testing
- `dotnet format src/LingoEngine.SDL2/LingoEngine.SDL2.csproj --verify-no-changes -v diag`
- `dotnet format Test/LingoEngine.SDL2.GfxVisualTest/LingoEngine.SDL2.GfxVisualTest.csproj --verify-no-changes -v diag`
- `dotnet build src/LingoEngine.SDL2/LingoEngine.SDL2.csproj`
- `dotnet build Test/LingoEngine.SDL2.GfxVisualTest/LingoEngine.SDL2.GfxVisualTest.csproj`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689ce96c5328833285955fc5ba9361ad