### PR TITLE
Add scripts and workflow to publish packages to GitHub releases

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,25 @@
+name: Publish packages
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Publish packages to GitHub Releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          ./scripts/publish-packages.sh "$VERSION"

--- a/scripts/publish-packages.ps1
+++ b/scripts/publish-packages.ps1
@@ -1,0 +1,32 @@
+#!/usr/bin/env pwsh
+param(
+    [Parameter(Mandatory=$true)][string]$Version,
+    [string]$ReleaseNotes
+)
+
+$ErrorActionPreference = "Stop"
+
+$rootDir = Resolve-Path (Join-Path $PSScriptRoot "..")
+$srcDir = Join-Path $rootDir "src"
+$outDir = Join-Path $rootDir "Publish/packages"
+
+if (-not (Get-Command "gh" -ErrorAction SilentlyContinue)) {
+    throw "GitHub CLI 'gh' is required"
+}
+
+New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+Write-Host "Packing projects under $srcDir"
+Get-ChildItem $srcDir -Recurse -Filter *.csproj | ForEach-Object {
+    Write-Host "Packing $($_.FullName)"
+    dotnet pack $_.FullName -c Release -p:PackageVersion=$Version -o $outDir
+}
+
+$tag = "v$Version"
+$assets = Get-ChildItem $outDir -Filter *.nupkg | ForEach-Object { $_.FullName }
+
+if ($ReleaseNotes) {
+    gh release create $tag $assets -t $tag -F $ReleaseNotes
+} else {
+    gh release create $tag $assets -t $tag -n "Release $Version"
+}

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$PATH"
+export DOTNET_ROOT="$HOME/.dotnet"
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <version> [release-notes-file]" >&2
+  exit 1
+fi
+
+VERSION="$1"
+NOTES_FILE="${2:-}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+SRC_DIR="$ROOT_DIR/src"
+OUT_DIR="$ROOT_DIR/Publish/packages"
+
+command -v gh >/dev/null 2>&1 || { echo "GitHub CLI 'gh' is required" >&2; exit 1; }
+
+mkdir -p "$OUT_DIR"
+
+echo "Packing projects under $SRC_DIR" >&2
+find "$SRC_DIR" -name '*.csproj' -print0 | while IFS= read -r -d '' proj; do
+  echo "Packing $proj" >&2
+  dotnet pack "$proj" -c Release -p:PackageVersion="$VERSION" -o "$OUT_DIR"
+done
+
+TAG="v$VERSION"
+ASSETS=("$OUT_DIR"/*.nupkg)
+
+if [ "${NOTES_FILE}" != "" ]; then
+  gh release create "$TAG" "${ASSETS[@]}" -t "$TAG" -F "$NOTES_FILE"
+else
+  gh release create "$TAG" "${ASSETS[@]}" -t "$TAG" -n "Release $VERSION"
+fi
+


### PR DESCRIPTION
## Summary
- add bash script to package projects and upload to GitHub release
- add PowerShell script with equivalent functionality
- add GitHub Actions workflow to publish packages when version tags are pushed

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_689ec8bfc36c833288a2faf7832aacb1