### PR TITLE
Fix SDL sprite registration point offset

### DIFF
--- a/src/LingoEngine.SDL2/Sprites/SdlSprite.cs
+++ b/src/LingoEngine.SDL2/Sprites/SdlSprite.cs
@@ -232,8 +232,8 @@ public class SdlSprite : ILingoFrameworkSprite, ILingoSDLComponent, IDisposable
             }
         }
 
-        ComponentContext.OffsetX = offset.X;
-        ComponentContext.OffsetY = offset.Y;
+        ComponentContext.OffsetX = -offset.X;
+        ComponentContext.OffsetY = -offset.Y;
         UpdateContextPosition();
         return _texture;
     }
@@ -359,13 +359,13 @@ public class SdlSprite : ILingoFrameworkSprite, ILingoSDLComponent, IDisposable
     private void ApplyBlend()
     {
         //ComponentContext.Blend = _directToStage ? 1f : _blend;
-        ComponentContext.Blend =  _directToStage ? 1f : _blend/100;
+        ComponentContext.Blend = _directToStage ? 1f : _blend / 100;
     }
 
     private void UpdateContextPosition()
     {
-        int x = (int)(_x - ComponentContext.OffsetX - ComponentContext.TargetWidth / 2f);
-        int y = (int)(_y - ComponentContext.OffsetY - ComponentContext.TargetHeight / 2f);
+        int x = (int)(_x - ComponentContext.TargetWidth / 2f);
+        int y = (int)(_y - ComponentContext.TargetHeight / 2f);
         ComponentContext.X = x;
         ComponentContext.Y = y;
     }


### PR DESCRIPTION
## Summary
- correct SDL sprite positioning by adjusting registration-point offset usage

## Testing
- `dotnet format src/LingoEngine.SDL2/LingoEngine.SDL2.csproj --include src/LingoEngine.SDL2/Sprites/SdlSprite.cs -v diagnostic`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689cfca8dbe883329f53eeabc1355ad4