### PR TITLE
Add README and NuGet metadata for AbstUI modules

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/README.md
+++ b/WillMoveToOwnRepo/AbstUI/README.md
@@ -1,0 +1,9 @@
+# AbstUI
+
+AbstUI (Abstraction User Interface) is an abstraction layer that decouples user interface components from specific rendering frameworks. It provides common UI primitives so the same UI code can render consistently across SDL2, Godot, Unity, or other platforms. This allows AbstUI to be reused independently of any particular engine.
+
+The repository currently includes the core abstractions and optional backends:
+- `AbstUI`: core primitives and components.
+- `AbstUI.SDL2`: SDL2 backend.
+- `AbstUI.LGodot`: Godot backend.
+- `AbstUI.LUnity`: Unity backend.

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj
@@ -1,17 +1,34 @@
 ﻿<Project Sdk="Godot.NET.Sdk/4.5.0-dev.5">
 
-	<PropertyGroup>
-		<OutputType>Library</OutputType>
-		<TargetFramework>net8</TargetFramework>
-		<!-- Use netstandard for compatibility -->
-		<GodotVersion>4.5.0-dev.5</GodotVersion>
-		<LangVersion>12</LangVersion>
-		<Nullable>enable</Nullable>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Platforms>AnyCPU;x64;x86</Platforms>
-		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-		<!-- Specify the Godot version -->
-	</PropertyGroup>
+        <PropertyGroup>
+                <OutputType>Library</OutputType>
+                <TargetFramework>net8</TargetFramework>
+                <!-- Use netstandard for compatibility -->
+                <GodotVersion>4.5.0-dev.5</GodotVersion>
+                <LangVersion>12</LangVersion>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Platforms>AnyCPU;x64;x86</Platforms>
+                <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+                <!-- Specify the Godot version -->
+        </PropertyGroup>
+
+        <PropertyGroup>
+                <!-- NuGet Packaging Metadata -->
+                <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+                <PackageId>AbstUI.LGodot</PackageId>
+                <Version>1.0.0</Version>
+                <Authors>Emmanuel The Creator</Authors>
+                <Company>The Community</Company>
+                <Description>Godot backend for the AbstUI framework, enabling AbstUI components to run within Godot.</Description>
+                <RepositoryUrl>https://github.com/EmmanuelTheCreator/LingoEngine</RepositoryUrl>
+                <PackageTags>AbstUI Godot</PackageTags>
+                <PackageLicenseExpression>MIT</PackageLicenseExpression>
+                <PackageReadmeFile>README.md</PackageReadmeFile>
+        </PropertyGroup>
+        <ItemGroup>
+                <None Include="README.md" Pack="true" PackagePath="" />
+        </ItemGroup>
 
 	<ItemGroup>
 	  <Compile Remove="obj\**" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/README.md
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/README.md
@@ -1,0 +1,3 @@
+# AbstUI.LGodot
+
+Godot backend for the AbstUI framework, enabling AbstUI components to run within Godot.

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj
@@ -1,12 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<LangVersion>12</LangVersion>
-		<Platforms>AnyCPU;x64;x86</Platforms>
-	</PropertyGroup>
+        <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+                <LangVersion>12</LangVersion>
+                <Platforms>AnyCPU;x64;x86</Platforms>
+        </PropertyGroup>
+
+        <PropertyGroup>
+                <!-- NuGet Packaging Metadata -->
+                <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+                <PackageId>AbstUI.LUnity</PackageId>
+                <Version>1.0.0</Version>
+                <Authors>Emmanuel The Creator</Authors>
+                <Company>The Community</Company>
+                <Description>Unity backend for the AbstUI framework, enabling AbstUI components to run within Unity.</Description>
+                <RepositoryUrl>https://github.com/EmmanuelTheCreator/LingoEngine</RepositoryUrl>
+                <PackageTags>AbstUI Unity</PackageTags>
+                <PackageLicenseExpression>MIT</PackageLicenseExpression>
+                <PackageReadmeFile>README.md</PackageReadmeFile>
+        </PropertyGroup>
+        <ItemGroup>
+                <None Include="README.md" Pack="true" PackagePath="" />
+        </ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/README.md
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/README.md
@@ -1,0 +1,3 @@
+# AbstUI.LUnity
+
+Unity backend for the AbstUI framework, enabling AbstUI components to run within Unity.

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj
@@ -1,17 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-		<Platforms>AnyCPU;x64;x86</Platforms>
+        <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+                <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+                <Platforms>AnyCPU;x64;x86</Platforms>
+        </PropertyGroup>
 
