### PR TITLE
Add user subscription management for textures

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Stages/StageSpriteSummaryOverlay.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/StageSpriteSummaryOverlay.cs
@@ -22,6 +22,8 @@ public class StageSpriteSummaryOverlay : IHasSpriteSelectedEvent, IDisposable
     private readonly IDirectorIconManager _iconManager;
     private readonly ILingoTexture2D _infoIcon;
     private readonly ILingoTexture2D _behaviorIcon;
+    private readonly ILingoTextureUserSubscription _infoIconSubscription;
+    private readonly ILingoTextureUserSubscription _behaviorIconSubscription;
 
     public LingoGfxCanvas Canvas => _canvas;
 
@@ -35,7 +37,9 @@ public class StageSpriteSummaryOverlay : IHasSpriteSelectedEvent, IDisposable
         _mediator.Subscribe(this);
         _iconManager = iconManager;
         _infoIcon = _iconManager.Get(DirectorIcon.Info);
+        _infoIconSubscription = _infoIcon.AddUser(this);
         _behaviorIcon = _iconManager.Get(DirectorIcon.BehaviorScript);
+        _behaviorIconSubscription = _behaviorIcon.AddUser(this);
     }
 
     /// <summary>Called when a sprite is selected.</summary>
@@ -71,7 +75,7 @@ public class StageSpriteSummaryOverlay : IHasSpriteSelectedEvent, IDisposable
             icons = icons.Append(_behaviorIcon).ToArray();
         }
 
-        int height = lines.Length * iconSize + (margin*2);
+        int height = lines.Length * iconSize + (margin * 2);
         int widthText = lines.Max(l => l.Length * 6);
         int width = Math.Max(120, widthText + iconSize + 8);
 
@@ -87,7 +91,7 @@ public class StageSpriteSummaryOverlay : IHasSpriteSelectedEvent, IDisposable
         {
             int y = i * iconSize + margin;
             _canvas.DrawPicture(icons[i], iconSize, iconSize, new LingoPoint(2, y));
-            _canvas.DrawText(new LingoPoint(iconSize + 4, y+ bugFixGodotNotUnderstandY), lines[i], null, LingoColorList.Black, fontSize);
+            _canvas.DrawText(new LingoPoint(iconSize + 4, y + bugFixGodotNotUnderstandY), lines[i], null, LingoColorList.Black, fontSize);
         }
 
         _canvas.Visibility = true;
@@ -96,6 +100,8 @@ public class StageSpriteSummaryOverlay : IHasSpriteSelectedEvent, IDisposable
     public void Dispose()
     {
         _mediator.Unsubscribe(this);
+        _infoIconSubscription.Release();
+        _behaviorIconSubscription.Release();
         _canvas.Dispose();
     }
 }

--- a/src/LingoEngine.LGodot/Bitmaps/LingoGodotImageTexture.cs
+++ b/src/LingoEngine.LGodot/Bitmaps/LingoGodotImageTexture.cs
@@ -1,21 +1,47 @@
-﻿using Godot;
+using System;
+using System.Collections.Generic;
+using Godot;
 using LingoEngine.Bitmaps;
 
-namespace LingoEngine.LGodot.Bitmaps
+namespace LingoEngine.LGodot.Bitmaps;
+
+public class LingoGodotTexture2D : ILingoTexture2D
 {
-   
-    public class LingoGodotTexture2D : ILingoTexture2D
+    private readonly Texture2D _texture;
+    public Texture2D Texture => _texture;
+
+    private readonly Dictionary<object, TextureSubscription> _users = new();
+
+    public LingoGodotTexture2D(Texture2D imageTexture)
     {
-        private readonly Texture2D _texture;
-        public Texture2D Texture => _texture;
+        _texture = imageTexture;
+    }
 
-        public LingoGodotTexture2D(Texture2D imageTexture)
+    public int Width => _texture.GetWidth();
+
+    public int Height => _texture._GetHeight();
+
+    public ILingoTextureUserSubscription AddUser(object user)
+    {
+        var sub = new TextureSubscription(() => RemoveUser(user));
+        _users.Add(user, sub);
+        return sub;
+    }
+
+    private void RemoveUser(object user)
+    {
+        _users.Remove(user);
+        if (_users.Count == 0)
         {
-            _texture = imageTexture;
+            _texture.Dispose();
         }
+    }
 
-        public int Width => _texture.GetWidth();
-
-        public int Height => _texture._GetHeight();
+    private class TextureSubscription : ILingoTextureUserSubscription
+    {
+        private readonly Action _onRelease;
+        public TextureSubscription(Action onRelease) => _onRelease = onRelease;
+        public void Release() => _onRelease();
     }
 }
