### PR TITLE
Add package metadata for Lingo, Director, and integration projects

### DIFF
--- a/src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj
+++ b/src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj
@@ -12,7 +12,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>LingoEngine.IdeLauncher</PackageId>
     <Version>1.0.0</Version>
-    <Authors>Emmanuel The Creatory</Authors>
+    <Authors>Emmanuel The Creator</Authors>
     <Company>The Community</Company>
     <Description>
       Editor tooling for LingoEngine that emulates the classic Macromedia Director authoring environment. Includes file navigation, script launching, and extensible integration points for modern IDEs like Visual Studio and VS Code.

--- a/src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj
+++ b/src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj
@@ -1,41 +1,51 @@
-﻿<Project Sdk="Godot.NET.Sdk/4.5.0-dev.5">
+<Project Sdk="Godot.NET.Sdk/4.5.0-dev.5">
 
-	<PropertyGroup>
-		<OutputType>Library</OutputType>
-		<TargetFramework>net8</TargetFramework>
-		<!-- Use netstandard for compatibility -->
-		<GodotVersion>4.5.0-dev.5</GodotVersion>
-		<LangVersion>12</LangVersion>
-		<Nullable>enable</Nullable>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Platforms>AnyCPU;x64;x86</Platforms>
-	</PropertyGroup>
-	<ItemGroup>
-		<Compile Remove="obj\**" />
-		<EmbeddedResource Remove="obj\**" />
-	</ItemGroup>
-	<ItemGroup>
-	  <None Include="ReadMe.md" />
-	</ItemGroup>
-
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net8</TargetFramework>
+    <!-- Use netstandard for compatibility -->
+    <GodotVersion>4.5.0-dev.5</GodotVersion>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Platforms>AnyCPU;x64;x86</Platforms>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!-- NuGet Packaging Metadata -->
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>LingoEngine.Director.LGodot</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Emmanuel The Creator</Authors>
+    <Company>The Community</Company>
+    <Description>Godot integration layer for LingoEngine Director tooling.</Description>
+    <RepositoryUrl>https://github.com/EmmanuelTheCreator/LingoEngine</RepositoryUrl>
+    <PackageTags>Lingo Director Godot LingoEngine</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="obj\\**" />
+    <EmbeddedResource Remove="obj\\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="ReadMe.md" />
+  </ItemGroup>
 
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <DefineConstants>$(DefineConstants);USE_WINDOWS_FEATURES</DefineConstants>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Godot.NET.Sdk" Version="4.5.0-dev.5" />
+  </ItemGroup>
 
   <ItemGroup>
-		<PackageReference Include="Godot.NET.Sdk" Version="4.5.0-dev.5" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <ProjectReference Include="..\..\LingoEngine.IO.Data\LingoEngine.IO.Data.csproj" />
-	  <ProjectReference Include="..\..\LingoEngine.IO\LingoEngine.IO.csproj" />
-	  <ProjectReference Include="..\..\LingoEngine.LGodot\LingoEngine.LGodot.csproj" />
-	  <ProjectReference Include="..\..\LingoEngine.Lingo.Core\LingoEngine.Lingo.Core.csproj" />
-	  <ProjectReference Include="..\..\LingoEngine\LingoEngine.csproj" />
-	  <ProjectReference Include="..\LingoEngine.Director.Core\LingoEngine.Director.Core.csproj" />
-	</ItemGroup>
-
+    <ProjectReference Include="..\..\LingoEngine.IO.Data\LingoEngine.IO.Data.csproj" />
+    <ProjectReference Include="..\..\LingoEngine.IO\LingoEngine.IO.csproj" />
+    <ProjectReference Include="..\..\LingoEngine.LGodot\LingoEngine.LGodot.csproj" />
+    <ProjectReference Include="..\..\LingoEngine.Lingo.Core\LingoEngine.Lingo.Core.csproj" />
+    <ProjectReference Include="..\..\LingoEngine\LingoEngine.csproj" />
+    <ProjectReference Include="..\LingoEngine.Director.Core\LingoEngine.Director.Core.csproj" />
+  </ItemGroup>
 
 </Project>
+

--- a/src/LingoEngine.LGodot/LingoEngine.LGodot.csproj
+++ b/src/LingoEngine.LGodot/LingoEngine.LGodot.csproj
@@ -1,18 +1,30 @@
 ﻿<Project Sdk="Godot.NET.Sdk/4.5.0-dev.5">
 
