### PR TITLE
feat: target net48

### DIFF
--- a/src/LingoEngine/Animations/LingoTween.cs
+++ b/src/LingoEngine/Animations/LingoTween.cs
@@ -71,8 +71,8 @@ namespace LingoEngine.Animations
                 return default!;
             if (frame <= _keys[0].Frame)
                 return _keys[0].Value;
-            if (frame >= _keys[^1].Frame)
-                return _keys[^1].Value;
+            if (frame >= _keys[_keys.Count - 1].Frame)
+                return _keys[_keys.Count - 1].Value;
 
             for (int i = 0; i < _keys.Count - 1; i++)
             {
@@ -92,7 +92,7 @@ namespace LingoEngine.Animations
                     return Lerp(k0.Value, k1.Value, t);
                 }
             }
-            return _keys[^1].Value;
+            return _keys[_keys.Count - 1].Value;
         }
 
         private static float ApplyEase(float t, LingoEaseType ease)

--- a/src/LingoEngine/Bitmaps/ILingoTexture2D.cs
+++ b/src/LingoEngine/Bitmaps/ILingoTexture2D.cs
@@ -1,5 +1,3 @@
-using System.Reflection.Metadata;
-
 namespace LingoEngine.Bitmaps;
 
 public interface ILingoTextureUserSubscription
@@ -13,7 +11,7 @@ public interface ILingoTexture2D : IDisposable
     int Width { get; }
 
     int Height { get; }
-    public bool IsDisposed{        get;}
+    public bool IsDisposed { get; }
     string Name { get; set; }
 
     ILingoTextureUserSubscription AddUser(object user);

--- a/src/LingoEngine/Bitmaps/LingoImage.cs
+++ b/src/LingoEngine/Bitmaps/LingoImage.cs
@@ -11,7 +11,7 @@
     }
     public class LingoImage : ILingoImage
     {
-        public static int[] AllowedBitDepthsValues => [1, 2, 4, 8, 16, 32];
+        public static int[] AllowedBitDepthsValues => new[] { 1, 2, 4, 8, 16, 32 };
         public int Width { get; private set; }
 
         public int Height { get; private set; }
@@ -21,7 +21,7 @@
         public LingoImage(int width, int height, int bitDepths)
         {
             if (!AllowedBitDepthsValues.Contains(bitDepths))
-                throw new ArgumentException("bitDepths must be in the range of " + string.Join(',', AllowedBitDepthsValues), nameof(BitDepths));
+                throw new ArgumentException("bitDepths must be in the range of " + string.Join(",", AllowedBitDepthsValues), nameof(BitDepths));
             Width = width;
             Height = height;
             BitDepths = bitDepths;

--- a/src/LingoEngine/Commands/ICommandHandler.cs
+++ b/src/LingoEngine/Commands/ICommandHandler.cs
@@ -2,6 +2,10 @@ namespace LingoEngine.Commands;
 
 public interface ICommandHandler<TCommand> where TCommand : ILingoCommand
 {
+#if NET48
+    bool CanExecute(TCommand command);
+#else
     bool CanExecute(TCommand command) => true;
+#endif
     bool Handle(TCommand command);
 }

--- a/src/LingoEngine/Core/LingoPlayer.cs
+++ b/src/LingoEngine/Core/LingoPlayer.cs
@@ -252,7 +252,11 @@ namespace LingoEngine.Core
             }
             else
             {
+#if NET48
+                var target = MathCompat.Clamp(movie.Frame + offset, 1, movie.FrameCount);
+#else
                 var target = Math.Clamp(movie.Frame + offset, 1, movie.FrameCount);
+#endif
                 movie.GoToAndStop(target);
             }
             return true;

--- a/src/LingoEngine/Core/NETFramework4/IsExternalInit.cs
+++ b/src/LingoEngine/Core/NETFramework4/IsExternalInit.cs
@@ -1,0 +1,6 @@
+#if NET48
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}
+#endif