+

--- a/src/LingoEngine.SDL2/Bitmaps/SdlImageTexture.cs
+++ b/src/LingoEngine.SDL2/Bitmaps/SdlImageTexture.cs
@@ -1,4 +1,6 @@
-﻿using LingoEngine.Bitmaps;
+using System;
+using System.Collections.Generic;
+using LingoEngine.Bitmaps;
 using LingoEngine.SDL2.SDLL;
 
 namespace LingoEngine.SDL2.Pictures;
@@ -8,10 +10,12 @@ public class SdlImageTexture : ILingoTexture2D
     private SDL.SDL_Surface _surfacePtr;
     public SDL.SDL_Surface Ptr => _surfacePtr;
 
-    public nint SurfaceId { get; }
+    public nint SurfaceId { get; private set; }
     public int Width { get; set; }
 
     public int Height { get; set; }
+
+    private readonly Dictionary<object, TextureSubscription> _users = new();
 
     public SdlImageTexture(SDL.SDL_Surface surfacePtr, nint surfaceId, int width, int height)
     {
@@ -20,13 +24,39 @@ public class SdlImageTexture : ILingoTexture2D
         Width = width;
         Height = height;
     }
+
+    public ILingoTextureUserSubscription AddUser(object user)
+    {
+        var sub = new TextureSubscription(() => RemoveUser(user));
+        _users.Add(user, sub);
+        return sub;
+    }
+
+    private void RemoveUser(object user)
+    {
+        _users.Remove(user);
+        if (_users.Count == 0 && SurfaceId != nint.Zero)
+        {
+            SDL.SDL_FreeSurface(SurfaceId);
+            SurfaceId = nint.Zero;
+        }
+    }
+
+    private class TextureSubscription : ILingoTextureUserSubscription
+    {
+        private readonly Action _onRelease;
+        public TextureSubscription(Action onRelease) => _onRelease = onRelease;
+        public void Release() => _onRelease();
+    }
 }
 
 public class SdlTexture2D : ILingoTexture2D
 {
-    public nint Texture { get; }
+    public nint Texture { get; private set; }
     public int Width { get; }
     public int Height { get; }
+
+    private readonly Dictionary<object, TextureSubscription> _users = new();
 
     public SdlTexture2D(nint texture, int width, int height)
     {
@@ -34,4 +64,29 @@ public class SdlTexture2D : ILingoTexture2D
         Width = width;
         Height = height;
     }
+
+    public ILingoTextureUserSubscription AddUser(object user)
+    {
+        var sub = new TextureSubscription(() => RemoveUser(user));
+        _users.Add(user, sub);
+        return sub;
+    }
+
+    private void RemoveUser(object user)
+    {
+        _users.Remove(user);
+        if (_users.Count == 0 && Texture != nint.Zero)
+        {
+            SDL.SDL_DestroyTexture(Texture);
+            Texture = nint.Zero;
+        }
+    }
+
+    private class TextureSubscription : ILingoTextureUserSubscription
+    {
+        private readonly Action _onRelease;
+        public TextureSubscription(Action onRelease) => _onRelease = onRelease;
+        public void Release() => _onRelease();
+    }
 }
+

--- a/src/LingoEngine.SDL2/Gfx/SdlGfxPanel.cs
+++ b/src/LingoEngine.SDL2/Gfx/SdlGfxPanel.cs
@@ -29,11 +29,14 @@ namespace LingoEngine.SDL2.Gfx
 
         public void RemoveItem(ILingoFrameworkGfxLayoutNode child)
         {
-            _children.Remove(child);
+            if (_children.Remove(child))
+                (child as IDisposable)?.Dispose();
         }
 
         public void RemoveAll()
         {
+            foreach (var child in _children)
+                (child as IDisposable)?.Dispose();
             _children.Clear();
         }
 

--- a/src/LingoEngine.Unity/Bitmaps/UnityImageTexture.cs
+++ b/src/LingoEngine.Unity/Bitmaps/UnityImageTexture.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using LingoEngine.Bitmaps;
 using UnityEngine;
 