-	</PropertyGroup>
+        <PropertyGroup>
+                <!-- NuGet Packaging Metadata -->
+                <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+                <PackageId>AbstUI.SDL2</PackageId>
+                <Version>1.0.0</Version>
+                <Authors>Emmanuel The Creator</Authors>
+                <Company>The Community</Company>
+                <Description>SDL2 backend for the AbstUI framework, rendering the abstract UI components through SDL2.</Description>
+                <RepositoryUrl>https://github.com/EmmanuelTheCreator/LingoEngine</RepositoryUrl>
+                <PackageTags>AbstUI SDL2</PackageTags>
+                <PackageLicenseExpression>MIT</PackageLicenseExpression>
+                <PackageReadmeFile>README.md</PackageReadmeFile>
+        </PropertyGroup>
+        <ItemGroup>
+                <None Include="README.md" Pack="true" PackagePath="" />
+        </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="ImGui.NET" Version="1.91.6.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+        <ItemGroup>
+                <PackageReference Include="ImGui.NET" Version="1.91.6.1" />
+                <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/README.md
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/README.md
@@ -1,0 +1,3 @@
+# AbstUI.SDL2
+
+SDL2 backend for the AbstUI framework, rendering the abstract UI components through SDL2.

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj
@@ -1,15 +1,31 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>net8.0;net48</TargetFrameworks>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<LangVersion>12</LangVersion>
-		<Platforms>AnyCPU;x64;x86</Platforms>
+        <PropertyGroup>
+                <TargetFrameworks>net8.0;net48</TargetFrameworks>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+                <LangVersion>12</LangVersion>
+                <Platforms>AnyCPU;x64;x86</Platforms>
+        </PropertyGroup>
 
-	</PropertyGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-		<PackageReference Include="System.Memory" Version="4.5.5" />
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-	</ItemGroup>
+        <PropertyGroup>
+                <!-- NuGet Packaging Metadata -->
+                <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+                <PackageId>AbstUI</PackageId>
+                <Version>1.0.0</Version>
+                <Authors>Emmanuel The Creator</Authors>
+                <Company>The Community</Company>
+                <Description>Core abstractions and components for the AbstUI framework, providing reusable UI primitives across multiple backends.</Description>
+                <RepositoryUrl>https://github.com/EmmanuelTheCreator/LingoEngine</RepositoryUrl>
+                <PackageTags>AbstUI</PackageTags>
+                <PackageLicenseExpression>MIT</PackageLicenseExpression>
+                <PackageReadmeFile>README.md</PackageReadmeFile>
+        </PropertyGroup>
+        <ItemGroup>
+                <None Include="README.md" Pack="true" PackagePath="" />
+        </ItemGroup>
+        <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+                <PackageReference Include="System.Memory" Version="4.5.5" />
+                <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+        </ItemGroup>
 </Project>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/README.md
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/README.md
@@ -1,0 +1,3 @@
+# AbstUI
+
+Core abstractions and components for the AbstUI framework. These primitives allow UI elements to be reused across multiple rendering backends without depending on any particular engine.


### PR DESCRIPTION
## Summary
- clarify AbstUI documentation to remove LingoEngine references
- supply full NuGet package metadata and README inclusion for all AbstUI projects

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689f3752c0608332ae4351874025af34