### PR TITLE
docs: add project structure overview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,33 @@ These instructions apply to the entire repository.
 - Use `dotnet format` to fix style issues when needed.
 - Prefer `rg` (ripgrep) over `grep` for searching the codebase.
 
+## Project Structure
+
+| Path | Description |
+| --- | --- |
+| src/LingoEngine/LingoEngine.csproj | Core engine functionality and dependency injection setup |
+| src/LingoEngine.Lingo.Core/LingoEngine.Lingo.Core.csproj | Runtime implementation of the Lingo scripting language |
+| src/LingoEngine.IO/LingoEngine.IO.csproj | File and resource I/O built on LingoEngine |
+| src/LingoEngine.IO.Data/LingoEngine.IO.Data.csproj | Shared data structures for the I/O layer |
+| src/LingoEngine.SDL2/LingoEngine.SDL2.csproj | SDL2 bindings and rendering support |
+| src/LingoEngine.Unity/LingoEngine.Unity.csproj | Unity engine integration layer |
+| src/LingoEngine.LGodot/LingoEngine.LGodot.csproj | Godot engine integration layer |
+| src/LingoEngine.3D.Core/LingoEngine.3D.Core.csproj | Core components for 3D features |
+| src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj | Editor tooling reminiscent of Macromedia Director |
+| src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj | Godot integration for Director tooling |
+| Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/LingoEngine.Demo.TetriGrounds.Core.csproj | Shared code for the TetriGrounds demo |
+| Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.SDL2/LingoEngine.Demo.TetriGrounds.SDL2.csproj | SDL2-based TetriGrounds demo |
+| Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/LingoEngine.Demo.TetriGrounds.Godot.csproj | Godot-based TetriGrounds demo |
+| Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj | Tests for the Lingo scripting runtime |
+| Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj | Tests for LingoEngine core features |
+| Test/LingoEngine.SDL2.GfxVisualTest/LingoEngine.SDL2.GfxVisualTest.csproj | Console app for manual SDL2 graphics checks |
+| WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj | Core abstractions for the AbstUI framework |
+| WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj | SDL2 backend for AbstUI |
+| WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj | Unity backend for AbstUI |
+| WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj | Godot backend for AbstUI |
+| WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/ProjectorRays.DotNet.csproj | Core ProjectorRays .NET library |
+| WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Console/ProjectorRays.Console.csproj | Console showcase for ProjectorRays |
+| WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/ProjectorRays.DotNet.Test.csproj | Tests for ProjectorRays library |
 ## Notes for Agents
 - The solution file is `LingoEngine.sln`.
 - Keep cross-platform compatibility in mind when making changes.


### PR DESCRIPTION
## Summary
- document all C# project files in AGENTS.md for quick orientation

## Testing
- `dotnet --version`


------
https://chatgpt.com/codex/tasks/task_e_68a01ba6176c8332ba53dead8cf9d8f2