@@ -5,13 +7,39 @@ namespace LingoEngine.Unity.Bitmaps;
 
 public class UnityTexture2D : ILingoTexture2D
 {
-    public Texture2D Texture { get; }
+    public Texture2D? Texture { get; private set; }
+
+    private readonly Dictionary<object, TextureSubscription> _users = new();
 
     public UnityTexture2D(Texture2D texture)
     {
         Texture = texture;
     }
 
-    public int Width => Texture.width;
-    public int Height => Texture.height;
+    public int Width => Texture!.width;
+    public int Height => Texture!.height;
+
+    public ILingoTextureUserSubscription AddUser(object user)
+    {
+        var sub = new TextureSubscription(() => RemoveUser(user));
+        _users.Add(user, sub);
+        return sub;
+    }
+
+    private void RemoveUser(object user)
+    {
+        _users.Remove(user);
+        if (_users.Count == 0 && Texture != null)
+        {
+            UnityEngine.Object.Destroy(Texture);
+            Texture = null;
+        }
+    }
+
+    private class TextureSubscription : ILingoTextureUserSubscription
+    {
+        private readonly Action _onRelease;
+        public TextureSubscription(Action onRelease) => _onRelease = onRelease;
+        public void Release() => _onRelease();
+    }
 }

--- a/src/LingoEngine/Bitmaps/LingoImageTexture.cs
+++ b/src/LingoEngine/Bitmaps/LingoImageTexture.cs
@@ -1,11 +1,16 @@
-﻿namespace LingoEngine.Bitmaps
+namespace LingoEngine.Bitmaps;
+
+public interface ILingoTextureUserSubscription
 {
-    
-    public interface ILingoTexture2D
-    {
-        int Width { get; }
-
-        int Height { get; }
-
-    }
+    void Release();
 }
+
+public interface ILingoTexture2D
+{
+    int Width { get; }
+
+    int Height { get; }
+
+    ILingoTextureUserSubscription AddUser(object user);
+}
+

--- a/src/LingoEngine/FilmLoops/LingoFilmLoopPlayer.cs
+++ b/src/LingoEngine/FilmLoops/LingoFilmLoopPlayer.cs
@@ -27,6 +27,7 @@ namespace LingoEngine.FilmLoops
         private LingoFilmLoopMember? FilmLoop => _sprite.Member as LingoFilmLoopMember;
 
         public ILingoTexture2D? Texture { get; private set; }
+        private ILingoTextureUserSubscription? _textureSubscription;
 
         internal LingoFilmLoopPlayer(ILingoSprite2DLight sprite, ILingoEventMediator eventMediator, ILingoCastLibsContainer castLibs, bool isInnerPlayer = false)
         {
@@ -70,7 +71,7 @@ namespace LingoEngine.FilmLoops
                     nestedPlayer = runtime.GetFilmLoopPlayer();
                     if (nestedPlayer == null)
                     {
-                        nestedPlayer = new LingoFilmLoopPlayer(runtime, _mediator, _castLibs,true);
+                        nestedPlayer = new LingoFilmLoopPlayer(runtime, _mediator, _castLibs, true);
                         runtime.AddActor(nestedPlayer);
                         nestedPlayer.BeginSprite();
                     }
@@ -79,7 +80,7 @@ namespace LingoEngine.FilmLoops
             }
         }
 
-        
+
 
         public void StepFrame()
         {
@@ -110,6 +111,9 @@ namespace LingoEngine.FilmLoops
                 layer.Runtime.RemoveMe();
             }
             _layers.Clear();
+            _textureSubscription?.Release();
+            _textureSubscription = null;
+            Texture = null;
             var fl = FilmLoop;
             if (fl != null)
                 fl.Framework<ILingoFrameworkMemberFilmLoop>().Media = null;
@@ -187,7 +191,9 @@ namespace LingoEngine.FilmLoops
                 return;
 
             var frameworkFilmLoop = fl.Framework<ILingoFrameworkMemberFilmLoop>();
+            _textureSubscription?.Release();
             Texture = frameworkFilmLoop.ComposeTexture(_sprite, _activeLayers);
+            _textureSubscription = Texture.AddUser(this);
             _sprite.UpdateTexture(Texture);
         }
 

--- a/src/LingoEngine/Gfx/LingoGfxButton.cs
+++ b/src/LingoEngine/Gfx/LingoGfxButton.cs
@@ -9,12 +9,30 @@ namespace LingoEngine.Gfx
     {
         public string Text { get => _framework.Text; set => _framework.Text = value; }
         public bool Enabled { get => _framework.Enabled; set => _framework.Enabled = value; }
-        public ILingoTexture2D? IconTexture { get => _framework.IconTexture; set => _framework.IconTexture = value; }
+        private ILingoTextureUserSubscription? _iconTextureSubscription;
+        public ILingoTexture2D? IconTexture
+        {
+            get => _framework.IconTexture;
+            set
+            {
+                _iconTextureSubscription?.Release();
+                _iconTextureSubscription = value?.AddUser(this);
+                _framework.IconTexture = value;
+            }
+        }
 
         public event Action? Pressed
         {
             add { _framework.Pressed += value; }
             remove { _framework.Pressed -= value; }
+        }
+
+        public override void Dispose()
+        {
+            _iconTextureSubscription?.Release();
+            _iconTextureSubscription = null;
+            _framework.IconTexture = null;
+            base.Dispose();
         }
     }
 }

