### PR TITLE
Add pixel transparency checks for BackgroundTransparent sprites

### DIFF
--- a/src/LingoEngine.LGodot/Bitmaps/LingoGodotMemberBitmap.cs
+++ b/src/LingoEngine.LGodot/Bitmaps/LingoGodotMemberBitmap.cs
@@ -204,6 +204,18 @@ namespace LingoEngine.LGodot.Bitmaps
             return tex;
         }
 
+        public bool IsPixelTransparent(int x, int y)
+        {
+            if (_image == null)
+                return false;
+
+            if (x < 0 || y < 0 || x >= Width || y >= Height)
+                return true;
+
+            var color = _image.GetPixel(x, y);
+            return color.A <= 0.001f;
+        }
+
         public void SetImageData(byte[] bytes) => ImageData = bytes;
 
         private void ClearCache()

--- a/src/LingoEngine/Members/ILingoFrameworkMember.cs
+++ b/src/LingoEngine/Members/ILingoFrameworkMember.cs
@@ -20,5 +20,14 @@ namespace LingoEngine.Members
         void Preload();
         void ReleaseFromSprite(LingoSprite2D lingoSprite);
         void Unload();
+
+        /// <summary>
+        /// Determines whether the pixel at the given coordinates is fully transparent.
+        /// Coordinates are relative to the member's top-left corner.
+        /// </summary>
+        /// <param name="x">X coordinate in pixels.</param>
+        /// <param name="y">Y coordinate in pixels.</param>
+        /// <returns><c>true</c> if the pixel is transparent; otherwise, <c>false</c>.</returns>
+        bool IsPixelTransparent(int x, int y) => false;
     }
 }

--- a/src/LingoEngine/Members/LingoMember.cs
+++ b/src/LingoEngine/Members/LingoMember.cs
@@ -179,6 +179,15 @@ namespace LingoEngine.Members
         /// Retrieves the next member
         /// </summary>
         ILingoMember? GetMemberInCastByOffset(int numberOffset);
+
+        /// <summary>
+        /// Determines whether the pixel at the specified coordinates is fully transparent.
+        /// Coordinates are relative to the member's top-left corner.
+        /// </summary>
+        /// <param name="x">X coordinate in pixels.</param>
+        /// <param name="y">Y coordinate in pixels.</param>
+        /// <returns><c>true</c> if the pixel is transparent; otherwise, <c>false</c>.</returns>
+        bool IsPixelTransparent(int x, int y);
     }
 
     /// <summary>
@@ -320,6 +329,10 @@ namespace LingoEngine.Members
             if (!_linkedMemberRefUsers.Contains(refUser))
                 _linkedMemberRefUsers.Add(refUser);
         }
+
+        /// <inheritdoc/>
+        public virtual bool IsPixelTransparent(int x, int y)
+            => _frameworkMember.IsPixelTransparent(x, y);
 
         internal virtual void ReleaseFromRefUser(IMemberRefUser refUser)
         {

--- a/src/LingoEngine/Sprites/LingoSprite2D.cs
+++ b/src/LingoEngine/Sprites/LingoSprite2D.cs
@@ -608,10 +608,34 @@ When a movie stops, events occur in the following order:
 
 
         /// <summary>
-        /// Check if the mouse position is inside the bounding box of the sprite
+        /// Determines whether the mouse is inside the sprite, considering
+        /// transparent pixels for <see cref="LingoInkType.BackgroundTransparent"/>.
         /// </summary>
         public bool IsMouseInsideBoundingBox(LingoMouse mouse)
-            => Rect.Contains((mouse.MouseH, mouse.MouseV));
+        {
+            if (!Rect.Contains((mouse.MouseH, mouse.MouseV)))
+                return false;
+
+            if (InkType != LingoInkType.BackgroundTransparent || Member == null)
+                return true;
+
+            var rect = Rect;
+            if (Member.Width == 0 || Member.Height == 0 || Width == 0 || Height == 0)
+                return true;
+
+            var relX = (mouse.MouseH - rect.Left) / Width;
+            var relY = (mouse.MouseV - rect.Top) / Height;
+
+            int pixelX = (int)(relX * Member.Width);
+            int pixelY = (int)(relY * Member.Height);
+
+            if (FlipH)
+                pixelX = Member.Width - 1 - pixelX;
+            if (FlipV)
+                pixelY = Member.Height - 1 - pixelY;
+
+            return !Member.IsPixelTransparent(pixelX, pixelY);
+        }
 
         /// <summary>
         /// Check if the given point is inside the bounding box of the sprite


### PR DESCRIPTION
## Summary
- add IsPixelTransparent to framework and member interfaces
- teach SDL and Godot bitmap members to report pixel transparency
- skip mouse hits on transparent pixels for BackgroundTransparent sprites

## Testing
- `dotnet format LingoEngine.sln --include src/LingoEngine/Members/ILingoFrameworkMember.cs src/LingoEngine/Members/LingoMember.cs src/LingoEngine.SDL2/Bitmaps/SdlMemberBitmap.cs src/LingoEngine.LGodot/Bitmaps/LingoGodotMemberBitmap.cs src/LingoEngine/Sprites/LingoSprite2D.cs`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689cf798e7a083329263cd5e7b0720df