--- a/src/LingoEngine/Core/NETFramework4/Polyfills.cs
+++ b/src/LingoEngine/Core/NETFramework4/Polyfills.cs
@@ -1,0 +1,47 @@
+#if NET48
+using System;
+
+namespace System
+{
+    internal static class MathF
+    {
+        public const float PI = (float)Math.PI;
+        public static float Pow(float x, float y) => (float)Math.Pow(x, y);
+        public static float Tan(float x) => (float)Math.Tan(x);
+        public static float Cos(float x) => (float)Math.Cos(x);
+        public static float Sin(float x) => (float)Math.Sin(x);
+        public static float Min(float x, float y) => Math.Min(x, y);
+        public static float Max(float x, float y) => Math.Max(x, y);
+        public static float Ceiling(float x) => (float)Math.Ceiling(x);
+    }
+
+    internal static class MathCompat
+    {
+        public static int Clamp(int value, int min, int max) => Math.Min(Math.Max(value, min), max);
+        public static float Clamp(float value, float min, float max) => Math.Min(Math.Max(value, min), max);
+    }
+
+    internal struct HashCode
+    {
+        private int _value;
+        public void Add<T>(T value) => _value = (_value * 31) + (value?.GetHashCode() ?? 0);
+        public int ToHashCode() => _value;
+        public static int Combine<T1, T2>(T1 v1, T2 v2)
+        {
+            int hash = 17;
+            hash = hash * 31 + (v1?.GetHashCode() ?? 0);
+            hash = hash * 31 + (v2?.GetHashCode() ?? 0);
+            return hash;
+        }
+        public static int Combine<T1, T2, T3, T4>(T1 v1, T2 v2, T3 v3, T4 v4)
+        {
+            int hash = 17;
+            hash = hash * 31 + (v1?.GetHashCode() ?? 0);
+            hash = hash * 31 + (v2?.GetHashCode() ?? 0);
+            hash = hash * 31 + (v3?.GetHashCode() ?? 0);
+            hash = hash * 31 + (v4?.GetHashCode() ?? 0);
+            return hash;
+        }
+    }
+}
+#endif

--- a/src/LingoEngine/FilmLoops/LingoFilmLoopComposer.cs
+++ b/src/LingoEngine/FilmLoops/LingoFilmLoopComposer.cs
@@ -125,7 +125,11 @@ public static class LingoFilmLoopComposer
                 destW,
                 destH,
                 transform,
+#if NET48
+                MathCompat.Clamp(layer.Blend / 100f, 0f, 1f),
+#else
                 Math.Clamp(layer.Blend / 100f, 0f, 1f),
+#endif
                 layer.InkType,
                 layer.BackColor,
                 layer));

--- a/src/LingoEngine/Gfx/ILingoFrameworkGfxInputNumber.cs
+++ b/src/LingoEngine/Gfx/ILingoFrameworkGfxInputNumber.cs
@@ -2,18 +2,22 @@ using LingoEngine.Primitives;
 
 namespace LingoEngine.Gfx
 {
-   
+
     public interface ILingoFrameworkGfxInputNumber : ILingoFrameworkGfxNodeInput
     {
         LingoNumberType NumberType { get; set; }
         int FontSize { get; set; }
     }
     public interface ILingoFrameworkGfxInputNumber<TValue> : ILingoFrameworkGfxInputNumber
+#if NET48
+        where TValue : struct
+#else
         where TValue : System.Numerics.INumber<TValue>
+#endif
     {
         TValue Value { get; set; }
         TValue Min { get; set; }
         TValue Max { get; set; }
-      
+
     }
 }