--- a/src/LingoEngine/Gfx/LingoGfxStateButton.cs
+++ b/src/LingoEngine/Gfx/LingoGfxStateButton.cs
@@ -9,10 +9,41 @@ namespace LingoEngine.Gfx
     {
         /// <summary>Displayed text on the button.</summary>
         public string Text { get => _framework.Text; set => _framework.Text = value; }
-        /// <summary>Icon texture displayed on the button.</summary>
-        public Bitmaps.ILingoTexture2D? TextureOn { get => _framework.TextureOn; set => _framework.TextureOn = value; }
+        /// <summary>Icon texture displayed when the button is on.</summary>
+        private ILingoTextureUserSubscription? _textureOnSubscription;
+        public ILingoTexture2D? TextureOn
+        {
+            get => _framework.TextureOn;
+            set
+            {
+                _textureOnSubscription?.Release();
+                _textureOnSubscription = value?.AddUser(this);
+                _framework.TextureOn = value;
+            }
+        }
         /// <summary>Current toggle state.</summary>
         public bool IsOn { get => _framework.IsOn; set => _framework.IsOn = value; }
-        public ILingoTexture2D? TextureOff { get => _framework.TextureOff; set => _framework.TextureOff = value; }
+        private ILingoTextureUserSubscription? _textureOffSubscription;
+        public ILingoTexture2D? TextureOff
+        {
+            get => _framework.TextureOff;
+            set
+            {
+                _textureOffSubscription?.Release();
+                _textureOffSubscription = value?.AddUser(this);
+                _framework.TextureOff = value;
+            }
+        }
+
+        public override void Dispose()
+        {
+            _textureOnSubscription?.Release();
+            _textureOffSubscription?.Release();
+            _textureOnSubscription = null;
+            _textureOffSubscription = null;
+            _framework.TextureOn = null;
+            _framework.TextureOff = null;
+            base.Dispose();
+        }
     }
 }

--- a/src/LingoEngine/Sprites/LingoSprite2DVirtual.cs
+++ b/src/LingoEngine/Sprites/LingoSprite2DVirtual.cs
@@ -20,6 +20,7 @@ namespace LingoEngine.Sprites
         private LingoMember? _Member;
         private Action<LingoSprite2DVirtual>? _onRemoveMe;
         private int _constraint;
+        private ILingoTextureUserSubscription? _textureSubscription;
 
 
         #region Properties
@@ -361,6 +362,9 @@ namespace LingoEngine.Sprites
 
         public override void OnRemoveMe()
         {
+            _textureSubscription?.Release();
+            _textureSubscription = null;
+            Texture = null;
             _Member?.ReleaseFromRefUser(this);
             if (_onRemoveMe != null)
                 _onRemoveMe(this);
@@ -368,6 +372,9 @@ namespace LingoEngine.Sprites
 
         public void MemberHasBeenRemoved()
         {
+            _textureSubscription?.Release();
+            _textureSubscription = null;
+            Texture = null;
             _Member = null;
         }
 
@@ -379,7 +386,9 @@ namespace LingoEngine.Sprites
 
         public void UpdateTexture(ILingoTexture2D texture)
         {
+            _textureSubscription?.Release();
             Texture = texture;
+            _textureSubscription = texture.AddUser(this);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure `LingoSprite2DVirtual` tracks texture usage and releases subscriptions when textures change or the sprite is removed
- add subscription tracking and cleanup for `LingoGfxButton` and `LingoGfxStateButton`, and subscribe icons in `StageSpriteSummaryOverlay`
- dispose child nodes in `SdlGfxPanel` to free their textures

## Testing
- `dotnet format whitespace src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/Sprites/LingoSprite2DVirtual.cs src/LingoEngine/Gfx/LingoGfxButton.cs src/LingoEngine/Gfx/LingoGfxStateButton.cs --verbosity diagnostic`
- `dotnet format whitespace src/LingoEngine.SDL2/LingoEngine.SDL2.csproj --include src/LingoEngine.SDL2/Gfx/SdlGfxPanel.cs --verbosity diagnostic`
- `dotnet format whitespace src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj --include src/Director/LingoEngine.Director.Core/Stages/StageSpriteSummaryOverlay.cs --verbosity diagnostic`
- `dotnet build src/LingoEngine.SDL2/LingoEngine.SDL2.csproj`
- `dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj` *(fails: CSharpCodeProvider type not found)*
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689dc3be374c8332ad3a13120e7532b4