### PR TITLE
feat: add behavior drag and drop

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Inspector/Commands/OpenBehaviorPopupCommand.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/Commands/OpenBehaviorPopupCommand.cs
@@ -1,0 +1,6 @@
+using LingoEngine.Commands;
+using LingoEngine.Sprites;
+
+namespace LingoEngine.Director.Core.Inspector.Commands;
+
+public sealed record OpenBehaviorPopupCommand(LingoSpriteBehavior Behavior) : ILingoCommand;

--- a/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
@@ -18,6 +18,7 @@ using LingoEngine.Director.Core.Tools;
 using LingoEngine.Director.Core.UI;
 using LingoEngine.Tools;
 using LingoEngine.Director.Core.Windowing;
+using LingoEngine.Director.Core.Inspector.Commands;
 using LingoEngine.Director.Core.Stages;
 using LingoEngine.Bitmaps;
 using LingoEngine.Casts;
@@ -31,7 +32,8 @@ using LingoEngine.FilmLoops;
 
 namespace LingoEngine.Director.Core.Inspector
 {
-    public class DirectorPropertyInspectorWindow : DirectorWindow<IDirFrameworkPropertyInspectorWindow>, IHasSpriteSelectedEvent, IHasMemberSelectedEvent
+    public class DirectorPropertyInspectorWindow : DirectorWindow<IDirFrameworkPropertyInspectorWindow>, IHasSpriteSelectedEvent, IHasMemberSelectedEvent,
+        ICommandHandler<OpenBehaviorPopupCommand>
     {
         public enum PropetyTabNames
         {
@@ -69,7 +71,7 @@ namespace LingoEngine.Director.Core.Inspector
         private float _lastHeight;
         private Dictionary<string, LingoSpriteBehavior> _behaviors = new();
         private LingoGfxItemList _behaviorList;
-        public event Action<LingoSpriteBehavior>? BehaviorSelected;
+        private LingoGfxWindow? _behaviorWindow;
 
         public LingoGfxPanel HeaderPanel => _headerPanel;
         public LingoGfxTabContainer Tabs => _tabs;
@@ -345,7 +347,7 @@ namespace LingoEngine.Director.Core.Inspector
             _behaviorList = _factory.CreateItemList("BehaviorList", x =>
             {
                 if (x != null && _behaviors.TryGetValue(x, out var behavior))
-                    BehaviorSelected?.Invoke(behavior);
+                    _commandManager.Handle(new OpenBehaviorPopupCommand(behavior));
             });
             _behaviorList.Height = 45;
             _behaviorList.Width = _lastWidh - 15;
@@ -360,6 +362,23 @@ namespace LingoEngine.Director.Core.Inspector
             {
                 _behaviorList.SelectedIndex = -1;
             });
+
+        public void ShowBehaviorPopup(LingoGfxWindow window)
+        {
+            _behaviorWindow?.Dispose();
+            _behaviorWindow = window;
+            window.PopupCentered();
+        }
+
+        public bool CanExecute(OpenBehaviorPopupCommand command) => true;
+
+        public bool Handle(OpenBehaviorPopupCommand command)
+        {
+            var win = BuildBehaviorPopup(command.Behavior);
+            if (win == null) return true;
+            ShowBehaviorPopup(win);
+            return true;
+        }
 
         #endregion
 

--- a/src/Director/LingoEngine.Director.Core/Inspector/IDirFrameworkPropertyInspectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/IDirFrameworkPropertyInspectorWindow.cs
@@ -1,4 +1,4 @@
-﻿using LingoEngine.Director.Core.Windowing;
+using LingoEngine.Director.Core.Windowing;
 
 namespace LingoEngine.Director.Core.Inspector
 {

--- a/src/Director/LingoEngine.Director.Core/Scores/DirScoreManager.cs
+++ b/src/Director/LingoEngine.Director.Core/Scores/DirScoreManager.cs
@@ -10,6 +10,9 @@ using LingoEngine.Movies;
 using System.Collections.Generic;
 using System.Linq;
 using LingoEngine.Director.Core.Scores.Sprites2D;
+using LingoEngine.Scripts;
+using System;
+using LingoEngine.Director.Core.Inspector.Commands;
 
 namespace LingoEngine.Director.Core.Scores
 {
@@ -207,7 +210,8 @@ namespace LingoEngine.Director.Core.Scores
                 if (_rectangleSelection.Update(channelNumber, frameNumber))
                     return;
                 // Drag from castlib?
-                if (DirectorDragDropHolder.IsDragging && !_isDropPreview && DirectorDragDropHolder.Member != null)
+                if (DirectorDragDropHolder.IsDragging && !_isDropPreview && DirectorDragDropHolder.Member != null &&
+                    DirectorDragDropHolder.Member is not LingoMemberScript { ScriptType: LingoScriptType.Behavior })
                     StartDropPreview();
 
                 if (_isDropPreview)
@@ -260,6 +264,13 @@ namespace LingoEngine.Director.Core.Scores
                         DropFromCastLib(DirectorDragDropHolder.Member);
                     }
                     StopPreview();
+                    return;
+                }
+                if (DirectorDragDropHolder.Member is LingoMemberScript { ScriptType: LingoScriptType.Behavior } script &&
+                    spriteScore?.Sprite is LingoSprite2D sprite2D)
+                {
+                    sprite2D.AttachBehavior(script, _commandManager);
+                    DirectorDragDropHolder.EndDrag();
                     return;
                 }
                 if (_dragKeyFrame)

--- a/src/Director/LingoEngine.Director.Core/Sprites/LingoSprite2DExtensions.cs
+++ b/src/Director/LingoEngine.Director.Core/Sprites/LingoSprite2DExtensions.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using LingoEngine.Commands;
+using LingoEngine.Director.Core.Inspector.Commands;
+using LingoEngine.Scripts;
+using LingoEngine.Sprites;
+
+namespace LingoEngine.Director.Core.Sprites;
+
+public static class LingoSprite2DExtensions
+{
+    public static void AttachBehavior(this LingoSprite2D sprite, LingoMemberScript script, ILingoCommandManager commandManager)
+    {
+        var type = script.GetBehaviorType();
+        if (type == null)
+        {
+            type = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(a =>
+                {
+                    try { return a.GetTypes(); }
+                    catch { return Array.Empty<Type>(); }
+                })
+                .FirstOrDefault(t => typeof(LingoSpriteBehavior).IsAssignableFrom(t) && t.Name == script.Name);
+            if (type != null)
+            {
+                var setMethod = typeof(LingoMemberScript).GetMethod(nameof(LingoMemberScript.SetBehaviorType));
+                setMethod?.MakeGenericMethod(type).Invoke(script, null);
+            }
+        }
+
+        if (type == null)
+            return;
+
+        var behavior = sprite.SetBehavior(type);
+        if (behavior == null) return;
+        behavior.Name = script.Name;
+        if (behavior is ILingoPropertyDescriptionList)
+            commandManager.Handle(new OpenBehaviorPopupCommand(behavior));
+        sprite.SpriteChannel?.RequireRedraw();
+    }
+
+    public static LingoSpriteBehavior? SetBehavior(this LingoSprite2D sprite, Type type)
+    {
+        var method = typeof(LingoSprite2D).GetMethod(nameof(LingoSprite2D.SetBehavior), BindingFlags.Instance | BindingFlags.Public);
+        if (method == null) return null;
+        var generic = method.MakeGenericMethod(type);
+        return (LingoSpriteBehavior?)generic.Invoke(sprite, new object?[] { null });
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
@@ -4,26 +4,23 @@ using LingoEngine.Core;
 using LingoEngine.LGodot.Gfx;
 using LingoEngine.Director.LGodot.Windowing;
 using LingoEngine.Director.Core.Icons;
-using LingoEngine.Sprites;
-using LingoEngine.Gfx;
 using LingoEngine.Director.Core.UI;
 
 namespace LingoEngine.Director.LGodot.Inspector;
 
 public partial class DirGodotPropertyInspector : BaseGodotWindow, IDirFrameworkPropertyInspectorWindow
 {
-   
+
     private readonly DirectorPropertyInspectorWindow _inspectorWindow;
     private LingoGodotPanel _headerPanel;
-    private LingoGfxWindow? _behaviorWindow;
 
     public DirGodotPropertyInspector(DirectorPropertyInspectorWindow inspectorWindow, ILingoPlayer player, IDirGodotWindowManager windowManager, IDirectorIconManager iconManager)
         : base(DirectorMenuCodes.PropertyInspector, "Property Inspector", windowManager)
     {
         _inspectorWindow = inspectorWindow;
-        
+
         Size = new Vector2(260, 450);
-        _inspectorWindow.Init(this, Size.X, Size.Y,TitleBarHeight);
+        _inspectorWindow.Init(this, Size.X, Size.Y, TitleBarHeight);
         CustomMinimumSize = Size;
 
         _headerPanel = _inspectorWindow.HeaderPanel.Framework<LingoGodotPanel>();
@@ -37,8 +34,6 @@ public partial class DirGodotPropertyInspector : BaseGodotWindow, IDirFrameworkP
         tabs.Size = new Vector2(Size.X, Size.Y - 30 - DirectorPropertyInspectorWindow.HeaderHeight);
         AddChild(tabs);
 
-        _inspectorWindow.BehaviorSelected += OnBehaviorSelected;
-
         //var behaviorPanel = _inspectorWindow.BehaviorPanel.Framework<LingoGodotPanel>();
         //behaviorPanel.Visibility = false;
         //behaviorPanel.Position = new Vector2(0, TitleBarHeight + DirectorPropertyInspectorWindow.HeaderHeight);
@@ -46,34 +41,13 @@ public partial class DirGodotPropertyInspector : BaseGodotWindow, IDirFrameworkP
         //AddChild(behaviorPanel);
 
     }
-  
+
     protected override void OnResizing(Vector2 size)
     {
         base.OnResizing(size);
 
-       _inspectorWindow.OnResizing(size.X, size.Y);
+        _inspectorWindow.OnResizing(size.X, size.Y);
 
     }
 
-    private void OnBehaviorSelected(LingoSpriteBehavior behavior)
-    {
-        //if (_behaviorWindow != null && _behaviorWindow.Framework<ILingoFrameworkGfxWindow>().FrameworkNode is Node oldNode)
-        if (_behaviorWindow != null)
-        {
-            //oldNode.QueueFree();
-            _behaviorWindow.Dispose();
-            _behaviorWindow = null;
-        }
-
-        var win = _inspectorWindow.BuildBehaviorPopup(behavior);
-        if (win == null) return;
-        //if (win.Framework<ILingoFrameworkGfxWindow>().FrameworkNode is Node node)
-        //    GetTree().Root.AddChild(node);
-        
-        win.PopupCentered();
-        _behaviorWindow = win;
-    }
- 
-
-    
 }

--- a/src/LingoEngine/Scripts/LingoMemberScript.cs
+++ b/src/LingoEngine/Scripts/LingoMemberScript.cs
@@ -1,14 +1,38 @@
-﻿using LingoEngine.Casts;
+using System;
+using System.Linq;
+using LingoEngine.Casts;
 using LingoEngine.Members;
 using LingoEngine.Primitives;
+using LingoEngine.Sprites;
 
 namespace LingoEngine.Scripts
 {
     public class LingoMemberScript : LingoMember
     {
         public LingoScriptType ScriptType { get; set; } = LingoScriptType.Behavior;
-        public LingoMemberScript(ILingoFrameworkMember frameworkMember, LingoCast cast, int numberInCast, string name = "", string fileName = "", LingoPoint regPoint = default) : base(frameworkMember, LingoMemberType.Script, cast, numberInCast, name, fileName, regPoint)
+        public string? BehaviorTypeName { get; private set; }
+
+        public LingoMemberScript(ILingoFrameworkMember frameworkMember, LingoCast cast, int numberInCast, string name = "", string fileName = "", LingoPoint regPoint = default)
+            : base(frameworkMember, LingoMemberType.Script, cast, numberInCast, name, fileName, regPoint)
         {
         }
+
+        public void SetBehaviorType<TBehavior>() where TBehavior : LingoSpriteBehavior
+            => BehaviorTypeName = typeof(TBehavior).FullName;
+
+        public void SetBehaviorType(Type behaviorType)
+            => BehaviorTypeName = behaviorType.FullName;
+
+        public Type? GetBehaviorType()
+            => BehaviorTypeName == null
+                ? null
+                : AppDomain.CurrentDomain.GetAssemblies()
+                    .SelectMany(a =>
+                    {
+                        try { return a.GetTypes(); }
+                        catch { return Array.Empty<Type>(); }
+                    })
+                    .FirstOrDefault(t => t.FullName == BehaviorTypeName);
     }
 }
+


### PR DESCRIPTION
## Summary
- add command to open behavior popup
- open behavior params via command in property inspector
- attach cast behaviors to sprites via drag and drop
- persist behavior type on scripts and centralize popup handling

## Testing
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/Scripts/LingoMemberScript.cs --verbosity diagnostic`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689eb8fda55c8332ad151c87e386def3