--- a/src/LingoEngine/Gfx/LingoGfxInputNumber.cs
+++ b/src/LingoEngine/Gfx/LingoGfxInputNumber.cs
@@ -4,11 +4,15 @@ namespace LingoEngine.Gfx
 {
 
     public struct NullableNum<TValue>
+#if NET48
+        where TValue : struct
+#else
         where TValue : System.Numerics.INumber<TValue>
+#endif
     {
         private TValue? _Value;
         public TValue Value => _Value ?? throw new InvalidOperationException("Value is null. Use HasValue to check if a value is present.");
-        public bool HasValue{ get; set; }
+        public bool HasValue { get; set; }
         public NullableNum()
         {
             HasValue = false;
@@ -37,7 +41,11 @@ namespace LingoEngine.Gfx
     /// Engine level wrapper for a numeric input field.
     /// </summary>
     public class LingoGfxInputNumber<TValue> : LingoGfxInputBase<ILingoFrameworkGfxInputNumber<TValue>>
+#if NET48
+        where TValue : struct
+#else
         where TValue : System.Numerics.INumber<TValue>
+#endif
     {
         public TValue Value { get => _framework.Value; set => _framework.Value = value; }
         public TValue Min { get => _framework.Min; set => _framework.Min = value; }

--- a/src/LingoEngine/Inputs/LingoJoystickKeyboard.cs
+++ b/src/LingoEngine/Inputs/LingoJoystickKeyboard.cs
@@ -290,7 +290,7 @@ namespace LingoEngine.Inputs
             if (value == "\b")
             {
                 if (Text.Length > 0)
-                    Text = Text[..^1];
+                    Text = Text.Substring(0, Text.Length - 1);
             }
             else
             {

--- a/src/LingoEngine/LingoEngine.csproj
+++ b/src/LingoEngine/LingoEngine.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!--<TargetFrameworks>net8.0; Net48</TargetFrameworks>-->
-    <TargetFrameworks>net8.0;</TargetFrameworks>
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
@@ -15,6 +14,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
 

--- a/src/LingoEngine/Members/ILingoFrameworkMember.cs
+++ b/src/LingoEngine/Members/ILingoFrameworkMember.cs
@@ -38,6 +38,10 @@ namespace LingoEngine.Members
         /// <param name="x">X coordinate in pixels.</param>
         /// <param name="y">Y coordinate in pixels.</param>
         /// <returns><c>true</c> if the pixel is transparent; otherwise, <c>false</c>.</returns>
+#if NET48
+        bool IsPixelTransparent(int x, int y);
+#else
         bool IsPixelTransparent(int x, int y) => false;
+#endif
     }
 }

--- a/src/LingoEngine/Movies/LingoFrameLabelManager.cs
+++ b/src/LingoEngine/Movies/LingoFrameLabelManager.cs
@@ -81,7 +81,7 @@ namespace LingoEngine.Movies
             if (next == int.MaxValue)
                 return frame + 10;
             return next;
-        } 
+        }
         public int GetPreviousLabelFrame(int frame)
         {
             var previous = _scoreLabels.Values
@@ -155,9 +155,11 @@ namespace LingoEngine.Movies
         }
 
 
+        public bool CanExecute(SetFrameLabelCommand command) => true;
+
         public bool Handle(SetFrameLabelCommand command)
         {
-           SetScoreLabel(command.FrameNumber, command.Name);
+            SetScoreLabel(command.FrameNumber, command.Name);
             return true;
         }
 
@@ -165,7 +167,7 @@ namespace LingoEngine.Movies
 
         public bool Handle(AddFrameLabelCommand command)
         {
-           SetScoreLabel(command.FrameNumber, command.Name);
+            SetScoreLabel(command.FrameNumber, command.Name);
             return true;
         }
 
@@ -176,7 +178,7 @@ namespace LingoEngine.Movies
             SetScoreLabel(command.PreviousFrame, null);
             SetScoreLabel(command.NewFrame, command.Name);
             return true;
-        } 
+        }
         public bool CanExecute(DeleteFrameLabelCommand command) => true;
 
         public bool Handle(DeleteFrameLabelCommand command)
@@ -184,6 +186,6 @@ namespace LingoEngine.Movies
             return DeleteLabel(command.Frame);
         }
 
-        
+
     }
 }