-	<PropertyGroup>
-		<OutputType>Library</OutputType>
-		<TargetFramework>net8</TargetFramework>
-		<!-- Use netstandard for compatibility -->
-		<GodotVersion>4.5.0-dev.5</GodotVersion>
-		<LangVersion>12</LangVersion>
-		<Nullable>enable</Nullable>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Platforms>AnyCPU;x64;x86</Platforms>
-		<AssemblyName>LingoEngine.LGodot</AssemblyName>
-		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-		<!-- Specify the Godot version -->
-	</PropertyGroup>
+  <PropertyGroup>
+                <OutputType>Library</OutputType>
+                <TargetFramework>net8</TargetFramework>
+                <!-- Use netstandard for compatibility -->
+                <GodotVersion>4.5.0-dev.5</GodotVersion>
+                <LangVersion>12</LangVersion>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Platforms>AnyCPU;x64;x86</Platforms>
+                <AssemblyName>LingoEngine.LGodot</AssemblyName>
+                <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+                <!-- Specify the Godot version -->
+        </PropertyGroup>
+  <PropertyGroup>
+    <!-- NuGet Packaging Metadata -->
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>LingoEngine.LGodot</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Emmanuel The Creator</Authors>
+    <Company>The Community</Company>
+    <Description>Godot engine integration for LingoEngine.</Description>
+    <RepositoryUrl>https://github.com/EmmanuelTheCreator/LingoEngine</RepositoryUrl>
+    <PackageTags>LingoEngine Godot</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Remove="obj\**" />
     <EmbeddedResource Remove="obj\**" />

--- a/src/LingoEngine.Lingo.Core/LingoEngine.Lingo.Core.csproj
+++ b/src/LingoEngine.Lingo.Core/LingoEngine.Lingo.Core.csproj
@@ -6,9 +6,21 @@
     <LangVersion>12</LangVersion>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
-	<ItemGroup>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-			<_Parameter1>LingoEngine.Lingo.Core.Tests</_Parameter1>
-		</AssemblyAttribute>
-	</ItemGroup>
+  <PropertyGroup>
+    <!-- NuGet Packaging Metadata -->
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>LingoEngine.Lingo.Core</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Emmanuel The Creator</Authors>
+    <Company>The Community</Company>
+    <Description>Core runtime implementation of the Lingo scripting language.</Description>
+    <RepositoryUrl>https://github.com/EmmanuelTheCreator/LingoEngine</RepositoryUrl>
+    <PackageTags>Lingo Director Scripting LingoEngine</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+        <ItemGroup>
+                <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+                        <_Parameter1>LingoEngine.Lingo.Core.Tests</_Parameter1>
+                </AssemblyAttribute>
+        </ItemGroup>
 </Project>

--- a/src/LingoEngine.SDL2/LingoEngine.SDL2.csproj
+++ b/src/LingoEngine.SDL2/LingoEngine.SDL2.csproj
@@ -6,7 +6,20 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <Platforms>AnyCPU;x64;x86</Platforms>
-	 
+
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet Packaging Metadata -->
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>LingoEngine.SDL2</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Emmanuel The Creator</Authors>
+    <Company>The Community</Company>
+    <Description>SDL2 bindings and rendering support for LingoEngine.</Description>
+    <RepositoryUrl>https://github.com/EmmanuelTheCreator/LingoEngine</RepositoryUrl>
+    <PackageTags>LingoEngine SDL2</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LingoEngine.Unity/LingoEngine.Unity.csproj
+++ b/src/LingoEngine.Unity/LingoEngine.Unity.csproj
@@ -8,6 +8,19 @@
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- NuGet Packaging Metadata -->
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>LingoEngine.Unity</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Emmanuel The Creator</Authors>
+    <Company>The Community</Company>
+    <Description>Unity engine integration for LingoEngine.</Description>
+    <RepositoryUrl>https://github.com/EmmanuelTheCreator/LingoEngine</RepositoryUrl>
+    <PackageTags>LingoEngine Unity</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\LingoEngine\LingoEngine.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- prepare LingoEngine.Lingo.Core for NuGet by adding package metadata and author
- correct author metadata and ensure packaging info for Director Core project
- add packaging details to Director Godot integration project
- include NuGet metadata for SDL2, Godot, and Unity integration libraries

## Testing
- `dotnet build src/LingoEngine.SDL2/LingoEngine.SDL2.csproj`
- `dotnet build src/LingoEngine.LGodot/LingoEngine.LGodot.csproj`
- `dotnet build src/LingoEngine.Unity/LingoEngine.Unity.csproj`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689eba257a448332b04d44921fa46469