--- a/src/LingoEngine/Primitives/LingoColor.cs
+++ b/src/LingoEngine/Primitives/LingoColor.cs
@@ -1,5 +1,7 @@
-﻿namespace LingoEngine.Primitives
-{
+﻿using System;
+
+namespace LingoEngine.Primitives
+{ 
     /// <summary>
     /// Represents a color value in the Lingo system, supporting palette index, RGB, and optional name.
     /// Platform-agnostic.
@@ -47,7 +49,11 @@
         /// </summary>
         public LingoColor Lighten(float factor)
         {
+#if NET48
+            factor = MathCompat.Clamp(factor, 0f, 1f);
+#else
             factor = Math.Clamp(factor, 0f, 1f);
+#endif
             byte r = (byte)(R + (255 - R) * factor);
             byte g = (byte)(G + (255 - G) * factor);
             byte b = (byte)(B + (255 - B) * factor);
@@ -59,7 +65,11 @@
         /// </summary>
         public LingoColor Darken(float factor)
         {
+#if NET48
+            factor = MathCompat.Clamp(factor, 0f, 1f);
+#else
             factor = Math.Clamp(factor, 0f, 1f);
+#endif
             byte r = (byte)(R * (1f - factor));
             byte g = (byte)(G * (1f - factor));
             byte b = (byte)(B * (1f - factor));

--- a/src/LingoEngine/Primitives/LingoList.cs
+++ b/src/LingoEngine/Primitives/LingoList.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 
 namespace LingoEngine.Primitives
 {
@@ -127,12 +128,22 @@ namespace LingoEngine.Primitives
         /// <summary>
         /// Gets the last item in the list.
         /// </summary>
-        public T GetLast() => _items[^1];
+        public T GetLast()
+#if NET48
+            => _items[_items.Count - 1];
+#else
+            => _items[^1];
+#endif
 
         /// <summary>
         /// Gets a random item in the list.
         /// </summary>
+#if NET48
+        private static readonly Random _random = new Random();
+        public T GetAValue() => _items[_random.Next(0, _items.Count)];
+#else
         public T GetAValue() => _items[Random.Shared.Next(0, _items.Count)];
+#endif
 
         /// <summary>
         /// Returns the Lingo type identifier.

--- a/src/LingoEngine/Primitives/LingoPropertyList.cs
+++ b/src/LingoEngine/Primitives/LingoPropertyList.cs
@@ -19,6 +19,9 @@
     {
         private readonly Dictionary<TKey, TValue> _dict = new();
         private readonly List<TKey> _keyOrder = new();
+#if NET48
+        private static readonly Random _random = new Random();
+#endif
 
         /// <summary>
         /// Gets or sets the value associated with the specified key.
@@ -279,14 +282,23 @@
         /// <summary>
         /// Gets the last value.
         /// </summary>
-        public TValue GetLast() => _dict[_keyOrder[^1]];
+        public TValue GetLast()
+#if NET48
+            => _dict[_keyOrder[_keyOrder.Count - 1]];
+#else
+            => _dict[_keyOrder[^1]];
+#endif
 
         /// <summary>
         /// Gets a random key.
         /// </summary>
         public TKey GetAProp()
         {
+#if NET48
+            int i = _random.Next(0, _keyOrder.Count);
+#else
             int i = Random.Shared.Next(0, _keyOrder.Count);
+#endif
             return _keyOrder[i];
         }
 

--- a/src/LingoEngine/Sounds/LingoAudioSpriteManager.cs
+++ b/src/LingoEngine/Sounds/LingoAudioSpriteManager.cs
@@ -2,6 +2,7 @@
 using LingoEngine.Movies;
 using LingoEngine.Scripts;
 using LingoEngine.Sprites;
+using System;
 
 namespace LingoEngine.Sounds
 {
@@ -27,7 +28,11 @@ namespace LingoEngine.Sounds
         public LingoSpriteSound Add(int channel, int startFrame, LingoMemberSound sound)
         {
             int lengthFrames = (int)Math.Ceiling(sound.Length * _movie.Tempo);
+#if NET48
+            int end = MathCompat.Clamp(startFrame + lengthFrames - 1, startFrame, _movie.FrameCount);
+#else
             int end = Math.Clamp(startFrame + lengthFrames - 1, startFrame, _movie.FrameCount);
+#endif
             return AddSprite(channel, "Audio "+channel, c =>
             {
                 c.Init(channel, startFrame, end, sound);

--- a/src/LingoEngine/Sounds/LingoSoundChannel.cs
+++ b/src/LingoEngine/Sounds/LingoSoundChannel.cs
@@ -1,9 +1,3 @@
-﻿using static System.Net.Mime.MediaTypeNames;
-using System.Net.NetworkInformation;
-using System.Numerics;
-using System;
-using System.Threading.Channels;
-
 namespace LingoEngine.Sounds
 {
     /// <summary>
@@ -183,7 +177,9 @@ namespace LingoEngine.Sounds
         /// <inheritdoc/>
         public float PreloadTime { get; set; }
         public float CurrentTime { get => _frameworkSoundChannel.CurrentTime; set => _frameworkSoundChannel.CurrentTime = value; }
-        public bool Mute { get => mute;
+        public bool Mute
+        {
+            get => mute;
             set
             {
                 mute = value;
@@ -288,7 +284,7 @@ namespace LingoEngine.Sounds
             if (preloadTime > -1) sound.PreloadTime = preloadTime;
             _playlist.Enqueue(sound);
         }
-       
+
         /// <inheritdoc/>
         public void Rewind() { _frameworkSoundChannel.Rewind(); }
         /// <inheritdoc/>
@@ -306,7 +302,7 @@ namespace LingoEngine.Sounds
             if (LoopCount > 1)
             {
                 _currentLoop++;
-                
+
                 if (_currentLoop >= LoopCount)
                 {
                     Status = LingoSoundChannelStatus.Idle;
@@ -320,7 +316,7 @@ namespace LingoEngine.Sounds
             {
                 Status = LingoSoundChannelStatus.Idle;
             }
-            
+
         }
     }
 

--- a/src/LingoEngine/Sprites/LingoSprite2DManager.cs
+++ b/src/LingoEngine/Sprites/LingoSprite2DManager.cs
@@ -2,6 +2,7 @@
 using LingoEngine.Members;
 using LingoEngine.Movies;
 using LingoEngine.Sounds;
+using System;
 
 namespace LingoEngine.Sprites
 {
@@ -185,14 +186,22 @@ namespace LingoEngine.Sprites
         {
             if (!_activeSprites.TryGetValue(spriteNumber, out var sprite))
                 return pos;
+#if NET48
+            return (int)MathCompat.Clamp(pos, sprite.Left, sprite.Right);
+#else
             return (int)Math.Clamp(pos, sprite.Left, sprite.Right);
+#endif
         }
 
         internal int ConstrainV(int spriteNumber, int pos)
         {
             if (!_activeSprites.TryGetValue(spriteNumber, out var sprite))
                 return pos;
+#if NET48
+            return (int)MathCompat.Clamp(pos, sprite.Top, sprite.Bottom);
+#else
             return (int)Math.Clamp(pos, sprite.Top, sprite.Bottom);
+#endif
         }
 
         internal LingoSprite2D? GetSpriteUnderMouse(bool skipLockedSprites = false)

--- a/src/LingoEngine/Texts/LingoWords.cs
+++ b/src/LingoEngine/Texts/LingoWords.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Data;
+using System.Linq;
 
 namespace LingoEngine.Texts
 {
@@ -54,7 +56,7 @@ namespace LingoEngine.Texts
 
         private void Parse()
         {
-            _words = _text.Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(x => new LingoWords(x)).ToArray();
+            _words = _text.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).Select(x => new LingoWords(x)).ToArray();
             _hasParsed = true;
         }
 

--- a/src/LingoEngine/Tools/CsvImporter.cs
+++ b/src/LingoEngine/Tools/CsvImporter.cs
@@ -2,6 +2,8 @@
 using LingoEngine.Members;
 using LingoEngine.Primitives;
 using LingoEngine.Texts;
+using System;
+using System.IO;
 using System.Reflection;
 using System.Text;
 using System.Xml.Linq;
@@ -37,7 +39,7 @@ namespace LingoEngine.Tools
         /// </summary>
         public void ImportInCastFromCsvFile(ILingoCast cast, string filePath, bool skipFirstLine = true)
         {
-            var rootFolder = Path.GetDirectoryName(Path.GetRelativePath(Environment.CurrentDirectory, filePath))??"";
+            var rootFolder = Path.GetDirectoryName(GetRelativePath(Environment.CurrentDirectory, filePath)) ?? "";
             var csv = ImportCsvCastFile(filePath, skipFirstLine);
             foreach (var row in csv)
             {
@@ -148,6 +150,21 @@ namespace LingoEngine.Tools
             result.Add(sb.ToString()); // Add last field
             return result.ToArray();
         }
+
+#if NET48
+        private static string GetRelativePath(string basePath, string filePath)
+        {
+            var baseUri = new Uri(AppendDirectorySeparatorChar(basePath));
+            var fileUri = new Uri(filePath);
+            var relative = baseUri.MakeRelativeUri(fileUri).ToString().Replace('/', Path.DirectorySeparatorChar);
+            return Uri.UnescapeDataString(relative);
+        }
+
+        private static string AppendDirectorySeparatorChar(string path)
+            => path.EndsWith(Path.DirectorySeparatorChar.ToString()) ? path : path + Path.DirectorySeparatorChar;
+#else
+        private static string GetRelativePath(string basePath, string filePath) => Path.GetRelativePath(basePath, filePath);
+#endif
     }
 
 }

--- a/src/LingoEngine/Tools/RtfExtracter.cs
+++ b/src/LingoEngine/Tools/RtfExtracter.cs
@@ -2,6 +2,7 @@
 using LingoEngine.Texts;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Linq;
 
 namespace LingoEngine.Tools
 {
@@ -54,11 +55,11 @@ namespace LingoEngine.Tools
                 //    sb.AppendLine("Text: " + match1.Groups["text"].Value);
                 //    sb.AppendLine("----------");
                 //}
-                fullText = string.Join(Environment.NewLine, blockMatches.Select(m => m.Groups["text"].Value));
+                fullText = string.Join(Environment.NewLine, blockMatches.Cast<Match>().Select(m => m.Groups["text"].Value));
             }
            // var ressss = sb.ToString();
             ///else
-                match = blockMatches[^1]; // Use last/innermost block
+                match = blockMatches[blockMatches.Count - 1]; // Use last/innermost block
 
             // Font index from block
             int fontIndex = int.Parse(match.Groups["f"].Value);


### PR DESCRIPTION
## Summary
- isolate .NET Framework 4.8 compatibility with preprocessor guards so modern APIs remain for .NET 8
- restore newer helpers like `Math.Clamp`, `Random.Shared`, and `HashCode.Combine` outside of net48

## Testing
- `dotnet build src/LingoEngine/LingoEngine.csproj -f net8.0`
- `dotnet build src/LingoEngine/LingoEngine.csproj -f net48`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689eb59ae4d08332a297c9a38446d30e