### PR TITLE
Add AbstUI.ImGui project

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/.gitignore
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/.gitignore
@@ -1,0 +1,7 @@
+# Ignore native binaries and fonts
+Fonts/
+cimgui/
+*.ttf
+*.dll
+*.so
+*.dylib

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstImGuiComponentContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstImGuiComponentContainer.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+namespace AbstUI.ImGui;
+
+public class AbstImGuiComponentContainer
+{
+    private readonly List<AbstImGuiComponentContext> _allComponents = new();
+    private readonly HashSet<AbstImGuiComponentContext> _activeComponents = new();
+
+    internal void Register(AbstImGuiComponentContext context) => _allComponents.Add(context);
+    internal void Unregister(AbstImGuiComponentContext context)
+    {
+        _activeComponents.Remove(context);
+        _allComponents.Remove(context);
+    }
+
+    public void Activate(AbstImGuiComponentContext context) => _activeComponents.Add(context);
+    public void Deactivate(AbstImGuiComponentContext context) => _activeComponents.Remove(context);
+
+    public void Render(AbstImGuiRenderContext renderContext)
+    {
+        foreach (var ctx in _activeComponents)
+        {
+            ctx.RenderToTexture(renderContext);
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstImGuiComponentContext.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstImGuiComponentContext.cs
@@ -1,0 +1,84 @@
+using System;
+using AbstUI.ImGui.ImGuiLL;
+
+namespace AbstUI.ImGui;
+
+public class AbstImGuiComponentContext : IDisposable
+{
+    private readonly AbstImGuiComponentContainer _container;
+    private bool _requireRender = true;
+    internal IAbstImGuiComponent? Component { get; private set; }
+    internal AbstImGuiComponentContext? Parent { get; }
+
+    public nint Texture { get; private set; }
+    public nint Renderer { get; set; }
+    public int TargetWidth { get; set; }
+    public int TargetHeight { get; set; }
+    public int X { get; set; }
+    public int Y { get; set; }
+    public bool Visible { get; set; }
+    public float Blend { get; set; }
+    public int? InkType { get; set; }
+    public float OffsetX { get; set; }
+    public float OffsetY { get; set; }
+    public bool FlipH { get; set; }
+    public bool FlipV { get; set; }
+    public SDL.SDL_BlendMode BlendMode { get; set; } = SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND;
+
+    internal AbstImGuiComponentContext(AbstImGuiComponentContainer container, IAbstImGuiComponent? component = null, AbstImGuiComponentContext? parent = null)
+    {
+        _container = container;
+        Parent = parent;
+        Component = component;
+        _container.Register(this);
+    }
+
+    public void QueueRedraw(IAbstImGuiComponent component)
+    {
+        _requireRender = true;
+        Component ??= component;
+        Parent?.QueueRedraw(Parent.Component!);
+    }
+
+    public void RenderToTexture(AbstImGuiRenderContext renderContext)
+    {
+        if (!Visible)
+            return;
+
+        Renderer = renderContext.Renderer;
+
+        if (_requireRender && Component is { })
+        {
+            var renderResult = Component.Render(renderContext);
+            Texture = renderResult.Texture;
+            _requireRender = renderResult.DoRender;
+        }
+
+        if (Texture == nint.Zero)
+            return;
+
+        int drawX = (int)(X + OffsetX);
+        int drawY = (int)(Y + OffsetY);
+        SDL.SDL_Rect dst = new SDL.SDL_Rect
+        {
+            x = drawX,
+            y = drawY,
+            w = TargetWidth,
+            h = TargetHeight
+        };
+        SDL.SDL_SetTextureAlphaMod(Texture, (byte)(Blend * 255));
+        SDL.SDL_SetTextureBlendMode(Texture, BlendMode);
+        SDL.SDL_RendererFlip flip = SDL.SDL_RendererFlip.SDL_FLIP_NONE;
+        if (FlipH)
+            flip |= SDL.SDL_RendererFlip.SDL_FLIP_HORIZONTAL;
+        if (FlipV)
+            flip |= SDL.SDL_RendererFlip.SDL_FLIP_VERTICAL;
+        SDL.SDL_RenderCopyEx(Renderer, Texture, nint.Zero, ref dst, 0, nint.Zero, flip);
+    }
+
+    public void Dispose()
+    {
+        Texture = nint.Zero;
+        _container.Unregister(this);
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstImGuiComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstImGuiComponentFactory.cs
@@ -1,0 +1,300 @@
+using AbstUI.Components;
+using AbstUI.Primitives;
+using AbstUI.ImGui.Components;
+using AbstUI.ImGui.Styles;
+
+namespace AbstUI.ImGui
+{
+    /// <summary>
+    /// Factory responsible for creating SDL specific GFX components.
+    /// </summary>
+    public class AbstImGuiComponentFactory : IAbstComponentFactory
+    {
+        private readonly IImGuiRootComponentContext _rootContext;
+        private readonly ImGuiFontManager _fontManager;
+
+        public IImGuiRootComponentContext RootContext => _rootContext;
+
+        public AbstImGuiComponentFactory(IImGuiRootComponentContext rootContext, ImGuiFontManager fontManager)
+        {
+            _rootContext = rootContext;
+            _fontManager = fontManager;
+        }
+
+        public AbstImGuiComponentContext CreateContext(IAbstImGuiComponent component, AbstImGuiComponentContext? parent = null)
+            => new(_rootContext.ComponentContainer, component, parent) { Renderer = _rootContext.Renderer };
+
+        public AbstImGuiRenderContext CreateRenderContext(IAbstImGuiComponent? component = null)
+            => new(_rootContext.Renderer, _rootContext.ImGuiViewPort, _rootContext.ImDrawList, _rootContext.ImGuiViewPort.WorkPos, _fontManager);
+
+        public AbstGfxCanvas CreateGfxCanvas(string name, int width, int height)
+        {
+            var canvas = new AbstGfxCanvas();
+            var impl = new AbstImGuiGfxCanvas(this, _fontManager, width, height);
+            canvas.Init(impl);
+            canvas.Width = width;
+            canvas.Height = height;
+            canvas.Name = name;
+            return canvas;
+        }
+
+        public AbstWrapPanel CreateWrapPanel(AOrientation orientation, string name)
+        {
+            var panel = new AbstWrapPanel(this);
+            var impl = new AbstImGuiWrapPanel(this, orientation);
+            panel.Init(impl);
+            panel.Name = name;
+            panel.Orientation = orientation;
+            return panel;
+        }
+
+        public AbstPanel CreatePanel(string name)
+        {
+            var panel = new AbstPanel(this);
+            var impl = new AbstImGuiPanel(this);
+            panel.Init(impl);
+            panel.Name = name;
+            return panel;
+        }
+
+        public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y)
+        {
+            if (content is IAbstLayoutNode)
+                throw new InvalidOperationException($"Content {content.Name} already supports layout  wrapping is unnecessary.");
+            var panel = new AbstLayoutWrapper(content);
+            var impl = new AbstImGuiLayoutWrapper(this, panel);
+            if (x != null) panel.X = x.Value;
+            if (y != null) panel.Y = y.Value;
+            return panel;
+        }
+
+        public AbstTabContainer CreateTabContainer(string name)
+        {
+            var tab = new AbstTabContainer();
+            var impl = new AbstImGuiTabContainer(this);
+            tab.Init(impl);
+            tab.Name = name;
+            return tab;
+        }
+
+        public AbstTabItem CreateTabItem(string name, string title)
+        {
+            var tab = new AbstTabItem();
+            var impl = new AbstImGuiTabItem(this, tab);
+            tab.Title = title;
+            tab.Name = name;
+            return tab;
+        }
+
+        public AbstScrollContainer CreateScrollContainer(string name)
+        {
+            var scroll = new AbstScrollContainer();
+            var impl = new AbstImGuiScrollContainer(this);
+            scroll.Init(impl);
+            scroll.Name = name;
+            return scroll;
+        }
+
+        public AbstInputSlider<float> CreateInputSliderFloat(AOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null)
+        {
+            var slider = new AbstInputSlider<float>();
+            var impl = new AbstImGuiInputSlider<float>(this);
+            slider.Init(impl);
+            slider.Name = name;
+            if (min.HasValue) slider.MinValue = min.Value;
+            if (max.HasValue) slider.MaxValue = max.Value;
+            if (step.HasValue) slider.Step = step.Value;
+            if (onChange != null)
+                slider.ValueChanged += () => onChange(slider.Value);
+            return slider;
+        }
+
+        public AbstInputSlider<int> CreateInputSliderInt(AOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null)
+        {
+            var slider = new AbstInputSlider<int>();
+            var impl = new AbstImGuiInputSlider<int>(this);
+            slider.Init(impl);
+            slider.Name = name;
+            if (min.HasValue) slider.MinValue = min.Value;
+            if (max.HasValue) slider.MaxValue = max.Value;
+            if (step.HasValue) slider.Step = step.Value;
+            if (onChange != null)
+                slider.ValueChanged += () => onChange(slider.Value);
+            return slider;
+        }
+
+        public AbstInputText CreateInputText(string name, int maxLength = 0, Action<string>? onChange = null, bool multiLine = false)
+        {
+            var input = new AbstInputText();
+            var impl = new AbstImGuiInputText(this, multiLine);
+            input.Init(impl);
+            input.Name = name;
+            input.MaxLength = maxLength;
+            if (onChange != null)
+                input.ValueChanged += () => onChange(input.Text);
+            return input;
+        }
+
+        public AbstInputNumber<float> CreateInputNumberFloat(string name, float? min = null, float? max = null, Action<float>? onChange = null)
+        {
+            var minNullableNum = min.HasValue ? new NullableNum<float>(min.Value) : new NullableNum<float>();
+            var maxNullableNum = max.HasValue ? new NullableNum<float>(max.Value) : new NullableNum<float>();
+            return CreateInputNumber(name, minNullableNum, maxNullableNum, onChange);
+        }
+
+        public AbstInputNumber<int> CreateInputNumberInt(string name, int? min = null, int? max = null, Action<int>? onChange = null)
+        {
+            var minNullableNum = min.HasValue ? new NullableNum<int>(min.Value) : new NullableNum<int>();
+            var maxNullableNum = max.HasValue ? new NullableNum<int>(max.Value) : new NullableNum<int>();
+            return CreateInputNumber(name, minNullableNum, maxNullableNum, onChange);
+        }
+
+        public AbstInputNumber<TValue> CreateInputNumber<TValue>(string name, NullableNum<TValue> min, NullableNum<TValue> max, Action<TValue>? onChange = null)
+            where TValue : System.Numerics.INumber<TValue>
+        {
+            throw new NotImplementedException();
+            var input = new AbstInputNumber<TValue>();
+            //var impl = new AbstImGuiInputNumber<float>(_rootContext.Renderer);
+            //input.Init(impl);
+            //input.Name = name;
+            //if (min.HasValue) input.Min = min.Value;
+            //if (max.HasValue) input.Max = max.Value;
+            return input;
+        }
+
+        public AbstInputSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null)
+        {
+            var spin = new AbstInputSpinBox();
+            var impl = new AbstImGuiSpinBox(this);
+            spin.Init(impl);
+            spin.Name = name;
+            if (min.HasValue) spin.Min = min.Value;
+            if (max.HasValue) spin.Max = max.Value;
+            if (onChange != null)
+                spin.ValueChanged += () => onChange(spin.Value);
+            return spin;
+        }
+
+        public AbstInputCheckbox CreateInputCheckbox(string name, Action<bool>? onChange = null)
+        {
+            var input = new AbstInputCheckbox();
+            var impl = new AbstImGuiInputCheckbox(this);
+            input.Init(impl);
+            input.Name = name;
+            input.ValueChanged += () => onChange?.Invoke(input.Checked);
+            return input;
+        }
+
+        public AbstInputCombobox CreateInputCombobox(string name, Action<string?>? onChange = null)
+        {
+            var input = new AbstInputCombobox();
+            var impl = new AbstImGuiInputCombobox(this);
+            input.Init(impl);
+            input.Name = name;
+            input.ValueChanged += () => onChange?.Invoke(input.SelectedKey);
+            return input;
+        }
+
+        public AbstItemList CreateItemList(string name, Action<string?>? onChange = null)
+        {
+            var list = new AbstItemList();
+            var impl = new AbstImGuiInputltemList(this);
+            list.Init(impl);
+            list.Name = name;
+            if (onChange != null)
+                list.ValueChanged += () => onChange(list.SelectedKey);
+            return list;
+        }
+
+        public AbstColorPicker CreateColorPicker(string name, Action<AColor>? onChange = null)
+        {
+            var picker = new AbstColorPicker();
+            var impl = new AbstImGuiColorPicker(this);
+            picker.Init(impl);
+            picker.Name = name;
+            if (onChange != null)
+                picker.ValueChanged += () => onChange(picker.Color);
+            return picker;
+        }
+
+        public AbstLabel CreateLabel(string name, string text = "")
+        {
+            var label = new AbstLabel();
+            var impl = new AbstImGuiLabel(this);
+            label.Init(impl);
+            label.Name = name;
+            label.Text = text;
+            return label;
+        }
+
+        public AbstButton CreateButton(string name, string text = "")
+        {
+            var button = new AbstButton();
+            var impl = new AbstImGuiButton(this);
+            button.Init(impl);
+            button.Name = name;
+            button.Text = text;
+            return button;
+        }
+
+        public AbstStateButton CreateStateButton(string name, IAbstTexture2D? texture = null, string text = "", Action<bool>? onChange = null)
+        {
+            var button = new AbstStateButton();
+            var impl = new AbstImGuiStateButton(this);
+            if (onChange != null)
+                button.ValueChanged += () => onChange(button.IsOn);
+            button.Init(impl);
+            button.Name = name;
+            button.Text = text;
+            if (texture != null)
+                button.TextureOn = texture;
+            return button;
+        }
+
+        public AbstMenu CreateMenu(string name)
+        {
+            var menu = new AbstMenu();
+            var impl = new AbstImGuiMenu(this, name);
+            menu.Init(impl);
+            return menu;
+        }
+
+
+        public AbstWindow CreateWindow(string name, string title = "")
+        {
+
+            var win = new AbstWindow();
+            var impl = new AbstImGuiWindow(win, this);
+            win.Name = name;
+            win.Title = title;
+            return win;
+        }
+
+
+        public AbstMenuItem CreateMenuItem(string name, string? shortcut = null)
+        {
+            var item = new AbstMenuItem();
+            var impl = new AbstImGuiMenuItem(this, name, shortcut);
+            item.Init(impl);
+            return item;
+        }
+
+        public AbstMenu CreateContextMenu(object window)
+        {
+            var menu = CreateMenu("ContextMenu");
+            return menu;
+        }
+
+        public AbstHorizontalLineSeparator CreateHorizontalLineSeparator(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public AbstVerticalLineSeparator CreateVerticalLineSeparator(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstImGuiRenderContext.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstImGuiRenderContext.cs
@@ -1,0 +1,32 @@
+using AbstUI.ImGui.Styles;
+using ImGuiNET;
+
+namespace AbstUI.ImGui;
+public class AbstImGuiRenderContext
+{
+    public nint Renderer { get; }
+    public ImGuiViewportPtr ImGuiViewPort { get; }
+    public ImDrawListPtr ImDrawList { get; }
+    public System.Numerics.Vector2 Origin { get; }
+    public ImGuiFontManager ImGuiFontManager { get; }
+
+    public AbstImGuiRenderContext(nint renderer, ImGuiViewportPtr imGuiViewPort, ImDrawListPtr imDrawList, System.Numerics.Vector2 origin, ImGuiFontManager sdlFontManager)
+    {
+        Renderer = renderer;
+        ImGuiViewPort = imGuiViewPort;
+        ImDrawList = imDrawList;
+        Origin = origin;
+        ImGuiFontManager = sdlFontManager;
+    }
+    public ImFontPtr? GetFont(int size) => ImGuiFontManager.GetFont(size);
+
+    public AbstImGuiRenderContext CreateNew(System.Numerics.Vector2 childOrigin)
+    {
+        var childCtx = new AbstImGuiRenderContext(
+                Renderer,
+                ImGuiViewPort,
+                global::ImGuiNET.ImGui.GetWindowDrawList(),
+                childOrigin, ImGuiFontManager);
+        return childCtx;
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstImGuiRenderResult.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstImGuiRenderResult.cs
@@ -1,0 +1,18 @@
+﻿namespace AbstUI.ImGui;
+
+public struct AbstImGuiRenderResult
+{
+    public bool DoRender { get; set; }
+    public nint Texture { get; set; }
+
+    internal static AbstImGuiRenderResult RequireRender() => new AbstImGuiRenderResult
+    {
+        DoRender = true,
+        Texture = nint.Zero
+    };
+
+    public static implicit operator AbstImGuiRenderResult(nint texture)
+       => new AbstImGuiRenderResult { Texture = texture, DoRender = texture != nint.Zero };
+
+    public static explicit operator nint(AbstImGuiRenderResult r) => r.Texture;
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj
@@ -1,0 +1,41 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+        <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+                <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+                <Platforms>AnyCPU;x64;x86</Platforms>
+        </PropertyGroup>
+
+        <PropertyGroup>
+                <!-- NuGet Packaging Metadata -->
+                <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+                <PackageId>AbstUI.ImGui</PackageId>
+                <Version>1.0.0</Version>
+                <Authors>Emmanuel The Creator</Authors>
+                <Company>The Community</Company>
+                <Description>ImGui backend for the AbstUI framework, rendering the abstract UI components through ImGui.</Description>
+                <RepositoryUrl>https://github.com/EmmanuelTheCreator/LingoEngine</RepositoryUrl>
+                <PackageTags>AbstUI ImGui</PackageTags>
+                <PackageLicenseExpression>MIT</PackageLicenseExpression>
+                <PackageReadmeFile>README.md</PackageReadmeFile>
+        </PropertyGroup>
+        <ItemGroup>
+                <None Include="README.md" Pack="true" PackagePath="" />
+        </ItemGroup>
+
+        <ItemGroup>
+                <PackageReference Include="ImGui.NET" Version="1.91.6.1" />
+                <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<InternalsVisibleTo Include="AbstUIEngine.ImGui.GfxVisualTest" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\AbstUI\AbstUI.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUIImGuiSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUIImGuiSetup.cs
@@ -1,0 +1,18 @@
+﻿using AbstUI.ImGui.Styles;
+using AbstUI.Styles;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AbstUI.ImGui
+{
+    public static class AbstUIImGuiSetup
+    {
+        public static IServiceCollection WithAbstUIImGui(this IServiceCollection services)
+        {
+            services
+                .AddSingleton<IAbstFontManager, ImGuiFontManager>()
+                        ;
+
+            return services;
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Bitmaps/ImGuiImageTexture.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Bitmaps/ImGuiImageTexture.cs
@@ -1,0 +1,21 @@
+using AbstUI.ImGui.ImGuiLL;
+
+namespace AbstUI.ImGui.Bitmaps;
+
+public class ImGuiImageTexture : ImGuiTexture2D
+{
+    private SDL.SDL_Surface _surfacePtr;
+    public SDL.SDL_Surface Ptr => _surfacePtr;
+    public nint SurfaceId { get; private set; }
+
+
+
+    public ImGuiImageTexture(SDL.SDL_Surface surfacePtr, nint surfaceId, int width, int height)
+        : base(nint.Zero, width, height) // Initialize with zero texture
+    {
+        _surfacePtr = surfacePtr;
+        SurfaceId = surfaceId;
+    }
+
+}
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Bitmaps/ImGuiTexture2D.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Bitmaps/ImGuiTexture2D.cs
@@ -1,0 +1,186 @@
+﻿using AbstUI.Primitives;
+using AbstUI.ImGui.ImGuiLL;
+using System.Runtime.InteropServices;
+
+namespace AbstUI.ImGui.Bitmaps;
+
+public class ImGuiTexture2D : IAbstTexture2D
+{
+    public nint Handle { get; private set; }
+    public int Width { get; }
+    public int Height { get; }
+    public bool IsDisposed { get; private set; }
+    public string Name { get; set; } = "";
+
+    private readonly Dictionary<object, TextureSubscription> _users = new();
+
+    public ImGuiTexture2D(nint texture, int width, int height, string name = "")
+    {
+        Handle = texture;
+        Width = width;
+        Height = height;
+        Name = name;
+    }
+
+    public IAbstUITextureUserSubscription AddUser(object user)
+    {
+        if (IsDisposed) throw new Exception("Texture is disposed and cannot be used anymore.");
+        var sub = new TextureSubscription(this, () => RemoveUser(user));
+        _users.Add(user, sub);
+        return sub;
+    }
+
+    private void RemoveUser(object user)
+    {
+        _users.Remove(user);
+        if (_users.Count == 0 && Handle != nint.Zero)
+            Dispose();
+    }
+    public void Dispose()
+    {
+        if (IsDisposed)
+            return;
+        IsDisposed = true;
+        if (Handle == nint.Zero)
+            return;
+        //Console.WriteLine("Disposing ImGuiTexture2D: " + Name);
+        SDL.SDL_DestroyTexture(Handle);
+        Handle = nint.Zero;
+    }
+
+    public nint ToSurface(nint renderer, out int w, out int h, uint? fmt = null)
+    {
+        if (fmt == null) fmt = SDL.SDL_PIXELFORMAT_ABGR8888;
+
+        SDL.SDL_QueryTexture(Handle, out _, out _, out w, out h);
+
+        // Create a render target in the desired pixel format
+        var target = SDL.SDL_CreateTexture(renderer, fmt.Value,
+            (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, w, h);
+        if (target == nint.Zero) throw new Exception(SDL.SDL_GetError());
+
+        // Save old state
+        var oldTarget = SDL.SDL_GetRenderTarget(renderer);
+        SDL.SDL_GetRenderDrawColor(renderer, out byte oldR, out byte oldG, out byte oldB, out byte oldA);
+        SDL.SDL_GetTextureBlendMode(Handle, out var oldBlend);
+
+        // Set up render target
+        SDL.SDL_SetRenderTarget(renderer, target);
+        SDL.SDL_SetTextureBlendMode(target, SDL.SDL_BlendMode.SDL_BLENDMODE_NONE);
+        SDL.SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0); // Transparent clear
+        SDL.SDL_RenderClear(renderer);
+
+        // Render this texture onto the target without blending
+        SDL.SDL_SetTextureBlendMode(Handle, SDL.SDL_BlendMode.SDL_BLENDMODE_NONE);
+        var rect = new SDL.SDL_Rect { x = 0, y = 0, w = w, h = h };
+        SDL.SDL_RenderCopy(renderer, Handle, nint.Zero, ref rect);
+        SDL.SDL_SetTextureBlendMode(Handle, oldBlend);
+
+        // Read back pixels into a surface
+        var surf = SDL.SDL_CreateRGBSurfaceWithFormat(0, w, h, 32, fmt.Value);
+        var s = Marshal.PtrToStructure<SDL.SDL_Surface>(surf);
+        SDL.SDL_RenderReadPixels(renderer, ref rect, fmt.Value, s.pixels, s.pitch);
+
+        // Restore render state
+        SDL.SDL_SetRenderTarget(renderer, oldTarget);
+        SDL.SDL_SetRenderDrawColor(renderer, oldR, oldG, oldB, oldA);
+
+        SDL.SDL_DestroyTexture(target);
+
+        return surf; // Caller must SDL_FreeSurface(surf)
+    }
+
+
+
+    public IAbstTexture2D Clone(nint renderer)
+    {
+        var cloned = CloneTexture(renderer, Handle);
+        var clone = new ImGuiTexture2D(cloned, Width, Height);
+        return clone;
+    }
+    public static nint CloneTexture(nint renderer, nint src)
+    {
+        SDL.SDL_QueryTexture(src, out uint fmt, out _, out int w, out int h);
+
+        var dst = SDL.SDL_CreateTexture(renderer, fmt,
+            (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, w, h);
+        if (dst == nint.Zero) throw new Exception(SDL.SDL_GetError());
+
+        SDL.SDL_GetTextureColorMod(src, out byte r, out byte g, out byte b);
+        SDL.SDL_GetTextureAlphaMod(src, out byte a);
+        SDL.SDL_GetTextureBlendMode(src, out SDL.SDL_BlendMode blend);
+        SDL.SDL_SetTextureColorMod(dst, r, g, b);
+        SDL.SDL_SetTextureAlphaMod(dst, a);
+        SDL.SDL_SetTextureBlendMode(dst, blend);
+
+        var old = SDL.SDL_GetRenderTarget(renderer);
+        SDL.SDL_SetRenderTarget(renderer, dst);
+        SDL.SDL_RenderClear(renderer);
+        var rect = new SDL.SDL_Rect { x = 0, y = 0, w = w, h = h };
+        SDL.SDL_RenderCopy(renderer, src, nint.Zero, ref rect);
+        SDL.SDL_SetRenderTarget(renderer, old);
+
+        return dst; // caller must SDL_DestroyTexture(dst)
+    }
+
+#if DEBUG
+    public void DebugWriteToDisk(nint renderer)
+        => DebugToDisk(renderer, Handle, Name);
+    public static void DebugToDisk(nint renderer, nint texture, string fileName)
+        => DebugToDisk(renderer, texture, "", fileName);
+    public static void DebugToDisk(nint renderer, nint texture, string folder, string fileName)
+    {
+        if (texture == nint.Zero)
+            throw new Exception("DebugToDisk: texture is null.");
+        var fn = $"C:/temp/director/{(!string.IsNullOrWhiteSpace(folder) ? folder + "/" : "")}SDL_{fileName}.png";
+        if (File.Exists(fn)) File.Delete(fn);
+
+        SDL.SDL_QueryTexture(texture, out _, out _, out int w, out int h);
+
+        // 1) temp target with a known format
+        var OUT_FMT = SDL.SDL_PIXELFORMAT_RGBA8888;
+        var target = SDL.SDL_CreateTexture(renderer, OUT_FMT, (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, w, h);
+        if (target == nint.Zero) throw new Exception(SDL.SDL_GetError());
+        SDL.SDL_SetTextureBlendMode(target, SDL.SDL_BlendMode.SDL_BLENDMODE_NONE);
+        SDL.SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);   // transparent clear
+        SDL.SDL_RenderClear(renderer);
+
+        // 2) render texture -> target
+        SDL.SDL_GetTextureBlendMode(texture, out var oldBlend);
+        SDL.SDL_SetTextureBlendMode(texture, SDL.SDL_BlendMode.SDL_BLENDMODE_NONE);
+        var old = SDL.SDL_GetRenderTarget(renderer);
+        SDL.SDL_SetRenderTarget(renderer, target);
+        SDL.SDL_RenderClear(renderer);
+        var rect = new SDL.SDL_Rect { x = 0, y = 0, w = w, h = h };
+        SDL.SDL_RenderCopy(renderer, texture, nint.Zero, ref rect);
+        SDL.SDL_SetTextureBlendMode(texture, oldBlend);     // restore
+
+        // 3) read pixels from target
+        nint surface = SDL.SDL_CreateRGBSurfaceWithFormat(0, w, h, 32, OUT_FMT);
+        var s = Marshal.PtrToStructure<SDL.SDL_Surface>(surface);
+        SDL.SDL_RenderReadPixels(renderer, ref rect, OUT_FMT, s.pixels, s.pitch);
+
+        // 4) restore target & save
+        SDL.SDL_SetRenderTarget(renderer, old);
+        if (SDL_image.IMG_SavePNG(surface, fn) != 0)
+            throw new Exception($"IMG_SavePNG failed: {SDL.SDL_GetError()}");
+
+        SDL.SDL_FreeSurface(surface);
+        SDL.SDL_DestroyTexture(target);
+    }
+
+#endif
+    private class TextureSubscription : IAbstUITextureUserSubscription
+    {
+        private readonly Action _onRelease;
+        public IAbstTexture2D Texture { get; }
+        public TextureSubscription(ImGuiTexture2D texture, Action onRelease)
+        {
+            Texture = texture;
+            _onRelease = onRelease;
+        }
+
+        public void Release() => _onRelease();
+    }
+}
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiButton.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Numerics;
+using ImGuiNET;
+using AbstUI.Components;
+using AbstUI.Primitives;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiButton : AbstImGuiComponent, IAbstFrameworkButton, IDisposable
+    {
+        public AbstImGuiButton(AbstImGuiComponentFactory factory) : base(factory)
+        {
+        }
+        public AMargin Margin { get; set; } = AMargin.Zero;
+        public string Text { get; set; } = string.Empty;
+        public bool Enabled { get; set; } = true;
+        public IAbstTexture2D? IconTexture { get; set; }
+
+        public object FrameworkNode => this;
+
+        public event Action? Pressed;
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility) return nint.Zero;
+
+            var basePos = context.Origin + new Vector2(X, Y);
+            global::ImGuiNET.ImGui.SetCursorScreenPos(basePos);
+            global::ImGuiNET.ImGui.PushID(Name);
+            if (!Enabled)
+                global::ImGuiNET.ImGui.BeginDisabled();
+
+            if (global::ImGuiNET.ImGui.Button(Text, new Vector2(Width, Height)))
+                Pressed?.Invoke();
+
+            if (!Enabled)
+                global::ImGuiNET.ImGui.EndDisabled();
+            global::ImGuiNET.ImGui.PopID();
+            return AbstImGuiRenderResult.RequireRender();
+        }
+
+        public void Invoke() => Pressed?.Invoke();
+        public override void Dispose() => base.Dispose();
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiColorPicker.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiColorPicker.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Numerics;
+using ImGuiNET;
+using AbstUI.Components;
+using AbstUI.Primitives;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiColorPicker : AbstImGuiComponent, IAbstFrameworkColorPicker, IDisposable
+    {
+        public AbstImGuiColorPicker(AbstImGuiComponentFactory factory) : base(factory)
+        {
+        }
+        public bool Enabled { get; set; } = true;
+        public AMargin Margin { get; set; } = AMargin.Zero;
+
+        private AColor _color;
+        public AColor Color
+        {
+            get => _color;
+            set
+            {
+                if (!_color.Equals(value))
+                {
+                    _color = value;
+                    ValueChanged?.Invoke();
+                }
+            }
+        }
+
+        public event Action? ValueChanged;
+        public object FrameworkNode => this;
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility) return nint.Zero;
+
+            global::ImGuiNET.ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
+            global::ImGuiNET.ImGui.PushID(Name);
+            if (!Enabled)
+                global::ImGuiNET.ImGui.BeginDisabled();
+
+            Vector3 col = new Vector3(_color.R / 255f, _color.G / 255f, _color.B / 255f);
+            if (global::ImGuiNET.ImGui.ColorEdit3("##color", ref col))
+            {
+                Color = new AColor((byte)(col.X * 255), (byte)(col.Y * 255), (byte)(col.Z * 255));
+            }
+
+            if (!Enabled)
+                global::ImGuiNET.ImGui.EndDisabled();
+            global::ImGuiNET.ImGui.PopID();
+            return AbstImGuiRenderResult.RequireRender();
+        }
+
+        public override void Dispose() => base.Dispose();
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiComponent.cs
@@ -1,0 +1,82 @@
+using System;
+
+namespace AbstUI.ImGui.Components;
+
+/// <summary>
+/// Base class for SDL GFX components providing common geometry and visibility
+/// handling that synchronizes with the <see cref="AbstImGuiComponentContext"/>.
+/// </summary>
+public abstract class AbstImGuiComponent : IAbstImGuiComponent, IDisposable
+{
+    protected AbstImGuiComponent(AbstImGuiComponentFactory factory)
+    {
+        ComponentContext = factory.CreateContext(this);
+        ComponentContext.Visible = _visibility;
+    }
+
+    public AbstImGuiComponentContext ComponentContext { get; }
+
+    private float _x;
+    public float X
+    {
+        get => _x;
+        set
+        {
+            _x = value;
+            ComponentContext.X = (int)value;
+        }
+    }
+
+    private float _y;
+    public float Y
+    {
+        get => _y;
+        set
+        {
+            _y = value;
+            ComponentContext.Y = (int)value;
+        }
+    }
+
+    private float _width;
+    public float Width
+    {
+        get => _width;
+        set
+        {
+            _width = value;
+            ComponentContext.TargetWidth = (int)value;
+        }
+    }
+
+    private float _height;
+    public float Height
+    {
+        get => _height;
+        set
+        {
+            _height = value;
+            ComponentContext.TargetHeight = (int)value;
+        }
+    }
+
+    private bool _visibility = true;
+    public bool Visibility
+    {
+        get => _visibility;
+        set
+        {
+            _visibility = value;
+            ComponentContext.Visible = value;
+        }
+    }
+
+    public string Name { get; set; } = string.Empty;
+
+    /// <inheritdoc />
+    public abstract AbstImGuiRenderResult Render(AbstImGuiRenderContext context);
+
+    /// <inheritdoc />
+    public virtual void Dispose() => ComponentContext.Dispose();
+}
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiGfxCanvas.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiGfxCanvas.cs
@@ -1,0 +1,341 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+using ImGuiNET;
+using AbstUI.Styles;
+using AbstUI.Primitives;
+using AbstUI.Components;
+using AbstUI.Texts;
+using AbstUI.ImGui.Bitmaps;
+using AbstUI.ImGui.ImGuiLL;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiGfxCanvas : AbstImGuiComponent, IAbstFrameworkGfxCanvas, IDisposable
+    {
+        public AMargin Margin { get; set; } = AMargin.Zero;
+
+        private readonly AbstImGuiComponentFactory _factory;
+        private readonly IAbstFontManager _fontManager;
+        private readonly int _width;
+        private readonly int _height;
+        private nint _texture;
+        private readonly nint _imguiTexture;
+        private readonly List<Action> _drawActions = new();
+        private AColor? _clearColor;
+        private bool _dirty;
+        public object FrameworkNode => this;
+        public nint Texture => _texture;
+
+        public bool Pixilated { get; set; }
+
+        public AbstImGuiGfxCanvas(AbstImGuiComponentFactory factory, IAbstFontManager fontManager, int width, int height) : base(factory)
+        {
+            _factory = factory;
+            _fontManager = fontManager;
+            _width = width;
+            _height = height;
+            _texture = SDL.SDL_CreateTexture(ComponentContext.Renderer, SDL.SDL_PIXELFORMAT_RGBA8888,
+                (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, width, height);
+            _imguiTexture = factory.RootContext.RegisterTexture(_texture);
+            Width = width;
+            Height = height;
+            _dirty = true;
+        }
+        public override void Dispose()
+        {
+            base.Dispose();
+            if (_texture != nint.Zero)
+            {
+                SDL.SDL_DestroyTexture(_texture);
+                _texture = nint.Zero;
+            }
+        }
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility)
+                return nint.Zero;
+
+            ComponentContext.Renderer = context.Renderer;
+
+            if (_dirty)
+            {
+                var prev = SDL.SDL_GetRenderTarget(ComponentContext.Renderer);
+                SDL.SDL_SetRenderTarget(ComponentContext.Renderer, _texture);
+                var clear = _clearColor ?? new AColor(0, 0, 0);
+                SDL.SDL_SetRenderDrawColor(ComponentContext.Renderer, clear.R, clear.G, clear.B, 255);
+                SDL.SDL_RenderClear(ComponentContext.Renderer);
+                foreach (var action in _drawActions)
+                    action();
+                SDL.SDL_SetRenderTarget(ComponentContext.Renderer, prev);
+                //SDL.BlendIm
+                _dirty = false;
+            }
+
+            var screenPos = context.Origin + new Vector2(X, Y);
+            global::ImGuiNET.ImGui.SetCursorScreenPos(screenPos);
+            global::ImGuiNET.ImGui.PushID(Name);
+            var imguiTexture = _factory.RootContext.GetTexture(_imguiTexture);
+            global::ImGuiNET.ImGui.Image(imguiTexture, new Vector2(Width, Height));
+            global::ImGuiNET.ImGui.PopID();
+
+            return AbstImGuiRenderResult.RequireRender();
+        }
+
+
+        private void MarkDirty() => _dirty = true;
+
+        public void Clear(AColor color)
+        {
+            _drawActions.Clear();
+            _clearColor = color;
+            MarkDirty();
+        }
+
+        public void SetPixel(APoint point, AColor color)
+        {
+            var p = point;
+            var c = color;
+            _drawActions.Add(() =>
+            {
+                SDL.SDL_SetRenderDrawColor(ComponentContext.Renderer, c.R, c.G, c.B, 255);
+                SDL.SDL_RenderDrawPointF(ComponentContext.Renderer, p.X, p.Y);
+            });
+            MarkDirty();
+        }
+
+        public void DrawLine(APoint start, APoint end, AColor color, float width = 1)
+        {
+            var s = start;
+            var e = end;
+            var c = color;
+            _drawActions.Add(() =>
+            {
+                SDL.SDL_SetRenderDrawColor(ComponentContext.Renderer, c.R, c.G, c.B, 255);
+                SDL.SDL_RenderDrawLineF(ComponentContext.Renderer, s.X, s.Y, e.X, e.Y);
+            });
+            MarkDirty();
+        }
+
+        public void DrawRect(ARect rect, AColor color, bool filled = true, float width = 1)
+        {
+            var rct = new SDL.SDL_Rect
+            {
+                x = (int)rect.Left,
+                y = (int)rect.Top,
+                w = (int)rect.Width,
+                h = (int)rect.Height
+            };
+            var c = color;
+            var f = filled;
+            _drawActions.Add(() =>
+            {
+                SDL.SDL_SetRenderDrawColor(ComponentContext.Renderer, c.R, c.G, c.B, 255);
+                if (f)
+                    SDL.SDL_RenderFillRect(ComponentContext.Renderer, ref rct);
+                else
+                    SDL.SDL_RenderDrawRect(ComponentContext.Renderer, ref rct);
+            });
+            MarkDirty();
+        }
+
+        public void DrawCircle(APoint center, float radius, AColor color, bool filled = true, float width = 1)
+        {
+            var ctr = center;
+            var rad = radius;
+            var c = color;
+            var f = filled;
+            _drawActions.Add(() =>
+            {
+                SDL.SDL_SetRenderDrawColor(ComponentContext.Renderer, c.R, c.G, c.B, 255);
+                int segs = (int)(rad * 6);
+                double step = Math.PI * 2 / segs;
+                float prevX = ctr.X + rad;
+                float prevY = ctr.Y;
+                for (int i = 1; i <= segs; i++)
+                {
+                    double angle = step * i;
+                    float x = ctr.X + (float)(rad * Math.Cos(angle));
+                    float y = ctr.Y + (float)(rad * Math.Sin(angle));
+                    SDL.SDL_RenderDrawLineF(ComponentContext.Renderer, prevX, prevY, x, y);
+                    if (f)
+                        SDL.SDL_RenderDrawLineF(ComponentContext.Renderer, ctr.X, ctr.Y, x, y);
+                    prevX = x;
+                    prevY = y;
+                }
+            });
+            MarkDirty();
+        }
+
+        public void DrawArc(APoint center, float radius, float startDeg, float endDeg, int segments, AColor color, float width = 1)
+        {
+            var ctr = center;
+            var rad = radius;
+            var sd = startDeg;
+            var ed = endDeg;
+            var segs = segments;
+            var c = color;
+            _drawActions.Add(() =>
+            {
+                SDL.SDL_SetRenderDrawColor(ComponentContext.Renderer, c.R, c.G, c.B, 255);
+                double startRad = sd * Math.PI / 180.0;
+                double endRad = ed * Math.PI / 180.0;
+                double step = (endRad - startRad) / segs;
+                float prevX = ctr.X + (float)(rad * Math.Cos(startRad));
+                float prevY = ctr.Y + (float)(rad * Math.Sin(startRad));
+                for (int i = 1; i <= segs; i++)
+                {
+                    double ang = startRad + i * step;
+                    float x = ctr.X + (float)(rad * Math.Cos(ang));
+                    float y = ctr.Y + (float)(rad * Math.Sin(ang));
+                    SDL.SDL_RenderDrawLineF(ComponentContext.Renderer, prevX, prevY, x, y);
+                    prevX = x;
+                    prevY = y;
+                }
+            });
+            MarkDirty();
+        }
+
+        public void DrawPolygon(IReadOnlyList<APoint> points, AColor color, bool filled = true, float width = 1)
+        {
+            if (points.Count < 2) return;
+            var pts = new APoint[points.Count];
+            for (int i = 0; i < points.Count; i++)
+                pts[i] = points[i];
+            var c = color;
+            var f = filled;
+            _drawActions.Add(() =>
+            {
+                SDL.SDL_SetRenderDrawColor(ComponentContext.Renderer, c.R, c.G, c.B, 255);
+                for (int i = 0; i < pts.Length - 1; i++)
+                    SDL.SDL_RenderDrawLineF(ComponentContext.Renderer, pts[i].X, pts[i].Y, pts[i + 1].X, pts[i + 1].Y);
+                SDL.SDL_RenderDrawLineF(ComponentContext.Renderer, pts[^1].X, pts[^1].Y, pts[0].X, pts[0].Y);
+                if (f)
+                {
+                    var p0 = pts[0];
+                    for (int i = 1; i < pts.Length - 1; i++)
+                    {
+                        SDL.SDL_RenderDrawLineF(ComponentContext.Renderer, p0.X, p0.Y, pts[i].X, pts[i].Y);
+                        SDL.SDL_RenderDrawLineF(ComponentContext.Renderer, p0.X, p0.Y, pts[i + 1].X, pts[i + 1].Y);
+                    }
+                }
+            });
+            MarkDirty();
+        }
+
+        public void DrawText(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, AbstTextAlignment alignment = default)
+        {
+            var pos = position;
+            var txt = text;
+            var fntName = font;
+            var col = color;
+            var fs = fontSize;
+            var w = width;
+            _drawActions.Add(() =>
+            {
+                var path = _fontManager.Get<string>(fntName ?? string.Empty);
+                if (string.IsNullOrEmpty(path)) return;
+                nint fnt = SDL_ttf.TTF_OpenFont(path, fs);
+                if (fnt == nint.Zero) return;
+                SDL.SDL_Color c = new SDL.SDL_Color { r = col?.R ?? 0, g = col?.G ?? 0, b = col?.B ?? 0, a = 255 };
+
+                string RenderLine(string line)
+                {
+                    if (w >= 0)
+                    {
+                        while (line.Length > 0 && SDL_ttf.TTF_SizeUTF8(fnt, line, out int tw, out _) == 0 && tw > w)
+                        {
+                            line = line.Substring(0, line.Length - 1);
+                        }
+                    }
+                    return line;
+                }
+
+                string[] lines = txt.Split('\n');
+                List<(nint surf, int w, int h)> surfaces = new();
+                foreach (var ln in lines)
+                {
+                    var line = RenderLine(ln);
+                    nint s = SDL_ttf.TTF_RenderUTF8_Blended(fnt, line, c);
+                    if (s == nint.Zero) continue;
+                    var sur = SDL.PtrToStructure<SDL.SDL_Surface>(s);
+                    surfaces.Add((s, sur.w, sur.h));
+                }
+
+                int y = (int)pos.Y;
+                foreach (var (s, tw, th) in surfaces)
+                {
+                    nint tex = SDL.SDL_CreateTextureFromSurface(ComponentContext.Renderer, s);
+                    if (tex != nint.Zero)
+                    {
+                        SDL.SDL_Rect dst = new SDL.SDL_Rect { x = (int)pos.X, y = y, w = tw, h = th };
+                        SDL.SDL_RenderCopy(ComponentContext.Renderer, tex, nint.Zero, ref dst);
+                        SDL.SDL_DestroyTexture(tex);
+                    }
+                    SDL.SDL_FreeSurface(s);
+                    y += th;
+                }
+
+                SDL_ttf.TTF_CloseFont(fnt);
+            });
+            MarkDirty();
+        }
+
+        public void DrawPicture(byte[] data, int width, int height, APoint position, APixelFormat format)
+        {
+            var dat = data;
+            var w = width;
+            var h = height;
+            var pos = position;
+            var fmt = format;
+            _drawActions.Add(() =>
+            {
+                fmt.GetMasks(out uint rmask, out uint gmask, out uint bmask, out uint amask, out int bpp);
+                var handle = GCHandle.Alloc(dat, GCHandleType.Pinned);
+                nint surf = SDL.SDL_CreateRGBSurfaceFrom(handle.AddrOfPinnedObject(), w, h, bpp, w * (bpp / 8), rmask, gmask, bmask, amask);
+                if (surf == nint.Zero) { handle.Free(); return; }
+                nint tex = SDL.SDL_CreateTextureFromSurface(ComponentContext.Renderer, surf);
+                if (tex != nint.Zero)
+                {
+                    SDL.SDL_Rect dst = new SDL.SDL_Rect { x = (int)pos.X, y = (int)pos.Y, w = w, h = h };
+                    SDL.SDL_RenderCopy(ComponentContext.Renderer, tex, nint.Zero, ref dst);
+                    SDL.SDL_DestroyTexture(tex);
+                }
+                SDL.SDL_FreeSurface(surf);
+                handle.Free();
+            });
+            MarkDirty();
+        }
+        public void DrawPicture(IAbstTexture2D texture, int width, int height, APoint position)
+        {
+            var tex = texture;
+            var w = width;
+            var h = height;
+            var pos = position;
+            _drawActions.Add(() =>
+            {
+                if (tex is ImGuiTexture2D img)
+                {
+
+                    nint sdlTex = SDL.SDL_CreateTextureFromSurface(ComponentContext.Renderer, img.Handle);
+                    if (sdlTex != nint.Zero)
+                    {
+                        SDL.SDL_Rect dst = new SDL.SDL_Rect
+                        {
+                            x = (int)pos.X,
+                            y = (int)pos.Y,
+                            w = w,
+                            h = h
+                        };
+                        SDL.SDL_RenderCopy(ComponentContext.Renderer, sdlTex, nint.Zero, ref dst);
+                        SDL.SDL_DestroyTexture(sdlTex);
+                    }
+                }
+            });
+            MarkDirty();
+        }
+
+
+
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputCheckbox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputCheckbox.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Numerics;
+using ImGuiNET;
+using AbstUI.Components;
+using AbstUI.Primitives;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiInputCheckbox : AbstImGuiComponent, IAbstFrameworkInputCheckbox, IDisposable
+    {
+        public AbstImGuiInputCheckbox(AbstImGuiComponentFactory factory) : base(factory)
+        {
+        }
+        public bool Enabled { get; set; } = true;
+        private bool _checked;
+        public bool Checked
+        {
+            get => _checked;
+            set
+            {
+                if (_checked != value)
+                {
+                    _checked = value;
+                    ValueChanged?.Invoke();
+                }
+            }
+        }
+        public AMargin Margin { get; set; } = AMargin.Zero;
+        public event Action? ValueChanged;
+        public object FrameworkNode => this;
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility) return nint.Zero;
+            global::ImGuiNET.ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
+            global::ImGuiNET.ImGui.PushID(Name);
+            if (!Enabled)
+                global::ImGuiNET.ImGui.BeginDisabled();
+            bool val = _checked;
+            if (global::ImGuiNET.ImGui.Checkbox("##check", ref val))
+                Checked = val;
+            if (!Enabled)
+                global::ImGuiNET.ImGui.EndDisabled();
+            global::ImGuiNET.ImGui.PopID();
+            return AbstImGuiRenderResult.RequireRender();
+        }
+
+        public override void Dispose() => base.Dispose();
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputCombobox.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using ImGuiNET;
+using AbstUI.Components;
+using AbstUI.Primitives;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiInputCombobox : AbstImGuiComponent, IAbstFrameworkInputCombobox, IDisposable
+    {
+        public AbstImGuiInputCombobox(AbstImGuiComponentFactory factory) : base(factory)
+        {
+        }
+        public bool Enabled { get; set; } = true;
+        public AMargin Margin { get; set; } = AMargin.Zero;
+
+        private readonly List<KeyValuePair<string, string>> _items = new();
+        public IReadOnlyList<KeyValuePair<string, string>> Items => _items;
+        public int SelectedIndex { get; set; } = -1;
+        public string? SelectedKey { get; set; }
+        public string? SelectedValue { get; set; }
+
+        public event Action? ValueChanged;
+        public object FrameworkNode => this;
+        public void AddItem(string key, string value)
+        {
+            _items.Add(new KeyValuePair<string, string>(key, value));
+        }
+
+        public void ClearItems()
+        {
+            _items.Clear();
+            SelectedIndex = -1;
+            SelectedKey = null;
+            SelectedValue = null;
+        }
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility) return nint.Zero;
+            global::ImGuiNET.ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
+            global::ImGuiNET.ImGui.PushID(Name);
+            if (!Enabled)
+                global::ImGuiNET.ImGui.BeginDisabled();
+
+            string preview = SelectedValue ?? string.Empty;
+            if (global::ImGuiNET.ImGui.BeginCombo("##combo", preview))
+            {
+                for (int i = 0; i < _items.Count; i++)
+                {
+                    bool selected = i == SelectedIndex;
+                    var it = _items[i];
+                    if (global::ImGuiNET.ImGui.Selectable(it.Value, selected))
+                    {
+                        SelectedIndex = i;
+                        SelectedKey = it.Key;
+                        SelectedValue = it.Value;
+                        ValueChanged?.Invoke();
+                    }
+                    if (selected)
+                        global::ImGuiNET.ImGui.SetItemDefaultFocus();
+                }
+                global::ImGuiNET.ImGui.EndCombo();
+            }
+
+            if (!Enabled)
+                global::ImGuiNET.ImGui.EndDisabled();
+            global::ImGuiNET.ImGui.PopID();
+            return AbstImGuiRenderResult.RequireRender();
+        }
+
+        public override void Dispose() => base.Dispose();
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputItemList.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using ImGuiNET;
+using AbstUI.Components;
+using AbstUI.Primitives;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiInputltemList : AbstImGuiComponent, IAbstFrameworkItemList, IDisposable
+    {
+        public AbstImGuiInputltemList(AbstImGuiComponentFactory factory) : base(factory)
+        {
+        }
+        public bool Enabled { get; set; } = true;
+        public AMargin Margin { get; set; } = AMargin.Zero;
+
+        private readonly List<KeyValuePair<string, string>> _items = new();
+        public IReadOnlyList<KeyValuePair<string, string>> Items => _items;
+        public int SelectedIndex { get; set; } = -1;
+        public string? SelectedKey { get; set; }
+        public string? SelectedValue { get; set; }
+
+        public event Action? ValueChanged;
+        public object FrameworkNode => this;
+        public void AddItem(string key, string value)
+        {
+            _items.Add(new KeyValuePair<string, string>(key, value));
+        }
+        public void ClearItems()
+        {
+            _items.Clear();
+            SelectedIndex = -1;
+            SelectedKey = null;
+            SelectedValue = null;
+        }
+        public override void Dispose() => base.Dispose();
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility)
+                return nint.Zero;
+
+            global::ImGuiNET.ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
+            global::ImGuiNET.ImGui.PushID(Name);
+
+            if (!Enabled)
+                global::ImGuiNET.ImGui.BeginDisabled();
+
+            if (global::ImGuiNET.ImGui.BeginListBox("##list", new Vector2(Width, Height)))
+            {
+                for (int i = 0; i < _items.Count; i++)
+                {
+                    var item = _items[i];
+                    bool selected = i == SelectedIndex;
+                    if (global::ImGuiNET.ImGui.Selectable(item.Value, selected))
+                    {
+                        SelectedIndex = i;
+                        SelectedKey = item.Key;
+                        SelectedValue = item.Value;
+                        ValueChanged?.Invoke();
+                    }
+                    if (selected)
+                        global::ImGuiNET.ImGui.SetItemDefaultFocus();
+                }
+                global::ImGuiNET.ImGui.EndListBox();
+            }
+
+            if (!Enabled)
+                global::ImGuiNET.ImGui.EndDisabled();
+
+            global::ImGuiNET.ImGui.PopID();
+
+            return AbstImGuiRenderResult.RequireRender();
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputNumber.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputNumber.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Numerics;
+using ImGuiNET;
+using AbstUI.Components;
+using AbstUI.Primitives;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiInputNumber : AbstImGuiComponent, IAbstFrameworkInputNumber<float>, IDisposable
+    {
+        public AbstImGuiInputNumber(AbstImGuiComponentFactory factory) : base(factory)
+        {
+        }
+        public bool Enabled { get; set; } = true;
+        private float _value;
+        public float Value
+        {
+            get => _value;
+            set
+            {
+                if (_value != value)
+                {
+                    _value = value;
+                    ValueChanged?.Invoke();
+                }
+            }
+        }
+        public float Min { get; set; }
+        public float Max { get; set; }
+        public ANumberType NumberType { get; set; } = ANumberType.Float;
+        public AMargin Margin { get; set; } = AMargin.Zero;
+        public event Action? ValueChanged;
+        public object FrameworkNode => this;
+
+        public int FontSize { get; set; } = 12;
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility) return nint.Zero;
+
+            global::ImGuiNET.ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
+            global::ImGuiNET.ImGui.PushID(Name);
+            if (!Enabled)
+                global::ImGuiNET.ImGui.BeginDisabled();
+
+            if (NumberType == ANumberType.Integer)
+            {
+                int val = (int)_value;
+                if (global::ImGuiNET.ImGui.InputInt("##num", ref val))
+                {
+                    val = Math.Clamp(val, (int)Min, (int)Max);
+                    Value = val;
+                }
+            }
+            else
+            {
+                float val = _value;
+                if (global::ImGuiNET.ImGui.InputFloat("##num", ref val))
+                {
+                    val = Math.Clamp(val, Min, Max);
+                    Value = val;
+                }
+            }
+
+            if (!Enabled)
+                global::ImGuiNET.ImGui.EndDisabled();
+            global::ImGuiNET.ImGui.PopID();
+            return AbstImGuiRenderResult.RequireRender();
+        }
+
+        public override void Dispose() => base.Dispose();
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputSlider.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputSlider.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Numerics;
+using ImGuiNET;
+using AbstUI.Components;
+using AbstUI.Primitives;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiInputSlider<TValue> : AbstImGuiComponent, IAbstFrameworkInputSlider<TValue>, IDisposable where TValue : struct
+    {
+        public AbstImGuiInputSlider(AbstImGuiComponentFactory factory) : base(factory)
+        {
+        }
+        public AMargin Margin { get; set; } = AMargin.Zero;
+        public bool Enabled { get; set; } = true;
+        private TValue _value = default!;
+        public TValue Value
+        {
+            get => _value;
+            set
+            {
+                if (!Equals(_value, value))
+                {
+                    _value = value;
+                    ValueChanged?.Invoke();
+                }
+            }
+        }
+        public TValue MinValue { get; set; } = default!;
+        public TValue MaxValue { get; set; } = default!;
+        public TValue Step { get; set; } = default!;
+        public event Action? ValueChanged;
+        public object FrameworkNode => this;
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility) return nint.Zero;
+            global::ImGuiNET.ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
+            global::ImGuiNET.ImGui.PushID(Name);
+            if (!Enabled)
+                global::ImGuiNET.ImGui.BeginDisabled();
+
+            if (typeof(TValue) == typeof(int))
+            {
+                int v = Convert.ToInt32(_value);
+                int min = Convert.ToInt32(MinValue);
+                int max = Convert.ToInt32(MaxValue);
+                if (global::ImGuiNET.ImGui.SliderInt("##slider", ref v, min, max))
+                    Value = (TValue)(object)v;
+            }
+            else
+            {
+                float v = Convert.ToSingle(_value);
+                float min = Convert.ToSingle(MinValue);
+                float max = Convert.ToSingle(MaxValue);
+                if (global::ImGuiNET.ImGui.SliderFloat("##slider", ref v, min, max))
+                    Value = (TValue)(object)v;
+            }
+
+            if (!Enabled)
+                global::ImGuiNET.ImGui.EndDisabled();
+            global::ImGuiNET.ImGui.PopID();
+            return AbstImGuiRenderResult.RequireRender();
+        }
+
+        public override void Dispose() => base.Dispose();
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputText.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Numerics;
+using ImGuiNET;
+using AbstUI.Components;
+using AbstUI.Primitives;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiInputText : AbstImGuiComponent, IAbstFrameworkInputText, IDisposable
+    {
+        public AbstImGuiInputText(AbstImGuiComponentFactory factory, bool multiLine) : base(factory)
+        {
+        }
+        public bool Enabled { get; set; } = true;
+        private string _text = string.Empty;
+        public string Text
+        {
+            get => _text;
+            set
+            {
+                if (_text != value)
+                {
+                    _text = value;
+                    ValueChanged?.Invoke();
+                }
+            }
+        }
+        public int MaxLength { get; set; }
+        public string? Font { get; set; }
+        public int FontSize { get; set; } = 12;
+        public AMargin Margin { get; set; } = AMargin.Zero;
+        public object FrameworkNode => this;
+
+        public bool IsMultiLine { get; set; }
+
+        public event Action? ValueChanged;
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility) return nint.Zero;
+
+            // place relative to current context origin
+            global::ImGuiNET.ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
+
+            if (Width > 0) global::ImGuiNET.ImGui.SetNextItemWidth(Width);
+
+            global::ImGuiNET.ImGui.PushID(Name);
+            if (!Enabled) global::ImGuiNET.ImGui.BeginDisabled();
+
+            uint cap = MaxLength > 0 ? (uint)MaxLength : 1024u;
+            if (global::ImGuiNET.ImGui.InputText("##text", ref _text, cap))
+                ValueChanged?.Invoke();
+
+            if (!Enabled) global::ImGuiNET.ImGui.EndDisabled();
+            global::ImGuiNET.ImGui.PopID();
+            return AbstImGuiRenderResult.RequireRender();
+        }
+
+
+        public override void Dispose() => base.Dispose();
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiLabel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiLabel.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Numerics;
+using AbstUI.Texts;
+using ImGuiNET;
+using AbstUI.Components;
+using AbstUI.Primitives;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiLabel : AbstImGuiComponent, IAbstFrameworkLabel, IDisposable
+    {
+        public AbstImGuiLabel(AbstImGuiComponentFactory factory) : base(factory)
+        {
+        }
+        public AMargin Margin { get; set; } = AMargin.Zero;
+
+        public string Text { get; set; } = string.Empty;
+        public int FontSize { get; set; }
+        public string? Font { get; set; }
+
+        public AColor FontColor { get; set; } = AColors.Black;
+        private int _lineHeight;
+        public int LineHeight { get => _lineHeight; set => _lineHeight = value; }
+        private ATextWrapMode _wrapMode;
+        public ATextWrapMode WrapMode { get => _wrapMode; set => _wrapMode = value; }
+        private AbstTextAlignment _textAlignment;
+        public AbstTextAlignment TextAlignment { get => _textAlignment; set => _textAlignment = value; }
+
+        public object FrameworkNode => this;
+
+
+        public event Action? ValueChanged;
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility || string.IsNullOrEmpty(Text))
+                return default; // DoRender=false
+            ImFontPtr? font = null;
+            if (FontSize > 0)
+            {
+                //font = context.GetFont(FontSize);
+                //if (font.HasValue)
+                //    global::ImGuiNET.ImGui.PushFont(font.Value);
+            }
+            var basePos = context.Origin + new Vector2(X, Y);
+            global::ImGuiNET.ImGui.SetCursorScreenPos(basePos);
+            global::ImGuiNET.ImGui.PushID(Name);
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.Text, FontColor.ToImGuiColor());
+
+
+            // Wrapping (only when Width > 0)
+            bool wrap = WrapMode != ATextWrapMode.Off && Width > 0;
+            if (wrap) global::ImGuiNET.ImGui.PushTextWrapPos(basePos.X + Width);
+
+            // Position with screen coords (no assertions)
+            if (!wrap && Width > 0 && TextAlignment != AbstTextAlignment.Left)
+            {
+                // single-line alignment
+                var sz = global::ImGuiNET.ImGui.CalcTextSize(Text);
+                float startX = basePos.X;
+                if (TextAlignment == AbstTextAlignment.Center) startX += (Width - sz.X) / 2f;
+                else if (TextAlignment == AbstTextAlignment.Right) startX += Width - sz.X;
+                global::ImGuiNET.ImGui.SetCursorScreenPos(new Vector2(startX, basePos.Y));
+                global::ImGuiNET.ImGui.TextUnformatted(Text);
+            }
+            else
+            {
+                // left aligned (or wrapped)
+                global::ImGuiNET.ImGui.SetCursorScreenPos(basePos);
+                if (wrap) global::ImGuiNET.ImGui.TextWrapped(Text);
+                else global::ImGuiNET.ImGui.TextUnformatted(Text);
+            }
+
+            if (wrap) global::ImGuiNET.ImGui.PopTextWrapPos();
+            global::ImGuiNET.ImGui.PopStyleColor();
+            global::ImGuiNET.ImGui.PopID();
+            if (font.HasValue)
+                global::ImGuiNET.ImGui.PopFont();
+            return AbstImGuiRenderResult.RequireRender(); // UI drawn via ImGui, no SDL texture
+        }
+
+
+        public override void Dispose() => base.Dispose();
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiLayoutWrapper.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiLayoutWrapper.cs
@@ -1,0 +1,28 @@
+﻿using AbstUI.Components;
+using AbstUI.Primitives;
+
+namespace AbstUI.ImGui.Components
+{
+    public partial class AbstImGuiLayoutWrapper : AbstImGuiComponent, IAbstFrameworkLayoutWrapper
+    {
+        private AbstLayoutWrapper _lingoLayoutWrapper;
+        public object FrameworkNode => this;
+
+        public AbstImGuiLayoutWrapper(AbstImGuiComponentFactory factory, AbstLayoutWrapper layoutWrapper) : base(factory)
+        {
+            _lingoLayoutWrapper = layoutWrapper;
+            _lingoLayoutWrapper.Init(this);
+            var content = layoutWrapper.Content.FrameworkObj;
+        }
+
+        public AMargin Margin { get; set; }
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            var sdlComponent = (AbstImGuiComponent)_lingoLayoutWrapper.Content.FrameworkObj;
+            sdlComponent.X = X;
+            sdlComponent.Y = Y;
+            return sdlComponent.Render(context);
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiMenu.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiMenu.cs
@@ -1,0 +1,25 @@
+using System;
+using AbstUI.Components;
+using AbstUI.Primitives;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiMenu : AbstImGuiComponent, IAbstFrameworkMenu, IDisposable
+    {
+        public AMargin Margin { get; set; } = AMargin.Zero;
+        public object FrameworkNode => this;
+
+        public AbstImGuiMenu(AbstImGuiComponentFactory factory, string name) : base(factory)
+        {
+            Name = name;
+        }
+
+        public void AddItem(IAbstFrameworkMenuItem item) { }
+        public void ClearItems() { }
+        public void PositionPopup(IAbstFrameworkButton button) { }
+        public void Popup() { }
+        public override void Dispose() => base.Dispose();
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context) => AbstImGuiRenderResult.RequireRender();
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiMenuItem.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiMenuItem.cs
@@ -1,0 +1,25 @@
+using System;
+using AbstUI.Components;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiMenuItem : AbstImGuiComponent, IAbstFrameworkMenuItem, IDisposable
+    {
+        public bool Enabled { get; set; } = true;
+        public bool CheckMark { get; set; }
+        public string? Shortcut { get; set; }
+        public event Action? Activated;
+        public object FrameworkNode => this;
+
+        public AbstImGuiMenuItem(AbstImGuiComponentFactory factory, string name, string? shortcut) : base(factory)
+        {
+            Name = name;
+            Shortcut = shortcut;
+        }
+
+        public void Invoke() => Activated?.Invoke();
+        public override void Dispose() => base.Dispose();
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context) => AbstImGuiRenderResult.RequireRender();
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiPanel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiPanel.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Components;
+using AbstUI.Primitives;
+using AbstUI.ImGui.ImGuiLL;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiPanel : AbstImGuiComponent, IAbstFrameworkPanel, IDisposable
+    {
+        public AbstImGuiPanel(AbstImGuiComponentFactory factory) : base(factory)
+        {
+        }
+        public AMargin Margin { get; set; } = AMargin.Zero;
+        public AColor? BackgroundColor { get; set; }
+        public AColor? BorderColor { get; set; }
+        public float BorderWidth { get; set; }
+        public object FrameworkNode => this;
+
+        private readonly List<IAbstFrameworkLayoutNode> _children = new();
+
+        public void AddItem(IAbstFrameworkLayoutNode child)
+        {
+            if (!_children.Contains(child))
+                _children.Add(child);
+        }
+
+        public IEnumerable<IAbstFrameworkLayoutNode> GetItems() => _children.ToArray();
+
+        public void RemoveItem(IAbstFrameworkLayoutNode child)
+        {
+            if (_children.Remove(child))
+                (child as IDisposable)?.Dispose();
+        }
+
+        public void RemoveAll()
+        {
+            foreach (var child in _children)
+                (child as IDisposable)?.Dispose();
+            _children.Clear();
+        }
+
+        private nint _texture;
+        private int _texW;
+        private int _texH;
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility)
+                return nint.Zero;
+
+            int w = (int)Width;
+            int h = (int)Height;
+            if (_texture == nint.Zero || w != _texW || h != _texH)
+            {
+                if (_texture != nint.Zero)
+                {
+                    SDL.SDL_DestroyTexture(_texture);
+                }
+                _texture = SDL.SDL_CreateTexture(context.Renderer, SDL.SDL_PIXELFORMAT_RGBA8888,
+                    (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, w, h);
+                _texW = w;
+                _texH = h;
+            }
+
+            SDL.SDL_SetRenderTarget(context.Renderer, _texture);
+
+            if (BackgroundColor is { } bg)
+            {
+                SDL.SDL_SetRenderDrawColor(context.Renderer, bg.R, bg.G, bg.B, bg.A);
+                SDL.SDL_RenderClear(context.Renderer);
+            }
+            else
+            {
+                SDL.SDL_SetRenderDrawColor(context.Renderer, 0, 0, 0, 0);
+                SDL.SDL_RenderClear(context.Renderer);
+            }
+
+            foreach (var child in _children)
+            {
+                if (child.FrameworkNode is AbstImGuiComponent comp)
+                {
+                    var ctx = comp.ComponentContext;
+                    var oldOffX = ctx.OffsetX;
+                    var oldOffY = ctx.OffsetY;
+                    ctx.OffsetX += -X;
+                    ctx.OffsetY += -Y;
+                    ctx.RenderToTexture(context);
+                    ctx.OffsetX = oldOffX;
+                    ctx.OffsetY = oldOffY;
+                }
+            }
+
+            if (BorderWidth > 0 && BorderColor is { } bc)
+            {
+                SDL.SDL_SetRenderDrawColor(context.Renderer, bc.R, bc.G, bc.B, bc.A);
+                SDL.SDL_Rect rect = new SDL.SDL_Rect { x = 0, y = 0, w = w, h = h };
+                for (int i = 0; i < (int)BorderWidth; i++)
+                {
+                    SDL.SDL_RenderDrawRect(context.Renderer, ref rect);
+                    rect.x++; rect.y++; rect.w -= 2; rect.h -= 2;
+                }
+            }
+
+            SDL.SDL_SetRenderTarget(context.Renderer, nint.Zero);
+            return _texture;
+        }
+
+        public override void Dispose()
+        {
+            RemoveAll();
+            if (_texture != nint.Zero)
+            {
+                SDL.SDL_DestroyTexture(_texture);
+                _texture = nint.Zero;
+            }
+            base.Dispose();
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiScrollContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiScrollContainer.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using ImGuiNET;
+using AbstUI.Components;
+using AbstUI.Primitives;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiScrollContainer : AbstImGuiComponent, IAbstFrameworkScrollContainer, IDisposable
+    {
+        public AbstImGuiScrollContainer(AbstImGuiComponentFactory factory) : base(factory)
+        {
+        }
+        public AMargin Margin { get; set; } = AMargin.Zero;
+        public float ScrollHorizontal { get; set; }
+        public float ScrollVertical { get; set; }
+        public bool ClipContents { get; set; }
+        public object FrameworkNode => this;
+
+        private readonly List<IAbstFrameworkLayoutNode> _children = new();
+
+        public void AddItem(IAbstFrameworkLayoutNode child)
+        {
+            if (!_children.Contains(child))
+                _children.Add(child);
+        }
+
+        public void RemoveItem(IAbstFrameworkLayoutNode child)
+        {
+            _children.Remove(child);
+        }
+
+        public IEnumerable<IAbstFrameworkLayoutNode> GetItems() => _children.ToArray();
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility) return nint.Zero;
+
+            var screenPos = context.Origin + new Vector2(X, Y);
+            global::ImGuiNET.ImGui.SetCursorScreenPos(screenPos);
+
+            global::ImGuiNET.ImGui.PushID(Name);
+
+            var childFlags = ImGuiChildFlags.None;
+            var winFlags = ImGuiWindowFlags.None; // add Always*Scrollbar if you want to force
+
+            // clip border if you like
+            if (ClipContents) childFlags |= ImGuiChildFlags.Borders;
+
+            global::ImGuiNET.ImGui.BeginChild("##scroll", new Vector2(Width, Height), childFlags, winFlags);
+
+            // child origin for nested components
+            var scroll = new Vector2(global::ImGuiNET.ImGui.GetScrollX(), global::ImGuiNET.ImGui.GetScrollY());
+            var childOrigin = global::ImGuiNET.ImGui.GetCursorScreenPos() - scroll;
+            var childCtx = context.CreateNew(childOrigin);
+
+            // render children & measure content extents
+            float maxX = 0, maxY = 0;
+            foreach (var child in _children)
+            {
+                if (child is AbstImGuiComponent comp)
+                {
+                    comp.Render(childCtx);
+                    maxX = MathF.Max(maxX, comp.X + comp.Width);
+                    maxY = MathF.Max(maxY, comp.Y + comp.Height);
+                }
+            }
+
+            // report content size to ImGui so it knows it should scroll
+            global::ImGuiNET.ImGui.SetCursorPos(Vector2.Zero);
+            global::ImGuiNET.ImGui.Dummy(new Vector2(maxX, maxY)); // <- drives scrollbar visibility
+
+            // capture user scroll position for external access
+            ScrollHorizontal = global::ImGuiNET.ImGui.GetScrollX();
+            ScrollVertical = global::ImGuiNET.ImGui.GetScrollY();
+
+            global::ImGuiNET.ImGui.EndChild();
+            global::ImGuiNET.ImGui.PopID();
+
+            return AbstImGuiRenderResult.RequireRender();
+        }
+
+
+
+        public override void Dispose()
+        {
+            _children.Clear();
+            base.Dispose();
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiSpinBox.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Numerics;
+using ImGuiNET;
+using AbstUI.Components;
+using AbstUI.Primitives;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiSpinBox : AbstImGuiComponent, IAbstFrameworkSpinBox, IDisposable
+    {
+        public AbstImGuiSpinBox(AbstImGuiComponentFactory factory) : base(factory)
+        {
+        }
+        public bool Enabled { get; set; } = true;
+        private float _value;
+        public float Value
+        {
+            get => _value;
+            set
+            {
+                if (_value != value)
+                {
+                    _value = value;
+                    ValueChanged?.Invoke();
+                }
+            }
+        }
+        public float Min { get; set; }
+        public float Max { get; set; }
+        public AMargin Margin { get; set; } = AMargin.Zero;
+        public object FrameworkNode => this;
+
+        public event Action? ValueChanged;
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility) return nint.Zero;
+            global::ImGuiNET.ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
+            global::ImGuiNET.ImGui.PushID(Name);
+            if (!Enabled)
+                global::ImGuiNET.ImGui.BeginDisabled();
+            float val = _value;
+            if (global::ImGuiNET.ImGui.InputFloat("##spin", ref val, 1f))
+            {
+                val = Math.Clamp(val, Min, Max);
+                Value = val;
+            }
+            if (!Enabled)
+                global::ImGuiNET.ImGui.EndDisabled();
+            global::ImGuiNET.ImGui.PopID();
+            return AbstImGuiRenderResult.RequireRender();
+        }
+
+        public override void Dispose() => base.Dispose();
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiStateButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiStateButton.cs
@@ -1,0 +1,118 @@
+using System.Numerics;
+using ImGuiNET;
+using AbstUI.Primitives;
+using AbstUI.Components;
+using AbstUI.ImGui.Bitmaps;
+using AbstUI.ImGui.ImGuiLL;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiStateButton : AbstImGuiComponent, IAbstFrameworkStateButton, IDisposable
+    {
+        private nint _textureOnPtr;
+        private IAbstTexture2D? _textureOn;
+        private nint _textureOffPtr;
+        private IAbstTexture2D? _textureOff;
+
+        public AbstImGuiStateButton(AbstImGuiComponentFactory factory) : base(factory)
+        {
+        }
+        public bool Enabled { get; set; } = true;
+        public string Text { get; set; } = string.Empty;
+        public IAbstTexture2D? TextureOn
+        {
+            get => _textureOn;
+            set
+            {
+                _textureOn = value;
+                if (_textureOnPtr != nint.Zero)
+                {
+                    SDL.SDL_DestroyTexture(_textureOnPtr);
+                    _textureOnPtr = nint.Zero;
+                }
+                if (value is ImGuiImageTexture img)
+                {
+                    _textureOnPtr = SDL.SDL_CreateTextureFromSurface(ComponentContext.Renderer, img.SurfaceId);
+                }
+            }
+        }
+
+        public IAbstTexture2D? TextureOff
+        {
+            get => _textureOff;
+            set
+            {
+                _textureOff = value;
+                if (_textureOffPtr != nint.Zero)
+                {
+                    SDL.SDL_DestroyTexture(_textureOffPtr);
+                    _textureOffPtr = nint.Zero;
+                }
+                if (value is ImGuiImageTexture img)
+                {
+                    _textureOffPtr = SDL.SDL_CreateTextureFromSurface(ComponentContext.Renderer, img.SurfaceId);
+                }
+            }
+        }
+        private bool _isOn;
+        public bool IsOn
+        {
+            get => _isOn;
+            set
+            {
+                if (_isOn != value)
+                {
+                    _isOn = value;
+                    ValueChanged?.Invoke();
+                }
+            }
+        }
+        public AMargin Margin { get; set; } = AMargin.Zero;
+        public event Action? ValueChanged;
+        public object FrameworkNode => this;
+
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility) return nint.Zero;
+            global::ImGuiNET.ImGui.SetCursorPos(new Vector2(X, Y));
+            global::ImGuiNET.ImGui.PushID(Name);
+            if (!Enabled)
+                global::ImGuiNET.ImGui.BeginDisabled();
+
+            nint tex = _isOn ? _textureOnPtr : _textureOffPtr;
+            if (tex != nint.Zero)
+            {
+                Vector4 bg = _isOn ? new Vector4(0.25f, 0.25f, 0.25f, 1f) : Vector4.Zero;
+                if (global::ImGuiNET.ImGui.ImageButton(Name, tex, new Vector2(Width, Height), Vector2.Zero, Vector2.One, bg, Vector4.One))
+                    IsOn = !_isOn;
+            }
+            else
+            {
+                bool value = _isOn;
+                if (global::ImGuiNET.ImGui.Checkbox(Text, ref value))
+                    IsOn = value;
+            }
+
+            if (!Enabled)
+                global::ImGuiNET.ImGui.EndDisabled();
+            global::ImGuiNET.ImGui.PopID();
+            return nint.Zero;
+        }
+
+        public override void Dispose()
+        {
+            if (_textureOnPtr != nint.Zero)
+            {
+                SDL.SDL_DestroyTexture(_textureOnPtr);
+                _textureOnPtr = nint.Zero;
+            }
+            if (_textureOffPtr != nint.Zero)
+            {
+                SDL.SDL_DestroyTexture(_textureOffPtr);
+                _textureOffPtr = nint.Zero;
+            }
+            base.Dispose();
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiTabContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiTabContainer.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using ImGuiNET;
+using AbstUI.Components;
+using AbstUI.Primitives;
+
+namespace AbstUI.ImGui.Components
+{
+    public class AbstImGuiTabContainer : AbstImGuiComponent, IAbstFrameworkTabContainer, IDisposable
+    {
+        private readonly List<IAbstFrameworkTabItem> _children = new();
+        private int _selectedIndex = -1;
+
+        public AMargin Margin { get; set; } = AMargin.Zero;
+        public object FrameworkNode => this;
+
+        public AbstImGuiTabContainer(AbstImGuiComponentFactory factory) : base(factory)
+        {
+        }
+
+        public string SelectedTabName =>
+            _selectedIndex >= 0 && _selectedIndex < _children.Count ? _children[_selectedIndex].Title : string.Empty;
+
+        public void AddTab(IAbstFrameworkTabItem content)
+        {
+            _children.Add(content);
+            if (_selectedIndex == -1)
+                _selectedIndex = 0;
+        }
+
+        public void RemoveTab(IAbstFrameworkTabItem content)
+        {
+            var index = _children.IndexOf(content);
+            if (index >= 0)
+            {
+                _children.RemoveAt(index);
+                if (_selectedIndex >= _children.Count)
+                    _selectedIndex = _children.Count - 1;
+            }
+        }
+
+        public IEnumerable<IAbstFrameworkTabItem> GetTabs() => _children.ToArray();
+
+        public void ClearTabs()
+        {
+            _children.Clear();
+            _selectedIndex = -1;
+        }
+
+        public void SelectTabByName(string tabName)
+        {
+            var idx = _children.FindIndex(t => t.Title == tabName);
+            if (idx >= 0)
+                _selectedIndex = idx;
+        }
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility)
+                return nint.Zero;
+
+            global::ImGuiNET.ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
+            global::ImGuiNET.ImGui.PushID(Name);
+            global::ImGuiNET.ImGui.BeginChild("##tabs", new Vector2(Width, Height), ImGuiChildFlags.None);
+
+            if (global::ImGuiNET.ImGui.BeginTabBar("##tabbar"))
+            {
+                for (int i = 0; i < _children.Count; i++)
+                {
+                    var tab = _children[i];
+                    if (global::ImGuiNET.ImGui.BeginTabItem(tab.Title))
+                    {
+                        _selectedIndex = i;
+                        if (tab.Content?.FrameworkObj is AbstImGuiComponent comp)
+                        {
+                            var origin = global::ImGuiNET.ImGui.GetCursorScreenPos();
+                            var childCtx = context.CreateNew(origin);
+                            comp.Render(childCtx);
+                        }
+                        global::ImGuiNET.ImGui.EndTabItem();
+                    }
+                }
+                global::ImGuiNET.ImGui.EndTabBar();
+            }
+
+            global::ImGuiNET.ImGui.EndChild();
+            global::ImGuiNET.ImGui.PopID();
+            return AbstImGuiRenderResult.RequireRender();
+        }
+
+        public override void Dispose()
+        {
+            ClearTabs();
+            base.Dispose();
+        }
+    }
+
+    public class AbstImGuiTabItem : AbstImGuiComponent, IAbstFrameworkTabItem
+    {
+        public AbstImGuiTabItem(AbstImGuiComponentFactory factory, AbstTabItem tab) : base(factory)
+        {
+            tab.Init(this);
+        }
+
+        public string Title { get; set; } = string.Empty;
+        public AMargin Margin { get; set; } = AMargin.Zero;
+        public IAbstNode? Content { get; set; }
+        public float TopHeight { get; set; }
+        public object FrameworkNode => this;
+
+        public override void Dispose() => base.Dispose();
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context) => AbstImGuiRenderResult.RequireRender();
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiWindow.cs
@@ -1,0 +1,100 @@
+using AbstUI.Components;
+using AbstUI.Inputs;
+using AbstUI.Primitives;
+
+namespace AbstUI.ImGui.Components;
+
+internal class AbstImGuiWindow : AbstImGuiPanel, IAbstFrameworkWindow, IDisposable
+{
+    private readonly AbstImGuiComponentFactory _factory;
+    private readonly AbstWindow _lingoWindow;
+    private string _title = string.Empty;
+    private bool _isPopup;
+    private bool _borderless;
+
+    public AbstImGuiWindow(AbstWindow window, AbstImGuiComponentFactory factory) : base(factory)
+    {
+        _lingoWindow = window;
+        _factory = factory;
+        var mouse = ((IAbstMouseInternal)factory.RootContext.AbstMouse).CreateNewInstance(window);
+        var key = ((AbstKey)factory.RootContext.AbstKey).CreateNewInstance(window);
+        _lingoWindow.Init(this, mouse, key);
+        Visibility = false;
+    }
+
+
+    public string Title
+    {
+        get => _title;
+        set => _title = value;
+    }
+
+    public new float Width
+    {
+        get => base.Width;
+        set
+        {
+            if (Math.Abs(base.Width - value) > float.Epsilon)
+                base.Width = value;
+        }
+    }
+
+    public new float Height
+    {
+        get => base.Height;
+        set
+        {
+            if (Math.Abs(base.Height - value) > float.Epsilon)
+                base.Height = value;
+        }
+    }
+
+    public bool IsPopup
+    {
+        get => _isPopup;
+        set => _isPopup = value;
+    }
+
+    public bool Borderless
+    {
+        get => _borderless;
+        set => _borderless = value;
+    }
+
+    public new AColor BackgroundColor
+    {
+        get => base.BackgroundColor ?? AColors.White;
+        set => base.BackgroundColor = value;
+    }
+
+
+    // TODO :  Resize SDL window.
+    public void OnResize(int width, int height)
+    {
+        _lingoWindow.Resize(width, height);
+    }
+
+    public void Popup()
+    {
+        _factory.RootContext.ComponentContainer.Activate(ComponentContext);
+        Visibility = true;
+        _lingoWindow.RaiseWindowStateChanged(true);
+    }
+
+    public void PopupCentered()
+    {
+        APoint size = _factory.RootContext.GetWindowSize();
+
+        X = (size.X - Width) / 2f;
+        Y = (size.Y - Height) / 2f;
+        Popup();
+        _lingoWindow.RaiseWindowStateChanged(true);
+    }
+
+    public void Hide()
+    {
+        Visibility = false;
+        _factory.RootContext.ComponentContainer.Deactivate(ComponentContext);
+        _lingoWindow.RaiseWindowStateChanged(false);
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiWrapPanel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiWrapPanel.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Components;
+using AbstUI.Primitives;
+using AbstUI.ImGui.ImGuiLL;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiWrapPanel : AbstImGuiComponent, IAbstFrameworkWrapPanel, IDisposable
+    {
+        public AOrientation Orientation { get; set; }
+        public APoint ItemMargin { get; set; }
+        public AMargin Margin { get; set; }
+        public object FrameworkNode => this;
+
+        private readonly List<IAbstFrameworkLayoutNode> _children = new();
+
+        public AbstImGuiWrapPanel(AbstImGuiComponentFactory factory, AOrientation orientation) : base(factory)
+        {
+            Orientation = orientation;
+            ItemMargin = new APoint(0, 0);
+            Margin = AMargin.Zero;
+        }
+
+        public void AddItem(IAbstFrameworkNode child)
+        {
+            if (child is IAbstFrameworkLayoutNode layout && !_children.Contains(layout))
+                _children.Add(layout);
+        }
+
+        public void RemoveItem(IAbstFrameworkNode child)
+        {
+            if (child is IAbstFrameworkLayoutNode layout)
+                _children.Remove(layout);
+        }
+
+        public IEnumerable<IAbstFrameworkNode> GetItems() => _children.ToArray();
+
+        public IAbstFrameworkNode? GetItem(int index)
+        {
+            if (index < 0 || index >= _children.Count)
+                return null;
+            return _children[index];
+        }
+
+        public void RemoveAll()
+        {
+            _children.Clear();
+        }
+
+        public override void Dispose()
+        {
+            RemoveAll();
+            if (_texture != nint.Zero)
+            {
+                SDL.SDL_DestroyTexture(_texture);
+                _texture = nint.Zero;
+            }
+            base.Dispose();
+        }
+
+        private nint _texture;
+        private int _texW;
+        private int _texH;
+
+        public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
+        {
+            if (!Visibility)
+                return nint.Zero;
+
+            int w = (int)Width;
+            int h = (int)Height;
+            if (_texture == nint.Zero || w != _texW || h != _texH)
+            {
+                if (_texture != nint.Zero)
+                {
+                    SDL.SDL_DestroyTexture(_texture);
+                }
+                _texture = SDL.SDL_CreateTexture(context.Renderer, SDL.SDL_PIXELFORMAT_RGBA8888,
+                    (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, w, h);
+                _texW = w;
+                _texH = h;
+            }
+
+            SDL.SDL_SetRenderTarget(context.Renderer, _texture);
+            SDL.SDL_SetRenderDrawColor(context.Renderer, 0, 0, 0, 0);
+            SDL.SDL_RenderClear(context.Renderer);
+
+            float curX = 0;
+            float curY = 0;
+            float lineSize = 0;
+            foreach (var child in _children)
+            {
+                var margin = child.Margin;
+                float childW = child.Width + margin.Left + margin.Right;
+                float childH = child.Height + margin.Top + margin.Bottom;
+
+                if (Orientation == AOrientation.Horizontal)
+                {
+                    if (curX + childW > Width)
+                    {
+                        curX = 0;
+                        curY += lineSize + ItemMargin.Y;
+                        lineSize = 0;
+                    }
+                    child.X = curX + margin.Left;
+                    child.Y = curY + margin.Top;
+                    curX += childW + ItemMargin.X;
+                    lineSize = Math.Max(lineSize, childH);
+                }
+                else
+                {
+                    if (curY + childH > Height)
+                    {
+                        curY = 0;
+                        curX += lineSize + ItemMargin.X;
+                        lineSize = 0;
+                    }
+                    child.X = curX + margin.Left;
+                    child.Y = curY + margin.Top;
+                    curY += childH + ItemMargin.Y;
+                    lineSize = Math.Max(lineSize, childW);
+                }
+
+                if (child.FrameworkNode is AbstImGuiComponent comp)
+                {
+                    comp.ComponentContext.RenderToTexture(context);
+                }
+            }
+
+            SDL.SDL_SetRenderTarget(context.Renderer, nint.Zero);
+            return _texture;
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/IAbstImGuiComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/IAbstImGuiComponent.cs
@@ -1,0 +1,11 @@
+namespace AbstUI.ImGui;
+
+public interface IAbstImGuiComponent
+{
+    /// <summary>
+    /// Renders the component and returns the texture handle if one was produced.
+    /// </summary>
+    /// <param name="context">Render context providing the SDL renderer.</param>
+    /// <returns>The texture handle or <c>nint.Zero</c> when no texture is created.</returns>
+    AbstImGuiRenderResult Render(AbstImGuiRenderContext context);
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/IImGuiRootComponentContext.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/IImGuiRootComponentContext.cs
@@ -1,0 +1,20 @@
+using ImGuiNET;
+using AbstUI.Primitives;
+using AbstUI.Inputs;
+
+namespace AbstUI.ImGui;
+
+public interface IImGuiRootComponentContext
+{
+    public ImGuiViewportPtr ImGuiViewPort { get; }
+    public ImDrawListPtr ImDrawList { get; }
+    AbstImGuiComponentContainer ComponentContainer { get; }
+    nint Renderer { get; }
+    IAbstMouse AbstMouse { get; }
+    IAbstKey AbstKey { get; }
+
+    nint RegisterTexture(nint sdlTexture);
+    nint GetTexture(nint textureId);
+
+    APoint GetWindowSize();
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiColorExtensions.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiColorExtensions.cs
@@ -1,0 +1,14 @@
+using System.Numerics;
+using AbstUI.Primitives;
+
+namespace AbstUI.ImGui;
+
+/// <summary>
+/// Extension helpers for converting <see cref="AColor"/> values to SDL-friendly types.
+/// </summary>
+public static class ImGuiColorExtensions
+{
+    /// <summary>Converts a <see cref="AColor"/> to an ImGui-compatible <see cref="Vector4"/>.</summary>
+    public static Vector4 ToImGuiColor(this AColor color)
+        => new(color.R / 255f, color.G / 255f, color.B / 255f, color.A / 255f);
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiImGuiBackend.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiImGuiBackend.cs
@@ -1,0 +1,302 @@
+﻿using System.Numerics;
+using ImGuiNET;
+using static AbstUI.ImGui.ImGuiLL.SDL;
+
+
+
+
+namespace AbstUI.ImGui
+{
+
+    public sealed class ImGuiImGuiBackend : IDisposable
+    {
+        private nint _window;
+        private nint _renderer;
+        private nint _fontTex;
+        private bool _inited;
+        private ulong _ticksLast;
+
+        public void Init(nint window, nint renderer)
+        {
+            _window = window;
+            _renderer = renderer;
+
+            global::ImGuiNET.ImGui.CreateContext();
+            global::ImGuiNET.ImGui.StyleColorsLight();
+
+            var io = global::ImGuiNET.ImGui.GetIO();
+            io.BackendFlags |= ImGuiBackendFlags.RendererHasVtxOffset;
+            io.ConfigFlags |= ImGuiConfigFlags.NavEnableKeyboard;
+
+            CreateFontTexture();
+            _ticksLast = SDL_GetPerformanceCounter();
+            _inited = true;
+        }
+
+        public void Shutdown()
+        {
+            if (!_inited) return;
+            var io = global::ImGuiNET.ImGui.GetIO();
+            io.Fonts.SetTexID(nint.Zero);
+            if (_fontTex != nint.Zero) { SDL_DestroyTexture(_fontTex); _fontTex = nint.Zero; }
+            global::ImGuiNET.ImGui.DestroyContext();
+            _inited = false;
+        }
+        public ImGuiViewportPtr BeginFrame()
+        {
+            NewFrame();
+            var imGuiViewPort = global::ImGuiNET.ImGui.GetMainViewport();
+
+            global::ImGuiNET.ImGui.SetNextWindowPos(imGuiViewPort.WorkPos);
+            global::ImGuiNET.ImGui.SetNextWindowSize(imGuiViewPort.WorkSize);
+            const ImGuiWindowFlags overlayFlags =
+                ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoMove |
+                ImGuiWindowFlags.NoSavedSettings | ImGuiWindowFlags.NoBringToFrontOnFocus |
+                ImGuiWindowFlags.NoFocusOnAppearing | ImGuiWindowFlags.NoNav |
+                ImGuiWindowFlags.NoBackground;
+
+            global::ImGuiNET.ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, Vector2.Zero);
+            global::ImGuiNET.ImGui.Begin("##overlay_root", overlayFlags);
+            return imGuiViewPort;
+        }
+        public void Dispose() => Shutdown();
+
+        /// <summary>Call this for each SDL event.</summary>
+        public void ProcessEvent(ref SDL_Event e)
+        {
+            var io = global::ImGuiNET.ImGui.GetIO();
+
+            switch (e.type)
+            {
+                case SDL_EventType.SDL_MOUSEMOTION:
+                    io.MousePos = new Vector2(e.motion.x, e.motion.y);
+                    break;
+
+                case SDL_EventType.SDL_MOUSEBUTTONDOWN:
+                case SDL_EventType.SDL_MOUSEBUTTONUP:
+                    {
+                        bool down = e.type == SDL_EventType.SDL_MOUSEBUTTONDOWN;
+                        if (e.button.button == SDL_BUTTON_LEFT) io.AddMouseButtonEvent(0, down);
+                        if (e.button.button == SDL_BUTTON_RIGHT) io.AddMouseButtonEvent(1, down);
+                        if (e.button.button == SDL_BUTTON_MIDDLE) io.AddMouseButtonEvent(2, down);
+                        break;
+                    }
+
+                case SDL_EventType.SDL_MOUSEWHEEL:
+                    io.AddMouseWheelEvent(e.wheel.preciseX, e.wheel.preciseY);
+                    break;
+
+                case SDL_EventType.SDL_TEXTINPUT:
+                    {
+                        unsafe
+                        {
+                            fixed (byte* p = e.text.text) // single fixed is OK
+                            {
+                                int len = 0; while (len < 32 && p[len] != 0) len++;
+                                if (len > 0)
+                                {
+                                    string s = System.Text.Encoding.UTF8.GetString(p, len);
+                                    global::ImGuiNET.ImGui.GetIO().AddInputCharactersUTF8(s);
+                                }
+                            }
+                        }
+                        break;
+                    }
+
+                case SDL_EventType.SDL_KEYDOWN:
+                case SDL_EventType.SDL_KEYUP:
+                    {
+                        bool down = e.type == SDL_EventType.SDL_KEYDOWN;
+                        var key = e.key.keysym.scancode;
+
+                        io.AddKeyEvent(ImGuiKey.ModCtrl, SDL_GetModState().HasFlag(SDL_Keymod.KMOD_CTRL));
+                        io.AddKeyEvent(ImGuiKey.ModShift, SDL_GetModState().HasFlag(SDL_Keymod.KMOD_SHIFT));
+                        io.AddKeyEvent(ImGuiKey.ModAlt, SDL_GetModState().HasFlag(SDL_Keymod.KMOD_ALT));
+                        io.AddKeyEvent(ImGuiKey.ModSuper, SDL_GetModState().HasFlag(SDL_Keymod.KMOD_GUI));
+
+                        MapKey(io, ImGuiKey.Tab, SDL_Scancode.SDL_SCANCODE_TAB, key, down);
+                        MapKey(io, ImGuiKey.LeftArrow, SDL_Scancode.SDL_SCANCODE_LEFT, key, down);
+                        MapKey(io, ImGuiKey.RightArrow, SDL_Scancode.SDL_SCANCODE_RIGHT, key, down);
+                        MapKey(io, ImGuiKey.UpArrow, SDL_Scancode.SDL_SCANCODE_UP, key, down);
+                        MapKey(io, ImGuiKey.DownArrow, SDL_Scancode.SDL_SCANCODE_DOWN, key, down);
+                        MapKey(io, ImGuiKey.Enter, SDL_Scancode.SDL_SCANCODE_RETURN, key, down);
+                        MapKey(io, ImGuiKey.Escape, SDL_Scancode.SDL_SCANCODE_ESCAPE, key, down);
+                        MapKey(io, ImGuiKey.Backspace, SDL_Scancode.SDL_SCANCODE_BACKSPACE, key, down);
+                        MapKey(io, ImGuiKey.Space, SDL_Scancode.SDL_SCANCODE_SPACE, key, down);
+                        break;
+                    }
+            }
+        }
+
+
+        public void NewFrame()
+        {
+            var io = global::ImGuiNET.ImGui.GetIO();
+
+            SDL_GetWindowSize(_window, out int w, out int h);
+            SDL_GL_GetDrawableSize(_window, out int dw, out int dh);
+            io.DisplaySize = new Vector2(w, h);
+            io.DisplayFramebufferScale = new Vector2(w > 0 ? (float)dw / w : 1f, h > 0 ? (float)dh / h : 1f);
+
+            ulong now = SDL_GetPerformanceCounter();
+            double freq = SDL_GetPerformanceFrequency();
+            io.DeltaTime = (float)((now - _ticksLast) / freq);
+            if (io.DeltaTime <= 0) io.DeltaTime = 1f / 60f;
+            _ticksLast = now;
+
+            global::ImGuiNET.ImGui.NewFrame();
+        }
+
+        public void EndFrame()
+        {
+            global::ImGuiNET.ImGui.End();
+            global::ImGuiNET.ImGui.PopStyleVar();
+            Render();
+            SDL_RenderPresent(_renderer);
+        }
+
+        public void Render()
+        {
+            global::ImGuiNET.ImGui.Render();
+            RenderDrawData(global::ImGuiNET.ImGui.GetDrawData());
+        }
+
+
+        private void CreateFontTexture()
+        {
+            var io = global::ImGuiNET.ImGui.GetIO();
+            io.Fonts.AddFontDefault();
+
+            io.Fonts.GetTexDataAsRGBA32(out nint pixels, out int width, out int height, out _);
+            uint fmt =
+#if HAS_SDL_PIXELFORMAT_RGBA32
+        SDL.SDL_PIXELFORMAT_RGBA32;
+#else
+    SDL_PIXELFORMAT_ABGR8888;
+#endif
+            // Fix enum: fully-qualify the type
+            _fontTex = SDL_CreateTexture(
+                _renderer,
+                fmt,
+                (int)SDL_TextureAccess.SDL_TEXTUREACCESS_STATIC,
+                width, height);
+
+            SDL_SetTextureBlendMode(_fontTex, SDL_BlendMode.SDL_BLENDMODE_BLEND);
+            SDL_UpdateTexture(_fontTex, nint.Zero, pixels, width * 4);
+
+            io.Fonts.SetTexID(_fontTex);
+            io.Fonts.ClearTexData();
+        }
+
+
+        private void RenderDrawData(ImDrawDataPtr drawData)
+        {
+            if (drawData.CmdListsCount == 0) return;
+
+            var fbScale = drawData.FramebufferScale;
+            int fbWidth = (int)(drawData.DisplaySize.X * fbScale.X);
+            int fbHeight = (int)(drawData.DisplaySize.Y * fbScale.Y);
+            if (fbWidth <= 0 || fbHeight <= 0) return;
+
+            var vp = new SDL_Rect { x = 0, y = 0, w = fbWidth, h = fbHeight };
+            SDL_RenderSetViewport(_renderer, ref vp);
+
+            for (int n = 0; n < drawData.CmdListsCount; n++)
+            {
+                // Fix: use CmdLists instead of CmdListsRange
+                var cmdList = drawData.CmdLists[n];
+
+                // Build SDL_Vertex array
+                var vertices = new SDL_Vertex[cmdList.VtxBuffer.Size];
+                for (int i = 0; i < cmdList.VtxBuffer.Size; i++)
+                {
+                    var v = cmdList.VtxBuffer[i];
+                    vertices[i].position.x = v.pos.X;
+                    vertices[i].position.y = v.pos.Y;
+                    vertices[i].tex_coord.x = v.uv.X;
+                    vertices[i].tex_coord.y = v.uv.Y;
+                    vertices[i].color = SDL_ColorFromUint(v.col);
+                }
+
+                // Build 32-bit indices (works for both 16/32 bit ImGui indices)
+                var indices = new int[cmdList.IdxBuffer.Size];
+                for (int i = 0; i < cmdList.IdxBuffer.Size; i++)
+                    indices[i] = unchecked(cmdList.IdxBuffer[i]);
+
+                int idxOffset = 0;
+                for (int cmd_i = 0; cmd_i < cmdList.CmdBuffer.Size; cmd_i++)
+                {
+                    var pcmd = cmdList.CmdBuffer[cmd_i];
+
+                    var clip = new SDL_Rect
+                    {
+                        x = (int)pcmd.ClipRect.X,
+                        y = (int)pcmd.ClipRect.Y,
+                        w = (int)(pcmd.ClipRect.Z - pcmd.ClipRect.X),
+                        h = (int)(pcmd.ClipRect.W - pcmd.ClipRect.Y)
+                    };
+                    SDL_RenderSetClipRect(_renderer, ref clip);
+
+                    nint tex = pcmd.TextureId != nint.Zero ? pcmd.TextureId : _fontTex;
+
+                    // Fix: use SDL_RenderGeometry (not *_Raw) to avoid pointer args
+                    SDL_RenderGeometry(
+                        _renderer,
+                        tex,
+                        vertices, vertices.Length,
+                        indices, (int)pcmd.ElemCount   // cast ElemCount -> int
+                    );
+
+                    idxOffset += (int)pcmd.ElemCount; // ensure int math
+                }
+            }
+
+            SDL_RenderSetClipRect(_renderer, nint.Zero);
+        }
+
+        private static SDL_Color SDL_ColorFromUint(uint packed)
+        {
+            // ImGui uses ABGR packing on little-endian; SDL expects RGBA in SDL_Color
+            return new SDL_Color
+            {
+                r = (byte)(packed >> 0),
+                g = (byte)(packed >> 8),
+                b = (byte)(packed >> 16),
+                a = (byte)(packed >> 24)
+            };
+        }
+
+        private static void MapKey(ImGuiIOPtr io, ImGuiKey imguiKey, SDL_Scancode scan, SDL_Scancode ev, bool down)
+        {
+            if (scan == ev) io.AddKeyEvent(imguiKey, down);
+        }
+
+
+
+
+
+        #region Textures
+
+        private readonly Dictionary<nint, nint> _tex = new();
+        private long _next = 1;
+        public nint RegisterTexture(nint sdlTexture)
+        {
+            var imGuiId = Add(sdlTexture);
+            // todo : set texture to the Gfx card it seems for global::ImGuiNET.ImGui. How to do this with SDL?
+            return imGuiId;
+        }
+
+        private nint Add(nint sdlTexture)
+        {
+            var id = new nint(_next++);
+            _tex[id] = sdlTexture;
+            return id;
+        }
+        public nint GetTexture(nint id) => _tex[id];
+
+
+        #endregion
+
+
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiLL/ImGui2.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiLL/ImGui2.cs
@@ -1,0 +1,9008 @@
+#region License
+/* SDL2# - C# Wrapper for SDL2
+ *
+ * Copyright (c) 2013-2024 Ethan Lee.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software in a
+ * product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * Ethan "flibitijibibo" Lee <flibitijibibo@flibitijibibo.com>
+ *
+ */
+#endregion
+
+#region Using Statements
+using System;
+using System.Diagnostics;
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+using System.Runtime.InteropServices;
+using System.Text;
+#endregion
+
+namespace AbstUI.ImGui.ImGuiLL
+{
+    public static class SDL
+    {
+        #region SDL2# Variables
+
+        private const string nativeLibName = "SDL2";
+
+        #endregion
+
+        #region Marshaling
+
+#if NET6_0_OR_GREATER
+        internal static T PtrToStructure<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>(nint ptr)
+        {
+            return Marshal.PtrToStructure<T>(ptr);
+        }
+
+        internal static T GetDelegateForFunctionPointer<T>(nint ptr) where T : Delegate
+        {
+            return Marshal.GetDelegateForFunctionPointer<T>(ptr);
+        }
+#else
+		internal static T PtrToStructure<T>(IntPtr ptr)
+		{
+			return (T) Marshal.PtrToStructure(ptr, typeof(T));
+		}
+
+		internal static Delegate GetDelegateForFunctionPointer<T>(IntPtr ptr)
+		{
+			return Marshal.GetDelegateForFunctionPointer(ptr, typeof(T));
+		}
+#endif
+
+        internal static int SizeOf<T>()
+        {
+#if NETSTANDARD2_0_OR_GREATER || NET6_0_OR_GREATER
+            return Marshal.SizeOf<T>();
+#else
+			return Marshal.SizeOf(typeof(T));
+#endif
+        }
+
+        #endregion
+
+        #region UTF8 Marshaling
+
+        /* Used for stack allocated string marshaling. */
+        internal static int Utf8Size(string str)
+        {
+            if (str == null)
+            {
+                return 0;
+            }
+            return str.Length * 4 + 1;
+        }
+        internal static unsafe byte* Utf8Encode(string str, byte* buffer, int bufferSize)
+        {
+            if (str == null)
+            {
+                return (byte*)0;
+            }
+            fixed (char* strPtr = str)
+            {
+                Encoding.UTF8.GetBytes(strPtr, str.Length + 1, buffer, bufferSize);
+            }
+            return buffer;
+        }
+
+        /* Used for heap allocated string marshaling.
+		 * Returned byte* must be free'd with FreeHGlobal.
+		 */
+        internal static unsafe byte* Utf8EncodeHeap(string str)
+        {
+            if (str == null)
+            {
+                return (byte*)0;
+            }
+
+            int bufferSize = Utf8Size(str);
+            byte* buffer = (byte*)Marshal.AllocHGlobal(bufferSize);
+            fixed (char* strPtr = str)
+            {
+                Encoding.UTF8.GetBytes(strPtr, str.Length + 1, buffer, bufferSize);
+            }
+            return buffer;
+        }
+
+        /* This is public because SDL_DropEvent needs it! */
+        public static unsafe string? UTF8_ToManaged(nint s, bool freePtr = false)
+        {
+            if (s == nint.Zero)
+            {
+                return null;
+            }
+
+            /* We get to do strlen ourselves! */
+            byte* ptr = (byte*)s;
+            while (*ptr != 0)
+            {
+                ptr++;
+            }
+
+            /* TODO: This #ifdef is only here because the equivalent
+			 * .NET 2.0 constructor appears to be less efficient?
+			 * Here's the pretty version, maybe steal this instead:
+			 *
+			string result = new string(
+				(sbyte*) s, // Also, why sbyte???
+				0,
+				(int) (ptr - (byte*) s),
+				System.Text.Encoding.UTF8
+			);
+			 * See the CoreCLR source for more info.
+			 * -flibit
+			 */
+#if NETSTANDARD2_0
+			/* Modern C# lets you just send the byte*, nice! */
+			string result = System.Text.Encoding.UTF8.GetString(
+				(byte*) s,
+				(int) (ptr - (byte*) s)
+			);
+#else
+            /* Old C# requires an extra memcpy, bleh! */
+            int len = (int)(ptr - (byte*)s);
+            if (len == 0)
+            {
+                return string.Empty;
+            }
+            char* chars = stackalloc char[len];
+            int strLen = Encoding.UTF8.GetChars((byte*)s, len, chars, len);
+            string result = new string(chars, 0, strLen);
+#endif
+
+            /* Some SDL functions will malloc, we have to free! */
+            if (freePtr)
+            {
+                SDL_free(s);
+            }
+            return result;
+        }
+
+        #endregion
+
+        #region SDL_stdinc.h
+
+        public static uint SDL_FOURCC(byte A, byte B, byte C, byte D)
+        {
+            return (uint)(A | B << 8 | C << 16 | D << 24);
+        }
+
+        public enum SDL_bool
+        {
+            SDL_FALSE = 0,
+            SDL_TRUE = 1
+        }
+
+        /* malloc/free are used by the marshaler! -flibit */
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern nint SDL_malloc(nint size);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void SDL_free(nint memblock);
+
+        /* Buffer.BlockCopy is not available in every runtime yet. Also,
+		 * using memcpy directly can be a compatibility issue in other
+		 * strange ways. So, we expose this to get around all that.
+		 * -flibit
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_memcpy(nint dst, nint src, nint len);
+
+        #endregion
+
+        #region SDL_rwops.h
+
+        public const int RW_SEEK_SET = 0;
+        public const int RW_SEEK_CUR = 1;
+        public const int RW_SEEK_END = 2;
+
+        public const uint SDL_RWOPS_UNKNOWN = 0; /* Unknown stream type */
+        public const uint SDL_RWOPS_WINFILE = 1; /* Win32 file */
+        public const uint SDL_RWOPS_STDFILE = 2; /* Stdio file */
+        public const uint SDL_RWOPS_JNIFILE = 3; /* Android asset */
+        public const uint SDL_RWOPS_MEMORY = 4; /* Memory stream */
+        public const uint SDL_RWOPS_MEMORY_RO = 5; /* Read-Only memory stream */
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate long SDLRWopsSizeCallback(nint context);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate long SDLRWopsSeekCallback(
+            nint context,
+            long offset,
+            int whence
+        );
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate nint SDLRWopsReadCallback(
+            nint context,
+            nint ptr,
+            nint size,
+            nint maxnum
+        );
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate nint SDLRWopsWriteCallback(
+            nint context,
+            nint ptr,
+            nint size,
+            nint num
+        );
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int SDLRWopsCloseCallback(
+            nint context
+        );
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_RWops
+        {
+            public nint size;
+            public nint seek;
+            public nint read;
+            public nint write;
+            public nint close;
+
+            public uint type;
+
+            /* NOTE: This isn't the full structure since
+			 * the native SDL_RWops contains a hidden union full of
+			 * internal information and platform-specific stuff depending
+			 * on what conditions the native library was built with
+			 */
+        }
+
+        /* IntPtr refers to an SDL_RWops* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_RWFromFile", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_SDL_RWFromFile(
+            byte* file,
+            byte* mode
+        );
+        public static unsafe nint SDL_RWFromFile(
+            string file,
+            string mode
+        )
+        {
+            byte* utf8File = Utf8EncodeHeap(file);
+            byte* utf8Mode = Utf8EncodeHeap(mode);
+            nint rwOps = INTERNAL_SDL_RWFromFile(
+                utf8File,
+                utf8Mode
+            );
+            Marshal.FreeHGlobal((nint)utf8Mode);
+            Marshal.FreeHGlobal((nint)utf8File);
+            return rwOps;
+        }
+
+        /* IntPtr refers to an SDL_RWops* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_AllocRW();
+
+        /* area refers to an SDL_RWops* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_FreeRW(nint area);
+
+        /* fp refers to a void* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_RWFromFP(nint fp, SDL_bool autoclose);
+
+        /* mem refers to a void*, IntPtr to an SDL_RWops* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_RWFromMem(nint mem, int size);
+
+        /* mem refers to a const void*, IntPtr to an SDL_RWops* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_RWFromConstMem(nint mem, int size);
+
+        /* context refers to an SDL_RWops*.
+		 * Only available in SDL 2.0.10 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern long SDL_RWsize(nint context);
+
+        /* context refers to an SDL_RWops*.
+		 * Only available in SDL 2.0.10 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern long SDL_RWseek(
+            nint context,
+            long offset,
+            int whence
+        );
+
+        /* context refers to an SDL_RWops*.
+		 * Only available in SDL 2.0.10 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern long SDL_RWtell(nint context);
+
+        /* context refers to an SDL_RWops*, ptr refers to a void*.
+		 * Only available in SDL 2.0.10 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern long SDL_RWread(
+            nint context,
+            nint ptr,
+            nint size,
+            nint maxnum
+        );
+
+        /* context refers to an SDL_RWops*, ptr refers to a const void*.
+		 * Only available in SDL 2.0.10 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern long SDL_RWwrite(
+            nint context,
+            nint ptr,
+            nint size,
+            nint maxnum
+        );
+
+        /* Read endian functions */
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern byte SDL_ReadU8(nint src);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ushort SDL_ReadLE16(nint src);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ushort SDL_ReadBE16(nint src);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_ReadLE32(nint src);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_ReadBE32(nint src);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ulong SDL_ReadLE64(nint src);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ulong SDL_ReadBE64(nint src);
+
+        /* Write endian functions */
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_WriteU8(nint dst, byte value);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_WriteLE16(nint dst, ushort value);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_WriteBE16(nint dst, ushort value);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_WriteLE32(nint dst, uint value);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_WriteBE32(nint dst, uint value);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_WriteLE64(nint dst, ulong value);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_WriteBE64(nint dst, ulong value);
+
+        /* context refers to an SDL_RWops*
+		 * Only available in SDL 2.0.10 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern long SDL_RWclose(nint context);
+
+        /* datasize refers to a size_t*
+		 * IntPtr refers to a void*
+		 * Only available in SDL 2.0.10 or higher.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "SDL_LoadFile", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_SDL_LoadFile(byte* file, out nint datasize);
+        public static unsafe nint SDL_LoadFile(string file, out nint datasize)
+        {
+            byte* utf8File = Utf8EncodeHeap(file);
+            nint result = INTERNAL_SDL_LoadFile(utf8File, out datasize);
+            Marshal.FreeHGlobal((nint)utf8File);
+            return result;
+        }
+
+        #endregion
+
+        #region SDL_main.h
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetMainReady();
+
+        /* This is used as a function pointer to a C main() function */
+        public delegate int SDL_main_func(int argc, nint argv);
+
+        /* Use this function with UWP to call your C# Main() function! */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_WinRTRunApp(
+            SDL_main_func mainFunction,
+            nint reserved
+        );
+
+        /* Use this function with GDK/GDKX to call your C# Main() function!
+		 * Only available in SDL 2.24.0 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GDKRunApp(
+            SDL_main_func mainFunction,
+            nint reserved
+        );
+
+        /* Use this function with iOS to call your C# Main() function!
+		 * Only available in SDL 2.0.10 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_UIKitRunApp(
+            int argc,
+            nint argv,
+            SDL_main_func mainFunction
+        );
+
+        #endregion
+
+        #region SDL.h
+
+        public const uint SDL_INIT_TIMER = 0x00000001;
+        public const uint SDL_INIT_AUDIO = 0x00000010;
+        public const uint SDL_INIT_VIDEO = 0x00000020;
+        public const uint SDL_INIT_JOYSTICK = 0x00000200;
+        public const uint SDL_INIT_HAPTIC = 0x00001000;
+        public const uint SDL_INIT_GAMECONTROLLER = 0x00002000;
+        public const uint SDL_INIT_EVENTS = 0x00004000;
+        public const uint SDL_INIT_SENSOR = 0x00008000;
+        public const uint SDL_INIT_NOPARACHUTE = 0x00100000;
+        public const uint SDL_INIT_EVERYTHING =
+            SDL_INIT_TIMER | SDL_INIT_AUDIO | SDL_INIT_VIDEO |
+            SDL_INIT_EVENTS | SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC |
+            SDL_INIT_GAMECONTROLLER | SDL_INIT_SENSOR
+        ;
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_Init(uint flags);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_InitSubSystem(uint flags);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_Quit();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_QuitSubSystem(uint flags);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_WasInit(uint flags);
+
+        #endregion
+
+        #region SDL_platform.h
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetPlatform", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetPlatform();
+        public static string SDL_GetPlatform()
+        {
+            return UTF8_ToManaged(INTERNAL_SDL_GetPlatform());
+        }
+
+        #endregion
+
+        #region SDL_hints.h
+
+        public const string SDL_HINT_FRAMEBUFFER_ACCELERATION =
+            "SDL_FRAMEBUFFER_ACCELERATION";
+        public const string SDL_HINT_RENDER_DRIVER =
+            "SDL_RENDER_DRIVER";
+        public const string SDL_HINT_RENDER_OPENGL_SHADERS =
+            "SDL_RENDER_OPENGL_SHADERS";
+        public const string SDL_HINT_RENDER_DIRECT3D_THREADSAFE =
+            "SDL_RENDER_DIRECT3D_THREADSAFE";
+        public const string SDL_HINT_RENDER_VSYNC =
+            "SDL_RENDER_VSYNC";
+        public const string SDL_HINT_VIDEO_X11_XVIDMODE =
+            "SDL_VIDEO_X11_XVIDMODE";
+        public const string SDL_HINT_VIDEO_X11_XINERAMA =
+            "SDL_VIDEO_X11_XINERAMA";
+        public const string SDL_HINT_VIDEO_X11_XRANDR =
+            "SDL_VIDEO_X11_XRANDR";
+        public const string SDL_HINT_GRAB_KEYBOARD =
+            "SDL_GRAB_KEYBOARD";
+        public const string SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS =
+            "SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS";
+        public const string SDL_HINT_IDLE_TIMER_DISABLED =
+            "SDL_IOS_IDLE_TIMER_DISABLED";
+        public const string SDL_HINT_ORIENTATIONS =
+            "SDL_IOS_ORIENTATIONS";
+        public const string SDL_HINT_XINPUT_ENABLED =
+            "SDL_XINPUT_ENABLED";
+        public const string SDL_HINT_GAMECONTROLLERCONFIG =
+            "SDL_GAMECONTROLLERCONFIG";
+        public const string SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS =
+            "SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS";
+        public const string SDL_HINT_ALLOW_TOPMOST =
+            "SDL_ALLOW_TOPMOST";
+        public const string SDL_HINT_TIMER_RESOLUTION =
+            "SDL_TIMER_RESOLUTION";
+        public const string SDL_HINT_RENDER_SCALE_QUALITY =
+            "SDL_RENDER_SCALE_QUALITY";
+
+        /* Only available in SDL 2.0.1 or higher. */
+        public const string SDL_HINT_VIDEO_HIGHDPI_DISABLED =
+            "SDL_VIDEO_HIGHDPI_DISABLED";
+
+        /* Only available in SDL 2.0.2 or higher. */
+        public const string SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK =
+            "SDL_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK";
+        public const string SDL_HINT_VIDEO_WIN_D3DCOMPILER =
+            "SDL_VIDEO_WIN_D3DCOMPILER";
+        public const string SDL_HINT_MOUSE_RELATIVE_MODE_WARP =
+            "SDL_MOUSE_RELATIVE_MODE_WARP";
+        public const string SDL_HINT_VIDEO_WINDOW_SHARE_PIXEL_FORMAT =
+            "SDL_VIDEO_WINDOW_SHARE_PIXEL_FORMAT";
+        public const string SDL_HINT_VIDEO_ALLOW_SCREENSAVER =
+            "SDL_VIDEO_ALLOW_SCREENSAVER";
+        public const string SDL_HINT_ACCELEROMETER_AS_JOYSTICK =
+            "SDL_ACCELEROMETER_AS_JOYSTICK";
+        public const string SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES =
+            "SDL_VIDEO_MAC_FULLSCREEN_SPACES";
+
+        /* Only available in SDL 2.0.3 or higher. */
+        public const string SDL_HINT_WINRT_PRIVACY_POLICY_URL =
+            "SDL_WINRT_PRIVACY_POLICY_URL";
+        public const string SDL_HINT_WINRT_PRIVACY_POLICY_LABEL =
+            "SDL_WINRT_PRIVACY_POLICY_LABEL";
+        public const string SDL_HINT_WINRT_HANDLE_BACK_BUTTON =
+            "SDL_WINRT_HANDLE_BACK_BUTTON";
+
+        /* Only available in SDL 2.0.4 or higher. */
+        public const string SDL_HINT_NO_SIGNAL_HANDLERS =
+            "SDL_NO_SIGNAL_HANDLERS";
+        public const string SDL_HINT_IME_INTERNAL_EDITING =
+            "SDL_IME_INTERNAL_EDITING";
+        public const string SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH =
+            "SDL_ANDROID_SEPARATE_MOUSE_AND_TOUCH";
+        public const string SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT =
+            "SDL_EMSCRIPTEN_KEYBOARD_ELEMENT";
+        public const string SDL_HINT_THREAD_STACK_SIZE =
+            "SDL_THREAD_STACK_SIZE";
+        public const string SDL_HINT_WINDOW_FRAME_USABLE_WHILE_CURSOR_HIDDEN =
+            "SDL_WINDOW_FRAME_USABLE_WHILE_CURSOR_HIDDEN";
+        public const string SDL_HINT_WINDOWS_ENABLE_MESSAGELOOP =
+            "SDL_WINDOWS_ENABLE_MESSAGELOOP";
+        public const string SDL_HINT_WINDOWS_NO_CLOSE_ON_ALT_F4 =
+            "SDL_WINDOWS_NO_CLOSE_ON_ALT_F4";
+        public const string SDL_HINT_XINPUT_USE_OLD_JOYSTICK_MAPPING =
+            "SDL_XINPUT_USE_OLD_JOYSTICK_MAPPING";
+        public const string SDL_HINT_MAC_BACKGROUND_APP =
+            "SDL_MAC_BACKGROUND_APP";
+        public const string SDL_HINT_VIDEO_X11_NET_WM_PING =
+            "SDL_VIDEO_X11_NET_WM_PING";
+        public const string SDL_HINT_ANDROID_APK_EXPANSION_MAIN_FILE_VERSION =
+            "SDL_ANDROID_APK_EXPANSION_MAIN_FILE_VERSION";
+        public const string SDL_HINT_ANDROID_APK_EXPANSION_PATCH_FILE_VERSION =
+            "SDL_ANDROID_APK_EXPANSION_PATCH_FILE_VERSION";
+
+        /* Only available in 2.0.5 or higher. */
+        public const string SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH =
+            "SDL_MOUSE_FOCUS_CLICKTHROUGH";
+        public const string SDL_HINT_BMP_SAVE_LEGACY_FORMAT =
+            "SDL_BMP_SAVE_LEGACY_FORMAT";
+        public const string SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING =
+            "SDL_WINDOWS_DISABLE_THREAD_NAMING";
+        public const string SDL_HINT_APPLE_TV_REMOTE_ALLOW_ROTATION =
+            "SDL_APPLE_TV_REMOTE_ALLOW_ROTATION";
+
+        /* Only available in 2.0.6 or higher. */
+        public const string SDL_HINT_AUDIO_RESAMPLING_MODE =
+            "SDL_AUDIO_RESAMPLING_MODE";
+        public const string SDL_HINT_RENDER_LOGICAL_SIZE_MODE =
+            "SDL_RENDER_LOGICAL_SIZE_MODE";
+        public const string SDL_HINT_MOUSE_NORMAL_SPEED_SCALE =
+            "SDL_MOUSE_NORMAL_SPEED_SCALE";
+        public const string SDL_HINT_MOUSE_RELATIVE_SPEED_SCALE =
+            "SDL_MOUSE_RELATIVE_SPEED_SCALE";
+        public const string SDL_HINT_TOUCH_MOUSE_EVENTS =
+            "SDL_TOUCH_MOUSE_EVENTS";
+        public const string SDL_HINT_WINDOWS_INTRESOURCE_ICON =
+            "SDL_WINDOWS_INTRESOURCE_ICON";
+        public const string SDL_HINT_WINDOWS_INTRESOURCE_ICON_SMALL =
+            "SDL_WINDOWS_INTRESOURCE_ICON_SMALL";
+
+        /* Only available in 2.0.8 or higher. */
+        public const string SDL_HINT_IOS_HIDE_HOME_INDICATOR =
+            "SDL_IOS_HIDE_HOME_INDICATOR";
+        public const string SDL_HINT_TV_REMOTE_AS_JOYSTICK =
+            "SDL_TV_REMOTE_AS_JOYSTICK";
+        public const string SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR =
+            "SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR";
+
+        /* Only available in 2.0.9 or higher. */
+        public const string SDL_HINT_MOUSE_DOUBLE_CLICK_TIME =
+            "SDL_MOUSE_DOUBLE_CLICK_TIME";
+        public const string SDL_HINT_MOUSE_DOUBLE_CLICK_RADIUS =
+            "SDL_MOUSE_DOUBLE_CLICK_RADIUS";
+        public const string SDL_HINT_JOYSTICK_HIDAPI =
+            "SDL_JOYSTICK_HIDAPI";
+        public const string SDL_HINT_JOYSTICK_HIDAPI_PS4 =
+            "SDL_JOYSTICK_HIDAPI_PS4";
+        public const string SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE =
+            "SDL_JOYSTICK_HIDAPI_PS4_RUMBLE";
+        public const string SDL_HINT_JOYSTICK_HIDAPI_STEAM =
+            "SDL_JOYSTICK_HIDAPI_STEAM";
+        public const string SDL_HINT_JOYSTICK_HIDAPI_SWITCH =
+            "SDL_JOYSTICK_HIDAPI_SWITCH";
+        public const string SDL_HINT_JOYSTICK_HIDAPI_XBOX =
+            "SDL_JOYSTICK_HIDAPI_XBOX";
+        public const string SDL_HINT_ENABLE_STEAM_CONTROLLERS =
+            "SDL_ENABLE_STEAM_CONTROLLERS";
+        public const string SDL_HINT_ANDROID_TRAP_BACK_BUTTON =
+            "SDL_ANDROID_TRAP_BACK_BUTTON";
+
+        /* Only available in 2.0.10 or higher. */
+        public const string SDL_HINT_MOUSE_TOUCH_EVENTS =
+            "SDL_MOUSE_TOUCH_EVENTS";
+        public const string SDL_HINT_GAMECONTROLLERCONFIG_FILE =
+            "SDL_GAMECONTROLLERCONFIG_FILE";
+        public const string SDL_HINT_ANDROID_BLOCK_ON_PAUSE =
+            "SDL_ANDROID_BLOCK_ON_PAUSE";
+        public const string SDL_HINT_RENDER_BATCHING =
+            "SDL_RENDER_BATCHING";
+        public const string SDL_HINT_EVENT_LOGGING =
+            "SDL_EVENT_LOGGING";
+        public const string SDL_HINT_WAVE_RIFF_CHUNK_SIZE =
+            "SDL_WAVE_RIFF_CHUNK_SIZE";
+        public const string SDL_HINT_WAVE_TRUNCATION =
+            "SDL_WAVE_TRUNCATION";
+        public const string SDL_HINT_WAVE_FACT_CHUNK =
+            "SDL_WAVE_FACT_CHUNK";
+
+        /* Only available in 2.0.11 or higher. */
+        public const string SDL_HINT_VIDO_X11_WINDOW_VISUALID =
+            "SDL_VIDEO_X11_WINDOW_VISUALID";
+        public const string SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS =
+            "SDL_GAMECONTROLLER_USE_BUTTON_LABELS";
+        public const string SDL_HINT_VIDEO_EXTERNAL_CONTEXT =
+            "SDL_VIDEO_EXTERNAL_CONTEXT";
+        public const string SDL_HINT_JOYSTICK_HIDAPI_GAMECUBE =
+            "SDL_JOYSTICK_HIDAPI_GAMECUBE";
+        public const string SDL_HINT_DISPLAY_USABLE_BOUNDS =
+            "SDL_DISPLAY_USABLE_BOUNDS";
+        public const string SDL_HINT_VIDEO_X11_FORCE_EGL =
+            "SDL_VIDEO_X11_FORCE_EGL";
+        public const string SDL_HINT_GAMECONTROLLERTYPE =
+            "SDL_GAMECONTROLLERTYPE";
+
+        /* Only available in 2.0.14 or higher. */
+        public const string SDL_HINT_JOYSTICK_HIDAPI_CORRELATE_XINPUT =
+            "SDL_JOYSTICK_HIDAPI_CORRELATE_XINPUT"; /* NOTE: This was removed in 2.0.16. */
+        public const string SDL_HINT_JOYSTICK_RAWINPUT =
+            "SDL_JOYSTICK_RAWINPUT";
+        public const string SDL_HINT_AUDIO_DEVICE_APP_NAME =
+            "SDL_AUDIO_DEVICE_APP_NAME";
+        public const string SDL_HINT_AUDIO_DEVICE_STREAM_NAME =
+            "SDL_AUDIO_DEVICE_STREAM_NAME";
+        public const string SDL_HINT_PREFERRED_LOCALES =
+            "SDL_PREFERRED_LOCALES";
+        public const string SDL_HINT_THREAD_PRIORITY_POLICY =
+            "SDL_THREAD_PRIORITY_POLICY";
+        public const string SDL_HINT_EMSCRIPTEN_ASYNCIFY =
+            "SDL_EMSCRIPTEN_ASYNCIFY";
+        public const string SDL_HINT_LINUX_JOYSTICK_DEADZONES =
+            "SDL_LINUX_JOYSTICK_DEADZONES";
+        public const string SDL_HINT_ANDROID_BLOCK_ON_PAUSE_PAUSEAUDIO =
+            "SDL_ANDROID_BLOCK_ON_PAUSE_PAUSEAUDIO";
+        public const string SDL_HINT_JOYSTICK_HIDAPI_PS5 =
+            "SDL_JOYSTICK_HIDAPI_PS5";
+        public const string SDL_HINT_THREAD_FORCE_REALTIME_TIME_CRITICAL =
+            "SDL_THREAD_FORCE_REALTIME_TIME_CRITICAL";
+        public const string SDL_HINT_JOYSTICK_THREAD =
+            "SDL_JOYSTICK_THREAD";
+        public const string SDL_HINT_AUTO_UPDATE_JOYSTICKS =
+            "SDL_AUTO_UPDATE_JOYSTICKS";
+        public const string SDL_HINT_AUTO_UPDATE_SENSORS =
+            "SDL_AUTO_UPDATE_SENSORS";
+        public const string SDL_HINT_MOUSE_RELATIVE_SCALING =
+            "SDL_MOUSE_RELATIVE_SCALING";
+        public const string SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE =
+            "SDL_JOYSTICK_HIDAPI_PS5_RUMBLE";
+
+        /* Only available in 2.0.16 or higher. */
+        public const string SDL_HINT_WINDOWS_FORCE_MUTEX_CRITICAL_SECTIONS =
+            "SDL_WINDOWS_FORCE_MUTEX_CRITICAL_SECTIONS";
+        public const string SDL_HINT_WINDOWS_FORCE_SEMAPHORE_KERNEL =
+            "SDL_WINDOWS_FORCE_SEMAPHORE_KERNEL";
+        public const string SDL_HINT_JOYSTICK_HIDAPI_PS5_PLAYER_LED =
+            "SDL_JOYSTICK_HIDAPI_PS5_PLAYER_LED";
+        public const string SDL_HINT_WINDOWS_USE_D3D9EX =
+            "SDL_WINDOWS_USE_D3D9EX";
+        public const string SDL_HINT_JOYSTICK_HIDAPI_JOY_CONS =
+            "SDL_JOYSTICK_HIDAPI_JOY_CONS";
+        public const string SDL_HINT_JOYSTICK_HIDAPI_STADIA =
+            "SDL_JOYSTICK_HIDAPI_STADIA";
+        public const string SDL_HINT_JOYSTICK_HIDAPI_SWITCH_HOME_LED =
+            "SDL_JOYSTICK_HIDAPI_SWITCH_HOME_LED";
+        public const string SDL_HINT_ALLOW_ALT_TAB_WHILE_GRABBED =
+            "SDL_ALLOW_ALT_TAB_WHILE_GRABBED";
+        public const string SDL_HINT_KMSDRM_REQUIRE_DRM_MASTER =
+            "SDL_KMSDRM_REQUIRE_DRM_MASTER";
+        public const string SDL_HINT_AUDIO_DEVICE_STREAM_ROLE =
+            "SDL_AUDIO_DEVICE_STREAM_ROLE";
+        public const string SDL_HINT_X11_FORCE_OVERRIDE_REDIRECT =
+            "SDL_X11_FORCE_OVERRIDE_REDIRECT";
+        public const string SDL_HINT_JOYSTICK_HIDAPI_LUNA =
+            "SDL_JOYSTICK_HIDAPI_LUNA";
+        public const string SDL_HINT_JOYSTICK_RAWINPUT_CORRELATE_XINPUT =
+            "SDL_JOYSTICK_RAWINPUT_CORRELATE_XINPUT";
+        public const string SDL_HINT_AUDIO_INCLUDE_MONITORS =
+            "SDL_AUDIO_INCLUDE_MONITORS";
+        public const string SDL_HINT_VIDEO_WAYLAND_ALLOW_LIBDECOR =
+            "SDL_VIDEO_WAYLAND_ALLOW_LIBDECOR";
+
+        /* Only available in 2.0.18 or higher. */
+        public const string SDL_HINT_VIDEO_EGL_ALLOW_TRANSPARENCY =
+            "SDL_VIDEO_EGL_ALLOW_TRANSPARENCY";
+        public const string SDL_HINT_APP_NAME =
+            "SDL_APP_NAME";
+        public const string SDL_HINT_SCREENSAVER_INHIBIT_ACTIVITY_NAME =
+            "SDL_SCREENSAVER_INHIBIT_ACTIVITY_NAME";
+        public const string SDL_HINT_IME_SHOW_UI =
+            "SDL_IME_SHOW_UI";
+        public const string SDL_HINT_WINDOW_NO_ACTIVATION_WHEN_SHOWN =
+            "SDL_WINDOW_NO_ACTIVATION_WHEN_SHOWN";
+        public const string SDL_HINT_POLL_SENTINEL =
+            "SDL_POLL_SENTINEL";
+        public const string SDL_HINT_JOYSTICK_DEVICE =
+            "SDL_JOYSTICK_DEVICE";
+        public const string SDL_HINT_LINUX_JOYSTICK_CLASSIC =
+            "SDL_LINUX_JOYSTICK_CLASSIC";
+
+        /* Only available in 2.0.20 or higher. */
+        public const string SDL_HINT_RENDER_LINE_METHOD =
+            "SDL_RENDER_LINE_METHOD";
+
+        /* Only available in 2.0.22 or higher. */
+        public const string SDL_HINT_FORCE_RAISEWINDOW =
+            "SDL_HINT_FORCE_RAISEWINDOW";
+        public const string SDL_HINT_IME_SUPPORT_EXTENDED_TEXT =
+            "SDL_IME_SUPPORT_EXTENDED_TEXT";
+        public const string SDL_HINT_JOYSTICK_GAMECUBE_RUMBLE_BRAKE =
+            "SDL_JOYSTICK_GAMECUBE_RUMBLE_BRAKE";
+        public const string SDL_HINT_JOYSTICK_ROG_CHAKRAM =
+            "SDL_JOYSTICK_ROG_CHAKRAM";
+        public const string SDL_HINT_MOUSE_RELATIVE_MODE_CENTER =
+            "SDL_MOUSE_RELATIVE_MODE_CENTER";
+        public const string SDL_HINT_MOUSE_AUTO_CAPTURE =
+            "SDL_MOUSE_AUTO_CAPTURE";
+        public const string SDL_HINT_VITA_TOUCH_MOUSE_DEVICE =
+            "SDL_HINT_VITA_TOUCH_MOUSE_DEVICE";
+        public const string SDL_HINT_VIDEO_WAYLAND_PREFER_LIBDECOR =
+            "SDL_VIDEO_WAYLAND_PREFER_LIBDECOR";
+        public const string SDL_HINT_VIDEO_FOREIGN_WINDOW_OPENGL =
+            "SDL_VIDEO_FOREIGN_WINDOW_OPENGL";
+        public const string SDL_HINT_VIDEO_FOREIGN_WINDOW_VULKAN =
+            "SDL_VIDEO_FOREIGN_WINDOW_VULKAN";
+        public const string SDL_HINT_X11_WINDOW_TYPE =
+            "SDL_X11_WINDOW_TYPE";
+        public const string SDL_HINT_QUIT_ON_LAST_WINDOW_CLOSE =
+            "SDL_QUIT_ON_LAST_WINDOW_CLOSE";
+
+        public enum SDL_HintPriority
+        {
+            SDL_HINT_DEFAULT,
+            SDL_HINT_NORMAL,
+            SDL_HINT_OVERRIDE
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_ClearHints();
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetHint", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_SDL_GetHint(byte* name);
+        public static unsafe string SDL_GetHint(string name)
+        {
+            int utf8NameBufSize = Utf8Size(name);
+            byte* utf8Name = stackalloc byte[utf8NameBufSize];
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GetHint(
+                    Utf8Encode(name, utf8Name, utf8NameBufSize)
+                )
+            );
+        }
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_SetHint", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe SDL_bool INTERNAL_SDL_SetHint(
+            byte* name,
+            byte* value
+        );
+        public static unsafe SDL_bool SDL_SetHint(string name, string value)
+        {
+            int utf8NameBufSize = Utf8Size(name);
+            byte* utf8Name = stackalloc byte[utf8NameBufSize];
+
+            int utf8ValueBufSize = Utf8Size(value);
+            byte* utf8Value = stackalloc byte[utf8ValueBufSize];
+
+            return INTERNAL_SDL_SetHint(
+                Utf8Encode(name, utf8Name, utf8NameBufSize),
+                Utf8Encode(value, utf8Value, utf8ValueBufSize)
+            );
+        }
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_SetHintWithPriority", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe SDL_bool INTERNAL_SDL_SetHintWithPriority(
+            byte* name,
+            byte* value,
+            SDL_HintPriority priority
+        );
+        public static unsafe SDL_bool SDL_SetHintWithPriority(
+            string name,
+            string value,
+            SDL_HintPriority priority
+        )
+        {
+            int utf8NameBufSize = Utf8Size(name);
+            byte* utf8Name = stackalloc byte[utf8NameBufSize];
+
+            int utf8ValueBufSize = Utf8Size(value);
+            byte* utf8Value = stackalloc byte[utf8ValueBufSize];
+
+            return INTERNAL_SDL_SetHintWithPriority(
+                Utf8Encode(name, utf8Name, utf8NameBufSize),
+                Utf8Encode(value, utf8Value, utf8ValueBufSize),
+                priority
+            );
+        }
+
+        /* Only available in 2.0.5 or higher. */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetHintBoolean", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe SDL_bool INTERNAL_SDL_GetHintBoolean(
+            byte* name,
+            SDL_bool default_value
+        );
+        public static unsafe SDL_bool SDL_GetHintBoolean(
+            string name,
+            SDL_bool default_value
+        )
+        {
+            int utf8NameBufSize = Utf8Size(name);
+            byte* utf8Name = stackalloc byte[utf8NameBufSize];
+            return INTERNAL_SDL_GetHintBoolean(
+                Utf8Encode(name, utf8Name, utf8NameBufSize),
+                default_value
+            );
+        }
+
+        #endregion
+
+        #region SDL_error.h
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_ClearError();
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetError", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetError();
+        public static string SDL_GetError()
+        {
+            return UTF8_ToManaged(INTERNAL_SDL_GetError());
+        }
+
+        /* Use string.Format for arglists */
+        [DllImport(nativeLibName, EntryPoint = "SDL_SetError", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe void INTERNAL_SDL_SetError(byte* fmtAndArglist);
+        public static unsafe void SDL_SetError(string fmtAndArglist)
+        {
+            int utf8FmtAndArglistBufSize = Utf8Size(fmtAndArglist);
+            byte* utf8FmtAndArglist = stackalloc byte[utf8FmtAndArglistBufSize];
+            INTERNAL_SDL_SetError(
+                Utf8Encode(fmtAndArglist, utf8FmtAndArglist, utf8FmtAndArglistBufSize)
+            );
+        }
+
+        /* IntPtr refers to a char*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetErrorMsg(nint errstr, int maxlength);
+
+        #endregion
+
+        #region SDL_log.h
+
+        public enum SDL_LogCategory
+        {
+            SDL_LOG_CATEGORY_APPLICATION,
+            SDL_LOG_CATEGORY_ERROR,
+            SDL_LOG_CATEGORY_ASSERT,
+            SDL_LOG_CATEGORY_SYSTEM,
+            SDL_LOG_CATEGORY_AUDIO,
+            SDL_LOG_CATEGORY_VIDEO,
+            SDL_LOG_CATEGORY_RENDER,
+            SDL_LOG_CATEGORY_INPUT,
+            SDL_LOG_CATEGORY_TEST,
+
+            /* Reserved for future SDL library use */
+            SDL_LOG_CATEGORY_RESERVED1,
+            SDL_LOG_CATEGORY_RESERVED2,
+            SDL_LOG_CATEGORY_RESERVED3,
+            SDL_LOG_CATEGORY_RESERVED4,
+            SDL_LOG_CATEGORY_RESERVED5,
+            SDL_LOG_CATEGORY_RESERVED6,
+            SDL_LOG_CATEGORY_RESERVED7,
+            SDL_LOG_CATEGORY_RESERVED8,
+            SDL_LOG_CATEGORY_RESERVED9,
+            SDL_LOG_CATEGORY_RESERVED10,
+
+            /* Beyond this point is reserved for application use, e.g.
+			enum {
+				MYAPP_CATEGORY_AWESOME1 = SDL_LOG_CATEGORY_CUSTOM,
+				MYAPP_CATEGORY_AWESOME2,
+				MYAPP_CATEGORY_AWESOME3,
+				...
+			};
+			*/
+            SDL_LOG_CATEGORY_CUSTOM
+        }
+
+        public enum SDL_LogPriority
+        {
+            SDL_LOG_PRIORITY_VERBOSE = 1,
+            SDL_LOG_PRIORITY_DEBUG,
+            SDL_LOG_PRIORITY_INFO,
+            SDL_LOG_PRIORITY_WARN,
+            SDL_LOG_PRIORITY_ERROR,
+            SDL_LOG_PRIORITY_CRITICAL,
+            SDL_NUM_LOG_PRIORITIES
+        }
+
+        /* userdata refers to a void*, message to a const char* */
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void SDL_LogOutputFunction(
+            nint userdata,
+            int category,
+            SDL_LogPriority priority,
+            nint message
+        );
+
+        /* Use string.Format for arglists */
+        [DllImport(nativeLibName, EntryPoint = "SDL_Log", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe void INTERNAL_SDL_Log(byte* fmtAndArglist);
+        public static unsafe void SDL_Log(string fmtAndArglist)
+        {
+            int utf8FmtAndArglistBufSize = Utf8Size(fmtAndArglist);
+            byte* utf8FmtAndArglist = stackalloc byte[utf8FmtAndArglistBufSize];
+            INTERNAL_SDL_Log(
+                Utf8Encode(fmtAndArglist, utf8FmtAndArglist, utf8FmtAndArglistBufSize)
+            );
+        }
+
+        /* Use string.Format for arglists */
+        [DllImport(nativeLibName, EntryPoint = "SDL_LogVerbose", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe void INTERNAL_SDL_LogVerbose(
+            int category,
+            byte* fmtAndArglist
+        );
+        public static unsafe void SDL_LogVerbose(
+            int category,
+            string fmtAndArglist
+        )
+        {
+            int utf8FmtAndArglistBufSize = Utf8Size(fmtAndArglist);
+            byte* utf8FmtAndArglist = stackalloc byte[utf8FmtAndArglistBufSize];
+            INTERNAL_SDL_LogVerbose(
+                category,
+                Utf8Encode(fmtAndArglist, utf8FmtAndArglist, utf8FmtAndArglistBufSize)
+            );
+        }
+
+        /* Use string.Format for arglists */
+        [DllImport(nativeLibName, EntryPoint = "SDL_LogDebug", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe void INTERNAL_SDL_LogDebug(
+            int category,
+            byte* fmtAndArglist
+        );
+        public static unsafe void SDL_LogDebug(
+            int category,
+            string fmtAndArglist
+        )
+        {
+            int utf8FmtAndArglistBufSize = Utf8Size(fmtAndArglist);
+            byte* utf8FmtAndArglist = stackalloc byte[utf8FmtAndArglistBufSize];
+            INTERNAL_SDL_LogDebug(
+                category,
+                Utf8Encode(fmtAndArglist, utf8FmtAndArglist, utf8FmtAndArglistBufSize)
+            );
+        }
+
+        /* Use string.Format for arglists */
+        [DllImport(nativeLibName, EntryPoint = "SDL_LogInfo", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe void INTERNAL_SDL_LogInfo(
+            int category,
+            byte* fmtAndArglist
+        );
+        public static unsafe void SDL_LogInfo(
+            int category,
+            string fmtAndArglist
+        )
+        {
+            int utf8FmtAndArglistBufSize = Utf8Size(fmtAndArglist);
+            byte* utf8FmtAndArglist = stackalloc byte[utf8FmtAndArglistBufSize];
+            INTERNAL_SDL_LogInfo(
+                category,
+                Utf8Encode(fmtAndArglist, utf8FmtAndArglist, utf8FmtAndArglistBufSize)
+            );
+        }
+
+        /* Use string.Format for arglists */
+        [DllImport(nativeLibName, EntryPoint = "SDL_LogWarn", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe void INTERNAL_SDL_LogWarn(
+            int category,
+            byte* fmtAndArglist
+        );
+        public static unsafe void SDL_LogWarn(
+            int category,
+            string fmtAndArglist
+        )
+        {
+            int utf8FmtAndArglistBufSize = Utf8Size(fmtAndArglist);
+            byte* utf8FmtAndArglist = stackalloc byte[utf8FmtAndArglistBufSize];
+            INTERNAL_SDL_LogWarn(
+                category,
+                Utf8Encode(fmtAndArglist, utf8FmtAndArglist, utf8FmtAndArglistBufSize)
+            );
+        }
+
+        /* Use string.Format for arglists */
+        [DllImport(nativeLibName, EntryPoint = "SDL_LogError", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe void INTERNAL_SDL_LogError(
+            int category,
+            byte* fmtAndArglist
+        );
+        public static unsafe void SDL_LogError(
+            int category,
+            string fmtAndArglist
+        )
+        {
+            int utf8FmtAndArglistBufSize = Utf8Size(fmtAndArglist);
+            byte* utf8FmtAndArglist = stackalloc byte[utf8FmtAndArglistBufSize];
+            INTERNAL_SDL_LogError(
+                category,
+                Utf8Encode(fmtAndArglist, utf8FmtAndArglist, utf8FmtAndArglistBufSize)
+            );
+        }
+
+        /* Use string.Format for arglists */
+        [DllImport(nativeLibName, EntryPoint = "SDL_LogCritical", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe void INTERNAL_SDL_LogCritical(
+            int category,
+            byte* fmtAndArglist
+        );
+        public static unsafe void SDL_LogCritical(
+            int category,
+            string fmtAndArglist
+        )
+        {
+            int utf8FmtAndArglistBufSize = Utf8Size(fmtAndArglist);
+            byte* utf8FmtAndArglist = stackalloc byte[utf8FmtAndArglistBufSize];
+            INTERNAL_SDL_LogCritical(
+                category,
+                Utf8Encode(fmtAndArglist, utf8FmtAndArglist, utf8FmtAndArglistBufSize)
+            );
+        }
+
+        /* Use string.Format for arglists */
+        [DllImport(nativeLibName, EntryPoint = "SDL_LogMessage", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe void INTERNAL_SDL_LogMessage(
+            int category,
+            SDL_LogPriority priority,
+            byte* fmtAndArglist
+        );
+        public static unsafe void SDL_LogMessage(
+            int category,
+            SDL_LogPriority priority,
+            string fmtAndArglist
+        )
+        {
+            int utf8FmtAndArglistBufSize = Utf8Size(fmtAndArglist);
+            byte* utf8FmtAndArglist = stackalloc byte[utf8FmtAndArglistBufSize];
+            INTERNAL_SDL_LogMessage(
+                category,
+                priority,
+                Utf8Encode(fmtAndArglist, utf8FmtAndArglist, utf8FmtAndArglistBufSize)
+            );
+        }
+
+        /* Use string.Format for arglists */
+        [DllImport(nativeLibName, EntryPoint = "SDL_LogMessageV", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe void INTERNAL_SDL_LogMessageV(
+            int category,
+            SDL_LogPriority priority,
+            byte* fmtAndArglist
+        );
+        public static unsafe void SDL_LogMessageV(
+            int category,
+            SDL_LogPriority priority,
+            string fmtAndArglist
+        )
+        {
+            int utf8FmtAndArglistBufSize = Utf8Size(fmtAndArglist);
+            byte* utf8FmtAndArglist = stackalloc byte[utf8FmtAndArglistBufSize];
+            INTERNAL_SDL_LogMessageV(
+                category,
+                priority,
+                Utf8Encode(fmtAndArglist, utf8FmtAndArglist, utf8FmtAndArglistBufSize)
+            );
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_LogPriority SDL_LogGetPriority(
+            int category
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_LogSetPriority(
+            int category,
+            SDL_LogPriority priority
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_LogSetAllPriority(
+            SDL_LogPriority priority
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_LogResetPriorities();
+
+        /* userdata refers to a void* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        private static extern void SDL_LogGetOutputFunction(
+            out nint callback,
+            out nint userdata
+        );
+        public static void SDL_LogGetOutputFunction(
+            out SDL_LogOutputFunction callback,
+            out nint userdata
+        )
+        {
+            nint result = nint.Zero;
+            SDL_LogGetOutputFunction(
+                out result,
+                out userdata
+            );
+            if (result != nint.Zero)
+            {
+                callback = GetDelegateForFunctionPointer<SDL_LogOutputFunction>(
+                    result
+                );
+            }
+            else
+            {
+                callback = null;
+            }
+        }
+
+        /* userdata refers to a void* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_LogSetOutputFunction(
+            SDL_LogOutputFunction callback,
+            nint userdata
+        );
+
+        #endregion
+
+        #region SDL_messagebox.h
+
+        [Flags]
+        public enum SDL_MessageBoxFlags : uint
+        {
+            SDL_MESSAGEBOX_ERROR = 0x00000010,
+            SDL_MESSAGEBOX_WARNING = 0x00000020,
+            SDL_MESSAGEBOX_INFORMATION = 0x00000040
+        }
+
+        [Flags]
+        public enum SDL_MessageBoxButtonFlags : uint
+        {
+            SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT = 0x00000001,
+            SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT = 0x00000002
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct INTERNAL_SDL_MessageBoxButtonData
+        {
+            public SDL_MessageBoxButtonFlags flags;
+            public int buttonid;
+            public nint text; /* The UTF-8 button text */
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_MessageBoxButtonData
+        {
+            public SDL_MessageBoxButtonFlags flags;
+            public int buttonid;
+            public string text; /* The UTF-8 button text */
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_MessageBoxColor
+        {
+            public byte r, g, b;
+        }
+
+        public enum SDL_MessageBoxColorType
+        {
+            SDL_MESSAGEBOX_COLOR_BACKGROUND,
+            SDL_MESSAGEBOX_COLOR_TEXT,
+            SDL_MESSAGEBOX_COLOR_BUTTON_BORDER,
+            SDL_MESSAGEBOX_COLOR_BUTTON_BACKGROUND,
+            SDL_MESSAGEBOX_COLOR_BUTTON_SELECTED,
+            SDL_MESSAGEBOX_COLOR_MAX
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_MessageBoxColorScheme
+        {
+            [MarshalAs(UnmanagedType.ByValArray, ArraySubType = UnmanagedType.Struct, SizeConst = (int)SDL_MessageBoxColorType.SDL_MESSAGEBOX_COLOR_MAX)]
+            public SDL_MessageBoxColor[] colors;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct INTERNAL_SDL_MessageBoxData
+        {
+            public SDL_MessageBoxFlags flags;
+            public nint window;               /* Parent window, can be NULL */
+            public nint title;                /* UTF-8 title */
+            public nint message;              /* UTF-8 message text */
+            public int numbuttons;
+            public nint buttons;
+            public nint colorScheme;          /* Can be NULL to use system settings */
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_MessageBoxData
+        {
+            public SDL_MessageBoxFlags flags;
+            public nint window;               /* Parent window, can be NULL */
+            public string title;                /* UTF-8 title */
+            public string message;              /* UTF-8 message text */
+            public int numbuttons;
+            public SDL_MessageBoxButtonData[] buttons;
+            public SDL_MessageBoxColorScheme? colorScheme;  /* Can be NULL to use system settings */
+        }
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_ShowMessageBox", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int INTERNAL_SDL_ShowMessageBox([In()] ref INTERNAL_SDL_MessageBoxData messageboxdata, out int buttonid);
+
+        /* Ripped from Jameson's LpUtf8StrMarshaler */
+        private static nint INTERNAL_AllocUTF8(string str)
+        {
+            if (string.IsNullOrEmpty(str))
+            {
+                return nint.Zero;
+            }
+            byte[] bytes = Encoding.UTF8.GetBytes(str + '\0');
+            nint mem = SDL_malloc(bytes.Length);
+            Marshal.Copy(bytes, 0, mem, bytes.Length);
+            return mem;
+        }
+
+        public static unsafe int SDL_ShowMessageBox([In()] ref SDL_MessageBoxData messageboxdata, out int buttonid)
+        {
+            var data = new INTERNAL_SDL_MessageBoxData()
+            {
+                flags = messageboxdata.flags,
+                window = messageboxdata.window,
+                title = INTERNAL_AllocUTF8(messageboxdata.title),
+                message = INTERNAL_AllocUTF8(messageboxdata.message),
+                numbuttons = messageboxdata.numbuttons,
+            };
+
+            var buttons = new INTERNAL_SDL_MessageBoxButtonData[messageboxdata.numbuttons];
+            for (int i = 0; i < messageboxdata.numbuttons; i++)
+            {
+                buttons[i] = new INTERNAL_SDL_MessageBoxButtonData()
+                {
+                    flags = messageboxdata.buttons[i].flags,
+                    buttonid = messageboxdata.buttons[i].buttonid,
+                    text = INTERNAL_AllocUTF8(messageboxdata.buttons[i].text),
+                };
+            }
+
+            if (messageboxdata.colorScheme != null)
+            {
+                data.colorScheme = Marshal.AllocHGlobal(SizeOf<SDL_MessageBoxColorScheme>());
+                Marshal.StructureToPtr(messageboxdata.colorScheme.Value, data.colorScheme, false);
+            }
+
+            int result;
+            fixed (INTERNAL_SDL_MessageBoxButtonData* buttonsPtr = &buttons[0])
+            {
+                data.buttons = (nint)buttonsPtr;
+                result = INTERNAL_SDL_ShowMessageBox(ref data, out buttonid);
+            }
+
+            Marshal.FreeHGlobal(data.colorScheme);
+            for (int i = 0; i < messageboxdata.numbuttons; i++)
+            {
+                SDL_free(buttons[i].text);
+            }
+            SDL_free(data.message);
+            SDL_free(data.title);
+
+            return result;
+        }
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_ShowSimpleMessageBox", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe int INTERNAL_SDL_ShowSimpleMessageBox(
+            SDL_MessageBoxFlags flags,
+            byte* title,
+            byte* message,
+            nint window
+        );
+        public static unsafe int SDL_ShowSimpleMessageBox(
+            SDL_MessageBoxFlags flags,
+            string title,
+            string message,
+            nint window
+        )
+        {
+            int utf8TitleBufSize = Utf8Size(title);
+            byte* utf8Title = stackalloc byte[utf8TitleBufSize];
+
+            int utf8MessageBufSize = Utf8Size(message);
+            byte* utf8Message = stackalloc byte[utf8MessageBufSize];
+
+            return INTERNAL_SDL_ShowSimpleMessageBox(
+                flags,
+                Utf8Encode(title, utf8Title, utf8TitleBufSize),
+                Utf8Encode(message, utf8Message, utf8MessageBufSize),
+                window
+            );
+        }
+
+        #endregion
+
+        #region SDL_version.h, SDL_revision.h
+
+        /* Similar to the headers, this is the version we're expecting to be
+		 * running with. You will likely want to check this somewhere in your
+		 * program!
+		 */
+        public const int SDL_MAJOR_VERSION = 2;
+        public const int SDL_MINOR_VERSION = 0;
+        public const int SDL_PATCHLEVEL = 22;
+
+        public static readonly int SDL_COMPILEDVERSION = SDL_VERSIONNUM(
+            SDL_MAJOR_VERSION,
+            SDL_MINOR_VERSION,
+            SDL_PATCHLEVEL
+        );
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_version
+        {
+            public byte major;
+            public byte minor;
+            public byte patch;
+        }
+
+        public static void SDL_VERSION(out SDL_version x)
+        {
+            x.major = SDL_MAJOR_VERSION;
+            x.minor = SDL_MINOR_VERSION;
+            x.patch = SDL_PATCHLEVEL;
+        }
+
+        public static int SDL_VERSIONNUM(int X, int Y, int Z)
+        {
+            return X * 1000 + Y * 100 + Z;
+        }
+
+        public static bool SDL_VERSION_ATLEAST(int X, int Y, int Z)
+        {
+            return SDL_COMPILEDVERSION >= SDL_VERSIONNUM(X, Y, Z);
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GetVersion(out SDL_version ver);
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetRevision", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetRevision();
+        public static string SDL_GetRevision()
+        {
+            return UTF8_ToManaged(INTERNAL_SDL_GetRevision());
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetRevisionNumber();
+
+        #endregion
+
+        #region SDL_video.h
+
+        public enum SDL_GLattr
+        {
+            SDL_GL_RED_SIZE,
+            SDL_GL_GREEN_SIZE,
+            SDL_GL_BLUE_SIZE,
+            SDL_GL_ALPHA_SIZE,
+            SDL_GL_BUFFER_SIZE,
+            SDL_GL_DOUBLEBUFFER,
+            SDL_GL_DEPTH_SIZE,
+            SDL_GL_STENCIL_SIZE,
+            SDL_GL_ACCUM_RED_SIZE,
+            SDL_GL_ACCUM_GREEN_SIZE,
+            SDL_GL_ACCUM_BLUE_SIZE,
+            SDL_GL_ACCUM_ALPHA_SIZE,
+            SDL_GL_STEREO,
+            SDL_GL_MULTISAMPLEBUFFERS,
+            SDL_GL_MULTISAMPLESAMPLES,
+            SDL_GL_ACCELERATED_VISUAL,
+            SDL_GL_RETAINED_BACKING,
+            SDL_GL_CONTEXT_MAJOR_VERSION,
+            SDL_GL_CONTEXT_MINOR_VERSION,
+            SDL_GL_CONTEXT_EGL,
+            SDL_GL_CONTEXT_FLAGS,
+            SDL_GL_CONTEXT_PROFILE_MASK,
+            SDL_GL_SHARE_WITH_CURRENT_CONTEXT,
+            SDL_GL_FRAMEBUFFER_SRGB_CAPABLE,
+            SDL_GL_CONTEXT_RELEASE_BEHAVIOR,
+            SDL_GL_CONTEXT_RESET_NOTIFICATION,  /* Requires >= 2.0.6 */
+            SDL_GL_CONTEXT_NO_ERROR,        /* Requires >= 2.0.6 */
+        }
+
+        [Flags]
+        public enum SDL_GLprofile
+        {
+            SDL_GL_CONTEXT_PROFILE_CORE = 0x0001,
+            SDL_GL_CONTEXT_PROFILE_COMPATIBILITY = 0x0002,
+            SDL_GL_CONTEXT_PROFILE_ES = 0x0004
+        }
+
+        [Flags]
+        public enum SDL_GLcontext
+        {
+            SDL_GL_CONTEXT_DEBUG_FLAG = 0x0001,
+            SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG = 0x0002,
+            SDL_GL_CONTEXT_ROBUST_ACCESS_FLAG = 0x0004,
+            SDL_GL_CONTEXT_RESET_ISOLATION_FLAG = 0x0008
+        }
+
+        public enum SDL_WindowEventID : byte
+        {
+            SDL_WINDOWEVENT_NONE,
+            SDL_WINDOWEVENT_SHOWN,
+            SDL_WINDOWEVENT_HIDDEN,
+            SDL_WINDOWEVENT_EXPOSED,
+            SDL_WINDOWEVENT_MOVED,
+            SDL_WINDOWEVENT_RESIZED,
+            SDL_WINDOWEVENT_SIZE_CHANGED,
+            SDL_WINDOWEVENT_MINIMIZED,
+            SDL_WINDOWEVENT_MAXIMIZED,
+            SDL_WINDOWEVENT_RESTORED,
+            SDL_WINDOWEVENT_ENTER,
+            SDL_WINDOWEVENT_LEAVE,
+            SDL_WINDOWEVENT_FOCUS_GAINED,
+            SDL_WINDOWEVENT_FOCUS_LOST,
+            SDL_WINDOWEVENT_CLOSE,
+            /* Only available in 2.0.5 or higher. */
+            SDL_WINDOWEVENT_TAKE_FOCUS,
+            SDL_WINDOWEVENT_HIT_TEST,
+            /* Only available in 2.0.18 or higher. */
+            SDL_WINDOWEVENT_ICCPROF_CHANGED,
+            SDL_WINDOWEVENT_DISPLAY_CHANGED
+        }
+
+        public enum SDL_DisplayEventID : byte
+        {
+            SDL_DISPLAYEVENT_NONE,
+            SDL_DISPLAYEVENT_ORIENTATION,
+            SDL_DISPLAYEVENT_CONNECTED, /* Requires >= 2.0.14 */
+            SDL_DISPLAYEVENT_DISCONNECTED   /* Requires >= 2.0.14 */
+        }
+
+        public enum SDL_DisplayOrientation
+        {
+            SDL_ORIENTATION_UNKNOWN,
+            SDL_ORIENTATION_LANDSCAPE,
+            SDL_ORIENTATION_LANDSCAPE_FLIPPED,
+            SDL_ORIENTATION_PORTRAIT,
+            SDL_ORIENTATION_PORTRAIT_FLIPPED
+        }
+
+        /* Only available in 2.0.16 or higher. */
+        public enum SDL_FlashOperation
+        {
+            SDL_FLASH_CANCEL,
+            SDL_FLASH_BRIEFLY,
+            SDL_FLASH_UNTIL_FOCUSED
+        }
+
+        [Flags]
+        public enum SDL_WindowFlags : uint
+        {
+            SDL_WINDOW_FULLSCREEN = 0x00000001,
+            SDL_WINDOW_OPENGL = 0x00000002,
+            SDL_WINDOW_SHOWN = 0x00000004,
+            SDL_WINDOW_HIDDEN = 0x00000008,
+            SDL_WINDOW_BORDERLESS = 0x00000010,
+            SDL_WINDOW_RESIZABLE = 0x00000020,
+            SDL_WINDOW_MINIMIZED = 0x00000040,
+            SDL_WINDOW_MAXIMIZED = 0x00000080,
+            SDL_WINDOW_MOUSE_GRABBED = 0x00000100,
+            SDL_WINDOW_INPUT_FOCUS = 0x00000200,
+            SDL_WINDOW_MOUSE_FOCUS = 0x00000400,
+            SDL_WINDOW_FULLSCREEN_DESKTOP =
+                SDL_WINDOW_FULLSCREEN | 0x00001000,
+            SDL_WINDOW_FOREIGN = 0x00000800,
+            SDL_WINDOW_ALLOW_HIGHDPI = 0x00002000,  /* Requires >= 2.0.1 */
+            SDL_WINDOW_MOUSE_CAPTURE = 0x00004000,  /* Requires >= 2.0.4 */
+            SDL_WINDOW_ALWAYS_ON_TOP = 0x00008000,  /* Requires >= 2.0.5 */
+            SDL_WINDOW_SKIP_TASKBAR = 0x00010000,   /* Requires >= 2.0.5 */
+            SDL_WINDOW_UTILITY = 0x00020000,    /* Requires >= 2.0.5 */
+            SDL_WINDOW_TOOLTIP = 0x00040000,    /* Requires >= 2.0.5 */
+            SDL_WINDOW_POPUP_MENU = 0x00080000, /* Requires >= 2.0.5 */
+            SDL_WINDOW_KEYBOARD_GRABBED = 0x00100000,   /* Requires >= 2.0.16 */
+            SDL_WINDOW_VULKAN = 0x10000000, /* Requires >= 2.0.6 */
+            SDL_WINDOW_METAL = 0x2000000,   /* Requires >= 2.0.14 */
+
+            SDL_WINDOW_INPUT_GRABBED =
+                SDL_WINDOW_MOUSE_GRABBED,
+        }
+
+        /* Only available in 2.0.4 or higher. */
+        public enum SDL_HitTestResult
+        {
+            SDL_HITTEST_NORMAL,     /* Region is normal. No special properties. */
+            SDL_HITTEST_DRAGGABLE,      /* Region can drag entire window. */
+            SDL_HITTEST_RESIZE_TOPLEFT,
+            SDL_HITTEST_RESIZE_TOP,
+            SDL_HITTEST_RESIZE_TOPRIGHT,
+            SDL_HITTEST_RESIZE_RIGHT,
+            SDL_HITTEST_RESIZE_BOTTOMRIGHT,
+            SDL_HITTEST_RESIZE_BOTTOM,
+            SDL_HITTEST_RESIZE_BOTTOMLEFT,
+            SDL_HITTEST_RESIZE_LEFT
+        }
+
+        public const int SDL_WINDOWPOS_UNDEFINED_MASK = 0x1FFF0000;
+        public const int SDL_WINDOWPOS_CENTERED_MASK = 0x2FFF0000;
+        public const int SDL_WINDOWPOS_UNDEFINED = 0x1FFF0000;
+        public const int SDL_WINDOWPOS_CENTERED = 0x2FFF0000;
+
+        public static int SDL_WINDOWPOS_UNDEFINED_DISPLAY(int X)
+        {
+            return SDL_WINDOWPOS_UNDEFINED_MASK | X;
+        }
+
+        public static bool SDL_WINDOWPOS_ISUNDEFINED(int X)
+        {
+            return (X & 0xFFFF0000) == SDL_WINDOWPOS_UNDEFINED_MASK;
+        }
+
+        public static int SDL_WINDOWPOS_CENTERED_DISPLAY(int X)
+        {
+            return SDL_WINDOWPOS_CENTERED_MASK | X;
+        }
+
+        public static bool SDL_WINDOWPOS_ISCENTERED(int X)
+        {
+            return (X & 0xFFFF0000) == SDL_WINDOWPOS_CENTERED_MASK;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_DisplayMode
+        {
+            public uint format;
+            public int w;
+            public int h;
+            public int refresh_rate;
+            public nint driverdata; // void*
+        }
+
+        /* win refers to an SDL_Window*, area to a const SDL_Point*, data to a void*.
+		 * Only available in 2.0.4 or higher.
+		 */
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate SDL_HitTestResult SDL_HitTest(nint win, nint area, nint data);
+
+        /* IntPtr refers to an SDL_Window* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_CreateWindow", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_SDL_CreateWindow(
+            byte* title,
+            int x,
+            int y,
+            int w,
+            int h,
+            SDL_WindowFlags flags
+        );
+        public static unsafe nint SDL_CreateWindow(
+            string title,
+            int x,
+            int y,
+            int w,
+            int h,
+            SDL_WindowFlags flags
+        )
+        {
+            int utf8TitleBufSize = Utf8Size(title);
+            byte* utf8Title = stackalloc byte[utf8TitleBufSize];
+            return INTERNAL_SDL_CreateWindow(
+                Utf8Encode(title, utf8Title, utf8TitleBufSize),
+                x, y, w, h,
+                flags
+            );
+        }
+
+        /* window refers to an SDL_Window*, renderer to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_CreateWindowAndRenderer(
+            int width,
+            int height,
+            SDL_WindowFlags window_flags,
+            out nint window,
+            out nint renderer
+        );
+
+        /* data refers to some native window type, IntPtr to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_CreateWindowFrom(nint data);
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_DestroyWindow(nint window);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_DisableScreenSaver();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_EnableScreenSaver();
+
+        /* IntPtr refers to an SDL_DisplayMode. Just use closest. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetClosestDisplayMode(
+            int displayIndex,
+            ref SDL_DisplayMode mode,
+            out SDL_DisplayMode closest
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetCurrentDisplayMode(
+            int displayIndex,
+            out SDL_DisplayMode mode
+        );
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetCurrentVideoDriver", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetCurrentVideoDriver();
+        public static string SDL_GetCurrentVideoDriver()
+        {
+            return UTF8_ToManaged(INTERNAL_SDL_GetCurrentVideoDriver());
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetDesktopDisplayMode(
+            int displayIndex,
+            out SDL_DisplayMode mode
+        );
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetDisplayName", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetDisplayName(int index);
+        public static string SDL_GetDisplayName(int index)
+        {
+            return UTF8_ToManaged(INTERNAL_SDL_GetDisplayName(index));
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetDisplayBounds(
+            int displayIndex,
+            out SDL_Rect rect
+        );
+
+        /* Only available in 2.0.4 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetDisplayDPI(
+            int displayIndex,
+            out float ddpi,
+            out float hdpi,
+            out float vdpi
+        );
+
+        /* Only available in 2.0.9 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_DisplayOrientation SDL_GetDisplayOrientation(
+            int displayIndex
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetDisplayMode(
+            int displayIndex,
+            int modeIndex,
+            out SDL_DisplayMode mode
+        );
+
+        /* Only available in 2.0.5 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetDisplayUsableBounds(
+            int displayIndex,
+            out SDL_Rect rect
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetNumDisplayModes(
+            int displayIndex
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetNumVideoDisplays();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetNumVideoDrivers();
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetVideoDriver", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetVideoDriver(
+            int index
+        );
+        public static string SDL_GetVideoDriver(int index)
+        {
+            return UTF8_ToManaged(INTERNAL_SDL_GetVideoDriver(index));
+        }
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern float SDL_GetWindowBrightness(
+            nint window
+        );
+
+        /* window refers to an SDL_Window*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetWindowOpacity(
+            nint window,
+            float opacity
+        );
+
+        /* window refers to an SDL_Window*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetWindowOpacity(
+            nint window,
+            out float out_opacity
+        );
+
+        /* modal_window and parent_window refer to an SDL_Window*s
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetWindowModalFor(
+            nint modal_window,
+            nint parent_window
+        );
+
+        /* window refers to an SDL_Window*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetWindowInputFocus(nint window);
+
+        /* window refers to an SDL_Window*, IntPtr to a void* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetWindowData", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_SDL_GetWindowData(
+            nint window,
+            byte* name
+        );
+        public static unsafe nint SDL_GetWindowData(
+            nint window,
+            string name
+        )
+        {
+            int utf8NameBufSize = Utf8Size(name);
+            byte* utf8Name = stackalloc byte[utf8NameBufSize];
+            return INTERNAL_SDL_GetWindowData(
+                window,
+                Utf8Encode(name, utf8Name, utf8NameBufSize)
+            );
+        }
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetWindowDisplayIndex(
+            nint window
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetWindowDisplayMode(
+            nint window,
+            out SDL_DisplayMode mode
+        );
+
+        /* IntPtr refers to a void*
+		 * window refers to an SDL_Window*
+		 * mode refers to a size_t*
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetWindowICCProfile(
+            nint window,
+            out nint mode
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_GetWindowFlags(nint window);
+
+        /* IntPtr refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetWindowFromID(uint id);
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetWindowGammaRamp(
+            nint window,
+            [Out()] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 256)]
+                ushort[] red,
+            [Out()] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 256)]
+                ushort[] green,
+            [Out()] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 256)]
+                ushort[] blue
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_GetWindowGrab(nint window);
+
+        /* window refers to an SDL_Window*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_GetWindowKeyboardGrab(nint window);
+
+        /* window refers to an SDL_Window*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_GetWindowMouseGrab(nint window);
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_GetWindowID(nint window);
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_GetWindowPixelFormat(
+            nint window
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GetWindowMaximumSize(
+            nint window,
+            out int max_w,
+            out int max_h
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GetWindowMinimumSize(
+            nint window,
+            out int min_w,
+            out int min_h
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GetWindowPosition(
+            nint window,
+            out int x,
+            out int y
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GetWindowSize(
+            nint window,
+            out int w,
+            out int h
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GetWindowSizeInPixels(
+            nint window,
+            out int w,
+            out int h
+        );
+
+        /* IntPtr refers to an SDL_Surface*, window to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetWindowSurface(nint window);
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetWindowTitle", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetWindowTitle(
+            nint window
+        );
+        public static string SDL_GetWindowTitle(nint window)
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GetWindowTitle(window)
+            );
+        }
+
+        /* texture refers to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GL_BindTexture(
+            nint texture,
+            out float texw,
+            out float texh
+        );
+
+        /* IntPtr and window refer to an SDL_GLContext and SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GL_CreateContext(nint window);
+
+        /* context refers to an SDL_GLContext */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GL_DeleteContext(nint context);
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GL_LoadLibrary", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe int INTERNAL_SDL_GL_LoadLibrary(byte* path);
+        public static unsafe int SDL_GL_LoadLibrary(string path)
+        {
+            byte* utf8Path = Utf8EncodeHeap(path);
+            int result = INTERNAL_SDL_GL_LoadLibrary(
+                utf8Path
+            );
+            Marshal.FreeHGlobal((nint)utf8Path);
+            return result;
+        }
+
+        /* IntPtr refers to a function pointer, proc to a const char* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GL_GetProcAddress(nint proc);
+
+        /* IntPtr refers to a function pointer */
+        public static unsafe nint SDL_GL_GetProcAddress(string proc)
+        {
+            int utf8ProcBufSize = Utf8Size(proc);
+            byte* utf8Proc = stackalloc byte[utf8ProcBufSize];
+            return SDL_GL_GetProcAddress(
+                (nint)Utf8Encode(proc, utf8Proc, utf8ProcBufSize)
+            );
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GL_UnloadLibrary();
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GL_ExtensionSupported", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe SDL_bool INTERNAL_SDL_GL_ExtensionSupported(
+            byte* extension
+        );
+        public static unsafe SDL_bool SDL_GL_ExtensionSupported(string extension)
+        {
+            int utf8ExtensionBufSize = Utf8Size(extension);
+            byte* utf8Extension = stackalloc byte[utf8ExtensionBufSize];
+            return INTERNAL_SDL_GL_ExtensionSupported(
+                Utf8Encode(extension, utf8Extension, utf8ExtensionBufSize)
+            );
+        }
+
+        /* Only available in SDL 2.0.2 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GL_ResetAttributes();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GL_GetAttribute(
+            SDL_GLattr attr,
+            out int value
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GL_GetSwapInterval();
+
+        /* window and context refer to an SDL_Window* and SDL_GLContext */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GL_MakeCurrent(
+            nint window,
+            nint context
+        );
+
+        /* IntPtr refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GL_GetCurrentWindow();
+
+        /* IntPtr refers to an SDL_Context */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GL_GetCurrentContext();
+
+        /* window refers to an SDL_Window*.
+		 * Only available in SDL 2.0.1 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GL_GetDrawableSize(
+            nint window,
+            out int w,
+            out int h
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GL_SetAttribute(
+            SDL_GLattr attr,
+            int value
+        );
+
+        public static int SDL_GL_SetAttribute(
+            SDL_GLattr attr,
+            SDL_GLprofile profile
+        )
+        {
+            return SDL_GL_SetAttribute(attr, (int)profile);
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GL_SetSwapInterval(int interval);
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GL_SwapWindow(nint window);
+
+        /* texture refers to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GL_UnbindTexture(nint texture);
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_HideWindow(nint window);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_IsScreenSaverEnabled();
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_MaximizeWindow(nint window);
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_MinimizeWindow(nint window);
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_RaiseWindow(nint window);
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_RestoreWindow(nint window);
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetWindowBrightness(
+            nint window,
+            float brightness
+        );
+
+        /* IntPtr and userdata are void*, window is an SDL_Window* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_SetWindowData", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_SDL_SetWindowData(
+            nint window,
+            byte* name,
+            nint userdata
+        );
+        public static unsafe nint SDL_SetWindowData(
+            nint window,
+            string name,
+            nint userdata
+        )
+        {
+            int utf8NameBufSize = Utf8Size(name);
+            byte* utf8Name = stackalloc byte[utf8NameBufSize];
+            return INTERNAL_SDL_SetWindowData(
+                window,
+                Utf8Encode(name, utf8Name, utf8NameBufSize),
+                userdata
+            );
+        }
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetWindowDisplayMode(
+            nint window,
+            ref SDL_DisplayMode mode
+        );
+
+        /* window refers to an SDL_Window* */
+        /* NULL overload - use the window's dimensions and the desktop's format and refresh rate */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetWindowDisplayMode(
+            nint window,
+            nint mode
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetWindowFullscreen(
+            nint window,
+            uint flags
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetWindowGammaRamp(
+            nint window,
+            [In()] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 256)]
+                ushort[] red,
+            [In()] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 256)]
+                ushort[] green,
+            [In()] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 256)]
+                ushort[] blue
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetWindowGrab(
+            nint window,
+            SDL_bool grabbed
+        );
+
+        /* window refers to an SDL_Window*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetWindowKeyboardGrab(
+            nint window,
+            SDL_bool grabbed
+        );
+
+        /* window refers to an SDL_Window*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetWindowMouseGrab(
+            nint window,
+            SDL_bool grabbed
+        );
+
+
+        /* window refers to an SDL_Window*, icon to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetWindowIcon(
+            nint window,
+            nint icon
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetWindowMaximumSize(
+            nint window,
+            int max_w,
+            int max_h
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetWindowMinimumSize(
+            nint window,
+            int min_w,
+            int min_h
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetWindowPosition(
+            nint window,
+            int x,
+            int y
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetWindowSize(
+            nint window,
+            int w,
+            int h
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetWindowBordered(
+            nint window,
+            SDL_bool bordered
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetWindowBordersSize(
+            nint window,
+            out int top,
+            out int left,
+            out int bottom,
+            out int right
+        );
+
+        /* window refers to an SDL_Window*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetWindowResizable(
+            nint window,
+            SDL_bool resizable
+        );
+
+        /* window refers to an SDL_Window*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetWindowAlwaysOnTop(
+            nint window,
+            SDL_bool on_top
+        );
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_SetWindowTitle", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe void INTERNAL_SDL_SetWindowTitle(
+            nint window,
+            byte* title
+        );
+        public static unsafe void SDL_SetWindowTitle(
+            nint window,
+            string title
+        )
+        {
+            int utf8TitleBufSize = Utf8Size(title);
+            byte* utf8Title = stackalloc byte[utf8TitleBufSize];
+            INTERNAL_SDL_SetWindowTitle(
+                window,
+                Utf8Encode(title, utf8Title, utf8TitleBufSize)
+            );
+        }
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_ShowWindow(nint window);
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_UpdateWindowSurface(nint window);
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_UpdateWindowSurfaceRects(
+            nint window,
+            [In] SDL_Rect[] rects,
+            int numrects
+        );
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_VideoInit", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe int INTERNAL_SDL_VideoInit(
+            byte* driver_name
+        );
+        public static unsafe int SDL_VideoInit(string driver_name)
+        {
+            int utf8DriverNameBufSize = Utf8Size(driver_name);
+            byte* utf8DriverName = stackalloc byte[utf8DriverNameBufSize];
+            return INTERNAL_SDL_VideoInit(
+                Utf8Encode(driver_name, utf8DriverName, utf8DriverNameBufSize)
+            );
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_VideoQuit();
+
+        /* window refers to an SDL_Window*, callback_data to a void*
+		 * Only available in 2.0.4 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetWindowHitTest(
+            nint window,
+            SDL_HitTest callback,
+            nint callback_data
+        );
+
+        /* IntPtr refers to an SDL_Window*
+		 * Only available in 2.0.4 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetGrabbedWindow();
+
+        /* window refers to an SDL_Window*
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetWindowMouseRect(
+            nint window,
+            ref SDL_Rect rect
+        );
+
+        /* window refers to an SDL_Window*
+		 * rect refers to an SDL_Rect*
+		 * This overload allows for IntPtr.Zero (null) to be passed for rect.
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetWindowMouseRect(
+            nint window,
+            nint rect
+        );
+
+        /* window refers to an SDL_Window*
+		 * IntPtr refers to an SDL_Rect*
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetWindowMouseRect(
+            nint window
+        );
+
+        /* window refers to an SDL_Window*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_FlashWindow(
+            nint window,
+            SDL_FlashOperation operation
+        );
+
+        #endregion
+
+        #region SDL_blendmode.h
+
+        [Flags]
+        public enum SDL_BlendMode
+        {
+            SDL_BLENDMODE_NONE = 0x00000000,
+            SDL_BLENDMODE_BLEND = 0x00000001,
+            SDL_BLENDMODE_ADD = 0x00000002,
+            SDL_BLENDMODE_MOD = 0x00000004,
+            SDL_BLENDMODE_MUL = 0x00000008, /* >= 2.0.11 */
+            SDL_BLENDMODE_INVALID = 0x7FFFFFFF
+        }
+
+        public enum SDL_BlendOperation
+        {
+            SDL_BLENDOPERATION_ADD = 0x1,
+            SDL_BLENDOPERATION_SUBTRACT = 0x2,
+            SDL_BLENDOPERATION_REV_SUBTRACT = 0x3,
+            SDL_BLENDOPERATION_MINIMUM = 0x4,
+            SDL_BLENDOPERATION_MAXIMUM = 0x5
+        }
+
+        public enum SDL_BlendFactor
+        {
+            SDL_BLENDFACTOR_ZERO = 0x1,
+            SDL_BLENDFACTOR_ONE = 0x2,
+            SDL_BLENDFACTOR_SRC_COLOR = 0x3,
+            SDL_BLENDFACTOR_ONE_MINUS_SRC_COLOR = 0x4,
+            SDL_BLENDFACTOR_SRC_ALPHA = 0x5,
+            SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA = 0x6,
+            SDL_BLENDFACTOR_DST_COLOR = 0x7,
+            SDL_BLENDFACTOR_ONE_MINUS_DST_COLOR = 0x8,
+            SDL_BLENDFACTOR_DST_ALPHA = 0x9,
+            SDL_BLENDFACTOR_ONE_MINUS_DST_ALPHA = 0xA
+        }
+
+        /* Only available in 2.0.6 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_BlendMode SDL_ComposeCustomBlendMode(
+            SDL_BlendFactor srcColorFactor,
+            SDL_BlendFactor dstColorFactor,
+            SDL_BlendOperation colorOperation,
+            SDL_BlendFactor srcAlphaFactor,
+            SDL_BlendFactor dstAlphaFactor,
+            SDL_BlendOperation alphaOperation
+        );
+
+        #endregion
+
+        #region SDL_vulkan.h
+
+        /* Only available in 2.0.6 or higher. */
+        [DllImport(nativeLibName, EntryPoint = "SDL_Vulkan_LoadLibrary", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe int INTERNAL_SDL_Vulkan_LoadLibrary(
+            byte* path
+        );
+        public static unsafe int SDL_Vulkan_LoadLibrary(string path)
+        {
+            byte* utf8Path = Utf8EncodeHeap(path);
+            int result = INTERNAL_SDL_Vulkan_LoadLibrary(
+                utf8Path
+            );
+            Marshal.FreeHGlobal((nint)utf8Path);
+            return result;
+        }
+
+        /* Only available in 2.0.6 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_Vulkan_GetVkGetInstanceProcAddr();
+
+        /* Only available in 2.0.6 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_Vulkan_UnloadLibrary();
+
+        /* window refers to an SDL_Window*, pNames to a const char**.
+		 * Only available in 2.0.6 or higher.
+		 * This overload allows for IntPtr.Zero (null) to be passed for pNames.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_Vulkan_GetInstanceExtensions(
+            nint window,
+            out uint pCount,
+            nint pNames
+        );
+
+        /* window refers to an SDL_Window*, pNames to a const char**.
+		 * Only available in 2.0.6 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_Vulkan_GetInstanceExtensions(
+            nint window,
+            out uint pCount,
+            nint[] pNames
+        );
+
+        /* window refers to an SDL_Window.
+		 * instance refers to a VkInstance.
+		 * surface refers to a VkSurfaceKHR.
+		 * Only available in 2.0.6 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_Vulkan_CreateSurface(
+            nint window,
+            nint instance,
+            out ulong surface
+        );
+
+        /* window refers to an SDL_Window*.
+		 * Only available in 2.0.6 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_Vulkan_GetDrawableSize(
+            nint window,
+            out int w,
+            out int h
+        );
+
+        #endregion
+
+        #region SDL_metal.h
+
+        /* Only available in 2.0.11 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_Metal_CreateView(
+            nint window
+        );
+
+        /* Only available in 2.0.11 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_Metal_DestroyView(
+            nint view
+        );
+
+        /* view refers to an SDL_MetalView.
+		 * Only available in 2.0.14 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_Metal_GetLayer(
+            nint view
+        );
+
+        /* window refers to an SDL_Window*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_Metal_GetDrawableSize(
+            nint window,
+            out int w,
+            out int h
+        );
+
+        #endregion
+
+        #region SDL_render.h
+
+        [Flags]
+        public enum SDL_RendererFlags : uint
+        {
+            SDL_RENDERER_SOFTWARE = 0x00000001,
+            SDL_RENDERER_ACCELERATED = 0x00000002,
+            SDL_RENDERER_PRESENTVSYNC = 0x00000004,
+            SDL_RENDERER_TARGETTEXTURE = 0x00000008
+        }
+
+        [Flags]
+        public enum SDL_RendererFlip
+        {
+            SDL_FLIP_NONE = 0x00000000,
+            SDL_FLIP_HORIZONTAL = 0x00000001,
+            SDL_FLIP_VERTICAL = 0x00000002
+        }
+
+        public enum SDL_TextureAccess
+        {
+            SDL_TEXTUREACCESS_STATIC,
+            SDL_TEXTUREACCESS_STREAMING,
+            SDL_TEXTUREACCESS_TARGET
+        }
+
+        [Flags]
+        public enum SDL_TextureModulate
+        {
+            SDL_TEXTUREMODULATE_NONE = 0x00000000,
+            SDL_TEXTUREMODULATE_HORIZONTAL = 0x00000001,
+            SDL_TEXTUREMODULATE_VERTICAL = 0x00000002
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public unsafe struct SDL_RendererInfo
+        {
+            public nint name; // const char*
+            public uint flags;
+            public uint num_texture_formats;
+            public fixed uint texture_formats[16];
+            public int max_texture_width;
+            public int max_texture_height;
+        }
+
+        /* Only available in 2.0.11 or higher. */
+        public enum SDL_ScaleMode
+        {
+            SDL_ScaleModeNearest,
+            SDL_ScaleModeLinear,
+            SDL_ScaleModeBest
+        }
+
+        /* Only available in 2.0.18 or higher. */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_Vertex
+        {
+            public SDL_FPoint position;
+            public SDL_Color color;
+            public SDL_FPoint tex_coord;
+        }
+
+        /* IntPtr refers to an SDL_Renderer*, window to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_CreateRenderer(
+            nint window,
+            int index,
+            SDL_RendererFlags flags
+        );
+
+        /* IntPtr refers to an SDL_Renderer*, surface to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_CreateSoftwareRenderer(nint surface);
+
+        /* IntPtr refers to an SDL_Texture*, renderer to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_CreateTexture(
+            nint renderer,
+            uint format,
+            int access,
+            int w,
+            int h
+        );
+
+        /* IntPtr refers to an SDL_Texture*
+		 * renderer refers to an SDL_Renderer*
+		 * surface refers to an SDL_Surface*
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_CreateTextureFromSurface(
+            nint renderer,
+            nint surface
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_DestroyRenderer(nint renderer);
+
+        /* texture refers to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_DestroyTexture(nint texture);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetNumRenderDrivers();
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetRenderDrawBlendMode(
+            nint renderer,
+            out SDL_BlendMode blendMode
+        );
+
+        /* texture refers to an SDL_Texture*
+		 * Only available in 2.0.11 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetTextureScaleMode(
+            nint texture,
+            SDL_ScaleMode scaleMode
+        );
+
+        /* texture refers to an SDL_Texture*
+		 * Only available in 2.0.11 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetTextureScaleMode(
+            nint texture,
+            out SDL_ScaleMode scaleMode
+        );
+
+        /* texture refers to an SDL_Texture*
+		 * userdata refers to a void*
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetTextureUserData(
+            nint texture,
+            nint userdata
+        );
+
+        /* IntPtr refers to a void*, texture refers to an SDL_Texture*
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetTextureUserData(nint texture);
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetRenderDrawColor(
+            nint renderer,
+            out byte r,
+            out byte g,
+            out byte b,
+            out byte a
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetRenderDriverInfo(
+            int index,
+            out SDL_RendererInfo info
+        );
+
+        /* IntPtr refers to an SDL_Renderer*, window to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetRenderer(nint window);
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetRendererInfo(
+            nint renderer,
+            out SDL_RendererInfo info
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetRendererOutputSize(
+            nint renderer,
+            out int w,
+            out int h
+        );
+
+        /* texture refers to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetTextureAlphaMod(
+            nint texture,
+            out byte alpha
+        );
+
+        /* texture refers to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetTextureBlendMode(
+            nint texture,
+            out SDL_BlendMode blendMode
+        );
+
+        /* texture refers to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetTextureColorMod(
+            nint texture,
+            out byte r,
+            out byte g,
+            out byte b
+        );
+
+        /* texture refers to an SDL_Texture*, pixels to a void* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_LockTexture(
+            nint texture,
+            ref SDL_Rect rect,
+            out nint pixels,
+            out int pitch
+        );
+
+        /* texture refers to an SDL_Texture*, pixels to a void*.
+		 * Internally, this function contains logic to use default values when
+		 * the rectangle is passed as NULL.
+		 * This overload allows for IntPtr.Zero to be passed for rect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_LockTexture(
+            nint texture,
+            nint rect,
+            out nint pixels,
+            out int pitch
+        );
+
+        /* texture refers to an SDL_Texture*, surface to an SDL_Surface*
+		 * Only available in 2.0.11 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_LockTextureToSurface(
+            nint texture,
+            ref SDL_Rect rect,
+            out nint surface
+        );
+
+        /* texture refers to an SDL_Texture*, surface to an SDL_Surface*
+		 * Internally, this function contains logic to use default values when
+		 * the rectangle is passed as NULL.
+		 * This overload allows for IntPtr.Zero to be passed for rect.
+		 * Only available in 2.0.11 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_LockTextureToSurface(
+            nint texture,
+            nint rect,
+            out nint surface
+        );
+
+        /* texture refers to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_QueryTexture(
+            nint texture,
+            out uint format,
+            out int access,
+            out int w,
+            out int h
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderClear(nint renderer);
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopy(
+            nint renderer,
+            nint texture,
+            ref SDL_Rect srcrect,
+            ref SDL_Rect dstrect
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source and destination rectangles are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for srcrect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopy(
+            nint renderer,
+            nint texture,
+            nint srcrect,
+            ref SDL_Rect dstrect
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source and destination rectangles are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for dstrect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopy(
+            nint renderer,
+            nint texture,
+            ref SDL_Rect srcrect,
+            nint dstrect
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source and destination rectangles are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for both SDL_Rects.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopy(
+            nint renderer,
+            nint texture,
+            nint srcrect,
+            nint dstrect
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyEx(
+            nint renderer,
+            nint texture,
+            ref SDL_Rect srcrect,
+            ref SDL_Rect dstrect,
+            double angle,
+            ref SDL_Point center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source, destination, and/or center are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for srcrect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyEx(
+            nint renderer,
+            nint texture,
+            nint srcrect,
+            ref SDL_Rect dstrect,
+            double angle,
+            ref SDL_Point center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source, destination, and/or center are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for dstrect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyEx(
+            nint renderer,
+            nint texture,
+            ref SDL_Rect srcrect,
+            nint dstrect,
+            double angle,
+            ref SDL_Point center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source, destination, and/or center are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for center.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyEx(
+            nint renderer,
+            nint texture,
+            ref SDL_Rect srcrect,
+            ref SDL_Rect dstrect,
+            double angle,
+            nint center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source, destination, and/or center are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for both
+		 * srcrect and dstrect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyEx(
+            nint renderer,
+            nint texture,
+            nint srcrect,
+            nint dstrect,
+            double angle,
+            ref SDL_Point center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source, destination, and/or center are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for both
+		 * srcrect and center.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyEx(
+            nint renderer,
+            nint texture,
+            nint srcrect,
+            ref SDL_Rect dstrect,
+            double angle,
+            nint center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source, destination, and/or center are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for both
+		 * dstrect and center.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyEx(
+            nint renderer,
+            nint texture,
+            ref SDL_Rect srcrect,
+            nint dstrect,
+            double angle,
+            nint center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source, destination, and/or center are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for all
+		 * three parameters.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyEx(
+            nint renderer,
+            nint texture,
+            nint srcrect,
+            nint dstrect,
+            double angle,
+            nint center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderDrawLine(
+            nint renderer,
+            int x1,
+            int y1,
+            int x2,
+            int y2
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderDrawLines(
+            nint renderer,
+            [In] SDL_Point[] points,
+            int count
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderDrawPoint(
+            nint renderer,
+            int x,
+            int y
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderDrawPoints(
+            nint renderer,
+            [In] SDL_Point[] points,
+            int count
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderDrawRect(
+            nint renderer,
+            ref SDL_Rect rect
+        );
+
+        /* renderer refers to an SDL_Renderer*, rect to an SDL_Rect*.
+		 * This overload allows for IntPtr.Zero (null) to be passed for rect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderDrawRect(
+            nint renderer,
+            nint rect
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderDrawRects(
+            nint renderer,
+            [In] SDL_Rect[] rects,
+            int count
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderFillRect(
+            nint renderer,
+            ref SDL_Rect rect
+        );
+
+        /* renderer refers to an SDL_Renderer*, rect to an SDL_Rect*.
+		 * This overload allows for IntPtr.Zero (null) to be passed for rect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderFillRect(
+            nint renderer,
+            nint rect
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderFillRects(
+            nint renderer,
+            [In] SDL_Rect[] rects,
+            int count
+        );
+
+        #region Floating Point Render Functions
+
+        /* This region only available in SDL 2.0.10 or higher. */
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyF(
+            nint renderer,
+            nint texture,
+            ref SDL_Rect srcrect,
+            ref SDL_FRect dstrect
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source and destination rectangles are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for srcrect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyF(
+            nint renderer,
+            nint texture,
+            nint srcrect,
+            ref SDL_FRect dstrect
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source and destination rectangles are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for dstrect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyF(
+            nint renderer,
+            nint texture,
+            ref SDL_Rect srcrect,
+            nint dstrect
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source and destination rectangles are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for both SDL_Rects.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyF(
+            nint renderer,
+            nint texture,
+            nint srcrect,
+            nint dstrect
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyExF(
+            nint renderer,
+            nint texture,
+            ref SDL_Rect srcrect,
+            ref SDL_FRect dstrect,
+            double angle,
+            ref SDL_FPoint center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source, destination, and/or center are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for srcrect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyExF(
+            nint renderer,
+            nint texture,
+            nint srcrect,
+            ref SDL_FRect dstrect,
+            double angle,
+            ref SDL_FPoint center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source, destination, and/or center are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for dstrect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyExF(
+            nint renderer,
+            nint texture,
+            ref SDL_Rect srcrect,
+            nint dstrect,
+            double angle,
+            ref SDL_FPoint center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source, destination, and/or center are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for center.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyExF(
+            nint renderer,
+            nint texture,
+            ref SDL_Rect srcrect,
+            ref SDL_FRect dstrect,
+            double angle,
+            nint center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source, destination, and/or center are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for both
+		 * srcrect and dstrect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyExF(
+            nint renderer,
+            nint texture,
+            nint srcrect,
+            nint dstrect,
+            double angle,
+            ref SDL_FPoint center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source, destination, and/or center are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for both
+		 * srcrect and center.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyExF(
+            nint renderer,
+            nint texture,
+            nint srcrect,
+            ref SDL_FRect dstrect,
+            double angle,
+            nint center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source, destination, and/or center are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for both
+		 * dstrect and center.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyExF(
+            nint renderer,
+            nint texture,
+            ref SDL_Rect srcrect,
+            nint dstrect,
+            double angle,
+            nint center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture*.
+		 * Internally, this function contains logic to use default values when
+		 * source, destination, and/or center are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for all
+		 * three parameters.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderCopyExF(
+            nint renderer,
+            nint texture,
+            nint srcrect,
+            nint dstrect,
+            double angle,
+            nint center,
+            SDL_RendererFlip flip
+        );
+
+        /* renderer refers to an SDL_Renderer*
+		 * texture refers to an SDL_Texture*
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderGeometry(
+            nint renderer,
+            nint texture,
+            [In] SDL_Vertex[] vertices,
+            int num_vertices,
+            [In] int[] indices,
+            int num_indices
+        );
+
+        /* renderer refers to an SDL_Renderer*
+		 * texture refers to an SDL_Texture*
+		 * indices refers to a void*
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderGeometryRaw(
+            nint renderer,
+            nint texture,
+            [In] float[] xy,
+            int xy_stride,
+            [In] int[] color,
+            int color_stride,
+            [In] float[] uv,
+            int uv_stride,
+            int num_vertices,
+            nint indices,
+            int num_indices,
+            int size_indices
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderDrawPointF(
+            nint renderer,
+            float x,
+            float y
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderDrawPointsF(
+            nint renderer,
+            [In] SDL_FPoint[] points,
+            int count
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderDrawLineF(
+            nint renderer,
+            float x1,
+            float y1,
+            float x2,
+            float y2
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderDrawLinesF(
+            nint renderer,
+            [In] SDL_FPoint[] points,
+            int count
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderDrawRectF(
+            nint renderer,
+            ref SDL_FRect rect
+        );
+
+        /* renderer refers to an SDL_Renderer*, rect to an SDL_Rect*.
+		 * This overload allows for IntPtr.Zero (null) to be passed for rect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderDrawRectF(
+            nint renderer,
+            nint rect
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderDrawRectsF(
+            nint renderer,
+            [In] SDL_FRect[] rects,
+            int count
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderFillRectF(
+            nint renderer,
+            ref SDL_FRect rect
+        );
+
+        /* renderer refers to an SDL_Renderer*, rect to an SDL_Rect*.
+		 * This overload allows for IntPtr.Zero (null) to be passed for rect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderFillRectF(
+            nint renderer,
+            nint rect
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderFillRectsF(
+            nint renderer,
+            [In] SDL_FRect[] rects,
+            int count
+        );
+
+        #endregion
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_RenderGetClipRect(
+            nint renderer,
+            out SDL_Rect rect
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_RenderGetLogicalSize(
+            nint renderer,
+            out int w,
+            out int h
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_RenderGetScale(
+            nint renderer,
+            out float scaleX,
+            out float scaleY
+        );
+
+        /* renderer refers to an SDL_Renderer*
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_RenderWindowToLogical(
+            nint renderer,
+            int windowX,
+            int windowY,
+            out float logicalX,
+            out float logicalY
+        );
+
+        /* renderer refers to an SDL_Renderer*
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_RenderLogicalToWindow(
+            nint renderer,
+            float logicalX,
+            float logicalY,
+            out int windowX,
+            out int windowY
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderGetViewport(
+            nint renderer,
+            out SDL_Rect rect
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_RenderPresent(nint renderer);
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderReadPixels(
+            nint renderer,
+            ref SDL_Rect rect,
+            uint format,
+            nint pixels,
+            int pitch
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderSetClipRect(
+            nint renderer,
+            ref SDL_Rect rect
+        );
+
+        /* renderer refers to an SDL_Renderer*
+		 * This overload allows for IntPtr.Zero (null) to be passed for rect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderSetClipRect(
+            nint renderer,
+            nint rect
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderSetLogicalSize(
+            nint renderer,
+            int w,
+            int h
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderSetScale(
+            nint renderer,
+            float scaleX,
+            float scaleY
+        );
+
+        /* renderer refers to an SDL_Renderer*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderSetIntegerScale(
+            nint renderer,
+            SDL_bool enable
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderSetViewport(
+            nint renderer,
+            ref SDL_Rect rect
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetRenderDrawBlendMode(
+            nint renderer,
+            SDL_BlendMode blendMode
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetRenderDrawColor(
+            nint renderer,
+            byte r,
+            byte g,
+            byte b,
+            byte a
+        );
+
+        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetRenderTarget(
+            nint renderer,
+            nint texture
+        );
+
+        /* texture refers to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetTextureAlphaMod(
+            nint texture,
+            byte alpha
+        );
+
+        /* texture refers to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetTextureBlendMode(
+            nint texture,
+            SDL_BlendMode blendMode
+        );
+
+        /* texture refers to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetTextureColorMod(
+            nint texture,
+            byte r,
+            byte g,
+            byte b
+        );
+
+        /* texture refers to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_UnlockTexture(nint texture);
+
+        /* texture refers to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_UpdateTexture(
+            nint texture,
+            ref SDL_Rect rect,
+            nint pixels,
+            int pitch
+        );
+
+        /* texture refers to an SDL_Texture* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_UpdateTexture(
+            nint texture,
+            nint rect,
+            nint pixels,
+            int pitch
+        );
+
+        /* texture refers to an SDL_Texture*
+		 * Only available in 2.0.1 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_UpdateYUVTexture(
+            nint texture,
+            ref SDL_Rect rect,
+            nint yPlane,
+            int yPitch,
+            nint uPlane,
+            int uPitch,
+            nint vPlane,
+            int vPitch
+        );
+
+        /* texture refers to an SDL_Texture*.
+		 * yPlane and uvPlane refer to const Uint*.
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_UpdateNVTexture(
+            nint texture,
+            ref SDL_Rect rect,
+            nint yPlane,
+            int yPitch,
+            nint uvPlane,
+            int uvPitch
+        );
+
+        /* renderer refers to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_RenderTargetSupported(
+            nint renderer
+        );
+
+        /* IntPtr refers to an SDL_Texture*, renderer to an SDL_Renderer* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetRenderTarget(nint renderer);
+
+        /* renderer refers to an SDL_Renderer*
+		 * Only available in 2.0.8 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_RenderGetMetalLayer(
+            nint renderer
+        );
+
+        /* renderer refers to an SDL_Renderer*
+		 * Only available in 2.0.8 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_RenderGetMetalCommandEncoder(
+            nint renderer
+        );
+
+        /* renderer refers to an SDL_Renderer*
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderSetVSync(nint renderer, int vsync);
+
+        /* renderer refers to an SDL_Renderer*
+		 * Only available in 2.0.4 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_RenderIsClipEnabled(nint renderer);
+
+        /* renderer refers to an SDL_Renderer*
+		 * Only available in 2.0.10 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_RenderFlush(nint renderer);
+
+        #endregion
+
+        #region SDL_pixels.h
+
+        public static uint SDL_DEFINE_PIXELFOURCC(byte A, byte B, byte C, byte D)
+        {
+            return SDL_FOURCC(A, B, C, D);
+        }
+
+        public static uint SDL_DEFINE_PIXELFORMAT(
+            SDL_PixelType type,
+            uint order,
+            SDL_PackedLayout layout,
+            byte bits,
+            byte bytes
+        )
+        {
+            return (uint)(
+                1 << 28 |
+                (byte)type << 24 |
+                (byte)order << 20 |
+                (byte)layout << 16 |
+                bits << 8 |
+                bytes
+            );
+        }
+
+        public static byte SDL_PIXELFLAG(uint X)
+        {
+            return (byte)(X >> 28 & 0x0F);
+        }
+
+        public static byte SDL_PIXELTYPE(uint X)
+        {
+            return (byte)(X >> 24 & 0x0F);
+        }
+
+        public static byte SDL_PIXELORDER(uint X)
+        {
+            return (byte)(X >> 20 & 0x0F);
+        }
+
+        public static byte SDL_PIXELLAYOUT(uint X)
+        {
+            return (byte)(X >> 16 & 0x0F);
+        }
+
+        public static byte SDL_BITSPERPIXEL(uint X)
+        {
+            return (byte)(X >> 8 & 0xFF);
+        }
+
+        public static byte SDL_BYTESPERPIXEL(uint X)
+        {
+            if (SDL_ISPIXELFORMAT_FOURCC(X))
+            {
+                if (X == SDL_PIXELFORMAT_YUY2 ||
+                        X == SDL_PIXELFORMAT_UYVY ||
+                        X == SDL_PIXELFORMAT_YVYU)
+                {
+                    return 2;
+                }
+                return 1;
+            }
+            return (byte)(X & 0xFF);
+        }
+
+        public static bool SDL_ISPIXELFORMAT_INDEXED(uint format)
+        {
+            if (SDL_ISPIXELFORMAT_FOURCC(format))
+            {
+                return false;
+            }
+            SDL_PixelType pType =
+                (SDL_PixelType)SDL_PIXELTYPE(format);
+            return
+                pType == SDL_PixelType.SDL_PIXELTYPE_INDEX1 ||
+                pType == SDL_PixelType.SDL_PIXELTYPE_INDEX4 ||
+                pType == SDL_PixelType.SDL_PIXELTYPE_INDEX8
+            ;
+        }
+
+        public static bool SDL_ISPIXELFORMAT_PACKED(uint format)
+        {
+            if (SDL_ISPIXELFORMAT_FOURCC(format))
+            {
+                return false;
+            }
+            SDL_PixelType pType =
+                (SDL_PixelType)SDL_PIXELTYPE(format);
+            return
+                pType == SDL_PixelType.SDL_PIXELTYPE_PACKED8 ||
+                pType == SDL_PixelType.SDL_PIXELTYPE_PACKED16 ||
+                pType == SDL_PixelType.SDL_PIXELTYPE_PACKED32
+            ;
+        }
+
+        public static bool SDL_ISPIXELFORMAT_ARRAY(uint format)
+        {
+            if (SDL_ISPIXELFORMAT_FOURCC(format))
+            {
+                return false;
+            }
+            SDL_PixelType pType =
+                (SDL_PixelType)SDL_PIXELTYPE(format);
+            return
+                pType == SDL_PixelType.SDL_PIXELTYPE_ARRAYU8 ||
+                pType == SDL_PixelType.SDL_PIXELTYPE_ARRAYU16 ||
+                pType == SDL_PixelType.SDL_PIXELTYPE_ARRAYU32 ||
+                pType == SDL_PixelType.SDL_PIXELTYPE_ARRAYF16 ||
+                pType == SDL_PixelType.SDL_PIXELTYPE_ARRAYF32
+            ;
+        }
+
+        public static bool SDL_ISPIXELFORMAT_ALPHA(uint format)
+        {
+            if (SDL_ISPIXELFORMAT_PACKED(format))
+            {
+                SDL_PackedOrder pOrder =
+                    (SDL_PackedOrder)SDL_PIXELORDER(format);
+                return
+                    pOrder == SDL_PackedOrder.SDL_PACKEDORDER_ARGB ||
+                    pOrder == SDL_PackedOrder.SDL_PACKEDORDER_RGBA ||
+                    pOrder == SDL_PackedOrder.SDL_PACKEDORDER_ABGR ||
+                    pOrder == SDL_PackedOrder.SDL_PACKEDORDER_BGRA
+                ;
+            }
+            else if (SDL_ISPIXELFORMAT_ARRAY(format))
+            {
+                SDL_ArrayOrder aOrder =
+                    (SDL_ArrayOrder)SDL_PIXELORDER(format);
+                return
+                    aOrder == SDL_ArrayOrder.SDL_ARRAYORDER_ARGB ||
+                    aOrder == SDL_ArrayOrder.SDL_ARRAYORDER_RGBA ||
+                    aOrder == SDL_ArrayOrder.SDL_ARRAYORDER_ABGR ||
+                    aOrder == SDL_ArrayOrder.SDL_ARRAYORDER_BGRA
+                ;
+            }
+            return false;
+        }
+
+        public static bool SDL_ISPIXELFORMAT_FOURCC(uint format)
+        {
+            return format == 0 && SDL_PIXELFLAG(format) != 1;
+        }
+
+        public enum SDL_PixelType
+        {
+            SDL_PIXELTYPE_UNKNOWN,
+            SDL_PIXELTYPE_INDEX1,
+            SDL_PIXELTYPE_INDEX4,
+            SDL_PIXELTYPE_INDEX8,
+            SDL_PIXELTYPE_PACKED8,
+            SDL_PIXELTYPE_PACKED16,
+            SDL_PIXELTYPE_PACKED32,
+            SDL_PIXELTYPE_ARRAYU8,
+            SDL_PIXELTYPE_ARRAYU16,
+            SDL_PIXELTYPE_ARRAYU32,
+            SDL_PIXELTYPE_ARRAYF16,
+            SDL_PIXELTYPE_ARRAYF32
+        }
+
+        public enum SDL_BitmapOrder
+        {
+            SDL_BITMAPORDER_NONE,
+            SDL_BITMAPORDER_4321,
+            SDL_BITMAPORDER_1234
+        }
+
+        public enum SDL_PackedOrder
+        {
+            SDL_PACKEDORDER_NONE,
+            SDL_PACKEDORDER_XRGB,
+            SDL_PACKEDORDER_RGBX,
+            SDL_PACKEDORDER_ARGB,
+            SDL_PACKEDORDER_RGBA,
+            SDL_PACKEDORDER_XBGR,
+            SDL_PACKEDORDER_BGRX,
+            SDL_PACKEDORDER_ABGR,
+            SDL_PACKEDORDER_BGRA
+        }
+
+        public enum SDL_ArrayOrder
+        {
+            SDL_ARRAYORDER_NONE,
+            SDL_ARRAYORDER_RGB,
+            SDL_ARRAYORDER_RGBA,
+            SDL_ARRAYORDER_ARGB,
+            SDL_ARRAYORDER_BGR,
+            SDL_ARRAYORDER_BGRA,
+            SDL_ARRAYORDER_ABGR
+        }
+
+        public enum SDL_PackedLayout
+        {
+            SDL_PACKEDLAYOUT_NONE,
+            SDL_PACKEDLAYOUT_332,
+            SDL_PACKEDLAYOUT_4444,
+            SDL_PACKEDLAYOUT_1555,
+            SDL_PACKEDLAYOUT_5551,
+            SDL_PACKEDLAYOUT_565,
+            SDL_PACKEDLAYOUT_8888,
+            SDL_PACKEDLAYOUT_2101010,
+            SDL_PACKEDLAYOUT_1010102
+        }
+
+        public static readonly uint SDL_PIXELFORMAT_UNKNOWN = 0;
+        public static readonly uint SDL_PIXELFORMAT_INDEX1LSB =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_INDEX1,
+                (uint)SDL_BitmapOrder.SDL_BITMAPORDER_4321,
+                0,
+                1, 0
+            );
+        public static readonly uint SDL_PIXELFORMAT_INDEX1MSB =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_INDEX1,
+                (uint)SDL_BitmapOrder.SDL_BITMAPORDER_1234,
+                0,
+                1, 0
+            );
+        public static readonly uint SDL_PIXELFORMAT_INDEX4LSB =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_INDEX4,
+                (uint)SDL_BitmapOrder.SDL_BITMAPORDER_4321,
+                0,
+                4, 0
+            );
+        public static readonly uint SDL_PIXELFORMAT_INDEX4MSB =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_INDEX4,
+                (uint)SDL_BitmapOrder.SDL_BITMAPORDER_1234,
+                0,
+                4, 0
+            );
+        public static readonly uint SDL_PIXELFORMAT_INDEX8 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_INDEX8,
+                0,
+                0,
+                8, 1
+            );
+        public static readonly uint SDL_PIXELFORMAT_RGB332 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED8,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_XRGB,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_332,
+                8, 1
+            );
+        public static readonly uint SDL_PIXELFORMAT_XRGB444 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED16,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_XRGB,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_4444,
+                12, 2
+            );
+        public static readonly uint SDL_PIXELFORMAT_RGB444 =
+            SDL_PIXELFORMAT_XRGB444;
+        public static readonly uint SDL_PIXELFORMAT_XBGR444 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED16,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_XBGR,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_4444,
+                12, 2
+            );
+        public static readonly uint SDL_PIXELFORMAT_BGR444 =
+            SDL_PIXELFORMAT_XBGR444;
+        public static readonly uint SDL_PIXELFORMAT_XRGB1555 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED16,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_XRGB,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_1555,
+                15, 2
+            );
+        public static readonly uint SDL_PIXELFORMAT_RGB555 =
+            SDL_PIXELFORMAT_XRGB1555;
+        public static readonly uint SDL_PIXELFORMAT_XBGR1555 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_INDEX1,
+                (uint)SDL_BitmapOrder.SDL_BITMAPORDER_4321,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_1555,
+                15, 2
+            );
+        public static readonly uint SDL_PIXELFORMAT_BGR555 =
+            SDL_PIXELFORMAT_XBGR1555;
+        public static readonly uint SDL_PIXELFORMAT_ARGB4444 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED16,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_ARGB,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_4444,
+                16, 2
+            );
+        public static readonly uint SDL_PIXELFORMAT_RGBA4444 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED16,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_RGBA,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_4444,
+                16, 2
+            );
+        public static readonly uint SDL_PIXELFORMAT_ABGR4444 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED16,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_ABGR,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_4444,
+                16, 2
+            );
+        public static readonly uint SDL_PIXELFORMAT_BGRA4444 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED16,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_BGRA,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_4444,
+                16, 2
+            );
+        public static readonly uint SDL_PIXELFORMAT_ARGB1555 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED16,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_ARGB,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_1555,
+                16, 2
+            );
+        public static readonly uint SDL_PIXELFORMAT_RGBA5551 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED16,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_RGBA,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_5551,
+                16, 2
+            );
+        public static readonly uint SDL_PIXELFORMAT_ABGR1555 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED16,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_ABGR,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_1555,
+                16, 2
+            );
+        public static readonly uint SDL_PIXELFORMAT_BGRA5551 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED16,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_BGRA,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_5551,
+                16, 2
+            );
+        public static readonly uint SDL_PIXELFORMAT_RGB565 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED16,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_XRGB,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_565,
+                16, 2
+            );
+        public static readonly uint SDL_PIXELFORMAT_BGR565 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED16,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_XBGR,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_565,
+                16, 2
+            );
+        public static readonly uint SDL_PIXELFORMAT_RGB24 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_ARRAYU8,
+                (uint)SDL_ArrayOrder.SDL_ARRAYORDER_RGB,
+                0,
+                24, 3
+            );
+        public static readonly uint SDL_PIXELFORMAT_BGR24 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_ARRAYU8,
+                (uint)SDL_ArrayOrder.SDL_ARRAYORDER_BGR,
+                0,
+                24, 3
+            );
+        public static readonly uint SDL_PIXELFORMAT_XRGB888 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED32,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_XRGB,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_8888,
+                24, 4
+            );
+        public static readonly uint SDL_PIXELFORMAT_RGB888 =
+            SDL_PIXELFORMAT_XRGB888;
+        public static readonly uint SDL_PIXELFORMAT_RGBX8888 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED32,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_RGBX,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_8888,
+                24, 4
+            );
+        public static readonly uint SDL_PIXELFORMAT_XBGR888 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED32,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_XBGR,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_8888,
+                24, 4
+            );
+        public static readonly uint SDL_PIXELFORMAT_BGR888 =
+            SDL_PIXELFORMAT_XBGR888;
+        public static readonly uint SDL_PIXELFORMAT_BGRX8888 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED32,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_BGRX,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_8888,
+                24, 4
+            );
+        public static readonly uint SDL_PIXELFORMAT_ARGB8888 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED32,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_ARGB,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_8888,
+                32, 4
+            );
+        public static readonly uint SDL_PIXELFORMAT_RGBA8888 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED32,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_RGBA,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_8888,
+                32, 4
+            );
+        public static readonly uint SDL_PIXELFORMAT_ABGR8888 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED32,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_ABGR,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_8888,
+                32, 4
+            );
+        public static readonly uint SDL_PIXELFORMAT_BGRA8888 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED32,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_BGRA,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_8888,
+                32, 4
+            );
+        public static readonly uint SDL_PIXELFORMAT_ARGB2101010 =
+            SDL_DEFINE_PIXELFORMAT(
+                SDL_PixelType.SDL_PIXELTYPE_PACKED32,
+                (uint)SDL_PackedOrder.SDL_PACKEDORDER_ARGB,
+                SDL_PackedLayout.SDL_PACKEDLAYOUT_2101010,
+                32, 4
+            );
+        public static readonly uint SDL_PIXELFORMAT_YV12 =
+            SDL_DEFINE_PIXELFOURCC(
+                (byte)'Y', (byte)'V', (byte)'1', (byte)'2'
+            );
+        public static readonly uint SDL_PIXELFORMAT_IYUV =
+            SDL_DEFINE_PIXELFOURCC(
+                (byte)'I', (byte)'Y', (byte)'U', (byte)'V'
+            );
+        public static readonly uint SDL_PIXELFORMAT_YUY2 =
+            SDL_DEFINE_PIXELFOURCC(
+                (byte)'Y', (byte)'U', (byte)'Y', (byte)'2'
+            );
+        public static readonly uint SDL_PIXELFORMAT_UYVY =
+            SDL_DEFINE_PIXELFOURCC(
+                (byte)'U', (byte)'Y', (byte)'V', (byte)'Y'
+            );
+        public static readonly uint SDL_PIXELFORMAT_YVYU =
+            SDL_DEFINE_PIXELFOURCC(
+                (byte)'Y', (byte)'V', (byte)'Y', (byte)'U'
+            );
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_Color
+        {
+            public byte r;
+            public byte g;
+            public byte b;
+            public byte a;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_Palette
+        {
+            public int ncolors;
+            public nint colors;
+            public int version;
+            public int refcount;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_PixelFormat
+        {
+            public uint format;
+            public nint palette; // SDL_Palette*
+            public byte BitsPerPixel;
+            public byte BytesPerPixel;
+            public uint Rmask;
+            public uint Gmask;
+            public uint Bmask;
+            public uint Amask;
+            public byte Rloss;
+            public byte Gloss;
+            public byte Bloss;
+            public byte Aloss;
+            public byte Rshift;
+            public byte Gshift;
+            public byte Bshift;
+            public byte Ashift;
+            public int refcount;
+            public nint next; // SDL_PixelFormat*
+        }
+
+        /* IntPtr refers to an SDL_PixelFormat* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_AllocFormat(uint pixel_format);
+
+        /* IntPtr refers to an SDL_Palette* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_AllocPalette(int ncolors);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_CalculateGammaRamp(
+            float gamma,
+            [Out()] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 256)]
+                ushort[] ramp
+        );
+
+        /* format refers to an SDL_PixelFormat* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_FreeFormat(nint format);
+
+        /* palette refers to an SDL_Palette* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_FreePalette(nint palette);
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetPixelFormatName", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetPixelFormatName(
+            uint format
+        );
+        public static string SDL_GetPixelFormatName(uint format)
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GetPixelFormatName(format)
+            );
+        }
+
+        /* format refers to an SDL_PixelFormat* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GetRGB(
+            uint pixel,
+            nint format,
+            out byte r,
+            out byte g,
+            out byte b
+        );
+
+        /* format refers to an SDL_PixelFormat* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GetRGBA(
+            uint pixel,
+            nint format,
+            out byte r,
+            out byte g,
+            out byte b,
+            out byte a
+        );
+
+        /* format refers to an SDL_PixelFormat* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_MapRGB(
+            nint format,
+            byte r,
+            byte g,
+            byte b
+        );
+
+        /* format refers to an SDL_PixelFormat* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_MapRGBA(
+            nint format,
+            byte r,
+            byte g,
+            byte b,
+            byte a
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_MasksToPixelFormatEnum(
+            int bpp,
+            uint Rmask,
+            uint Gmask,
+            uint Bmask,
+            uint Amask
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_PixelFormatEnumToMasks(
+            uint format,
+            out int bpp,
+            out uint Rmask,
+            out uint Gmask,
+            out uint Bmask,
+            out uint Amask
+        );
+
+        /* palette refers to an SDL_Palette* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetPaletteColors(
+            nint palette,
+            [In] SDL_Color[] colors,
+            int firstcolor,
+            int ncolors
+        );
+
+        /* format and palette refer to an SDL_PixelFormat* and SDL_Palette* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetPixelFormatPalette(
+            nint format,
+            nint palette
+        );
+
+        #endregion
+
+        #region SDL_rect.h
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_Point
+        {
+            public int x;
+            public int y;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_Rect
+        {
+            public int x;
+            public int y;
+            public int w;
+            public int h;
+        }
+
+        /* Only available in 2.0.10 or higher. */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_FPoint
+        {
+            public float x;
+            public float y;
+        }
+
+        /* Only available in 2.0.10 or higher. */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_FRect
+        {
+            public float x;
+            public float y;
+            public float w;
+            public float h;
+        }
+
+        /* Only available in 2.0.4 or higher. */
+        public static SDL_bool SDL_PointInRect(ref SDL_Point p, ref SDL_Rect r)
+        {
+            return p.x >= r.x &&
+                    p.x < r.x + r.w &&
+                    p.y >= r.y &&
+                    p.y < r.y + r.h ?
+                SDL_bool.SDL_TRUE :
+                SDL_bool.SDL_FALSE;
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_EnclosePoints(
+            [In] SDL_Point[] points,
+            int count,
+            ref SDL_Rect clip,
+            out SDL_Rect result
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasIntersection(
+            ref SDL_Rect A,
+            ref SDL_Rect B
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_IntersectRect(
+            ref SDL_Rect A,
+            ref SDL_Rect B,
+            out SDL_Rect result
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_IntersectRectAndLine(
+            ref SDL_Rect rect,
+            ref int X1,
+            ref int Y1,
+            ref int X2,
+            ref int Y2
+        );
+
+        public static SDL_bool SDL_RectEmpty(ref SDL_Rect r)
+        {
+            return r.w <= 0 || r.h <= 0 ?
+                SDL_bool.SDL_TRUE :
+                SDL_bool.SDL_FALSE;
+        }
+
+        public static SDL_bool SDL_RectEquals(
+            ref SDL_Rect a,
+            ref SDL_Rect b
+        )
+        {
+            return a.x == b.x &&
+                    a.y == b.y &&
+                    a.w == b.w &&
+                    a.h == b.h ?
+                SDL_bool.SDL_TRUE :
+                SDL_bool.SDL_FALSE;
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_UnionRect(
+            ref SDL_Rect A,
+            ref SDL_Rect B,
+            out SDL_Rect result
+        );
+
+        #endregion
+
+        #region SDL_shape.h
+
+        public const int SDL_NONSHAPEABLE_WINDOW = -1;
+        public const int SDL_INVALID_SHAPE_ARGUMENT = -2;
+        public const int SDL_WINDOW_LACKS_SHAPE = -3;
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_CreateShapedWindow", CallingConvention = CallingConvention.Cdecl)]
+        private static unsafe extern nint INTERNAL_SDL_CreateShapedWindow(
+            byte* title,
+            uint x,
+            uint y,
+            uint w,
+            uint h,
+            SDL_WindowFlags flags
+        );
+
+        public static unsafe nint SDL_CreateShapedWindow(string title, uint x, uint y, uint w, uint h, SDL_WindowFlags flags)
+        {
+            byte* utf8Title = Utf8EncodeHeap(title);
+            nint result = INTERNAL_SDL_CreateShapedWindow(utf8Title, x, y, w, h, flags);
+            Marshal.FreeHGlobal((nint)utf8Title);
+            return result;
+        }
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_IsShapedWindow", CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_IsShapedWindow(nint window);
+
+        public enum WindowShapeMode
+        {
+            ShapeModeDefault,
+            ShapeModeBinarizeAlpha,
+            ShapeModeReverseBinarizeAlpha,
+            ShapeModeColorKey
+        }
+
+        public static bool SDL_SHAPEMODEALPHA(WindowShapeMode mode)
+        {
+            switch (mode)
+            {
+                case WindowShapeMode.ShapeModeDefault:
+                case WindowShapeMode.ShapeModeBinarizeAlpha:
+                case WindowShapeMode.ShapeModeReverseBinarizeAlpha:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        public struct SDL_WindowShapeParams
+        {
+            [FieldOffset(0)]
+            public byte binarizationCutoff;
+            [FieldOffset(0)]
+            public SDL_Color colorKey;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_WindowShapeMode
+        {
+            public WindowShapeMode mode;
+            public SDL_WindowShapeParams parameters;
+        }
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_SetWindowShape", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetWindowShape(
+            nint window,
+            nint shape,
+            ref SDL_WindowShapeMode shape_mode
+        );
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetShapedWindowMode", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetShapedWindowMode(
+            nint window,
+            out SDL_WindowShapeMode shape_mode
+        );
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetShapedWindowMode", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetShapedWindowMode(
+            nint window,
+            nint shape_mode
+        );
+
+        #endregion
+
+        #region SDL_surface.h
+
+        public const uint SDL_SWSURFACE = 0x00000000;
+        public const uint SDL_PREALLOC = 0x00000001;
+        public const uint SDL_RLEACCEL = 0x00000002;
+        public const uint SDL_DONTFREE = 0x00000004;
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_Surface
+        {
+            public uint flags;
+            public nint format; // SDL_PixelFormat*
+            public int w;
+            public int h;
+            public int pitch;
+            public nint pixels; // void*
+            public nint userdata; // void*
+            public int locked;
+            public nint list_blitmap; // void*
+            public SDL_Rect clip_rect;
+            public nint map; // SDL_BlitMap*
+            public int refcount;
+        }
+
+        /* surface refers to an SDL_Surface* */
+        public static bool SDL_MUSTLOCK(nint surface)
+        {
+            SDL_Surface sur;
+            sur = PtrToStructure<SDL_Surface>(
+                surface
+            );
+            return (sur.flags & SDL_RLEACCEL) != 0;
+        }
+
+        /* src and dst refer to an SDL_Surface* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_UpperBlit", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_BlitSurface(
+            nint src,
+            ref SDL_Rect srcrect,
+            nint dst,
+            ref SDL_Rect dstrect
+        );
+
+        /* src and dst refer to an SDL_Surface*
+		 * Internally, this function contains logic to use default values when
+		 * source and destination rectangles are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for srcrect.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "SDL_UpperBlit", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_BlitSurface(
+            nint src,
+            nint srcrect,
+            nint dst,
+            ref SDL_Rect dstrect
+        );
+
+        /* src and dst refer to an SDL_Surface*
+		 * Internally, this function contains logic to use default values when
+		 * source and destination rectangles are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for dstrect.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "SDL_UpperBlit", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_BlitSurface(
+            nint src,
+            ref SDL_Rect srcrect,
+            nint dst,
+            nint dstrect
+        );
+
+        /* src and dst refer to an SDL_Surface*
+		 * Internally, this function contains logic to use default values when
+		 * source and destination rectangles are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for both SDL_Rects.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "SDL_UpperBlit", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_BlitSurface(
+            nint src,
+            nint srcrect,
+            nint dst,
+            nint dstrect
+        );
+
+        /* src and dst refer to an SDL_Surface* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_UpperBlitScaled", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_BlitScaled(
+            nint src,
+            ref SDL_Rect srcrect,
+            nint dst,
+            ref SDL_Rect dstrect
+        );
+
+        /* src and dst refer to an SDL_Surface*
+		 * Internally, this function contains logic to use default values when
+		 * source and destination rectangles are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for srcrect.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "SDL_UpperBlitScaled", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_BlitScaled(
+            nint src,
+            nint srcrect,
+            nint dst,
+            ref SDL_Rect dstrect
+        );
+
+        /* src and dst refer to an SDL_Surface*
+		 * Internally, this function contains logic to use default values when
+		 * source and destination rectangles are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for dstrect.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "SDL_UpperBlitScaled", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_BlitScaled(
+            nint src,
+            ref SDL_Rect srcrect,
+            nint dst,
+            nint dstrect
+        );
+
+        /* src and dst refer to an SDL_Surface*
+		 * Internally, this function contains logic to use default values when
+		 * source and destination rectangles are passed as NULL.
+		 * This overload allows for IntPtr.Zero (null) to be passed for both SDL_Rects.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "SDL_UpperBlitScaled", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_BlitScaled(
+            nint src,
+            nint srcrect,
+            nint dst,
+            nint dstrect
+        );
+
+        /* src and dst are void* pointers */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_ConvertPixels(
+            int width,
+            int height,
+            uint src_format,
+            nint src,
+            int src_pitch,
+            uint dst_format,
+            nint dst,
+            int dst_pitch
+        );
+
+        /* src and dst are void* pointers
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_PremultiplyAlpha(
+            int width,
+            int height,
+            uint src_format,
+            nint src,
+            int src_pitch,
+            uint dst_format,
+            nint dst,
+            int dst_pitch
+        );
+
+        /* IntPtr refers to an SDL_Surface*
+		 * src refers to an SDL_Surface*
+		 * fmt refers to an SDL_PixelFormat*
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_ConvertSurface(
+            nint src,
+            nint fmt,
+            uint flags
+        );
+
+        /* IntPtr refers to an SDL_Surface*, src to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_ConvertSurfaceFormat(
+            nint src,
+            uint pixel_format,
+            uint flags
+        );
+
+        /* IntPtr refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_CreateRGBSurface(
+            uint flags,
+            int width,
+            int height,
+            int depth,
+            uint Rmask,
+            uint Gmask,
+            uint Bmask,
+            uint Amask
+        );
+
+        /* IntPtr refers to an SDL_Surface*, pixels to a void* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_CreateRGBSurfaceFrom(
+            nint pixels,
+            int width,
+            int height,
+            int depth,
+            int pitch,
+            uint Rmask,
+            uint Gmask,
+            uint Bmask,
+            uint Amask
+        );
+
+        /* IntPtr refers to an SDL_Surface*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_CreateRGBSurfaceWithFormat(
+            uint flags,
+            int width,
+            int height,
+            int depth,
+            uint format
+        );
+
+        /* IntPtr refers to an SDL_Surface*, pixels to a void*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_CreateRGBSurfaceWithFormatFrom(
+            nint pixels,
+            int width,
+            int height,
+            int depth,
+            int pitch,
+            uint format
+        );
+
+        /* dst refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_FillRect(
+            nint dst,
+            ref SDL_Rect rect,
+            uint color
+        );
+
+        /* dst refers to an SDL_Surface*.
+		 * This overload allows passing NULL to rect.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_FillRect(
+            nint dst,
+            nint rect,
+            uint color
+        );
+
+        /* dst refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_FillRects(
+            nint dst,
+            [In] SDL_Rect[] rects,
+            int count,
+            uint color
+        );
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_FreeSurface(nint surface);
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GetClipRect(
+            nint surface,
+            out SDL_Rect rect
+        );
+
+        /* surface refers to an SDL_Surface*.
+		 * Only available in 2.0.9 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasColorKey(nint surface);
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetColorKey(
+            nint surface,
+            out uint key
+        );
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetSurfaceAlphaMod(
+            nint surface,
+            out byte alpha
+        );
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetSurfaceBlendMode(
+            nint surface,
+            out SDL_BlendMode blendMode
+        );
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetSurfaceColorMod(
+            nint surface,
+            out byte r,
+            out byte g,
+            out byte b
+        );
+
+        /* These are for SDL_LoadBMP, which is a macro in the SDL headers. */
+        /* IntPtr refers to an SDL_Surface* */
+        /* THIS IS AN RWops FUNCTION! */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_LoadBMP_RW(
+            nint src,
+            int freesrc
+        );
+        public static nint SDL_LoadBMP(string file)
+        {
+            nint rwops = SDL_RWFromFile(file, "rb");
+            return SDL_LoadBMP_RW(rwops, 1);
+        }
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_LockSurface(nint surface);
+
+        /* src and dst refer to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_LowerBlit(
+            nint src,
+            ref SDL_Rect srcrect,
+            nint dst,
+            ref SDL_Rect dstrect
+        );
+
+        /* src and dst refer to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_LowerBlitScaled(
+            nint src,
+            ref SDL_Rect srcrect,
+            nint dst,
+            ref SDL_Rect dstrect
+        );
+
+        /* These are for SDL_SaveBMP, which is a macro in the SDL headers. */
+        /* IntPtr refers to an SDL_Surface* */
+        /* THIS IS AN RWops FUNCTION! */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SaveBMP_RW(
+            nint surface,
+            nint src,
+            int freesrc
+        );
+        public static int SDL_SaveBMP(nint surface, string file)
+        {
+            nint rwops = SDL_RWFromFile(file, "wb");
+            return SDL_SaveBMP_RW(surface, rwops, 1);
+        }
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_SetClipRect(
+            nint surface,
+            ref SDL_Rect rect
+        );
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetColorKey(
+            nint surface,
+            int flag,
+            uint key
+        );
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetSurfaceAlphaMod(
+            nint surface,
+            byte alpha
+        );
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetSurfaceBlendMode(
+            nint surface,
+            SDL_BlendMode blendMode
+        );
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetSurfaceColorMod(
+            nint surface,
+            byte r,
+            byte g,
+            byte b
+        );
+
+        /* surface refers to an SDL_Surface*, palette to an SDL_Palette* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetSurfacePalette(
+            nint surface,
+            nint palette
+        );
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetSurfaceRLE(
+            nint surface,
+            int flag
+        );
+
+        /* surface refers to an SDL_Surface*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasSurfaceRLE(
+            nint surface
+        );
+
+        /* src and dst refer to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SoftStretch(
+            nint src,
+            ref SDL_Rect srcrect,
+            nint dst,
+            ref SDL_Rect dstrect
+        );
+
+        /* src and dst refer to an SDL_Surface*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SoftStretchLinear(
+            nint src,
+            ref SDL_Rect srcrect,
+            nint dst,
+            ref SDL_Rect dstrect
+        );
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_UnlockSurface(nint surface);
+
+        /* src and dst refer to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_UpperBlit(
+            nint src,
+            ref SDL_Rect srcrect,
+            nint dst,
+            ref SDL_Rect dstrect
+        );
+
+        /* src and dst refer to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_UpperBlitScaled(
+            nint src,
+            ref SDL_Rect srcrect,
+            nint dst,
+            ref SDL_Rect dstrect
+        );
+
+        /* surface and IntPtr refer to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_DuplicateSurface(nint surface);
+
+        #endregion
+
+        #region SDL_clipboard.h
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasClipboardText();
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetClipboardText", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetClipboardText();
+        public static string SDL_GetClipboardText()
+        {
+            return UTF8_ToManaged(INTERNAL_SDL_GetClipboardText(), true);
+        }
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_SetClipboardText", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe int INTERNAL_SDL_SetClipboardText(
+            byte* text
+        );
+        public static unsafe int SDL_SetClipboardText(
+            string text
+        )
+        {
+            byte* utf8Text = Utf8EncodeHeap(text);
+            int result = INTERNAL_SDL_SetClipboardText(
+                utf8Text
+            );
+            Marshal.FreeHGlobal((nint)utf8Text);
+            return result;
+        }
+
+        #endregion
+
+        #region SDL_events.h
+
+        /* General keyboard/mouse state definitions. */
+        public const byte SDL_PRESSED = 1;
+        public const byte SDL_RELEASED = 0;
+
+        /* Default size is according to SDL2 default. */
+        public const int SDL_TEXTEDITINGEVENT_TEXT_SIZE = 32;
+        public const int SDL_TEXTINPUTEVENT_TEXT_SIZE = 32;
+
+        /* The types of events that can be delivered. */
+        public enum SDL_EventType : uint
+        {
+            SDL_FIRSTEVENT = 0,
+
+            /* Application events */
+            SDL_QUIT = 0x100,
+
+            /* iOS/Android/WinRT app events */
+            SDL_APP_TERMINATING,
+            SDL_APP_LOWMEMORY,
+            SDL_APP_WILLENTERBACKGROUND,
+            SDL_APP_DIDENTERBACKGROUND,
+            SDL_APP_WILLENTERFOREGROUND,
+            SDL_APP_DIDENTERFOREGROUND,
+
+            /* Only available in SDL 2.0.14 or higher. */
+            SDL_LOCALECHANGED,
+
+            /* Display events */
+            /* Only available in SDL 2.0.9 or higher. */
+            SDL_DISPLAYEVENT = 0x150,
+
+            /* Window events */
+            SDL_WINDOWEVENT = 0x200,
+            SDL_SYSWMEVENT,
+
+            /* Keyboard events */
+            SDL_KEYDOWN = 0x300,
+            SDL_KEYUP,
+            SDL_TEXTEDITING,
+            SDL_TEXTINPUT,
+            SDL_KEYMAPCHANGED,
+            SDL_TEXTEDITING_EXT,
+
+            /* Mouse events */
+            SDL_MOUSEMOTION = 0x400,
+            SDL_MOUSEBUTTONDOWN,
+            SDL_MOUSEBUTTONUP,
+            SDL_MOUSEWHEEL,
+
+            /* Joystick events */
+            SDL_JOYAXISMOTION = 0x600,
+            SDL_JOYBALLMOTION,
+            SDL_JOYHATMOTION,
+            SDL_JOYBUTTONDOWN,
+            SDL_JOYBUTTONUP,
+            SDL_JOYDEVICEADDED,
+            SDL_JOYDEVICEREMOVED,
+
+            /* Game controller events */
+            SDL_CONTROLLERAXISMOTION = 0x650,
+            SDL_CONTROLLERBUTTONDOWN,
+            SDL_CONTROLLERBUTTONUP,
+            SDL_CONTROLLERDEVICEADDED,
+            SDL_CONTROLLERDEVICEREMOVED,
+            SDL_CONTROLLERDEVICEREMAPPED,
+            SDL_CONTROLLERTOUCHPADDOWN, /* Requires >= 2.0.14 */
+            SDL_CONTROLLERTOUCHPADMOTION,   /* Requires >= 2.0.14 */
+            SDL_CONTROLLERTOUCHPADUP,   /* Requires >= 2.0.14 */
+            SDL_CONTROLLERSENSORUPDATE, /* Requires >= 2.0.14 */
+
+            /* Touch events */
+            SDL_FINGERDOWN = 0x700,
+            SDL_FINGERUP,
+            SDL_FINGERMOTION,
+
+            /* Gesture events */
+            SDL_DOLLARGESTURE = 0x800,
+            SDL_DOLLARRECORD,
+            SDL_MULTIGESTURE,
+
+            /* Clipboard events */
+            SDL_CLIPBOARDUPDATE = 0x900,
+
+            /* Drag and drop events */
+            SDL_DROPFILE = 0x1000,
+            /* Only available in 2.0.4 or higher. */
+            SDL_DROPTEXT,
+            SDL_DROPBEGIN,
+            SDL_DROPCOMPLETE,
+
+            /* Audio hotplug events */
+            /* Only available in SDL 2.0.4 or higher. */
+            SDL_AUDIODEVICEADDED = 0x1100,
+            SDL_AUDIODEVICEREMOVED,
+
+            /* Sensor events */
+            /* Only available in SDL 2.0.9 or higher. */
+            SDL_SENSORUPDATE = 0x1200,
+
+            /* Render events */
+            /* Only available in SDL 2.0.2 or higher. */
+            SDL_RENDER_TARGETS_RESET = 0x2000,
+            /* Only available in SDL 2.0.4 or higher. */
+            SDL_RENDER_DEVICE_RESET,
+
+            /* Internal events */
+            /* Only available in 2.0.18 or higher. */
+            SDL_POLLSENTINEL = 0x7F00,
+
+            /* Events SDL_USEREVENT through SDL_LASTEVENT are for
+			 * your use, and should be allocated with
+			 * SDL_RegisterEvents()
+			 */
+            SDL_USEREVENT = 0x8000,
+
+            /* The last event, used for bouding arrays. */
+            SDL_LASTEVENT = 0xFFFF
+        }
+
+        /* Only available in 2.0.4 or higher. */
+        public enum SDL_MouseWheelDirection : uint
+        {
+            SDL_MOUSEWHEEL_NORMAL,
+            SDL_MOUSEWHEEL_FLIPPED
+        }
+
+        /* Fields shared by every event */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_GenericEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+        }
+
+        // Ignore private members used for padding in this struct
+#pragma warning disable 0169
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_DisplayEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public uint display;
+            public SDL_DisplayEventID displayEvent; // event, lolC#
+            private byte padding1;
+            private byte padding2;
+            private byte padding3;
+            public int data1;
+        }
+#pragma warning restore 0169
+
+        // Ignore private members used for padding in this struct
+#pragma warning disable 0169
+        /* Window state change event data (event.window.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_WindowEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public uint windowID;
+            public SDL_WindowEventID windowEvent; // event, lolC#
+            private byte padding1;
+            private byte padding2;
+            private byte padding3;
+            public int data1;
+            public int data2;
+        }
+#pragma warning restore 0169
+
+        // Ignore private members used for padding in this struct
+#pragma warning disable 0169
+        /* Keyboard button event structure (event.key.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_KeyboardEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public uint windowID;
+            public byte state;
+            public byte repeat; /* non-zero if this is a repeat */
+            private byte padding2;
+            private byte padding3;
+            public SDL_Keysym keysym;
+        }
+#pragma warning restore 0169
+
+        [StructLayout(LayoutKind.Sequential)]
+        public unsafe struct SDL_TextEditingEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public uint windowID;
+            public fixed byte text[SDL_TEXTEDITINGEVENT_TEXT_SIZE];
+            public int start;
+            public int length;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public unsafe struct SDL_TextEditingExtEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public uint windowID;
+            public nint text; /* char*, free with SDL_free */
+            public int start;
+            public int length;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public unsafe struct SDL_TextInputEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public uint windowID;
+            public fixed byte text[SDL_TEXTINPUTEVENT_TEXT_SIZE];
+        }
+
+        // Ignore private members used for padding in this struct
+#pragma warning disable 0169
+        /* Mouse motion event structure (event.motion.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_MouseMotionEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public uint windowID;
+            public uint which;
+            public byte state; /* bitmask of buttons */
+            private byte padding1;
+            private byte padding2;
+            private byte padding3;
+            public int x;
+            public int y;
+            public int xrel;
+            public int yrel;
+        }
+#pragma warning restore 0169
+
+        // Ignore private members used for padding in this struct
+#pragma warning disable 0169
+        /* Mouse button event structure (event.button.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_MouseButtonEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public uint windowID;
+            public uint which;
+            public byte button; /* button id */
+            public byte state; /* SDL_PRESSED or SDL_RELEASED */
+            public byte clicks; /* 1 for single-click, 2 for double-click, etc. */
+            private byte padding1;
+            public int x;
+            public int y;
+        }
+#pragma warning restore 0169
+
+        /* Mouse wheel event structure (event.wheel.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_MouseWheelEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public uint windowID;
+            public uint which;
+            public int x; /* amount scrolled horizontally */
+            public int y; /* amount scrolled vertically */
+            public uint direction; /* Set to one of the SDL_MOUSEWHEEL_* defines */
+            public float preciseX; /* Requires >= 2.0.18 */
+            public float preciseY; /* Requires >= 2.0.18 */
+        }
+
+        // Ignore private members used for padding in this struct
+#pragma warning disable 0169
+        /* Joystick axis motion event structure (event.jaxis.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_JoyAxisEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public int which; /* SDL_JoystickID */
+            public byte axis;
+            private byte padding1;
+            private byte padding2;
+            private byte padding3;
+            public short axisValue; /* value, lolC# */
+            public ushort padding4;
+        }
+#pragma warning restore 0169
+
+        // Ignore private members used for padding in this struct
+#pragma warning disable 0169
+        /* Joystick trackball motion event structure (event.jball.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_JoyBallEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public int which; /* SDL_JoystickID */
+            public byte ball;
+            private byte padding1;
+            private byte padding2;
+            private byte padding3;
+            public short xrel;
+            public short yrel;
+        }
+#pragma warning restore 0169
+
+        // Ignore private members used for padding in this struct
+#pragma warning disable 0169
+        /* Joystick hat position change event struct (event.jhat.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_JoyHatEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public int which; /* SDL_JoystickID */
+            public byte hat; /* index of the hat */
+            public byte hatValue; /* value, lolC# */
+            private byte padding1;
+            private byte padding2;
+        }
+#pragma warning restore 0169
+
+        // Ignore private members used for padding in this struct
+#pragma warning disable 0169
+        /* Joystick button event structure (event.jbutton.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_JoyButtonEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public int which; /* SDL_JoystickID */
+            public byte button;
+            public byte state; /* SDL_PRESSED or SDL_RELEASED */
+            private byte padding1;
+            private byte padding2;
+        }
+#pragma warning restore 0169
+
+        /* Joystick device event structure (event.jdevice.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_JoyDeviceEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public int which; /* SDL_JoystickID */
+        }
+
+        // Ignore private members used for padding in this struct
+#pragma warning disable 0169
+        /* Game controller axis motion event (event.caxis.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_ControllerAxisEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public int which; /* SDL_JoystickID */
+            public byte axis;
+            private byte padding1;
+            private byte padding2;
+            private byte padding3;
+            public short axisValue; /* value, lolC# */
+            private ushort padding4;
+        }
+#pragma warning restore 0169
+
+        // Ignore private members used for padding in this struct
+#pragma warning disable 0169
+        /* Game controller button event (event.cbutton.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_ControllerButtonEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public int which; /* SDL_JoystickID */
+            public byte button;
+            public byte state;
+            private byte padding1;
+            private byte padding2;
+        }
+#pragma warning restore 0169
+
+        /* Game controller device event (event.cdevice.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_ControllerDeviceEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public int which; /* joystick id for ADDED,
+						 * else instance id
+						 */
+        }
+
+        /* Game controller touchpad event structure (event.ctouchpad.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_ControllerTouchpadEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public int which; /* SDL_JoystickID */
+            public int touchpad;
+            public int finger;
+            public float x;
+            public float y;
+            public float pressure;
+        }
+
+        /* Game controller sensor event structure (event.csensor.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_ControllerSensorEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public int which; /* SDL_JoystickID */
+            public int sensor;
+            public float data1;
+            public float data2;
+            public float data3;
+        }
+
+        // Ignore private members used for padding in this struct
+#pragma warning disable 0169
+        /* Audio device event (event.adevice.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_AudioDeviceEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public uint which;
+            public byte iscapture;
+            private byte padding1;
+            private byte padding2;
+            private byte padding3;
+        }
+#pragma warning restore 0169
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_TouchFingerEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public long touchId; // SDL_TouchID
+            public long fingerId; // SDL_GestureID
+            public float x;
+            public float y;
+            public float dx;
+            public float dy;
+            public float pressure;
+            public uint windowID;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_MultiGestureEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public long touchId; // SDL_TouchID
+            public float dTheta;
+            public float dDist;
+            public float x;
+            public float y;
+            public ushort numFingers;
+            public ushort padding;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_DollarGestureEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public long touchId; // SDL_TouchID
+            public long gestureId; // SDL_GestureID
+            public uint numFingers;
+            public float error;
+            public float x;
+            public float y;
+        }
+
+        /* File open request by system (event.drop.*), enabled by
+		 * default
+		 */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_DropEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+
+            /* char* filename, to be freed.
+			 * Access the variable EXACTLY ONCE like this:
+			 * string s = SDL.UTF8_ToManaged(evt.drop.file, true);
+			 */
+            public nint file;
+            public uint windowID;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public unsafe struct SDL_SensorEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public int which;
+            public fixed float data[6];
+        }
+
+        /* The "quit requested" event */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_QuitEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+        }
+
+        /* A user defined event (event.user.*) */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_UserEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public uint windowID;
+            public int code;
+            public nint data1; /* user-defined */
+            public nint data2; /* user-defined */
+        }
+
+        /* A video driver dependent event (event.syswm.*), disabled */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_SysWMEvent
+        {
+            public SDL_EventType type;
+            public uint timestamp;
+            public nint msg; /* SDL_SysWMmsg*, system-dependent*/
+        }
+
+        /* General event structure */
+        // C# doesn't do unions, so we do this ugly thing. */
+        [StructLayout(LayoutKind.Explicit)]
+        public unsafe struct SDL_Event
+        {
+            [FieldOffset(0)]
+            public SDL_EventType type;
+            [FieldOffset(0)]
+            public SDL_EventType typeFSharp;
+            [FieldOffset(0)]
+            public SDL_DisplayEvent display;
+            [FieldOffset(0)]
+            public SDL_WindowEvent window;
+            [FieldOffset(0)]
+            public SDL_KeyboardEvent key;
+            [FieldOffset(0)]
+            public SDL_TextEditingEvent edit;
+            [FieldOffset(0)]
+            public SDL_TextEditingExtEvent editExt;
+            [FieldOffset(0)]
+            public SDL_TextInputEvent text;
+            [FieldOffset(0)]
+            public SDL_MouseMotionEvent motion;
+            [FieldOffset(0)]
+            public SDL_MouseButtonEvent button;
+            [FieldOffset(0)]
+            public SDL_MouseWheelEvent wheel;
+            [FieldOffset(0)]
+            public SDL_JoyAxisEvent jaxis;
+            [FieldOffset(0)]
+            public SDL_JoyBallEvent jball;
+            [FieldOffset(0)]
+            public SDL_JoyHatEvent jhat;
+            [FieldOffset(0)]
+            public SDL_JoyButtonEvent jbutton;
+            [FieldOffset(0)]
+            public SDL_JoyDeviceEvent jdevice;
+            [FieldOffset(0)]
+            public SDL_ControllerAxisEvent caxis;
+            [FieldOffset(0)]
+            public SDL_ControllerButtonEvent cbutton;
+            [FieldOffset(0)]
+            public SDL_ControllerDeviceEvent cdevice;
+            [FieldOffset(0)]
+            public SDL_ControllerTouchpadEvent ctouchpad;
+            [FieldOffset(0)]
+            public SDL_ControllerSensorEvent csensor;
+            [FieldOffset(0)]
+            public SDL_AudioDeviceEvent adevice;
+            [FieldOffset(0)]
+            public SDL_SensorEvent sensor;
+            [FieldOffset(0)]
+            public SDL_QuitEvent quit;
+            [FieldOffset(0)]
+            public SDL_UserEvent user;
+            [FieldOffset(0)]
+            public SDL_SysWMEvent syswm;
+            [FieldOffset(0)]
+            public SDL_TouchFingerEvent tfinger;
+            [FieldOffset(0)]
+            public SDL_MultiGestureEvent mgesture;
+            [FieldOffset(0)]
+            public SDL_DollarGestureEvent dgesture;
+            [FieldOffset(0)]
+            public SDL_DropEvent drop;
+            [FieldOffset(0)]
+            private fixed byte padding[56];
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int SDL_EventFilter(
+            nint userdata, // void*
+            nint sdlevent // SDL_Event* event, lolC#
+        );
+
+        /* Pump the event loop, getting events from the input devices*/
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_PumpEvents();
+
+        public enum SDL_eventaction
+        {
+            SDL_ADDEVENT,
+            SDL_PEEKEVENT,
+            SDL_GETEVENT
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_PeepEvents(
+            [Out] SDL_Event[] events,
+            int numevents,
+            SDL_eventaction action,
+            SDL_EventType minType,
+            SDL_EventType maxType
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int SDL_PeepEvents(
+            SDL_Event* events,
+            int numevents,
+            SDL_eventaction action,
+            SDL_EventType minType,
+            SDL_EventType maxType
+        );
+
+        /* Checks to see if certain events are in the event queue */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasEvent(SDL_EventType type);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasEvents(
+            SDL_EventType minType,
+            SDL_EventType maxType
+        );
+
+        /* Clears events from the event queue */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_FlushEvent(SDL_EventType type);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_FlushEvents(
+            SDL_EventType min,
+            SDL_EventType max
+        );
+
+        /* Polls for currently pending events */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_PollEvent(out SDL_Event _event);
+
+        /* Waits indefinitely for the next event */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_WaitEvent(out SDL_Event _event);
+
+        /* Waits until the specified timeout (in ms) for the next event
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_WaitEventTimeout(out SDL_Event _event, int timeout);
+
+        /* Add an event to the event queue */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_PushEvent(ref SDL_Event _event);
+
+        /* userdata refers to a void* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetEventFilter(
+            SDL_EventFilter filter,
+            nint userdata
+        );
+
+        /* userdata refers to a void* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        private static extern SDL_bool SDL_GetEventFilter(
+            out nint filter,
+            out nint userdata
+        );
+        public static SDL_bool SDL_GetEventFilter(
+            out SDL_EventFilter filter,
+            out nint userdata
+        )
+        {
+            nint result = nint.Zero;
+            SDL_bool retval = SDL_GetEventFilter(out result, out userdata);
+            if (result != nint.Zero)
+            {
+                filter = GetDelegateForFunctionPointer<SDL_EventFilter>(
+                    result
+                );
+            }
+            else
+            {
+                filter = null;
+            }
+            return retval;
+        }
+
+        /* userdata refers to a void* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_AddEventWatch(
+            SDL_EventFilter filter,
+            nint userdata
+        );
+
+        /* userdata refers to a void* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_DelEventWatch(
+            SDL_EventFilter filter,
+            nint userdata
+        );
+
+        /* userdata refers to a void* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_FilterEvents(
+            SDL_EventFilter filter,
+            nint userdata
+        );
+
+        /* These are for SDL_EventState() */
+        public const int SDL_QUERY = -1;
+        public const int SDL_IGNORE = 0;
+        public const int SDL_DISABLE = 0;
+        public const int SDL_ENABLE = 1;
+
+        /* This function allows you to enable/disable certain events */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern byte SDL_EventState(SDL_EventType type, int state);
+
+        /* Get the state of an event */
+        public static byte SDL_GetEventState(SDL_EventType type)
+        {
+            return SDL_EventState(type, SDL_QUERY);
+        }
+
+        /* Allocate a set of user-defined events */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_RegisterEvents(int numevents);
+        #endregion
+
+        #region SDL_scancode.h
+
+        /* Scancodes based off USB keyboard page (0x07) */
+        public enum SDL_Scancode
+        {
+            SDL_SCANCODE_UNKNOWN = 0,
+
+            SDL_SCANCODE_A = 4,
+            SDL_SCANCODE_B = 5,
+            SDL_SCANCODE_C = 6,
+            SDL_SCANCODE_D = 7,
+            SDL_SCANCODE_E = 8,
+            SDL_SCANCODE_F = 9,
+            SDL_SCANCODE_G = 10,
+            SDL_SCANCODE_H = 11,
+            SDL_SCANCODE_I = 12,
+            SDL_SCANCODE_J = 13,
+            SDL_SCANCODE_K = 14,
+            SDL_SCANCODE_L = 15,
+            SDL_SCANCODE_M = 16,
+            SDL_SCANCODE_N = 17,
+            SDL_SCANCODE_O = 18,
+            SDL_SCANCODE_P = 19,
+            SDL_SCANCODE_Q = 20,
+            SDL_SCANCODE_R = 21,
+            SDL_SCANCODE_S = 22,
+            SDL_SCANCODE_T = 23,
+            SDL_SCANCODE_U = 24,
+            SDL_SCANCODE_V = 25,
+            SDL_SCANCODE_W = 26,
+            SDL_SCANCODE_X = 27,
+            SDL_SCANCODE_Y = 28,
+            SDL_SCANCODE_Z = 29,
+
+            SDL_SCANCODE_1 = 30,
+            SDL_SCANCODE_2 = 31,
+            SDL_SCANCODE_3 = 32,
+            SDL_SCANCODE_4 = 33,
+            SDL_SCANCODE_5 = 34,
+            SDL_SCANCODE_6 = 35,
+            SDL_SCANCODE_7 = 36,
+            SDL_SCANCODE_8 = 37,
+            SDL_SCANCODE_9 = 38,
+            SDL_SCANCODE_0 = 39,
+
+            SDL_SCANCODE_RETURN = 40,
+            SDL_SCANCODE_ESCAPE = 41,
+            SDL_SCANCODE_BACKSPACE = 42,
+            SDL_SCANCODE_TAB = 43,
+            SDL_SCANCODE_SPACE = 44,
+
+            SDL_SCANCODE_MINUS = 45,
+            SDL_SCANCODE_EQUALS = 46,
+            SDL_SCANCODE_LEFTBRACKET = 47,
+            SDL_SCANCODE_RIGHTBRACKET = 48,
+            SDL_SCANCODE_BACKSLASH = 49,
+            SDL_SCANCODE_NONUSHASH = 50,
+            SDL_SCANCODE_SEMICOLON = 51,
+            SDL_SCANCODE_APOSTROPHE = 52,
+            SDL_SCANCODE_GRAVE = 53,
+            SDL_SCANCODE_COMMA = 54,
+            SDL_SCANCODE_PERIOD = 55,
+            SDL_SCANCODE_SLASH = 56,
+
+            SDL_SCANCODE_CAPSLOCK = 57,
+
+            SDL_SCANCODE_F1 = 58,
+            SDL_SCANCODE_F2 = 59,
+            SDL_SCANCODE_F3 = 60,
+            SDL_SCANCODE_F4 = 61,
+            SDL_SCANCODE_F5 = 62,
+            SDL_SCANCODE_F6 = 63,
+            SDL_SCANCODE_F7 = 64,
+            SDL_SCANCODE_F8 = 65,
+            SDL_SCANCODE_F9 = 66,
+            SDL_SCANCODE_F10 = 67,
+            SDL_SCANCODE_F11 = 68,
+            SDL_SCANCODE_F12 = 69,
+
+            SDL_SCANCODE_PRINTSCREEN = 70,
+            SDL_SCANCODE_SCROLLLOCK = 71,
+            SDL_SCANCODE_PAUSE = 72,
+            SDL_SCANCODE_INSERT = 73,
+            SDL_SCANCODE_HOME = 74,
+            SDL_SCANCODE_PAGEUP = 75,
+            SDL_SCANCODE_DELETE = 76,
+            SDL_SCANCODE_END = 77,
+            SDL_SCANCODE_PAGEDOWN = 78,
+            SDL_SCANCODE_RIGHT = 79,
+            SDL_SCANCODE_LEFT = 80,
+            SDL_SCANCODE_DOWN = 81,
+            SDL_SCANCODE_UP = 82,
+
+            SDL_SCANCODE_NUMLOCKCLEAR = 83,
+            SDL_SCANCODE_KP_DIVIDE = 84,
+            SDL_SCANCODE_KP_MULTIPLY = 85,
+            SDL_SCANCODE_KP_MINUS = 86,
+            SDL_SCANCODE_KP_PLUS = 87,
+            SDL_SCANCODE_KP_ENTER = 88,
+            SDL_SCANCODE_KP_1 = 89,
+            SDL_SCANCODE_KP_2 = 90,
+            SDL_SCANCODE_KP_3 = 91,
+            SDL_SCANCODE_KP_4 = 92,
+            SDL_SCANCODE_KP_5 = 93,
+            SDL_SCANCODE_KP_6 = 94,
+            SDL_SCANCODE_KP_7 = 95,
+            SDL_SCANCODE_KP_8 = 96,
+            SDL_SCANCODE_KP_9 = 97,
+            SDL_SCANCODE_KP_0 = 98,
+            SDL_SCANCODE_KP_PERIOD = 99,
+
+            SDL_SCANCODE_NONUSBACKSLASH = 100,
+            SDL_SCANCODE_APPLICATION = 101,
+            SDL_SCANCODE_POWER = 102,
+            SDL_SCANCODE_KP_EQUALS = 103,
+            SDL_SCANCODE_F13 = 104,
+            SDL_SCANCODE_F14 = 105,
+            SDL_SCANCODE_F15 = 106,
+            SDL_SCANCODE_F16 = 107,
+            SDL_SCANCODE_F17 = 108,
+            SDL_SCANCODE_F18 = 109,
+            SDL_SCANCODE_F19 = 110,
+            SDL_SCANCODE_F20 = 111,
+            SDL_SCANCODE_F21 = 112,
+            SDL_SCANCODE_F22 = 113,
+            SDL_SCANCODE_F23 = 114,
+            SDL_SCANCODE_F24 = 115,
+            SDL_SCANCODE_EXECUTE = 116,
+            SDL_SCANCODE_HELP = 117,
+            SDL_SCANCODE_MENU = 118,
+            SDL_SCANCODE_SELECT = 119,
+            SDL_SCANCODE_STOP = 120,
+            SDL_SCANCODE_AGAIN = 121,
+            SDL_SCANCODE_UNDO = 122,
+            SDL_SCANCODE_CUT = 123,
+            SDL_SCANCODE_COPY = 124,
+            SDL_SCANCODE_PASTE = 125,
+            SDL_SCANCODE_FIND = 126,
+            SDL_SCANCODE_MUTE = 127,
+            SDL_SCANCODE_VOLUMEUP = 128,
+            SDL_SCANCODE_VOLUMEDOWN = 129,
+            /* not sure whether there's a reason to enable these */
+            /*	SDL_SCANCODE_LOCKINGCAPSLOCK = 130, */
+            /*	SDL_SCANCODE_LOCKINGNUMLOCK = 131, */
+            /*	SDL_SCANCODE_LOCKINGSCROLLLOCK = 132, */
+            SDL_SCANCODE_KP_COMMA = 133,
+            SDL_SCANCODE_KP_EQUALSAS400 = 134,
+
+            SDL_SCANCODE_INTERNATIONAL1 = 135,
+            SDL_SCANCODE_INTERNATIONAL2 = 136,
+            SDL_SCANCODE_INTERNATIONAL3 = 137,
+            SDL_SCANCODE_INTERNATIONAL4 = 138,
+            SDL_SCANCODE_INTERNATIONAL5 = 139,
+            SDL_SCANCODE_INTERNATIONAL6 = 140,
+            SDL_SCANCODE_INTERNATIONAL7 = 141,
+            SDL_SCANCODE_INTERNATIONAL8 = 142,
+            SDL_SCANCODE_INTERNATIONAL9 = 143,
+            SDL_SCANCODE_LANG1 = 144,
+            SDL_SCANCODE_LANG2 = 145,
+            SDL_SCANCODE_LANG3 = 146,
+            SDL_SCANCODE_LANG4 = 147,
+            SDL_SCANCODE_LANG5 = 148,
+            SDL_SCANCODE_LANG6 = 149,
+            SDL_SCANCODE_LANG7 = 150,
+            SDL_SCANCODE_LANG8 = 151,
+            SDL_SCANCODE_LANG9 = 152,
+
+            SDL_SCANCODE_ALTERASE = 153,
+            SDL_SCANCODE_SYSREQ = 154,
+            SDL_SCANCODE_CANCEL = 155,
+            SDL_SCANCODE_CLEAR = 156,
+            SDL_SCANCODE_PRIOR = 157,
+            SDL_SCANCODE_RETURN2 = 158,
+            SDL_SCANCODE_SEPARATOR = 159,
+            SDL_SCANCODE_OUT = 160,
+            SDL_SCANCODE_OPER = 161,
+            SDL_SCANCODE_CLEARAGAIN = 162,
+            SDL_SCANCODE_CRSEL = 163,
+            SDL_SCANCODE_EXSEL = 164,
+
+            SDL_SCANCODE_KP_00 = 176,
+            SDL_SCANCODE_KP_000 = 177,
+            SDL_SCANCODE_THOUSANDSSEPARATOR = 178,
+            SDL_SCANCODE_DECIMALSEPARATOR = 179,
+            SDL_SCANCODE_CURRENCYUNIT = 180,
+            SDL_SCANCODE_CURRENCYSUBUNIT = 181,
+            SDL_SCANCODE_KP_LEFTPAREN = 182,
+            SDL_SCANCODE_KP_RIGHTPAREN = 183,
+            SDL_SCANCODE_KP_LEFTBRACE = 184,
+            SDL_SCANCODE_KP_RIGHTBRACE = 185,
+            SDL_SCANCODE_KP_TAB = 186,
+            SDL_SCANCODE_KP_BACKSPACE = 187,
+            SDL_SCANCODE_KP_A = 188,
+            SDL_SCANCODE_KP_B = 189,
+            SDL_SCANCODE_KP_C = 190,
+            SDL_SCANCODE_KP_D = 191,
+            SDL_SCANCODE_KP_E = 192,
+            SDL_SCANCODE_KP_F = 193,
+            SDL_SCANCODE_KP_XOR = 194,
+            SDL_SCANCODE_KP_POWER = 195,
+            SDL_SCANCODE_KP_PERCENT = 196,
+            SDL_SCANCODE_KP_LESS = 197,
+            SDL_SCANCODE_KP_GREATER = 198,
+            SDL_SCANCODE_KP_AMPERSAND = 199,
+            SDL_SCANCODE_KP_DBLAMPERSAND = 200,
+            SDL_SCANCODE_KP_VERTICALBAR = 201,
+            SDL_SCANCODE_KP_DBLVERTICALBAR = 202,
+            SDL_SCANCODE_KP_COLON = 203,
+            SDL_SCANCODE_KP_HASH = 204,
+            SDL_SCANCODE_KP_SPACE = 205,
+            SDL_SCANCODE_KP_AT = 206,
+            SDL_SCANCODE_KP_EXCLAM = 207,
+            SDL_SCANCODE_KP_MEMSTORE = 208,
+            SDL_SCANCODE_KP_MEMRECALL = 209,
+            SDL_SCANCODE_KP_MEMCLEAR = 210,
+            SDL_SCANCODE_KP_MEMADD = 211,
+            SDL_SCANCODE_KP_MEMSUBTRACT = 212,
+            SDL_SCANCODE_KP_MEMMULTIPLY = 213,
+            SDL_SCANCODE_KP_MEMDIVIDE = 214,
+            SDL_SCANCODE_KP_PLUSMINUS = 215,
+            SDL_SCANCODE_KP_CLEAR = 216,
+            SDL_SCANCODE_KP_CLEARENTRY = 217,
+            SDL_SCANCODE_KP_BINARY = 218,
+            SDL_SCANCODE_KP_OCTAL = 219,
+            SDL_SCANCODE_KP_DECIMAL = 220,
+            SDL_SCANCODE_KP_HEXADECIMAL = 221,
+
+            SDL_SCANCODE_LCTRL = 224,
+            SDL_SCANCODE_LSHIFT = 225,
+            SDL_SCANCODE_LALT = 226,
+            SDL_SCANCODE_LGUI = 227,
+            SDL_SCANCODE_RCTRL = 228,
+            SDL_SCANCODE_RSHIFT = 229,
+            SDL_SCANCODE_RALT = 230,
+            SDL_SCANCODE_RGUI = 231,
+
+            SDL_SCANCODE_MODE = 257,
+
+            /* These come from the USB consumer page (0x0C) */
+            SDL_SCANCODE_AUDIONEXT = 258,
+            SDL_SCANCODE_AUDIOPREV = 259,
+            SDL_SCANCODE_AUDIOSTOP = 260,
+            SDL_SCANCODE_AUDIOPLAY = 261,
+            SDL_SCANCODE_AUDIOMUTE = 262,
+            SDL_SCANCODE_MEDIASELECT = 263,
+            SDL_SCANCODE_WWW = 264,
+            SDL_SCANCODE_MAIL = 265,
+            SDL_SCANCODE_CALCULATOR = 266,
+            SDL_SCANCODE_COMPUTER = 267,
+            SDL_SCANCODE_AC_SEARCH = 268,
+            SDL_SCANCODE_AC_HOME = 269,
+            SDL_SCANCODE_AC_BACK = 270,
+            SDL_SCANCODE_AC_FORWARD = 271,
+            SDL_SCANCODE_AC_STOP = 272,
+            SDL_SCANCODE_AC_REFRESH = 273,
+            SDL_SCANCODE_AC_BOOKMARKS = 274,
+
+            /* These come from other sources, and are mostly mac related */
+            SDL_SCANCODE_BRIGHTNESSDOWN = 275,
+            SDL_SCANCODE_BRIGHTNESSUP = 276,
+            SDL_SCANCODE_DISPLAYSWITCH = 277,
+            SDL_SCANCODE_KBDILLUMTOGGLE = 278,
+            SDL_SCANCODE_KBDILLUMDOWN = 279,
+            SDL_SCANCODE_KBDILLUMUP = 280,
+            SDL_SCANCODE_EJECT = 281,
+            SDL_SCANCODE_SLEEP = 282,
+
+            SDL_SCANCODE_APP1 = 283,
+            SDL_SCANCODE_APP2 = 284,
+
+            /* These come from the USB consumer page (0x0C) */
+            SDL_SCANCODE_AUDIOREWIND = 285,
+            SDL_SCANCODE_AUDIOFASTFORWARD = 286,
+
+            /* This is not a key, simply marks the number of scancodes
+			 * so that you know how big to make your arrays. */
+            SDL_NUM_SCANCODES = 512
+        }
+
+        #endregion
+
+        #region SDL_keycode.h
+
+        public const int SDLK_SCANCODE_MASK = 1 << 30;
+        public static SDL_Keycode SDL_SCANCODE_TO_KEYCODE(SDL_Scancode X)
+        {
+            return (SDL_Keycode)((int)X | SDLK_SCANCODE_MASK);
+        }
+
+        public enum SDL_Keycode
+        {
+            SDLK_UNKNOWN = 0,
+
+            SDLK_RETURN = '\r',
+            SDLK_ESCAPE = 27, // '\033'
+            SDLK_BACKSPACE = '\b',
+            SDLK_TAB = '\t',
+            SDLK_SPACE = ' ',
+            SDLK_EXCLAIM = '!',
+            SDLK_QUOTEDBL = '"',
+            SDLK_HASH = '#',
+            SDLK_PERCENT = '%',
+            SDLK_DOLLAR = '$',
+            SDLK_AMPERSAND = '&',
+            SDLK_QUOTE = '\'',
+            SDLK_LEFTPAREN = '(',
+            SDLK_RIGHTPAREN = ')',
+            SDLK_ASTERISK = '*',
+            SDLK_PLUS = '+',
+            SDLK_COMMA = ',',
+            SDLK_MINUS = '-',
+            SDLK_PERIOD = '.',
+            SDLK_SLASH = '/',
+            SDLK_0 = '0',
+            SDLK_1 = '1',
+            SDLK_2 = '2',
+            SDLK_3 = '3',
+            SDLK_4 = '4',
+            SDLK_5 = '5',
+            SDLK_6 = '6',
+            SDLK_7 = '7',
+            SDLK_8 = '8',
+            SDLK_9 = '9',
+            SDLK_COLON = ':',
+            SDLK_SEMICOLON = ';',
+            SDLK_LESS = '<',
+            SDLK_EQUALS = '=',
+            SDLK_GREATER = '>',
+            SDLK_QUESTION = '?',
+            SDLK_AT = '@',
+            /*
+			Skip uppercase letters
+			*/
+            SDLK_LEFTBRACKET = '[',
+            SDLK_BACKSLASH = '\\',
+            SDLK_RIGHTBRACKET = ']',
+            SDLK_CARET = '^',
+            SDLK_UNDERSCORE = '_',
+            SDLK_BACKQUOTE = '`',
+            SDLK_a = 'a',
+            SDLK_b = 'b',
+            SDLK_c = 'c',
+            SDLK_d = 'd',
+            SDLK_e = 'e',
+            SDLK_f = 'f',
+            SDLK_g = 'g',
+            SDLK_h = 'h',
+            SDLK_i = 'i',
+            SDLK_j = 'j',
+            SDLK_k = 'k',
+            SDLK_l = 'l',
+            SDLK_m = 'm',
+            SDLK_n = 'n',
+            SDLK_o = 'o',
+            SDLK_p = 'p',
+            SDLK_q = 'q',
+            SDLK_r = 'r',
+            SDLK_s = 's',
+            SDLK_t = 't',
+            SDLK_u = 'u',
+            SDLK_v = 'v',
+            SDLK_w = 'w',
+            SDLK_x = 'x',
+            SDLK_y = 'y',
+            SDLK_z = 'z',
+
+            SDLK_CAPSLOCK = SDL_Scancode.SDL_SCANCODE_CAPSLOCK | SDLK_SCANCODE_MASK,
+
+            SDLK_F1 = SDL_Scancode.SDL_SCANCODE_F1 | SDLK_SCANCODE_MASK,
+            SDLK_F2 = SDL_Scancode.SDL_SCANCODE_F2 | SDLK_SCANCODE_MASK,
+            SDLK_F3 = SDL_Scancode.SDL_SCANCODE_F3 | SDLK_SCANCODE_MASK,
+            SDLK_F4 = SDL_Scancode.SDL_SCANCODE_F4 | SDLK_SCANCODE_MASK,
+            SDLK_F5 = SDL_Scancode.SDL_SCANCODE_F5 | SDLK_SCANCODE_MASK,
+            SDLK_F6 = SDL_Scancode.SDL_SCANCODE_F6 | SDLK_SCANCODE_MASK,
+            SDLK_F7 = SDL_Scancode.SDL_SCANCODE_F7 | SDLK_SCANCODE_MASK,
+            SDLK_F8 = SDL_Scancode.SDL_SCANCODE_F8 | SDLK_SCANCODE_MASK,
+            SDLK_F9 = SDL_Scancode.SDL_SCANCODE_F9 | SDLK_SCANCODE_MASK,
+            SDLK_F10 = SDL_Scancode.SDL_SCANCODE_F10 | SDLK_SCANCODE_MASK,
+            SDLK_F11 = SDL_Scancode.SDL_SCANCODE_F11 | SDLK_SCANCODE_MASK,
+            SDLK_F12 = SDL_Scancode.SDL_SCANCODE_F12 | SDLK_SCANCODE_MASK,
+
+            SDLK_PRINTSCREEN = SDL_Scancode.SDL_SCANCODE_PRINTSCREEN | SDLK_SCANCODE_MASK,
+            SDLK_SCROLLLOCK = SDL_Scancode.SDL_SCANCODE_SCROLLLOCK | SDLK_SCANCODE_MASK,
+            SDLK_PAUSE = SDL_Scancode.SDL_SCANCODE_PAUSE | SDLK_SCANCODE_MASK,
+            SDLK_INSERT = SDL_Scancode.SDL_SCANCODE_INSERT | SDLK_SCANCODE_MASK,
+            SDLK_HOME = SDL_Scancode.SDL_SCANCODE_HOME | SDLK_SCANCODE_MASK,
+            SDLK_PAGEUP = SDL_Scancode.SDL_SCANCODE_PAGEUP | SDLK_SCANCODE_MASK,
+            SDLK_DELETE = 127,
+            SDLK_END = SDL_Scancode.SDL_SCANCODE_END | SDLK_SCANCODE_MASK,
+            SDLK_PAGEDOWN = SDL_Scancode.SDL_SCANCODE_PAGEDOWN | SDLK_SCANCODE_MASK,
+            SDLK_RIGHT = SDL_Scancode.SDL_SCANCODE_RIGHT | SDLK_SCANCODE_MASK,
+            SDLK_LEFT = SDL_Scancode.SDL_SCANCODE_LEFT | SDLK_SCANCODE_MASK,
+            SDLK_DOWN = SDL_Scancode.SDL_SCANCODE_DOWN | SDLK_SCANCODE_MASK,
+            SDLK_UP = SDL_Scancode.SDL_SCANCODE_UP | SDLK_SCANCODE_MASK,
+
+            SDLK_NUMLOCKCLEAR = SDL_Scancode.SDL_SCANCODE_NUMLOCKCLEAR | SDLK_SCANCODE_MASK,
+            SDLK_KP_DIVIDE = SDL_Scancode.SDL_SCANCODE_KP_DIVIDE | SDLK_SCANCODE_MASK,
+            SDLK_KP_MULTIPLY = SDL_Scancode.SDL_SCANCODE_KP_MULTIPLY | SDLK_SCANCODE_MASK,
+            SDLK_KP_MINUS = SDL_Scancode.SDL_SCANCODE_KP_MINUS | SDLK_SCANCODE_MASK,
+            SDLK_KP_PLUS = SDL_Scancode.SDL_SCANCODE_KP_PLUS | SDLK_SCANCODE_MASK,
+            SDLK_KP_ENTER = SDL_Scancode.SDL_SCANCODE_KP_ENTER | SDLK_SCANCODE_MASK,
+            SDLK_KP_1 = SDL_Scancode.SDL_SCANCODE_KP_1 | SDLK_SCANCODE_MASK,
+            SDLK_KP_2 = SDL_Scancode.SDL_SCANCODE_KP_2 | SDLK_SCANCODE_MASK,
+            SDLK_KP_3 = SDL_Scancode.SDL_SCANCODE_KP_3 | SDLK_SCANCODE_MASK,
+            SDLK_KP_4 = SDL_Scancode.SDL_SCANCODE_KP_4 | SDLK_SCANCODE_MASK,
+            SDLK_KP_5 = SDL_Scancode.SDL_SCANCODE_KP_5 | SDLK_SCANCODE_MASK,
+            SDLK_KP_6 = SDL_Scancode.SDL_SCANCODE_KP_6 | SDLK_SCANCODE_MASK,
+            SDLK_KP_7 = SDL_Scancode.SDL_SCANCODE_KP_7 | SDLK_SCANCODE_MASK,
+            SDLK_KP_8 = SDL_Scancode.SDL_SCANCODE_KP_8 | SDLK_SCANCODE_MASK,
+            SDLK_KP_9 = SDL_Scancode.SDL_SCANCODE_KP_9 | SDLK_SCANCODE_MASK,
+            SDLK_KP_0 = SDL_Scancode.SDL_SCANCODE_KP_0 | SDLK_SCANCODE_MASK,
+            SDLK_KP_PERIOD = SDL_Scancode.SDL_SCANCODE_KP_PERIOD | SDLK_SCANCODE_MASK,
+
+            SDLK_APPLICATION = SDL_Scancode.SDL_SCANCODE_APPLICATION | SDLK_SCANCODE_MASK,
+            SDLK_POWER = SDL_Scancode.SDL_SCANCODE_POWER | SDLK_SCANCODE_MASK,
+            SDLK_KP_EQUALS = SDL_Scancode.SDL_SCANCODE_KP_EQUALS | SDLK_SCANCODE_MASK,
+            SDLK_F13 = SDL_Scancode.SDL_SCANCODE_F13 | SDLK_SCANCODE_MASK,
+            SDLK_F14 = SDL_Scancode.SDL_SCANCODE_F14 | SDLK_SCANCODE_MASK,
+            SDLK_F15 = SDL_Scancode.SDL_SCANCODE_F15 | SDLK_SCANCODE_MASK,
+            SDLK_F16 = SDL_Scancode.SDL_SCANCODE_F16 | SDLK_SCANCODE_MASK,
+            SDLK_F17 = SDL_Scancode.SDL_SCANCODE_F17 | SDLK_SCANCODE_MASK,
+            SDLK_F18 = SDL_Scancode.SDL_SCANCODE_F18 | SDLK_SCANCODE_MASK,
+            SDLK_F19 = SDL_Scancode.SDL_SCANCODE_F19 | SDLK_SCANCODE_MASK,
+            SDLK_F20 = SDL_Scancode.SDL_SCANCODE_F20 | SDLK_SCANCODE_MASK,
+            SDLK_F21 = SDL_Scancode.SDL_SCANCODE_F21 | SDLK_SCANCODE_MASK,
+            SDLK_F22 = SDL_Scancode.SDL_SCANCODE_F22 | SDLK_SCANCODE_MASK,
+            SDLK_F23 = SDL_Scancode.SDL_SCANCODE_F23 | SDLK_SCANCODE_MASK,
+            SDLK_F24 = SDL_Scancode.SDL_SCANCODE_F24 | SDLK_SCANCODE_MASK,
+            SDLK_EXECUTE = SDL_Scancode.SDL_SCANCODE_EXECUTE | SDLK_SCANCODE_MASK,
+            SDLK_HELP = SDL_Scancode.SDL_SCANCODE_HELP | SDLK_SCANCODE_MASK,
+            SDLK_MENU = SDL_Scancode.SDL_SCANCODE_MENU | SDLK_SCANCODE_MASK,
+            SDLK_SELECT = SDL_Scancode.SDL_SCANCODE_SELECT | SDLK_SCANCODE_MASK,
+            SDLK_STOP = SDL_Scancode.SDL_SCANCODE_STOP | SDLK_SCANCODE_MASK,
+            SDLK_AGAIN = SDL_Scancode.SDL_SCANCODE_AGAIN | SDLK_SCANCODE_MASK,
+            SDLK_UNDO = SDL_Scancode.SDL_SCANCODE_UNDO | SDLK_SCANCODE_MASK,
+            SDLK_CUT = SDL_Scancode.SDL_SCANCODE_CUT | SDLK_SCANCODE_MASK,
+            SDLK_COPY = SDL_Scancode.SDL_SCANCODE_COPY | SDLK_SCANCODE_MASK,
+            SDLK_PASTE = SDL_Scancode.SDL_SCANCODE_PASTE | SDLK_SCANCODE_MASK,
+            SDLK_FIND = SDL_Scancode.SDL_SCANCODE_FIND | SDLK_SCANCODE_MASK,
+            SDLK_MUTE = SDL_Scancode.SDL_SCANCODE_MUTE | SDLK_SCANCODE_MASK,
+            SDLK_VOLUMEUP = SDL_Scancode.SDL_SCANCODE_VOLUMEUP | SDLK_SCANCODE_MASK,
+            SDLK_VOLUMEDOWN = SDL_Scancode.SDL_SCANCODE_VOLUMEDOWN | SDLK_SCANCODE_MASK,
+            SDLK_KP_COMMA = SDL_Scancode.SDL_SCANCODE_KP_COMMA | SDLK_SCANCODE_MASK,
+            SDLK_KP_EQUALSAS400 =
+            SDL_Scancode.SDL_SCANCODE_KP_EQUALSAS400 | SDLK_SCANCODE_MASK,
+
+            SDLK_ALTERASE = SDL_Scancode.SDL_SCANCODE_ALTERASE | SDLK_SCANCODE_MASK,
+            SDLK_SYSREQ = SDL_Scancode.SDL_SCANCODE_SYSREQ | SDLK_SCANCODE_MASK,
+            SDLK_CANCEL = SDL_Scancode.SDL_SCANCODE_CANCEL | SDLK_SCANCODE_MASK,
+            SDLK_CLEAR = SDL_Scancode.SDL_SCANCODE_CLEAR | SDLK_SCANCODE_MASK,
+            SDLK_PRIOR = SDL_Scancode.SDL_SCANCODE_PRIOR | SDLK_SCANCODE_MASK,
+            SDLK_RETURN2 = SDL_Scancode.SDL_SCANCODE_RETURN2 | SDLK_SCANCODE_MASK,
+            SDLK_SEPARATOR = SDL_Scancode.SDL_SCANCODE_SEPARATOR | SDLK_SCANCODE_MASK,
+            SDLK_OUT = SDL_Scancode.SDL_SCANCODE_OUT | SDLK_SCANCODE_MASK,
+            SDLK_OPER = SDL_Scancode.SDL_SCANCODE_OPER | SDLK_SCANCODE_MASK,
+            SDLK_CLEARAGAIN = SDL_Scancode.SDL_SCANCODE_CLEARAGAIN | SDLK_SCANCODE_MASK,
+            SDLK_CRSEL = SDL_Scancode.SDL_SCANCODE_CRSEL | SDLK_SCANCODE_MASK,
+            SDLK_EXSEL = SDL_Scancode.SDL_SCANCODE_EXSEL | SDLK_SCANCODE_MASK,
+
+            SDLK_KP_00 = SDL_Scancode.SDL_SCANCODE_KP_00 | SDLK_SCANCODE_MASK,
+            SDLK_KP_000 = SDL_Scancode.SDL_SCANCODE_KP_000 | SDLK_SCANCODE_MASK,
+            SDLK_THOUSANDSSEPARATOR =
+            SDL_Scancode.SDL_SCANCODE_THOUSANDSSEPARATOR | SDLK_SCANCODE_MASK,
+            SDLK_DECIMALSEPARATOR =
+            SDL_Scancode.SDL_SCANCODE_DECIMALSEPARATOR | SDLK_SCANCODE_MASK,
+            SDLK_CURRENCYUNIT = SDL_Scancode.SDL_SCANCODE_CURRENCYUNIT | SDLK_SCANCODE_MASK,
+            SDLK_CURRENCYSUBUNIT =
+            SDL_Scancode.SDL_SCANCODE_CURRENCYSUBUNIT | SDLK_SCANCODE_MASK,
+            SDLK_KP_LEFTPAREN = SDL_Scancode.SDL_SCANCODE_KP_LEFTPAREN | SDLK_SCANCODE_MASK,
+            SDLK_KP_RIGHTPAREN = SDL_Scancode.SDL_SCANCODE_KP_RIGHTPAREN | SDLK_SCANCODE_MASK,
+            SDLK_KP_LEFTBRACE = SDL_Scancode.SDL_SCANCODE_KP_LEFTBRACE | SDLK_SCANCODE_MASK,
+            SDLK_KP_RIGHTBRACE = SDL_Scancode.SDL_SCANCODE_KP_RIGHTBRACE | SDLK_SCANCODE_MASK,
+            SDLK_KP_TAB = SDL_Scancode.SDL_SCANCODE_KP_TAB | SDLK_SCANCODE_MASK,
+            SDLK_KP_BACKSPACE = SDL_Scancode.SDL_SCANCODE_KP_BACKSPACE | SDLK_SCANCODE_MASK,
+            SDLK_KP_A = SDL_Scancode.SDL_SCANCODE_KP_A | SDLK_SCANCODE_MASK,
+            SDLK_KP_B = SDL_Scancode.SDL_SCANCODE_KP_B | SDLK_SCANCODE_MASK,
+            SDLK_KP_C = SDL_Scancode.SDL_SCANCODE_KP_C | SDLK_SCANCODE_MASK,
+            SDLK_KP_D = SDL_Scancode.SDL_SCANCODE_KP_D | SDLK_SCANCODE_MASK,
+            SDLK_KP_E = SDL_Scancode.SDL_SCANCODE_KP_E | SDLK_SCANCODE_MASK,
+            SDLK_KP_F = SDL_Scancode.SDL_SCANCODE_KP_F | SDLK_SCANCODE_MASK,
+            SDLK_KP_XOR = SDL_Scancode.SDL_SCANCODE_KP_XOR | SDLK_SCANCODE_MASK,
+            SDLK_KP_POWER = SDL_Scancode.SDL_SCANCODE_KP_POWER | SDLK_SCANCODE_MASK,
+            SDLK_KP_PERCENT = SDL_Scancode.SDL_SCANCODE_KP_PERCENT | SDLK_SCANCODE_MASK,
+            SDLK_KP_LESS = SDL_Scancode.SDL_SCANCODE_KP_LESS | SDLK_SCANCODE_MASK,
+            SDLK_KP_GREATER = SDL_Scancode.SDL_SCANCODE_KP_GREATER | SDLK_SCANCODE_MASK,
+            SDLK_KP_AMPERSAND = SDL_Scancode.SDL_SCANCODE_KP_AMPERSAND | SDLK_SCANCODE_MASK,
+            SDLK_KP_DBLAMPERSAND =
+            SDL_Scancode.SDL_SCANCODE_KP_DBLAMPERSAND | SDLK_SCANCODE_MASK,
+            SDLK_KP_VERTICALBAR =
+            SDL_Scancode.SDL_SCANCODE_KP_VERTICALBAR | SDLK_SCANCODE_MASK,
+            SDLK_KP_DBLVERTICALBAR =
+            SDL_Scancode.SDL_SCANCODE_KP_DBLVERTICALBAR | SDLK_SCANCODE_MASK,
+            SDLK_KP_COLON = SDL_Scancode.SDL_SCANCODE_KP_COLON | SDLK_SCANCODE_MASK,
+            SDLK_KP_HASH = SDL_Scancode.SDL_SCANCODE_KP_HASH | SDLK_SCANCODE_MASK,
+            SDLK_KP_SPACE = SDL_Scancode.SDL_SCANCODE_KP_SPACE | SDLK_SCANCODE_MASK,
+            SDLK_KP_AT = SDL_Scancode.SDL_SCANCODE_KP_AT | SDLK_SCANCODE_MASK,
+            SDLK_KP_EXCLAM = SDL_Scancode.SDL_SCANCODE_KP_EXCLAM | SDLK_SCANCODE_MASK,
+            SDLK_KP_MEMSTORE = SDL_Scancode.SDL_SCANCODE_KP_MEMSTORE | SDLK_SCANCODE_MASK,
+            SDLK_KP_MEMRECALL = SDL_Scancode.SDL_SCANCODE_KP_MEMRECALL | SDLK_SCANCODE_MASK,
+            SDLK_KP_MEMCLEAR = SDL_Scancode.SDL_SCANCODE_KP_MEMCLEAR | SDLK_SCANCODE_MASK,
+            SDLK_KP_MEMADD = SDL_Scancode.SDL_SCANCODE_KP_MEMADD | SDLK_SCANCODE_MASK,
+            SDLK_KP_MEMSUBTRACT =
+            SDL_Scancode.SDL_SCANCODE_KP_MEMSUBTRACT | SDLK_SCANCODE_MASK,
+            SDLK_KP_MEMMULTIPLY =
+            SDL_Scancode.SDL_SCANCODE_KP_MEMMULTIPLY | SDLK_SCANCODE_MASK,
+            SDLK_KP_MEMDIVIDE = SDL_Scancode.SDL_SCANCODE_KP_MEMDIVIDE | SDLK_SCANCODE_MASK,
+            SDLK_KP_PLUSMINUS = SDL_Scancode.SDL_SCANCODE_KP_PLUSMINUS | SDLK_SCANCODE_MASK,
+            SDLK_KP_CLEAR = SDL_Scancode.SDL_SCANCODE_KP_CLEAR | SDLK_SCANCODE_MASK,
+            SDLK_KP_CLEARENTRY = SDL_Scancode.SDL_SCANCODE_KP_CLEARENTRY | SDLK_SCANCODE_MASK,
+            SDLK_KP_BINARY = SDL_Scancode.SDL_SCANCODE_KP_BINARY | SDLK_SCANCODE_MASK,
+            SDLK_KP_OCTAL = SDL_Scancode.SDL_SCANCODE_KP_OCTAL | SDLK_SCANCODE_MASK,
+            SDLK_KP_DECIMAL = SDL_Scancode.SDL_SCANCODE_KP_DECIMAL | SDLK_SCANCODE_MASK,
+            SDLK_KP_HEXADECIMAL =
+            SDL_Scancode.SDL_SCANCODE_KP_HEXADECIMAL | SDLK_SCANCODE_MASK,
+
+            SDLK_LCTRL = SDL_Scancode.SDL_SCANCODE_LCTRL | SDLK_SCANCODE_MASK,
+            SDLK_LSHIFT = SDL_Scancode.SDL_SCANCODE_LSHIFT | SDLK_SCANCODE_MASK,
+            SDLK_LALT = SDL_Scancode.SDL_SCANCODE_LALT | SDLK_SCANCODE_MASK,
+            SDLK_LGUI = SDL_Scancode.SDL_SCANCODE_LGUI | SDLK_SCANCODE_MASK,
+            SDLK_RCTRL = SDL_Scancode.SDL_SCANCODE_RCTRL | SDLK_SCANCODE_MASK,
+            SDLK_RSHIFT = SDL_Scancode.SDL_SCANCODE_RSHIFT | SDLK_SCANCODE_MASK,
+            SDLK_RALT = SDL_Scancode.SDL_SCANCODE_RALT | SDLK_SCANCODE_MASK,
+            SDLK_RGUI = SDL_Scancode.SDL_SCANCODE_RGUI | SDLK_SCANCODE_MASK,
+
+            SDLK_MODE = SDL_Scancode.SDL_SCANCODE_MODE | SDLK_SCANCODE_MASK,
+
+            SDLK_AUDIONEXT = SDL_Scancode.SDL_SCANCODE_AUDIONEXT | SDLK_SCANCODE_MASK,
+            SDLK_AUDIOPREV = SDL_Scancode.SDL_SCANCODE_AUDIOPREV | SDLK_SCANCODE_MASK,
+            SDLK_AUDIOSTOP = SDL_Scancode.SDL_SCANCODE_AUDIOSTOP | SDLK_SCANCODE_MASK,
+            SDLK_AUDIOPLAY = SDL_Scancode.SDL_SCANCODE_AUDIOPLAY | SDLK_SCANCODE_MASK,
+            SDLK_AUDIOMUTE = SDL_Scancode.SDL_SCANCODE_AUDIOMUTE | SDLK_SCANCODE_MASK,
+            SDLK_MEDIASELECT = SDL_Scancode.SDL_SCANCODE_MEDIASELECT | SDLK_SCANCODE_MASK,
+            SDLK_WWW = SDL_Scancode.SDL_SCANCODE_WWW | SDLK_SCANCODE_MASK,
+            SDLK_MAIL = SDL_Scancode.SDL_SCANCODE_MAIL | SDLK_SCANCODE_MASK,
+            SDLK_CALCULATOR = SDL_Scancode.SDL_SCANCODE_CALCULATOR | SDLK_SCANCODE_MASK,
+            SDLK_COMPUTER = SDL_Scancode.SDL_SCANCODE_COMPUTER | SDLK_SCANCODE_MASK,
+            SDLK_AC_SEARCH = SDL_Scancode.SDL_SCANCODE_AC_SEARCH | SDLK_SCANCODE_MASK,
+            SDLK_AC_HOME = SDL_Scancode.SDL_SCANCODE_AC_HOME | SDLK_SCANCODE_MASK,
+            SDLK_AC_BACK = SDL_Scancode.SDL_SCANCODE_AC_BACK | SDLK_SCANCODE_MASK,
+            SDLK_AC_FORWARD = SDL_Scancode.SDL_SCANCODE_AC_FORWARD | SDLK_SCANCODE_MASK,
+            SDLK_AC_STOP = SDL_Scancode.SDL_SCANCODE_AC_STOP | SDLK_SCANCODE_MASK,
+            SDLK_AC_REFRESH = SDL_Scancode.SDL_SCANCODE_AC_REFRESH | SDLK_SCANCODE_MASK,
+            SDLK_AC_BOOKMARKS = SDL_Scancode.SDL_SCANCODE_AC_BOOKMARKS | SDLK_SCANCODE_MASK,
+
+            SDLK_BRIGHTNESSDOWN =
+            SDL_Scancode.SDL_SCANCODE_BRIGHTNESSDOWN | SDLK_SCANCODE_MASK,
+            SDLK_BRIGHTNESSUP = SDL_Scancode.SDL_SCANCODE_BRIGHTNESSUP | SDLK_SCANCODE_MASK,
+            SDLK_DISPLAYSWITCH = SDL_Scancode.SDL_SCANCODE_DISPLAYSWITCH | SDLK_SCANCODE_MASK,
+            SDLK_KBDILLUMTOGGLE =
+            SDL_Scancode.SDL_SCANCODE_KBDILLUMTOGGLE | SDLK_SCANCODE_MASK,
+            SDLK_KBDILLUMDOWN = SDL_Scancode.SDL_SCANCODE_KBDILLUMDOWN | SDLK_SCANCODE_MASK,
+            SDLK_KBDILLUMUP = SDL_Scancode.SDL_SCANCODE_KBDILLUMUP | SDLK_SCANCODE_MASK,
+            SDLK_EJECT = SDL_Scancode.SDL_SCANCODE_EJECT | SDLK_SCANCODE_MASK,
+            SDLK_SLEEP = SDL_Scancode.SDL_SCANCODE_SLEEP | SDLK_SCANCODE_MASK,
+            SDLK_APP1 = SDL_Scancode.SDL_SCANCODE_APP1 | SDLK_SCANCODE_MASK,
+            SDLK_APP2 = SDL_Scancode.SDL_SCANCODE_APP2 | SDLK_SCANCODE_MASK,
+
+            SDLK_AUDIOREWIND = SDL_Scancode.SDL_SCANCODE_AUDIOREWIND | SDLK_SCANCODE_MASK,
+            SDLK_AUDIOFASTFORWARD = SDL_Scancode.SDL_SCANCODE_AUDIOFASTFORWARD | SDLK_SCANCODE_MASK
+        }
+
+        /* Key modifiers (bitfield) */
+        [Flags]
+        public enum SDL_Keymod : ushort
+        {
+            KMOD_NONE = 0x0000,
+            KMOD_LSHIFT = 0x0001,
+            KMOD_RSHIFT = 0x0002,
+            KMOD_LCTRL = 0x0040,
+            KMOD_RCTRL = 0x0080,
+            KMOD_LALT = 0x0100,
+            KMOD_RALT = 0x0200,
+            KMOD_LGUI = 0x0400,
+            KMOD_RGUI = 0x0800,
+            KMOD_NUM = 0x1000,
+            KMOD_CAPS = 0x2000,
+            KMOD_MODE = 0x4000,
+            KMOD_SCROLL = 0x8000,
+
+            /* These are defines in the SDL headers */
+            KMOD_CTRL = KMOD_LCTRL | KMOD_RCTRL,
+            KMOD_SHIFT = KMOD_LSHIFT | KMOD_RSHIFT,
+            KMOD_ALT = KMOD_LALT | KMOD_RALT,
+            KMOD_GUI = KMOD_LGUI | KMOD_RGUI,
+
+            KMOD_RESERVED = KMOD_SCROLL
+        }
+
+        #endregion
+
+        #region SDL_keyboard.h
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_Keysym
+        {
+            public SDL_Scancode scancode;
+            public SDL_Keycode sym;
+            public SDL_Keymod mod; /* UInt16 */
+            public uint unicode; /* Deprecated */
+        }
+
+        /* Get the window which has kbd focus */
+        /* Return type is an SDL_Window pointer */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetKeyboardFocus();
+
+        /* Get a snapshot of the keyboard state. */
+        /* Return value is a pointer to a UInt8 array */
+        /* Numkeys returns the size of the array if non-null */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetKeyboardState(out int numkeys);
+
+        /* Get the current key modifier state for the keyboard. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_Keymod SDL_GetModState();
+
+        /* Set the current key modifier state */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetModState(SDL_Keymod modstate);
+
+        /* Get the key code corresponding to the given scancode
+		 * with the current keyboard layout.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_Keycode SDL_GetKeyFromScancode(SDL_Scancode scancode);
+
+        /* Get the scancode for the given keycode */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_Scancode SDL_GetScancodeFromKey(SDL_Keycode key);
+
+        /* Wrapper for SDL_GetScancodeName */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetScancodeName", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetScancodeName(SDL_Scancode scancode);
+        public static string SDL_GetScancodeName(SDL_Scancode scancode)
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GetScancodeName(scancode)
+            );
+        }
+
+        /* Get a scancode from a human-readable name */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetScancodeFromName", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe SDL_Scancode INTERNAL_SDL_GetScancodeFromName(
+            byte* name
+        );
+        public static unsafe SDL_Scancode SDL_GetScancodeFromName(string name)
+        {
+            int utf8NameBufSize = Utf8Size(name);
+            byte* utf8Name = stackalloc byte[utf8NameBufSize];
+            return INTERNAL_SDL_GetScancodeFromName(
+                Utf8Encode(name, utf8Name, utf8NameBufSize)
+            );
+        }
+
+        /* Wrapper for SDL_GetKeyName */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetKeyName", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetKeyName(SDL_Keycode key);
+        public static string SDL_GetKeyName(SDL_Keycode key)
+        {
+            return UTF8_ToManaged(INTERNAL_SDL_GetKeyName(key));
+        }
+
+        /* Get a key code from a human-readable name */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetKeyFromName", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe SDL_Keycode INTERNAL_SDL_GetKeyFromName(
+            byte* name
+        );
+        public static unsafe SDL_Keycode SDL_GetKeyFromName(string name)
+        {
+            int utf8NameBufSize = Utf8Size(name);
+            byte* utf8Name = stackalloc byte[utf8NameBufSize];
+            return INTERNAL_SDL_GetKeyFromName(
+                Utf8Encode(name, utf8Name, utf8NameBufSize)
+            );
+        }
+
+        /* Start accepting Unicode text input events, show keyboard */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_StartTextInput();
+
+        /* Check if unicode input events are enabled */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_IsTextInputActive();
+
+        /* Stop receiving any text input events, hide onscreen kbd */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_StopTextInput();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_ClearComposition();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_IsTextInputShown();
+
+        /* Set the rectangle used for text input, hint for IME */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetTextInputRect(ref SDL_Rect rect);
+
+        /* Does the platform support an on-screen keyboard? */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasScreenKeyboardSupport();
+
+        /* Is the on-screen keyboard shown for a given window? */
+        /* window is an SDL_Window pointer */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_IsScreenKeyboardShown(nint window);
+
+        #endregion
+
+        #region SDL_mouse.c
+
+        /* Note: SDL_Cursor is a typedef normally. We'll treat it as
+		 * an IntPtr, because C# doesn't do typedefs. Yay!
+		 */
+
+        /* System cursor types */
+        public enum SDL_SystemCursor
+        {
+            SDL_SYSTEM_CURSOR_ARROW,    // Arrow
+            SDL_SYSTEM_CURSOR_IBEAM,    // I-beam
+            SDL_SYSTEM_CURSOR_WAIT,     // Wait
+            SDL_SYSTEM_CURSOR_CROSSHAIR,    // Crosshair
+            SDL_SYSTEM_CURSOR_WAITARROW,    // Small wait cursor (or Wait if not available)
+            SDL_SYSTEM_CURSOR_SIZENWSE, // Double arrow pointing northwest and southeast
+            SDL_SYSTEM_CURSOR_SIZENESW, // Double arrow pointing northeast and southwest
+            SDL_SYSTEM_CURSOR_SIZEWE,   // Double arrow pointing west and east
+            SDL_SYSTEM_CURSOR_SIZENS,   // Double arrow pointing north and south
+            SDL_SYSTEM_CURSOR_SIZEALL,  // Four pointed arrow pointing north, south, east, and west
+            SDL_SYSTEM_CURSOR_NO,       // Slashed circle or crossbones
+            SDL_SYSTEM_CURSOR_HAND,     // Hand
+            SDL_NUM_SYSTEM_CURSORS
+        }
+
+        /* Get the window which currently has mouse focus */
+        /* Return value is an SDL_Window pointer */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetMouseFocus();
+
+        /* Get the current state of the mouse */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_GetMouseState(out int x, out int y);
+
+        /* Get the current state of the mouse */
+        /* This overload allows for passing NULL to x */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_GetMouseState(nint x, out int y);
+
+        /* Get the current state of the mouse */
+        /* This overload allows for passing NULL to y */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_GetMouseState(out int x, nint y);
+
+        /* Get the current state of the mouse */
+        /* This overload allows for passing NULL to both x and y */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_GetMouseState(nint x, nint y);
+
+        /* Get the current state of the mouse, in relation to the desktop.
+		 * Only available in 2.0.4 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_GetGlobalMouseState(out int x, out int y);
+
+        /* Get the current state of the mouse, in relation to the desktop.
+		 * Only available in 2.0.4 or higher.
+		 * This overload allows for passing NULL to x.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_GetGlobalMouseState(nint x, out int y);
+
+        /* Get the current state of the mouse, in relation to the desktop.
+		 * Only available in 2.0.4 or higher.
+		 * This overload allows for passing NULL to y.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_GetGlobalMouseState(out int x, nint y);
+
+        /* Get the current state of the mouse, in relation to the desktop.
+		 * Only available in 2.0.4 or higher.
+		 * This overload allows for passing NULL to both x and y
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_GetGlobalMouseState(nint x, nint y);
+
+        /* Get the mouse state with relative coords*/
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_GetRelativeMouseState(out int x, out int y);
+
+        /* Set the mouse cursor's position (within a window) */
+        /* window is an SDL_Window pointer */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_WarpMouseInWindow(nint window, int x, int y);
+
+        /* Set the mouse cursor's position in global screen space.
+		 * Only available in 2.0.4 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_WarpMouseGlobal(int x, int y);
+
+        /* Enable/Disable relative mouse mode (grabs mouse, rel coords) */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SetRelativeMouseMode(SDL_bool enabled);
+
+        /* Capture the mouse, to track input outside an SDL window.
+		 * Only available in 2.0.4 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_CaptureMouse(SDL_bool enabled);
+
+        /* Query if the relative mouse mode is enabled */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_GetRelativeMouseMode();
+
+        /* Create a cursor from bitmap data (amd mask) in MSB format.
+		 * data and mask are byte arrays, and w must be a multiple of 8.
+		 * return value is an SDL_Cursor pointer.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_CreateCursor(
+            nint data,
+            nint mask,
+            int w,
+            int h,
+            int hot_x,
+            int hot_y
+        );
+
+        /* Create a cursor from an SDL_Surface.
+		 * IntPtr refers to an SDL_Cursor*, surface to an SDL_Surface*
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_CreateColorCursor(
+            nint surface,
+            int hot_x,
+            int hot_y
+        );
+
+        /* Create a cursor from a system cursor id.
+		 * return value is an SDL_Cursor pointer
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_CreateSystemCursor(SDL_SystemCursor id);
+
+        /* Set the active cursor.
+		 * cursor is an SDL_Cursor pointer
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetCursor(nint cursor);
+
+        /* Return the active cursor
+		 * return value is an SDL_Cursor pointer
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetCursor();
+
+        /* Frees a cursor created with one of the CreateCursor functions.
+		 * cursor in an SDL_Cursor pointer
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_FreeCursor(nint cursor);
+
+        /* Toggle whether or not the cursor is shown */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_ShowCursor(int toggle);
+
+        public static uint SDL_BUTTON(uint X)
+        {
+            // If only there were a better way of doing this in C#
+            return (uint)(1 << (int)X - 1);
+        }
+
+        public const uint SDL_BUTTON_LEFT = 1;
+        public const uint SDL_BUTTON_MIDDLE = 2;
+        public const uint SDL_BUTTON_RIGHT = 3;
+        public const uint SDL_BUTTON_X1 = 4;
+        public const uint SDL_BUTTON_X2 = 5;
+        public static readonly uint SDL_BUTTON_LMASK = SDL_BUTTON(SDL_BUTTON_LEFT);
+        public static readonly uint SDL_BUTTON_MMASK = SDL_BUTTON(SDL_BUTTON_MIDDLE);
+        public static readonly uint SDL_BUTTON_RMASK = SDL_BUTTON(SDL_BUTTON_RIGHT);
+        public static readonly uint SDL_BUTTON_X1MASK = SDL_BUTTON(SDL_BUTTON_X1);
+        public static readonly uint SDL_BUTTON_X2MASK = SDL_BUTTON(SDL_BUTTON_X2);
+
+        #endregion
+
+        #region SDL_touch.h
+
+        public const uint SDL_TOUCH_MOUSEID = uint.MaxValue;
+
+        public struct SDL_Finger
+        {
+            public long id; // SDL_FingerID
+            public float x;
+            public float y;
+            public float pressure;
+        }
+
+        /* Only available in 2.0.10 or higher. */
+        public enum SDL_TouchDeviceType
+        {
+            SDL_TOUCH_DEVICE_INVALID = -1,
+            SDL_TOUCH_DEVICE_DIRECT,            /* touch screen with window-relative coordinates */
+            SDL_TOUCH_DEVICE_INDIRECT_ABSOLUTE, /* trackpad with absolute device coordinates */
+            SDL_TOUCH_DEVICE_INDIRECT_RELATIVE  /* trackpad with screen cursor-relative coordinates */
+        }
+
+        /**
+		 *  \brief Get the number of registered touch devices.
+ 		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetNumTouchDevices();
+
+        /**
+		 *  \brief Get the touch ID with the given index, or 0 if the index is invalid.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern long SDL_GetTouchDevice(int index);
+
+        /**
+		 *  \brief Get the number of active fingers for a given touch device.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetNumTouchFingers(long touchID);
+
+        /**
+		 *  \brief Get the finger object of the given touch, with the given index.
+		 *  Returns pointer to SDL_Finger.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetTouchFinger(long touchID, int index);
+
+        /* Only available in 2.0.10 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_TouchDeviceType SDL_GetTouchDeviceType(long touchID);
+
+        /* Only available in 2.0.22 or higher. */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetTouchName", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetTouchName(int index);
+
+        /* Only available in 2.0.22 or higher. */
+        public static string SDL_GetTouchName(int index)
+        {
+            return UTF8_ToManaged(INTERNAL_SDL_GetTouchName(index));
+        }
+
+        #endregion
+
+        #region SDL_joystick.h
+
+        public const byte SDL_HAT_CENTERED = 0x00;
+        public const byte SDL_HAT_UP = 0x01;
+        public const byte SDL_HAT_RIGHT = 0x02;
+        public const byte SDL_HAT_DOWN = 0x04;
+        public const byte SDL_HAT_LEFT = 0x08;
+        public const byte SDL_HAT_RIGHTUP = SDL_HAT_RIGHT | SDL_HAT_UP;
+        public const byte SDL_HAT_RIGHTDOWN = SDL_HAT_RIGHT | SDL_HAT_DOWN;
+        public const byte SDL_HAT_LEFTUP = SDL_HAT_LEFT | SDL_HAT_UP;
+        public const byte SDL_HAT_LEFTDOWN = SDL_HAT_LEFT | SDL_HAT_DOWN;
+
+        public enum SDL_JoystickPowerLevel
+        {
+            SDL_JOYSTICK_POWER_UNKNOWN = -1,
+            SDL_JOYSTICK_POWER_EMPTY,
+            SDL_JOYSTICK_POWER_LOW,
+            SDL_JOYSTICK_POWER_MEDIUM,
+            SDL_JOYSTICK_POWER_FULL,
+            SDL_JOYSTICK_POWER_WIRED,
+            SDL_JOYSTICK_POWER_MAX
+        }
+
+        public enum SDL_JoystickType
+        {
+            SDL_JOYSTICK_TYPE_UNKNOWN,
+            SDL_JOYSTICK_TYPE_GAMECONTROLLER,
+            SDL_JOYSTICK_TYPE_WHEEL,
+            SDL_JOYSTICK_TYPE_ARCADE_STICK,
+            SDL_JOYSTICK_TYPE_FLIGHT_STICK,
+            SDL_JOYSTICK_TYPE_DANCE_PAD,
+            SDL_JOYSTICK_TYPE_GUITAR,
+            SDL_JOYSTICK_TYPE_DRUM_KIT,
+            SDL_JOYSTICK_TYPE_ARCADE_PAD
+        }
+
+        /* Only available in 2.0.14 or higher. */
+        public const float SDL_IPHONE_MAX_GFORCE = 5.0f;
+
+        /* joystick refers to an SDL_Joystick*.
+		 * Only available in 2.0.9 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickRumble(
+            nint joystick,
+            ushort low_frequency_rumble,
+            ushort high_frequency_rumble,
+            uint duration_ms
+        );
+
+        /* joystick refers to an SDL_Joystick*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickRumbleTriggers(
+            nint joystick,
+            ushort left_rumble,
+            ushort right_rumble,
+            uint duration_ms
+        );
+
+        /* joystick refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_JoystickClose(nint joystick);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickEventState(int state);
+
+        /* joystick refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern short SDL_JoystickGetAxis(
+            nint joystick,
+            int axis
+        );
+
+        /* joystick refers to an SDL_Joystick*.
+		 * Only available in 2.0.6 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_JoystickGetAxisInitialState(
+            nint joystick,
+            int axis,
+            out short state
+        );
+
+        /* joystick refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickGetBall(
+            nint joystick,
+            int ball,
+            out int dx,
+            out int dy
+        );
+
+        /* joystick refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern byte SDL_JoystickGetButton(
+            nint joystick,
+            int button
+        );
+
+        /* joystick refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern byte SDL_JoystickGetHat(
+            nint joystick,
+            int hat
+        );
+
+        /* joystick refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_JoystickName", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_JoystickName(
+            nint joystick
+        );
+        public static string SDL_JoystickName(nint joystick)
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_JoystickName(joystick)
+            );
+        }
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_JoystickNameForIndex", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_JoystickNameForIndex(
+            int device_index
+        );
+        public static string SDL_JoystickNameForIndex(int device_index)
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_JoystickNameForIndex(device_index)
+            );
+        }
+
+        /* joystick refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickNumAxes(nint joystick);
+
+        /* joystick refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickNumBalls(nint joystick);
+
+        /* joystick refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickNumButtons(nint joystick);
+
+        /* joystick refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickNumHats(nint joystick);
+
+        /* IntPtr refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_JoystickOpen(int device_index);
+
+        /* joystick refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_JoystickUpdate();
+
+        /* joystick refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_NumJoysticks();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Guid SDL_JoystickGetDeviceGUID(
+            int device_index
+        );
+
+        /* joystick refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Guid SDL_JoystickGetGUID(
+            nint joystick
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_JoystickGetGUIDString(
+            Guid guid,
+            byte[] pszGUID,
+            int cbGUID
+        );
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_JoystickGetGUIDFromString", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe Guid INTERNAL_SDL_JoystickGetGUIDFromString(
+            byte* pchGUID
+        );
+        public static unsafe Guid SDL_JoystickGetGUIDFromString(string pchGuid)
+        {
+            int utf8PchGuidBufSize = Utf8Size(pchGuid);
+            byte* utf8PchGuid = stackalloc byte[utf8PchGuidBufSize];
+            return INTERNAL_SDL_JoystickGetGUIDFromString(
+                Utf8Encode(pchGuid, utf8PchGuid, utf8PchGuidBufSize)
+            );
+        }
+
+        /* Only available in 2.0.6 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ushort SDL_JoystickGetDeviceVendor(int device_index);
+
+        /* Only available in 2.0.6 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ushort SDL_JoystickGetDeviceProduct(int device_index);
+
+        /* Only available in 2.0.6 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ushort SDL_JoystickGetDeviceProductVersion(int device_index);
+
+        /* Only available in 2.0.6 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_JoystickType SDL_JoystickGetDeviceType(int device_index);
+
+        /* int refers to an SDL_JoystickID.
+		 * Only available in 2.0.6 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickGetDeviceInstanceID(int device_index);
+
+        /* joystick refers to an SDL_Joystick*.
+		 * Only available in 2.0.6 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ushort SDL_JoystickGetVendor(nint joystick);
+
+        /* joystick refers to an SDL_Joystick*.
+		 * Only available in 2.0.6 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ushort SDL_JoystickGetProduct(nint joystick);
+
+        /* joystick refers to an SDL_Joystick*.
+		 * Only available in 2.0.6 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ushort SDL_JoystickGetProductVersion(nint joystick);
+
+        /* joystick refers to an SDL_Joystick*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "SDL_JoystickGetSerial", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_JoystickGetSerial(
+            nint joystick
+        );
+        public static string SDL_JoystickGetSerial(
+            nint joystick
+        )
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_JoystickGetSerial(joystick)
+            );
+        }
+
+        /* joystick refers to an SDL_Joystick*.
+		 * Only available in 2.0.6 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_JoystickType SDL_JoystickGetType(nint joystick);
+
+        /* joystick refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_JoystickGetAttached(nint joystick);
+
+        /* int refers to an SDL_JoystickID, joystick to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickInstanceID(nint joystick);
+
+        /* joystick refers to an SDL_Joystick*.
+		 * Only available in 2.0.4 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_JoystickPowerLevel SDL_JoystickCurrentPowerLevel(
+            nint joystick
+        );
+
+        /* int refers to an SDL_JoystickID, IntPtr to an SDL_Joystick*.
+		 * Only available in 2.0.4 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_JoystickFromInstanceID(int instance_id);
+
+        /* Only available in 2.0.7 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_LockJoysticks();
+
+        /* Only available in 2.0.7 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_UnlockJoysticks();
+
+        /* IntPtr refers to an SDL_Joystick*.
+		 * Only available in 2.0.11 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_JoystickFromPlayerIndex(int player_index);
+
+        /* IntPtr refers to an SDL_Joystick*.
+		 * Only available in 2.0.11 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_JoystickSetPlayerIndex(
+            nint joystick,
+            int player_index
+        );
+
+        /* Int32 refers to an SDL_JoystickType.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickAttachVirtual(
+            int type,
+            int naxes,
+            int nbuttons,
+            int nhats
+        );
+
+        /* Only available in 2.0.14 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickDetachVirtual(int device_index);
+
+        /* Only available in 2.0.14 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_JoystickIsVirtual(int device_index);
+
+        /* IntPtr refers to an SDL_Joystick*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickSetVirtualAxis(
+            nint joystick,
+            int axis,
+            short value
+        );
+
+        /* IntPtr refers to an SDL_Joystick*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickSetVirtualButton(
+            nint joystick,
+            int button,
+            byte value
+        );
+
+        /* IntPtr refers to an SDL_Joystick*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickSetVirtualHat(
+            nint joystick,
+            int hat,
+            byte value
+        );
+
+        /* IntPtr refers to an SDL_Joystick*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_JoystickHasLED(nint joystick);
+
+        /* IntPtr refers to an SDL_Joystick*.
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_JoystickHasRumble(nint joystick);
+
+        /* IntPtr refers to an SDL_Joystick*.
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_JoystickHasRumbleTriggers(nint joystick);
+
+        /* IntPtr refers to an SDL_Joystick*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickSetLED(
+            nint joystick,
+            byte red,
+            byte green,
+            byte blue
+        );
+
+        /* joystick refers to an SDL_Joystick*.
+		 * data refers to a const void*.
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickSendEffect(
+            nint joystick,
+            nint data,
+            int size
+        );
+
+        #endregion
+
+        #region SDL_gamecontroller.h
+
+        public enum SDL_GameControllerBindType
+        {
+            SDL_CONTROLLER_BINDTYPE_NONE,
+            SDL_CONTROLLER_BINDTYPE_BUTTON,
+            SDL_CONTROLLER_BINDTYPE_AXIS,
+            SDL_CONTROLLER_BINDTYPE_HAT
+        }
+
+        public enum SDL_GameControllerAxis
+        {
+            SDL_CONTROLLER_AXIS_INVALID = -1,
+            SDL_CONTROLLER_AXIS_LEFTX,
+            SDL_CONTROLLER_AXIS_LEFTY,
+            SDL_CONTROLLER_AXIS_RIGHTX,
+            SDL_CONTROLLER_AXIS_RIGHTY,
+            SDL_CONTROLLER_AXIS_TRIGGERLEFT,
+            SDL_CONTROLLER_AXIS_TRIGGERRIGHT,
+            SDL_CONTROLLER_AXIS_MAX
+        }
+
+        public enum SDL_GameControllerButton
+        {
+            SDL_CONTROLLER_BUTTON_INVALID = -1,
+            SDL_CONTROLLER_BUTTON_A,
+            SDL_CONTROLLER_BUTTON_B,
+            SDL_CONTROLLER_BUTTON_X,
+            SDL_CONTROLLER_BUTTON_Y,
+            SDL_CONTROLLER_BUTTON_BACK,
+            SDL_CONTROLLER_BUTTON_GUIDE,
+            SDL_CONTROLLER_BUTTON_START,
+            SDL_CONTROLLER_BUTTON_LEFTSTICK,
+            SDL_CONTROLLER_BUTTON_RIGHTSTICK,
+            SDL_CONTROLLER_BUTTON_LEFTSHOULDER,
+            SDL_CONTROLLER_BUTTON_RIGHTSHOULDER,
+            SDL_CONTROLLER_BUTTON_DPAD_UP,
+            SDL_CONTROLLER_BUTTON_DPAD_DOWN,
+            SDL_CONTROLLER_BUTTON_DPAD_LEFT,
+            SDL_CONTROLLER_BUTTON_DPAD_RIGHT,
+            SDL_CONTROLLER_BUTTON_MISC1,
+            SDL_CONTROLLER_BUTTON_PADDLE1,
+            SDL_CONTROLLER_BUTTON_PADDLE2,
+            SDL_CONTROLLER_BUTTON_PADDLE3,
+            SDL_CONTROLLER_BUTTON_PADDLE4,
+            SDL_CONTROLLER_BUTTON_TOUCHPAD,
+            SDL_CONTROLLER_BUTTON_MAX,
+        }
+
+        public enum SDL_GameControllerType
+        {
+            SDL_CONTROLLER_TYPE_UNKNOWN = 0,
+            SDL_CONTROLLER_TYPE_XBOX360,
+            SDL_CONTROLLER_TYPE_XBOXONE,
+            SDL_CONTROLLER_TYPE_PS3,
+            SDL_CONTROLLER_TYPE_PS4,
+            SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_PRO,
+            SDL_CONTROLLER_TYPE_VIRTUAL,        /* Requires >= 2.0.14 */
+            SDL_CONTROLLER_TYPE_PS5,        /* Requires >= 2.0.14 */
+            SDL_CONTROLLER_TYPE_AMAZON_LUNA,    /* Requires >= 2.0.16 */
+            SDL_CONTROLLER_TYPE_GOOGLE_STADIA   /* Requires >= 2.0.16 */
+        }
+
+        // FIXME: I'd rather this somehow be private...
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INTERNAL_GameControllerButtonBind_hat
+        {
+            public int hat;
+            public int hat_mask;
+        }
+
+        // FIXME: I'd rather this somehow be private...
+        [StructLayout(LayoutKind.Explicit)]
+        public struct INTERNAL_GameControllerButtonBind_union
+        {
+            [FieldOffset(0)]
+            public int button;
+            [FieldOffset(0)]
+            public int axis;
+            [FieldOffset(0)]
+            public INTERNAL_GameControllerButtonBind_hat hat;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_GameControllerButtonBind
+        {
+            public SDL_GameControllerBindType bindType;
+            public INTERNAL_GameControllerButtonBind_union value;
+        }
+
+        /* This exists to deal with C# being stupid about blittable types. */
+        [StructLayout(LayoutKind.Sequential)]
+        private struct INTERNAL_SDL_GameControllerButtonBind
+        {
+            public int bindType;
+            /* Largest data type in the union is two ints in size */
+            public int unionVal0;
+            public int unionVal1;
+        }
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerAddMapping", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe int INTERNAL_SDL_GameControllerAddMapping(
+            byte* mappingString
+        );
+        public static unsafe int SDL_GameControllerAddMapping(
+            string mappingString
+        )
+        {
+            byte* utf8MappingString = Utf8EncodeHeap(mappingString);
+            int result = INTERNAL_SDL_GameControllerAddMapping(
+                utf8MappingString
+            );
+            Marshal.FreeHGlobal((nint)utf8MappingString);
+            return result;
+        }
+
+        /* Only available in 2.0.6 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GameControllerNumMappings();
+
+        /* Only available in 2.0.6 or higher. */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerMappingForIndex", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GameControllerMappingForIndex(int mapping_index);
+        public static string SDL_GameControllerMappingForIndex(int mapping_index)
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GameControllerMappingForIndex(
+                    mapping_index
+                ),
+                true
+            );
+        }
+
+        /* THIS IS AN RWops FUNCTION! */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerAddMappingsFromRW", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int INTERNAL_SDL_GameControllerAddMappingsFromRW(
+            nint rw,
+            int freerw
+        );
+        public static int SDL_GameControllerAddMappingsFromFile(string file)
+        {
+            nint rwops = SDL_RWFromFile(file, "rb");
+            return INTERNAL_SDL_GameControllerAddMappingsFromRW(rwops, 1);
+        }
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerMappingForGUID", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GameControllerMappingForGUID(
+            Guid guid
+        );
+        public static string SDL_GameControllerMappingForGUID(Guid guid)
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GameControllerMappingForGUID(guid),
+                true
+            );
+        }
+
+        /* gamecontroller refers to an SDL_GameController* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerMapping", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GameControllerMapping(
+            nint gamecontroller
+        );
+        public static string SDL_GameControllerMapping(
+            nint gamecontroller
+        )
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GameControllerMapping(
+                    gamecontroller
+                ),
+                true
+            );
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_IsGameController(int joystick_index);
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerNameForIndex", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GameControllerNameForIndex(
+            int joystick_index
+        );
+        public static string SDL_GameControllerNameForIndex(
+            int joystick_index
+        )
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GameControllerNameForIndex(joystick_index)
+            );
+        }
+
+        /* Only available in 2.0.9 or higher. */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerMappingForDeviceIndex", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GameControllerMappingForDeviceIndex(
+            int joystick_index
+        );
+        public static string SDL_GameControllerMappingForDeviceIndex(
+            int joystick_index
+        )
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GameControllerMappingForDeviceIndex(joystick_index),
+                true
+            );
+        }
+
+        /* IntPtr refers to an SDL_GameController* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GameControllerOpen(int joystick_index);
+
+        /* gamecontroller refers to an SDL_GameController* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerName", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GameControllerName(
+            nint gamecontroller
+        );
+        public static string SDL_GameControllerName(
+            nint gamecontroller
+        )
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GameControllerName(gamecontroller)
+            );
+        }
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.6 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ushort SDL_GameControllerGetVendor(
+            nint gamecontroller
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.6 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ushort SDL_GameControllerGetProduct(
+            nint gamecontroller
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.6 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ushort SDL_GameControllerGetProductVersion(
+            nint gamecontroller
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerGetSerial", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GameControllerGetSerial(
+            nint gamecontroller
+        );
+        public static string SDL_GameControllerGetSerial(
+            nint gamecontroller
+        )
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GameControllerGetSerial(gamecontroller)
+            );
+        }
+
+        /* gamecontroller refers to an SDL_GameController* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_GameControllerGetAttached(
+            nint gamecontroller
+        );
+
+        /* IntPtr refers to an SDL_Joystick*
+		 * gamecontroller refers to an SDL_GameController*
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GameControllerGetJoystick(
+            nint gamecontroller
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GameControllerEventState(int state);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GameControllerUpdate();
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerGetAxisFromString", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe SDL_GameControllerAxis INTERNAL_SDL_GameControllerGetAxisFromString(
+            byte* pchString
+        );
+        public static unsafe SDL_GameControllerAxis SDL_GameControllerGetAxisFromString(
+            string pchString
+        )
+        {
+            int utf8PchStringBufSize = Utf8Size(pchString);
+            byte* utf8PchString = stackalloc byte[utf8PchStringBufSize];
+            return INTERNAL_SDL_GameControllerGetAxisFromString(
+                Utf8Encode(pchString, utf8PchString, utf8PchStringBufSize)
+            );
+        }
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerGetStringForAxis", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GameControllerGetStringForAxis(
+            SDL_GameControllerAxis axis
+        );
+        public static string SDL_GameControllerGetStringForAxis(
+            SDL_GameControllerAxis axis
+        )
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GameControllerGetStringForAxis(
+                    axis
+                )
+            );
+        }
+
+        /* gamecontroller refers to an SDL_GameController* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerGetBindForAxis", CallingConvention = CallingConvention.Cdecl)]
+        private static extern INTERNAL_SDL_GameControllerButtonBind INTERNAL_SDL_GameControllerGetBindForAxis(
+            nint gamecontroller,
+            SDL_GameControllerAxis axis
+        );
+        public static SDL_GameControllerButtonBind SDL_GameControllerGetBindForAxis(
+            nint gamecontroller,
+            SDL_GameControllerAxis axis
+        )
+        {
+            // This is guaranteed to never be null
+            INTERNAL_SDL_GameControllerButtonBind dumb = INTERNAL_SDL_GameControllerGetBindForAxis(
+                gamecontroller,
+                axis
+            );
+            SDL_GameControllerButtonBind result = new SDL_GameControllerButtonBind();
+            result.bindType = (SDL_GameControllerBindType)dumb.bindType;
+            result.value.hat.hat = dumb.unionVal0;
+            result.value.hat.hat_mask = dumb.unionVal1;
+            return result;
+        }
+
+        /* gamecontroller refers to an SDL_GameController* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern short SDL_GameControllerGetAxis(
+            nint gamecontroller,
+            SDL_GameControllerAxis axis
+        );
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerGetButtonFromString", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe SDL_GameControllerButton INTERNAL_SDL_GameControllerGetButtonFromString(
+            byte* pchString
+        );
+        public static unsafe SDL_GameControllerButton SDL_GameControllerGetButtonFromString(
+            string pchString
+        )
+        {
+            int utf8PchStringBufSize = Utf8Size(pchString);
+            byte* utf8PchString = stackalloc byte[utf8PchStringBufSize];
+            return INTERNAL_SDL_GameControllerGetButtonFromString(
+                Utf8Encode(pchString, utf8PchString, utf8PchStringBufSize)
+            );
+        }
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerGetStringForButton", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GameControllerGetStringForButton(
+            SDL_GameControllerButton button
+        );
+        public static string SDL_GameControllerGetStringForButton(
+            SDL_GameControllerButton button
+        )
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GameControllerGetStringForButton(button)
+            );
+        }
+
+        /* gamecontroller refers to an SDL_GameController* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerGetBindForButton", CallingConvention = CallingConvention.Cdecl)]
+        private static extern INTERNAL_SDL_GameControllerButtonBind INTERNAL_SDL_GameControllerGetBindForButton(
+            nint gamecontroller,
+            SDL_GameControllerButton button
+        );
+        public static SDL_GameControllerButtonBind SDL_GameControllerGetBindForButton(
+            nint gamecontroller,
+            SDL_GameControllerButton button
+        )
+        {
+            // This is guaranteed to never be null
+            INTERNAL_SDL_GameControllerButtonBind dumb = INTERNAL_SDL_GameControllerGetBindForButton(
+                gamecontroller,
+                button
+            );
+            SDL_GameControllerButtonBind result = new SDL_GameControllerButtonBind();
+            result.bindType = (SDL_GameControllerBindType)dumb.bindType;
+            result.value.hat.hat = dumb.unionVal0;
+            result.value.hat.hat_mask = dumb.unionVal1;
+            return result;
+        }
+
+        /* gamecontroller refers to an SDL_GameController* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern byte SDL_GameControllerGetButton(
+            nint gamecontroller,
+            SDL_GameControllerButton button
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.9 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GameControllerRumble(
+            nint gamecontroller,
+            ushort low_frequency_rumble,
+            ushort high_frequency_rumble,
+            uint duration_ms
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GameControllerRumbleTriggers(
+            nint gamecontroller,
+            ushort left_rumble,
+            ushort right_rumble,
+            uint duration_ms
+        );
+
+        /* gamecontroller refers to an SDL_GameController* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GameControllerClose(
+            nint gamecontroller
+        );
+
+        /* gamecontroller refers to an SDL_GameController*
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerGetAppleSFSymbolsNameForButton", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GameControllerGetAppleSFSymbolsNameForButton(
+            nint gamecontroller,
+            SDL_GameControllerButton button
+        );
+        public static string SDL_GameControllerGetAppleSFSymbolsNameForButton(
+            nint gamecontroller,
+            SDL_GameControllerButton button
+        )
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GameControllerGetAppleSFSymbolsNameForButton(gamecontroller, button)
+            );
+        }
+
+        /* gamecontroller refers to an SDL_GameController*
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GameControllerGetAppleSFSymbolsNameForAxis", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GameControllerGetAppleSFSymbolsNameForAxis(
+            nint gamecontroller,
+            SDL_GameControllerAxis axis
+        );
+        public static string SDL_GameControllerGetAppleSFSymbolsNameForAxis(
+            nint gamecontroller,
+            SDL_GameControllerAxis axis
+        )
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GameControllerGetAppleSFSymbolsNameForAxis(gamecontroller, axis)
+            );
+        }
+
+        /* int refers to an SDL_JoystickID, IntPtr to an SDL_GameController*.
+		 * Only available in 2.0.4 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GameControllerFromInstanceID(int joyid);
+
+        /* Only available in 2.0.11 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_GameControllerType SDL_GameControllerTypeForIndex(
+            int joystick_index
+        );
+
+        /* IntPtr refers to an SDL_GameController*.
+		 * Only available in 2.0.11 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_GameControllerType SDL_GameControllerGetType(
+            nint gamecontroller
+        );
+
+        /* IntPtr refers to an SDL_GameController*.
+		 * Only available in 2.0.11 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GameControllerFromPlayerIndex(
+            int player_index
+        );
+
+        /* IntPtr refers to an SDL_GameController*.
+		 * Only available in 2.0.11 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_GameControllerSetPlayerIndex(
+            nint gamecontroller,
+            int player_index
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_GameControllerHasLED(
+            nint gamecontroller
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_GameControllerHasRumble(
+            nint gamecontroller
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_GameControllerHasRumbleTriggers(
+            nint gamecontroller
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GameControllerSetLED(
+            nint gamecontroller,
+            byte red,
+            byte green,
+            byte blue
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_GameControllerHasAxis(
+            nint gamecontroller,
+            SDL_GameControllerAxis axis
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_GameControllerHasButton(
+            nint gamecontroller,
+            SDL_GameControllerButton button
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GameControllerGetNumTouchpads(
+            nint gamecontroller
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GameControllerGetNumTouchpadFingers(
+            nint gamecontroller,
+            int touchpad
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GameControllerGetTouchpadFinger(
+            nint gamecontroller,
+            int touchpad,
+            int finger,
+            out byte state,
+            out float x,
+            out float y,
+            out float pressure
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_GameControllerHasSensor(
+            nint gamecontroller,
+            SDL_SensorType type
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GameControllerSetSensorEnabled(
+            nint gamecontroller,
+            SDL_SensorType type,
+            SDL_bool enabled
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_GameControllerIsSensorEnabled(
+            nint gamecontroller,
+            SDL_SensorType type
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * data refers to a float*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GameControllerGetSensorData(
+            nint gamecontroller,
+            SDL_SensorType type,
+            nint data,
+            int num_values
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GameControllerGetSensorData(
+            nint gamecontroller,
+            SDL_SensorType type,
+            [In] float[] data,
+            int num_values
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern float SDL_GameControllerGetSensorDataRate(
+            nint gamecontroller,
+            SDL_SensorType type
+        );
+
+        /* gamecontroller refers to an SDL_GameController*.
+		 * data refers to a const void*.
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GameControllerSendEffect(
+            nint gamecontroller,
+            nint data,
+            int size
+        );
+
+        #endregion
+
+        #region SDL_haptic.h
+
+        /* SDL_HapticEffect type */
+        public const ushort SDL_HAPTIC_CONSTANT = 1 << 0;
+        public const ushort SDL_HAPTIC_SINE = 1 << 1;
+        public const ushort SDL_HAPTIC_LEFTRIGHT = 1 << 2;
+        public const ushort SDL_HAPTIC_TRIANGLE = 1 << 3;
+        public const ushort SDL_HAPTIC_SAWTOOTHUP = 1 << 4;
+        public const ushort SDL_HAPTIC_SAWTOOTHDOWN = 1 << 5;
+        public const ushort SDL_HAPTIC_SPRING = 1 << 7;
+        public const ushort SDL_HAPTIC_DAMPER = 1 << 8;
+        public const ushort SDL_HAPTIC_INERTIA = 1 << 9;
+        public const ushort SDL_HAPTIC_FRICTION = 1 << 10;
+        public const ushort SDL_HAPTIC_CUSTOM = 1 << 11;
+        public const ushort SDL_HAPTIC_GAIN = 1 << 12;
+        public const ushort SDL_HAPTIC_AUTOCENTER = 1 << 13;
+        public const ushort SDL_HAPTIC_STATUS = 1 << 14;
+        public const ushort SDL_HAPTIC_PAUSE = 1 << 15;
+
+        /* SDL_HapticDirection type */
+        public const byte SDL_HAPTIC_POLAR = 0;
+        public const byte SDL_HAPTIC_CARTESIAN = 1;
+        public const byte SDL_HAPTIC_SPHERICAL = 2;
+        public const byte SDL_HAPTIC_STEERING_AXIS = 3; /* Requires >= 2.0.14 */
+
+        /* SDL_HapticRunEffect */
+        public const uint SDL_HAPTIC_INFINITY = 4294967295U;
+
+        [StructLayout(LayoutKind.Sequential)]
+        public unsafe struct SDL_HapticDirection
+        {
+            public byte type;
+            public fixed int dir[3];
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_HapticConstant
+        {
+            // Header
+            public ushort type;
+            public SDL_HapticDirection direction;
+            // Replay
+            public uint length;
+            public ushort delay;
+            // Trigger
+            public ushort button;
+            public ushort interval;
+            // Constant
+            public short level;
+            // Envelope
+            public ushort attack_length;
+            public ushort attack_level;
+            public ushort fade_length;
+            public ushort fade_level;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_HapticPeriodic
+        {
+            // Header
+            public ushort type;
+            public SDL_HapticDirection direction;
+            // Replay
+            public uint length;
+            public ushort delay;
+            // Trigger
+            public ushort button;
+            public ushort interval;
+            // Periodic
+            public ushort period;
+            public short magnitude;
+            public short offset;
+            public ushort phase;
+            // Envelope
+            public ushort attack_length;
+            public ushort attack_level;
+            public ushort fade_length;
+            public ushort fade_level;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public unsafe struct SDL_HapticCondition
+        {
+            // Header
+            public ushort type;
+            public SDL_HapticDirection direction;
+            // Replay
+            public uint length;
+            public ushort delay;
+            // Trigger
+            public ushort button;
+            public ushort interval;
+            // Condition
+            public fixed ushort right_sat[3];
+            public fixed ushort left_sat[3];
+            public fixed short right_coeff[3];
+            public fixed short left_coeff[3];
+            public fixed ushort deadband[3];
+            public fixed short center[3];
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_HapticRamp
+        {
+            // Header
+            public ushort type;
+            public SDL_HapticDirection direction;
+            // Replay
+            public uint length;
+            public ushort delay;
+            // Trigger
+            public ushort button;
+            public ushort interval;
+            // Ramp
+            public short start;
+            public short end;
+            // Envelope
+            public ushort attack_length;
+            public ushort attack_level;
+            public ushort fade_length;
+            public ushort fade_level;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_HapticLeftRight
+        {
+            // Header
+            public ushort type;
+            // Replay
+            public uint length;
+            // Rumble
+            public ushort large_magnitude;
+            public ushort small_magnitude;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_HapticCustom
+        {
+            // Header
+            public ushort type;
+            public SDL_HapticDirection direction;
+            // Replay
+            public uint length;
+            public ushort delay;
+            // Trigger
+            public ushort button;
+            public ushort interval;
+            // Custom
+            public byte channels;
+            public ushort period;
+            public ushort samples;
+            public nint data; // Uint16*
+                              // Envelope
+            public ushort attack_length;
+            public ushort attack_level;
+            public ushort fade_length;
+            public ushort fade_level;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        public struct SDL_HapticEffect
+        {
+            [FieldOffset(0)]
+            public ushort type;
+            [FieldOffset(0)]
+            public SDL_HapticConstant constant;
+            [FieldOffset(0)]
+            public SDL_HapticPeriodic periodic;
+            [FieldOffset(0)]
+            public SDL_HapticCondition condition;
+            [FieldOffset(0)]
+            public SDL_HapticRamp ramp;
+            [FieldOffset(0)]
+            public SDL_HapticLeftRight leftright;
+            [FieldOffset(0)]
+            public SDL_HapticCustom custom;
+        }
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_HapticClose(nint haptic);
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_HapticDestroyEffect(
+            nint haptic,
+            int effect
+        );
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticEffectSupported(
+            nint haptic,
+            ref SDL_HapticEffect effect
+        );
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticGetEffectStatus(
+            nint haptic,
+            int effect
+        );
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticIndex(nint haptic);
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_HapticName", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_HapticName(int device_index);
+        public static string SDL_HapticName(int device_index)
+        {
+            return UTF8_ToManaged(INTERNAL_SDL_HapticName(device_index));
+        }
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticNewEffect(
+            nint haptic,
+            ref SDL_HapticEffect effect
+        );
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticNumAxes(nint haptic);
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticNumEffects(nint haptic);
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticNumEffectsPlaying(nint haptic);
+
+        /* IntPtr refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_HapticOpen(int device_index);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticOpened(int device_index);
+
+        /* IntPtr refers to an SDL_Haptic*, joystick to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_HapticOpenFromJoystick(
+            nint joystick
+        );
+
+        /* IntPtr refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_HapticOpenFromMouse();
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticPause(nint haptic);
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_HapticQuery(nint haptic);
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticRumbleInit(nint haptic);
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticRumblePlay(
+            nint haptic,
+            float strength,
+            uint length
+        );
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticRumbleStop(nint haptic);
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticRumbleSupported(nint haptic);
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticRunEffect(
+            nint haptic,
+            int effect,
+            uint iterations
+        );
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticSetAutocenter(
+            nint haptic,
+            int autocenter
+        );
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticSetGain(
+            nint haptic,
+            int gain
+        );
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticStopAll(nint haptic);
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticStopEffect(
+            nint haptic,
+            int effect
+        );
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticUnpause(nint haptic);
+
+        /* haptic refers to an SDL_Haptic* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_HapticUpdateEffect(
+            nint haptic,
+            int effect,
+            ref SDL_HapticEffect data
+        );
+
+        /* joystick refers to an SDL_Joystick* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_JoystickIsHaptic(nint joystick);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_MouseIsHaptic();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_NumHaptics();
+
+        #endregion
+
+        #region SDL_sensor.h
+
+        /* This region is only available in 2.0.9 or higher. */
+
+        public enum SDL_SensorType
+        {
+            SDL_SENSOR_INVALID = -1,
+            SDL_SENSOR_UNKNOWN,
+            SDL_SENSOR_ACCEL,
+            SDL_SENSOR_GYRO
+        }
+
+        public const float SDL_STANDARD_GRAVITY = 9.80665f;
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_NumSensors();
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_SensorGetDeviceName", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_SensorGetDeviceName(int device_index);
+        public static string SDL_SensorGetDeviceName(int device_index)
+        {
+            return UTF8_ToManaged(INTERNAL_SDL_SensorGetDeviceName(device_index));
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_SensorType SDL_SensorGetDeviceType(int device_index);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SensorGetDeviceNonPortableType(int device_index);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SensorGetDeviceInstanceID(int device_index);
+
+        /* IntPtr refers to an SDL_Sensor* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_SensorOpen(int device_index);
+
+        /* IntPtr refers to an SDL_Sensor* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_SensorFromInstanceID(
+            int instance_id
+        );
+
+        /* sensor refers to an SDL_Sensor* */
+        [DllImport(nativeLibName, EntryPoint = "SDL_SensorGetName", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_SensorGetName(nint sensor);
+        public static string SDL_SensorGetName(nint sensor)
+        {
+            return UTF8_ToManaged(INTERNAL_SDL_SensorGetName(sensor));
+        }
+
+        /* sensor refers to an SDL_Sensor* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_SensorType SDL_SensorGetType(nint sensor);
+
+        /* sensor refers to an SDL_Sensor* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SensorGetNonPortableType(nint sensor);
+
+        /* sensor refers to an SDL_Sensor* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SensorGetInstanceID(nint sensor);
+
+        /* sensor refers to an SDL_Sensor* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_SensorGetData(
+            nint sensor,
+            float[] data,
+            int num_values
+        );
+
+        /* sensor refers to an SDL_Sensor* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SensorClose(nint sensor);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SensorUpdate();
+
+        /* Only available in 2.0.14 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_LockSensors();
+
+        /* Only available in 2.0.14 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_UnlockSensors();
+
+        #endregion
+
+        #region SDL_audio.h
+
+        public const ushort SDL_AUDIO_MASK_BITSIZE = 0xFF;
+        public const ushort SDL_AUDIO_MASK_DATATYPE = 1 << 8;
+        public const ushort SDL_AUDIO_MASK_ENDIAN = 1 << 12;
+        public const ushort SDL_AUDIO_MASK_SIGNED = 1 << 15;
+
+        public static ushort SDL_AUDIO_BITSIZE(ushort x)
+        {
+            return (ushort)(x & SDL_AUDIO_MASK_BITSIZE);
+        }
+
+        public static bool SDL_AUDIO_ISFLOAT(ushort x)
+        {
+            return (x & SDL_AUDIO_MASK_DATATYPE) != 0;
+        }
+
+        public static bool SDL_AUDIO_ISBIGENDIAN(ushort x)
+        {
+            return (x & SDL_AUDIO_MASK_ENDIAN) != 0;
+        }
+
+        public static bool SDL_AUDIO_ISSIGNED(ushort x)
+        {
+            return (x & SDL_AUDIO_MASK_SIGNED) != 0;
+        }
+
+        public static bool SDL_AUDIO_ISINT(ushort x)
+        {
+            return (x & SDL_AUDIO_MASK_DATATYPE) == 0;
+        }
+
+        public static bool SDL_AUDIO_ISLITTLEENDIAN(ushort x)
+        {
+            return (x & SDL_AUDIO_MASK_ENDIAN) == 0;
+        }
+
+        public static bool SDL_AUDIO_ISUNSIGNED(ushort x)
+        {
+            return (x & SDL_AUDIO_MASK_SIGNED) == 0;
+        }
+
+        public const ushort AUDIO_U8 = 0x0008;
+        public const ushort AUDIO_S8 = 0x8008;
+        public const ushort AUDIO_U16LSB = 0x0010;
+        public const ushort AUDIO_S16LSB = 0x8010;
+        public const ushort AUDIO_U16MSB = 0x1010;
+        public const ushort AUDIO_S16MSB = 0x9010;
+        public const ushort AUDIO_U16 = AUDIO_U16LSB;
+        public const ushort AUDIO_S16 = AUDIO_S16LSB;
+        public const ushort AUDIO_S32LSB = 0x8020;
+        public const ushort AUDIO_S32MSB = 0x9020;
+        public const ushort AUDIO_S32 = AUDIO_S32LSB;
+        public const ushort AUDIO_F32LSB = 0x8120;
+        public const ushort AUDIO_F32MSB = 0x9120;
+        public const ushort AUDIO_F32 = AUDIO_F32LSB;
+
+        public static readonly ushort AUDIO_U16SYS =
+            BitConverter.IsLittleEndian ? AUDIO_U16LSB : AUDIO_U16MSB;
+        public static readonly ushort AUDIO_S16SYS =
+            BitConverter.IsLittleEndian ? AUDIO_S16LSB : AUDIO_S16MSB;
+        public static readonly ushort AUDIO_S32SYS =
+            BitConverter.IsLittleEndian ? AUDIO_S32LSB : AUDIO_S32MSB;
+        public static readonly ushort AUDIO_F32SYS =
+            BitConverter.IsLittleEndian ? AUDIO_F32LSB : AUDIO_F32MSB;
+
+        public const uint SDL_AUDIO_ALLOW_FREQUENCY_CHANGE = 0x00000001;
+        public const uint SDL_AUDIO_ALLOW_FORMAT_CHANGE = 0x00000002;
+        public const uint SDL_AUDIO_ALLOW_CHANNELS_CHANGE = 0x00000004;
+        public const uint SDL_AUDIO_ALLOW_SAMPLES_CHANGE = 0x00000008;
+        public const uint SDL_AUDIO_ALLOW_ANY_CHANGE =
+            SDL_AUDIO_ALLOW_FREQUENCY_CHANGE |
+            SDL_AUDIO_ALLOW_FORMAT_CHANGE |
+            SDL_AUDIO_ALLOW_CHANNELS_CHANGE |
+            SDL_AUDIO_ALLOW_SAMPLES_CHANGE
+        ;
+
+        public const int SDL_MIX_MAXVOLUME = 128;
+
+        public enum SDL_AudioStatus
+        {
+            SDL_AUDIO_STOPPED,
+            SDL_AUDIO_PLAYING,
+            SDL_AUDIO_PAUSED
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_AudioSpec
+        {
+            public int freq;
+            public ushort format; // SDL_AudioFormat
+            public byte channels;
+            public byte silence;
+            public ushort samples;
+            public uint size;
+            public SDL_AudioCallback callback;
+            public nint userdata; // void*
+        }
+
+        /* userdata refers to a void*, stream to a Uint8 */
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void SDL_AudioCallback(
+            nint userdata,
+            nint stream,
+            int len
+        );
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_AudioInit", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe int INTERNAL_SDL_AudioInit(
+            byte* driver_name
+        );
+        public static unsafe int SDL_AudioInit(string driver_name)
+        {
+            int utf8DriverNameBufSize = Utf8Size(driver_name);
+            byte* utf8DriverName = stackalloc byte[utf8DriverNameBufSize];
+            return INTERNAL_SDL_AudioInit(
+                Utf8Encode(driver_name, utf8DriverName, utf8DriverNameBufSize)
+            );
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_AudioQuit();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_CloseAudio();
+
+        /* dev refers to an SDL_AudioDeviceID */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_CloseAudioDevice(uint dev);
+
+        /* audio_buf refers to a malloc()'d buffer from SDL_LoadWAV */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_FreeWAV(nint audio_buf);
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetAudioDeviceName", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetAudioDeviceName(
+            int index,
+            int iscapture
+        );
+        public static string SDL_GetAudioDeviceName(
+            int index,
+            int iscapture
+        )
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GetAudioDeviceName(index, iscapture)
+            );
+        }
+
+        /* dev refers to an SDL_AudioDeviceID */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_AudioStatus SDL_GetAudioDeviceStatus(
+            uint dev
+        );
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetAudioDriver", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetAudioDriver(int index);
+        public static string SDL_GetAudioDriver(int index)
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GetAudioDriver(index)
+            );
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_AudioStatus SDL_GetAudioStatus();
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetCurrentAudioDriver", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetCurrentAudioDriver();
+        public static string SDL_GetCurrentAudioDriver()
+        {
+            return UTF8_ToManaged(INTERNAL_SDL_GetCurrentAudioDriver());
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetNumAudioDevices(int iscapture);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetNumAudioDrivers();
+
+        /* audio_buf refers to a malloc()'d buffer, IntPtr to an SDL_AudioSpec* */
+        /* THIS IS AN RWops FUNCTION! */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_LoadWAV_RW(
+            nint src,
+            int freesrc,
+            out SDL_AudioSpec spec,
+            out nint audio_buf,
+            out uint audio_len
+        );
+        public static nint SDL_LoadWAV(
+            string file,
+            out SDL_AudioSpec spec,
+            out nint audio_buf,
+            out uint audio_len
+        )
+        {
+            nint rwops = SDL_RWFromFile(file, "rb");
+            return SDL_LoadWAV_RW(
+                rwops,
+                1,
+                out spec,
+                out audio_buf,
+                out audio_len
+            );
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_LockAudio();
+
+        /* dev refers to an SDL_AudioDeviceID */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_LockAudioDevice(uint dev);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_MixAudio(
+            [Out()] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeParamIndex = 2)]
+                byte[] dst,
+            [In()] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeParamIndex = 2)]
+                byte[] src,
+            uint len,
+            int volume
+        );
+
+        /* format refers to an SDL_AudioFormat */
+        /* This overload allows raw pointers to be passed for dst and src. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_MixAudioFormat(
+            nint dst,
+            nint src,
+            ushort format,
+            uint len,
+            int volume
+        );
+
+        /* format refers to an SDL_AudioFormat */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_MixAudioFormat(
+            [Out()] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeParamIndex = 3)]
+                byte[] dst,
+            [In()] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeParamIndex = 3)]
+                byte[] src,
+            ushort format,
+            uint len,
+            int volume
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_OpenAudio(
+            ref SDL_AudioSpec desired,
+            out SDL_AudioSpec obtained
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_OpenAudio(
+            ref SDL_AudioSpec desired,
+            nint obtained
+        );
+
+        /* uint refers to an SDL_AudioDeviceID */
+        /* This overload allows for IntPtr.Zero (null) to be passed for device. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe uint SDL_OpenAudioDevice(
+            nint device,
+            int iscapture,
+            ref SDL_AudioSpec desired,
+            out SDL_AudioSpec obtained,
+            int allowed_changes
+        );
+
+        /* uint refers to an SDL_AudioDeviceID */
+        [DllImport(nativeLibName, EntryPoint = "SDL_OpenAudioDevice", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe uint INTERNAL_SDL_OpenAudioDevice(
+            byte* device,
+            int iscapture,
+            ref SDL_AudioSpec desired,
+            out SDL_AudioSpec obtained,
+            int allowed_changes
+        );
+        public static unsafe uint SDL_OpenAudioDevice(
+            string device,
+            int iscapture,
+            ref SDL_AudioSpec desired,
+            out SDL_AudioSpec obtained,
+            int allowed_changes
+        )
+        {
+            int utf8DeviceBufSize = Utf8Size(device);
+            byte* utf8Device = stackalloc byte[utf8DeviceBufSize];
+            return INTERNAL_SDL_OpenAudioDevice(
+                Utf8Encode(device, utf8Device, utf8DeviceBufSize),
+                iscapture,
+                ref desired,
+                out obtained,
+                allowed_changes
+            );
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_PauseAudio(int pause_on);
+
+        /* dev refers to an SDL_AudioDeviceID */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_PauseAudioDevice(
+            uint dev,
+            int pause_on
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_UnlockAudio();
+
+        /* dev refers to an SDL_AudioDeviceID */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_UnlockAudioDevice(uint dev);
+
+        /* dev refers to an SDL_AudioDeviceID, data to a void*
+		 * Only available in 2.0.4 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_QueueAudio(
+            uint dev,
+            nint data,
+            uint len
+        );
+
+        /* dev refers to an SDL_AudioDeviceID, data to a void*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_DequeueAudio(
+            uint dev,
+            nint data,
+            uint len
+        );
+
+        /* dev refers to an SDL_AudioDeviceID
+		 * Only available in 2.0.4 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_GetQueuedAudioSize(uint dev);
+
+        /* dev refers to an SDL_AudioDeviceID
+		 * Only available in 2.0.4 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_ClearQueuedAudio(uint dev);
+
+        /* src_format and dst_format refer to SDL_AudioFormats.
+		 * IntPtr refers to an SDL_AudioStream*.
+		 * Only available in 2.0.7 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_NewAudioStream(
+            ushort src_format,
+            byte src_channels,
+            int src_rate,
+            ushort dst_format,
+            byte dst_channels,
+            int dst_rate
+        );
+
+        /* stream refers to an SDL_AudioStream*, buf to a void*.
+		 * Only available in 2.0.7 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_AudioStreamPut(
+            nint stream,
+            nint buf,
+            int len
+        );
+
+        /* stream refers to an SDL_AudioStream*, buf to a void*.
+		 * Only available in 2.0.7 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_AudioStreamGet(
+            nint stream,
+            nint buf,
+            int len
+        );
+
+        /* stream refers to an SDL_AudioStream*.
+		 * Only available in 2.0.7 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_AudioStreamAvailable(nint stream);
+
+        /* stream refers to an SDL_AudioStream*.
+		 * Only available in 2.0.7 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_AudioStreamClear(nint stream);
+
+        /* stream refers to an SDL_AudioStream*.
+		 * Only available in 2.0.7 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_FreeAudioStream(nint stream);
+
+        /* Only available in 2.0.16 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetAudioDeviceSpec(
+            int index,
+            int iscapture,
+            out SDL_AudioSpec spec
+        );
+
+        #endregion
+
+        #region SDL_timer.h
+
+        /* System timers rely on different OS mechanisms depending on
+		 * which operating system SDL2 is compiled against.
+		 */
+
+        /* Compare tick values, return true if A has passed B. Introduced in SDL 2.0.1,
+		 * but does not require it (it was a macro).
+		 */
+        public static bool SDL_TICKS_PASSED(uint A, uint B)
+        {
+            return (int)(B - A) <= 0;
+        }
+
+        /* Delays the thread's processing based on the milliseconds parameter */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_Delay(uint ms);
+
+        /* Returns the milliseconds that have passed since SDL was initialized */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_GetTicks();
+
+        /* Returns the milliseconds that have passed since SDL was initialized
+		 * Only available in 2.0.18 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ulong SDL_GetTicks64();
+
+        /* Get the current value of the high resolution counter */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ulong SDL_GetPerformanceCounter();
+
+        /* Get the count per second of the high resolution counter */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ulong SDL_GetPerformanceFrequency();
+
+        /* param refers to a void* */
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate uint SDL_TimerCallback(uint interval, nint param);
+
+        /* int refers to an SDL_TimerID, param to a void* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_AddTimer(
+            uint interval,
+            SDL_TimerCallback callback,
+            nint param
+        );
+
+        /* id refers to an SDL_TimerID */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_RemoveTimer(int id);
+
+        #endregion
+
+        #region SDL_system.h
+
+        /* Windows */
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate nint SDL_WindowsMessageHook(
+            nint userdata,
+            nint hWnd,
+            uint message,
+            ulong wParam,
+            long lParam
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SetWindowsMessageHook(
+            SDL_WindowsMessageHook callback,
+            nint userdata
+        );
+
+        /* renderer refers to an SDL_Renderer*
+		 * IntPtr refers to an IDirect3DDevice9*
+		 * Only available in 2.0.1 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_RenderGetD3D9Device(nint renderer);
+
+        /* renderer refers to an SDL_Renderer*
+		 * IntPtr refers to an ID3D11Device*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_RenderGetD3D11Device(nint renderer);
+
+        /* iOS */
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void SDL_iPhoneAnimationCallback(nint p);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_iPhoneSetAnimationCallback(
+            nint window, /* SDL_Window* */
+            int interval,
+            SDL_iPhoneAnimationCallback callback,
+            nint callbackParam
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_iPhoneSetEventPump(SDL_bool enabled);
+
+        /* Android */
+
+        public const int SDL_ANDROID_EXTERNAL_STORAGE_READ = 0x01;
+        public const int SDL_ANDROID_EXTERNAL_STORAGE_WRITE = 0x02;
+
+        /* IntPtr refers to a JNIEnv* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_AndroidGetJNIEnv();
+
+        /* IntPtr refers to a jobject */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_AndroidGetActivity();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_IsAndroidTV();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_IsChromebook();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_IsDeXMode();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_AndroidBackButton();
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_AndroidGetInternalStoragePath", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_AndroidGetInternalStoragePath();
+
+        public static string SDL_AndroidGetInternalStoragePath()
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_AndroidGetInternalStoragePath()
+            );
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_AndroidGetExternalStorageState();
+
+        [DllImport(nativeLibName, EntryPoint = "SDL_AndroidGetExternalStoragePath", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_AndroidGetExternalStoragePath();
+
+        public static string SDL_AndroidGetExternalStoragePath()
+        {
+            return UTF8_ToManaged(
+                INTERNAL_SDL_AndroidGetExternalStoragePath()
+            );
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetAndroidSDKVersion();
+
+        /* Only available in 2.0.14 or higher. */
+        [DllImport(nativeLibName, EntryPoint = "SDL_AndroidRequestPermission", CallingConvention = CallingConvention.Cdecl)]
+        private static unsafe extern SDL_bool INTERNAL_SDL_AndroidRequestPermission(
+            byte* permission
+        );
+        public static unsafe SDL_bool SDL_AndroidRequestPermission(
+            string permission
+        )
+        {
+            byte* permissionPtr = Utf8EncodeHeap(permission);
+            SDL_bool result = INTERNAL_SDL_AndroidRequestPermission(
+                permissionPtr
+            );
+            Marshal.FreeHGlobal((nint)permissionPtr);
+            return result;
+        }
+
+        /* Only available in 2.0.16 or higher. */
+        [DllImport(nativeLibName, EntryPoint = "SDL_AndroidShowToast", CallingConvention = CallingConvention.Cdecl)]
+        private static unsafe extern int INTERNAL_SDL_AndroidShowToast(
+            byte* message,
+            int duration,
+            int gravity,
+            int xOffset,
+            int yOffset
+        );
+        public static unsafe int SDL_AndroidShowToast(
+            string message,
+            int duration,
+            int gravity,
+            int xOffset,
+            int yOffset
+        )
+        {
+            byte* messagePtr = Utf8EncodeHeap(message);
+            int result = INTERNAL_SDL_AndroidShowToast(
+                messagePtr,
+                duration,
+                gravity,
+                xOffset,
+                yOffset
+            );
+            Marshal.FreeHGlobal((nint)messagePtr);
+            return result;
+        }
+
+        /* WinRT */
+
+        public enum SDL_WinRT_DeviceFamily
+        {
+            SDL_WINRT_DEVICEFAMILY_UNKNOWN,
+            SDL_WINRT_DEVICEFAMILY_DESKTOP,
+            SDL_WINRT_DEVICEFAMILY_MOBILE,
+            SDL_WINRT_DEVICEFAMILY_XBOX
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_WinRT_DeviceFamily SDL_WinRTGetDeviceFamily();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_IsTablet();
+
+        #endregion
+
+        #region SDL_syswm.h
+
+        public enum SDL_SYSWM_TYPE
+        {
+            SDL_SYSWM_UNKNOWN,
+            SDL_SYSWM_WINDOWS,
+            SDL_SYSWM_X11,
+            SDL_SYSWM_DIRECTFB,
+            SDL_SYSWM_COCOA,
+            SDL_SYSWM_UIKIT,
+            SDL_SYSWM_WAYLAND,
+            SDL_SYSWM_MIR,
+            SDL_SYSWM_WINRT,
+            SDL_SYSWM_ANDROID,
+            SDL_SYSWM_VIVANTE,
+            SDL_SYSWM_OS2,
+            SDL_SYSWM_HAIKU,
+            SDL_SYSWM_KMSDRM /* requires >= 2.0.16 */
+        }
+
+        // FIXME: I wish these weren't public...
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INTERNAL_windows_wminfo
+        {
+            public nint window; // Refers to an HWND
+            public nint hdc; // Refers to an HDC
+            public nint hinstance; // Refers to an HINSTANCE
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INTERNAL_winrt_wminfo
+        {
+            public nint window; // Refers to an IInspectable*
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INTERNAL_x11_wminfo
+        {
+            public nint display; // Refers to a Display*
+            public nint window; // Refers to a Window (XID, use ToInt64!)
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INTERNAL_directfb_wminfo
+        {
+            public nint dfb; // Refers to an IDirectFB*
+            public nint window; // Refers to an IDirectFBWindow*
+            public nint surface; // Refers to an IDirectFBSurface*
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INTERNAL_cocoa_wminfo
+        {
+            public nint window; // Refers to an NSWindow*
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INTERNAL_uikit_wminfo
+        {
+            public nint window; // Refers to a UIWindow*
+            public uint framebuffer;
+            public uint colorbuffer;
+            public uint resolveFramebuffer;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INTERNAL_wayland_wminfo
+        {
+            public nint display; // Refers to a wl_display*
+            public nint surface; // Refers to a wl_surface*
+            public nint shell_surface; // Refers to a wl_shell_surface*
+            public nint egl_window; // Refers to an egl_window*, requires >= 2.0.16
+            public nint xdg_surface; // Refers to an xdg_surface*, requires >= 2.0.16
+            public nint xdg_toplevel; // Referes to an xdg_toplevel*, requires >= 2.0.18
+            public nint xdg_popup;
+            public nint xdg_positioner;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INTERNAL_mir_wminfo
+        {
+            public nint connection; // Refers to a MirConnection*
+            public nint surface; // Refers to a MirSurface*
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INTERNAL_android_wminfo
+        {
+            public nint window; // Refers to an ANativeWindow
+            public nint surface; // Refers to an EGLSurface
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INTERNAL_vivante_wminfo
+        {
+            public nint display; // Refers to an EGLNativeDisplayType
+            public nint window; // Refers to an EGLNativeWindowType
+        }
+
+        /* Only available in 2.0.14 or higher. */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INTERNAL_os2_wminfo
+        {
+            public nint hwnd; // Refers to an HWND
+            public nint hwndFrame; // Refers to an HWND
+        }
+
+        /* Only available in 2.0.16 or higher. */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INTERNAL_kmsdrm_wminfo
+        {
+            int dev_index;
+            int drm_fd;
+            nint gbm_dev; // Refers to a gbm_device*
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        public struct INTERNAL_SysWMDriverUnion
+        {
+            [FieldOffset(0)]
+            public INTERNAL_windows_wminfo win;
+            [FieldOffset(0)]
+            public INTERNAL_winrt_wminfo winrt;
+            [FieldOffset(0)]
+            public INTERNAL_x11_wminfo x11;
+            [FieldOffset(0)]
+            public INTERNAL_directfb_wminfo dfb;
+            [FieldOffset(0)]
+            public INTERNAL_cocoa_wminfo cocoa;
+            [FieldOffset(0)]
+            public INTERNAL_uikit_wminfo uikit;
+            [FieldOffset(0)]
+            public INTERNAL_wayland_wminfo wl;
+            [FieldOffset(0)]
+            public INTERNAL_mir_wminfo mir;
+            [FieldOffset(0)]
+            public INTERNAL_android_wminfo android;
+            [FieldOffset(0)]
+            public INTERNAL_os2_wminfo os2;
+            [FieldOffset(0)]
+            public INTERNAL_vivante_wminfo vivante;
+            [FieldOffset(0)]
+            public INTERNAL_kmsdrm_wminfo ksmdrm;
+            // private int dummy;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_SysWMinfo
+        {
+            public SDL_version version;
+            public SDL_SYSWM_TYPE subsystem;
+            public INTERNAL_SysWMDriverUnion info;
+        }
+
+        /* window refers to an SDL_Window* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_GetWindowWMInfo(
+            nint window,
+            ref SDL_SysWMinfo info
+        );
+
+        #endregion
+
+        #region SDL_filesystem.h
+
+        /* Only available in 2.0.1 or higher. */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetBasePath", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_SDL_GetBasePath();
+        public static string SDL_GetBasePath()
+        {
+            return UTF8_ToManaged(INTERNAL_SDL_GetBasePath(), true);
+        }
+
+        /* Only available in 2.0.1 or higher. */
+        [DllImport(nativeLibName, EntryPoint = "SDL_GetPrefPath", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_SDL_GetPrefPath(
+            byte* org,
+            byte* app
+        );
+        public static unsafe string SDL_GetPrefPath(string org, string app)
+        {
+            int utf8OrgBufSize = Utf8Size(org);
+            byte* utf8Org = stackalloc byte[utf8OrgBufSize];
+
+            int utf8AppBufSize = Utf8Size(app);
+            byte* utf8App = stackalloc byte[utf8AppBufSize];
+
+            return UTF8_ToManaged(
+                INTERNAL_SDL_GetPrefPath(
+                    Utf8Encode(org, utf8Org, utf8OrgBufSize),
+                    Utf8Encode(app, utf8App, utf8AppBufSize)
+                ),
+                true
+            );
+        }
+
+        #endregion
+
+        #region SDL_power.h
+
+        public enum SDL_PowerState
+        {
+            SDL_POWERSTATE_UNKNOWN = 0,
+            SDL_POWERSTATE_ON_BATTERY,
+            SDL_POWERSTATE_NO_BATTERY,
+            SDL_POWERSTATE_CHARGING,
+            SDL_POWERSTATE_CHARGED
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_PowerState SDL_GetPowerInfo(
+            out int secs,
+            out int pct
+        );
+
+        #endregion
+
+        #region SDL_cpuinfo.h
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetCPUCount();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetCPUCacheLineSize();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasRDTSC();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasAltiVec();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasMMX();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_Has3DNow();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasSSE();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasSSE2();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasSSE3();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasSSE41();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasSSE42();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasAVX();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasAVX2();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasAVX512F();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasNEON();
+
+        /* Only available in 2.0.1 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetSystemRAM();
+
+        /* Only available in SDL 2.0.10 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_SIMDGetAlignment();
+
+        /* Only available in SDL 2.0.10 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_SIMDAlloc(uint len);
+
+        /* Only available in SDL 2.0.14 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_SIMDRealloc(nint ptr, uint len);
+
+        /* Only available in SDL 2.0.10 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_SIMDFree(nint ptr);
+
+        /* Only available in SDL 2.0.11 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern SDL_bool SDL_HasARMSIMD();
+
+        #endregion
+
+        #region SDL_locale.h
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_Locale
+        {
+            public nint language; /* char* */
+            public nint country; /* char* */
+        }
+
+        /* IntPtr refers to an SDL_Locale*.
+		 * Only available in 2.0.14 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint SDL_GetPreferredLocales();
+
+        #endregion
+
+        #region SDL_misc.h
+
+        /* Only available in 2.0.14 or higher. */
+        [DllImport(nativeLibName, EntryPoint = "SDL_OpenURL", CallingConvention = CallingConvention.Cdecl)]
+        private static unsafe extern int INTERNAL_SDL_OpenURL(byte* url);
+        public static unsafe int SDL_OpenURL(string url)
+        {
+            byte* urlPtr = Utf8EncodeHeap(url);
+            int result = INTERNAL_SDL_OpenURL(urlPtr);
+            Marshal.FreeHGlobal((nint)urlPtr);
+            return result;
+        }
+
+        #endregion
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiLL/ImGui2_More.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiLL/ImGui2_More.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AbstUI.ImGui.ImGuiLL
+{
+    public static partial class SDL_gfx
+    {
+        [DllImport("SDL2_gfx")]
+        public static extern int stringColor(IntPtr renderer, int x, int y, string text, uint color);
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiLL/ImGui2_gfx.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiLL/ImGui2_gfx.cs
@@ -1,0 +1,390 @@
+#region License
+/* SDL2# - C# Wrapper for SDL2
+ *
+ * Copyright (c) 2013-2024 Ethan Lee.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software in a
+ * product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * Ethan "flibitijibibo" Lee <flibitijibibo@flibitijibibo.com>
+ *
+ */
+#endregion
+
+#region Using Statements
+using System;
+using System.Runtime.InteropServices;
+#endregion
+
+namespace AbstUI.ImGui.ImGuiLL
+{
+    public static partial class SDL_gfx
+    {
+        #region SDL2# Variables
+
+        /* Used by DllImport to load the native library. */
+        private const string nativeLibName = "SDL2_gfx";
+
+        #endregion
+
+        public const double M_PI = 3.1415926535897932384626433832795;
+
+        #region SDL2_gfxPrimitives.h
+
+        public const uint SDL2_GFXPRIMITIVES_MAJOR = 1;
+        public const uint SDL2_GFXPRIMITIVES_MINOR = 0;
+        public const uint SDL2_GFXPRIMITIVES_MICRO = 1;
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int pixelColor(nint renderer, short x, short y, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int pixelRGBA(nint renderer, short x, short y, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hlineColor(nint renderer, short x1, short x2, short y, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hlineRGBA(nint renderer, short x1, short x2, short y, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int vlineColor(nint renderer, short x, short y1, short y2, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int vlineRGBA(nint renderer, short x, short y1, short y2, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int rectangleColor(nint renderer, short x1, short y1, short x2, short y2, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int rectangleRGBA(nint renderer, short x1, short y1, short x2, short y2, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int roundedRectangleColor(nint renderer, short x1, short y1, short x2, short y2, short rad, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int roundedRectangleRGBA(nint renderer, short x1, short y1, short x2, short y2, short rad, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int boxColor(nint renderer, short x1, short y1, short x2, short y2, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int boxRGBA(nint renderer, short x1, short y1, short x2, short y2, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int roundedBoxColor(nint renderer, short x1, short y1, short x2, short y2, short rad, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int roundedBoxRGBA(nint renderer, short x1, short y1, short x2, short y2, short rad, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int lineColor(nint renderer, short x1, short y1, short x2, short y2, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int lineRGBA(nint renderer, short x1, short y1, short x2, short y2, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int aalineColor(nint renderer, short x1, short y1, short x2, short y2, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int aalineRGBA(nint renderer, short x1, short y1, short x2, short y2, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int thickLineColor(nint renderer, short x1, short y1, short x2, short y2, byte width, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int thickLineRGBA(nint renderer, short x1, short y1, short x2, short y2, byte width, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int circleColor(nint renderer, short x, short y, short rad, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int circleRGBA(nint renderer, short x, short y, short rad, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int arcColor(nint renderer, short x, short y, short rad, short start, short end, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int arcRGBA(nint renderer, short x, short y, short rad, short start, short end, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int aacircleColor(nint renderer, short x, short y, short rad, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int aacircleRGBA(nint renderer, short x, short y, short rad, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int filledCircleColor(nint renderer, short x, short y, short rad, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int filledCircleRGBA(nint renderer, short x, short y, short rad, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int ellipseColor(nint renderer, short x, short y, short rx, short ry, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int ellipseRGBA(nint renderer, short x, short y, short rx, short ry, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int aaellipseColor(nint renderer, short x, short y, short rx, short ry, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int aaellipseRGBA(nint renderer, short x, short y, short rx, short ry, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int filledEllipseColor(nint renderer, short x, short y, short rx, short ry, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int filledEllipseRGBA(nint renderer, short x, short y, short rx, short ry, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int pieColor(nint renderer, short x, short y, short rad, short start, short end, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int pieRGBA(nint renderer, short x, short y, short rad, short start, short end, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int filledPieColor(nint renderer, short x, short y, short rad, short start, short end, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int filledPieRGBA(nint renderer, short x, short y, short rad, short start, short end, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int trigonColor(nint renderer, short x1, short y1, short x2, short y2, short x3, short y3, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int trigonRGBA(nint renderer, short x1, short y1, short x2, short y2, short x3, short y3, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int aatrigonColor(nint renderer, short x1, short y1, short x2, short y2, short x3, short y3, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int aatrigonRGBA(nint renderer, short x1, short y1, short x2, short y2, short x3, short y3, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int filledTrigonColor(nint renderer, short x1, short y1, short x2, short y2, short x3, short y3, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int filledTrigonRGBA(nint renderer, short x1, short y1, short x2, short y2, short x3, short y3, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int polygonColor(nint renderer, [In] short[] vx, [In] short[] vy, int n, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int polygonRGBA(nint renderer, [In] short[] vx, [In] short[] vy, int n, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int aapolygonColor(nint renderer, [In] short[] vx, [In] short[] vy, int n, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int aapolygonRGBA(nint renderer, [In] short[] vx, [In] short[] vy, int n, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int filledPolygonColor(nint renderer, [In] short[] vx, [In] short[] vy, int n, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int filledPolygonRGBA(nint renderer, [In] short[] vx, [In] short[] vy, int n, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int texturedPolygon(nint renderer, [In] short[] vx, [In] short[] vy, int n, nint texture, int texture_dx, int texture_dy);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int bezierColor(nint renderer, [In] short[] vx, [In] short[] vy, int n, int s, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int bezierRGBA(nint renderer, [In] short[] vx, [In] short[] vy, int n, int s, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void gfxPrimitivesSetFont([In] byte[] fontdata, uint cw, uint ch);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void gfxPrimitivesSetFontRotation(uint rotation);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int characterColor(nint renderer, short x, short y, char c, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int characterRGBA(nint renderer, short x, short y, char c, byte r, byte g, byte b, byte a);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int stringColor(nint renderer, short x, short y, string s, uint color);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int stringRGBA(nint renderer, short x, short y, string s, byte r, byte g, byte b, byte a);
+
+        #endregion
+
+        #region SDL2_rotozoom.h
+
+        public const int SMOOTHING_OFF = 0;
+        public const int SMOOTHING_ON = 1;
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint rotozoomSurface(nint src, double angle, double zoom, int smooth);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint rotozoomSurfaceXY(nint src, double angle, double zoomx, double zoomy, int smooth);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void rotozoomSurfaceSize(int width, int height, double angle, double zoom, out int dstwidth, out int dstheight);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void rotozoomSurfaceSizeXY(int width, int height, double angle, double zoomx, double zoomy, out int dstwidth, out int dstheight);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint zoomSurface(nint src, double zoomx, double zoomy, int smooth);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void zoomSurfaceSize(int width, int height, double zoomx, double zoomy, out int dstwidth, out int dstheight);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint shrinkSurface(nint src, int factorx, int factory);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint rotateSurface90Degrees(nint src, int numClockwiseTurns);
+
+        #endregion
+
+        #region SDL2_framerate.h
+
+        public const int FPS_UPPER_LIMIT = 200;
+        public const int FPS_LOWER_LIMIT = 1;
+        public const int FPS_DEFAULT = 30;
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct FPSmanager
+        {
+            public uint framecount;
+            public float rateticks;
+            public uint baseticks;
+            public uint lastticks;
+            public uint rate;
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_initFramerate(ref FPSmanager manager);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_setFramerate(ref FPSmanager manager, uint rate);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_getFramerate(ref FPSmanager manager);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_getFramecount(ref FPSmanager manager);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint SDL_framerateDelay(ref FPSmanager manager);
+
+        #endregion
+
+        #region SDL2_imageFilter.h
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterMMXdetect();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_imageFilterMMXoff();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_imageFilterMMXon();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterAdd([In] byte[] src1, [In] byte[] src2, [Out] byte[] dest, uint length);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterMean([In] byte[] src1, [In] byte[] src2, [Out] byte[] dest, uint length);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterSub([In] byte[] src1, [In] byte[] src2, [Out] byte[] dest, uint length);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterAbsDiff([In] byte[] src1, [In] byte[] src2, [Out] byte[] dest, uint length);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterMult([In] byte[] src1, [In] byte[] src2, [Out] byte[] dest, uint length);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterMultNor([In] byte[] src1, [In] byte[] src2, [Out] byte[] dest, uint length);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterMultDivby2([In] byte[] src1, [In] byte[] src2, [Out] byte[] dest, uint length);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterMultDivby4([In] byte[] src1, [In] byte[] src2, [Out] byte[] dest, uint length);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterBitAnd([In] byte[] src1, [In] byte[] src2, [Out] byte[] dest, uint length);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterBitOr([In] byte[] src1, [In] byte[] src2, [Out] byte[] dest, uint length);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterDiv([In] byte[] src1, [In] byte[] src2, [Out] byte[] dest, uint length);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterBitNegation([In] byte[] src1, [Out] byte[] dest, uint length);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterAddByte([In] byte[] src1, [Out] byte[] dest, uint length, byte c);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterAddUint([In] byte[] src1, [Out] byte[] dest, uint length, uint c);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterAddByteToHalf([In] byte[] src1, [Out] byte[] dest, uint length, byte c);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterSubByte([In] byte[] src1, [Out] byte[] dest, uint length, byte c);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterSubUint([In] byte[] src1, [Out] byte[] dest, uint length, uint c);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterShiftRight([In] byte[] src1, [Out] byte[] dest, uint length, byte n);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterShiftRightUint([In] byte[] src1, [Out] byte[] dest, uint length, byte n);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterMultByByte([In] byte[] src1, [Out] byte[] dest, uint length, byte c);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterShiftRightAndMultByByte([In] byte[] src1, [Out] byte[] dest, uint length, byte n, byte c);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterShiftLeftByte([In] byte[] src1, [Out] byte[] dest, uint length, byte n);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterShiftLeftUint([In] byte[] src1, [Out] byte[] dest, uint length, byte n);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterShiftLeft([In] byte[] src1, [Out] byte[] dest, uint length, byte n);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterBinarizeUsingThreshold([In] byte[] src1, [Out] byte[] dest, uint length, byte t);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterClipToRange([In] byte[] src1, [Out] byte[] dest, uint length, byte tmin, byte tmax);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_imageFilterNormalizeLinear([In] byte[] src1, [Out] byte[] dest, uint length, int cmin, int cmax, int nmin, int nmax);
+
+        #endregion
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiLL/ImGui2_image.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiLL/ImGui2_image.cs
@@ -1,0 +1,319 @@
+#region License
+/* SDL2# - C# Wrapper for SDL2
+ *
+ * Copyright (c) 2013-2024 Ethan Lee.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software in a
+ * product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * Ethan "flibitijibibo" Lee <flibitijibibo@flibitijibibo.com>
+ *
+ */
+#endregion
+
+#region Using Statements
+using System;
+using System.Runtime.InteropServices;
+#endregion
+
+namespace AbstUI.ImGui.ImGuiLL
+{
+    public static class SDL_image
+    {
+        #region SDL2# Variables
+
+        /* Used by DllImport to load the native library. */
+        private const string nativeLibName = "SDL2_image";
+
+        #endregion
+
+        #region SDL_image.h
+
+        /* Similar to the headers, this is the version we're expecting to be
+		 * running with. You will likely want to check this somewhere in your
+		 * program!
+		 */
+        public const int SDL_IMAGE_MAJOR_VERSION = 2;
+        public const int SDL_IMAGE_MINOR_VERSION = 0;
+        public const int SDL_IMAGE_PATCHLEVEL = 6;
+
+        [Flags]
+        public enum IMG_InitFlags
+        {
+            IMG_INIT_JPG = 0x00000001,
+            IMG_INIT_PNG = 0x00000002,
+            IMG_INIT_TIF = 0x00000004,
+            IMG_INIT_WEBP = 0x00000008
+        }
+
+        public static void SDL_IMAGE_VERSION(out SDL.SDL_version X)
+        {
+            X.major = SDL_IMAGE_MAJOR_VERSION;
+            X.minor = SDL_IMAGE_MINOR_VERSION;
+            X.patch = SDL_IMAGE_PATCHLEVEL;
+        }
+
+        [DllImport(nativeLibName, EntryPoint = "IMG_Linked_Version", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_IMG_Linked_Version();
+        public static SDL.SDL_version IMG_Linked_Version()
+        {
+            SDL.SDL_version result;
+            nint result_ptr = INTERNAL_IMG_Linked_Version();
+            result = SDL.PtrToStructure<SDL.SDL_version>(
+                result_ptr
+            );
+            return result;
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int IMG_Init(IMG_InitFlags flags);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void IMG_Quit();
+
+        /* IntPtr refers to an SDL_Surface* */
+        [DllImport(nativeLibName, EntryPoint = "IMG_Load", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_IMG_Load(
+            byte* file
+        );
+        public static unsafe nint IMG_Load(string file)
+        {
+            byte* utf8File = SDL.Utf8EncodeHeap(file);
+            nint handle = INTERNAL_IMG_Load(
+                utf8File
+            );
+            Marshal.FreeHGlobal((nint)utf8File);
+            return handle;
+        }
+
+        /* src refers to an SDL_RWops*, IntPtr to an SDL_Surface* */
+        /* THIS IS A PUBLIC RWops FUNCTION! */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint IMG_Load_RW(
+            nint src,
+            int freesrc
+        );
+
+        /* src refers to an SDL_RWops*, IntPtr to an SDL_Surface* */
+        /* THIS IS A PUBLIC RWops FUNCTION! */
+        [DllImport(nativeLibName, EntryPoint = "IMG_LoadTyped_RW", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_IMG_LoadTyped_RW(
+            nint src,
+            int freesrc,
+            byte* type
+        );
+        public static unsafe nint IMG_LoadTyped_RW(
+            nint src,
+            int freesrc,
+            string type
+        )
+        {
+            int utf8TypeBufSize = SDL.Utf8Size(type);
+            byte* utf8Type = stackalloc byte[utf8TypeBufSize];
+            return INTERNAL_IMG_LoadTyped_RW(
+                src,
+                freesrc,
+                SDL.Utf8Encode(type, utf8Type, utf8TypeBufSize)
+            );
+        }
+
+        /* IntPtr refers to an SDL_Texture*, renderer to an SDL_Renderer* */
+        [DllImport(nativeLibName, EntryPoint = "IMG_LoadTexture", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_IMG_LoadTexture(
+            nint renderer,
+            byte* file
+        );
+        public static unsafe nint IMG_LoadTexture(
+            nint renderer,
+            string file
+        )
+        {
+            byte* utf8File = SDL.Utf8EncodeHeap(file);
+            nint handle = INTERNAL_IMG_LoadTexture(
+                renderer,
+                utf8File
+            );
+            Marshal.FreeHGlobal((nint)utf8File);
+            return handle;
+        }
+
+        /* renderer refers to an SDL_Renderer*.
+		 * src refers to an SDL_RWops*.
+		 * IntPtr to an SDL_Texture*.
+		 */
+        /* THIS IS A PUBLIC RWops FUNCTION! */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint IMG_LoadTexture_RW(
+            nint renderer,
+            nint src,
+            int freesrc
+        );
+
+        /* renderer refers to an SDL_Renderer*.
+		 * src refers to an SDL_RWops*.
+		 * IntPtr to an SDL_Texture*.
+		 */
+        /* THIS IS A PUBLIC RWops FUNCTION! */
+        [DllImport(nativeLibName, EntryPoint = "IMG_LoadTextureTyped_RW", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_IMG_LoadTextureTyped_RW(
+            nint renderer,
+            nint src,
+            int freesrc,
+            byte* type
+        );
+        public static unsafe nint IMG_LoadTextureTyped_RW(
+            nint renderer,
+            nint src,
+            int freesrc,
+            string type
+        )
+        {
+            byte* utf8Type = SDL.Utf8EncodeHeap(type);
+            nint handle = INTERNAL_IMG_LoadTextureTyped_RW(
+                renderer,
+                src,
+                freesrc,
+                utf8Type
+            );
+            Marshal.FreeHGlobal((nint)utf8Type);
+            return handle;
+        }
+
+        /* IntPtr refers to an SDL_Surface* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint IMG_ReadXPMFromArray(
+            [In()] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)]
+                string[] xpm
+        );
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, EntryPoint = "IMG_SavePNG", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe int INTERNAL_IMG_SavePNG(
+            nint surface,
+            byte* file
+        );
+        public static unsafe int IMG_SavePNG(nint surface, string file)
+        {
+            byte* utf8File = SDL.Utf8EncodeHeap(file);
+            int result = INTERNAL_IMG_SavePNG(
+                surface,
+                utf8File
+            );
+            Marshal.FreeHGlobal((nint)utf8File);
+            return result;
+        }
+
+        /* surface refers to an SDL_Surface*, dst to an SDL_RWops* */
+        /* THIS IS A PUBLIC RWops FUNCTION! */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int IMG_SavePNG_RW(
+            nint surface,
+            nint dst,
+            int freedst
+        );
+
+        /* surface refers to an SDL_Surface* */
+        [DllImport(nativeLibName, EntryPoint = "IMG_SaveJPG", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe int INTERNAL_IMG_SaveJPG(
+            nint surface,
+            byte* file,
+            int quality
+        );
+        public static unsafe int IMG_SaveJPG(nint surface, string file, int quality)
+        {
+            byte* utf8File = SDL.Utf8EncodeHeap(file);
+            int result = INTERNAL_IMG_SaveJPG(
+                surface,
+                utf8File,
+                quality
+            );
+            Marshal.FreeHGlobal((nint)utf8File);
+            return result;
+        }
+
+        /* surface refers to an SDL_Surface*, dst to an SDL_RWops* */
+        /* THIS IS A PUBLIC RWops FUNCTION! */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int IMG_SaveJPG_RW(
+            nint surface,
+            nint dst,
+            int freedst,
+            int quality
+        );
+
+        public static string IMG_GetError()
+        {
+            return SDL.SDL_GetError();
+        }
+
+        public static void IMG_SetError(string fmtAndArglist)
+        {
+            SDL.SDL_SetError(fmtAndArglist);
+        }
+
+        #region Animated Image Support
+
+        /* This region is only available in 2.0.6 or higher. */
+
+        public struct IMG_Animation
+        {
+            public int w;
+            public int h;
+            public nint frames; /* SDL_Surface** */
+            public nint delays; /* int* */
+        }
+
+        /* IntPtr refers to an IMG_Animation* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint IMG_LoadAnimation(
+            [In()] [MarshalAs(UnmanagedType.LPStr)]
+                string file
+        );
+
+        /* IntPtr refers to an IMG_Animation*, src to an SDL_RWops* */
+        /* THIS IS A PUBLIC RWops FUNCTION! */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint IMG_LoadAnimation_RW(
+            nint src,
+            int freesrc
+        );
+
+        /* IntPtr refers to an IMG_Animation*, src to an SDL_RWops* */
+        /* THIS IS A PUBLIC RWops FUNCTION! */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint IMG_LoadAnimationTyped_RW(
+            nint src,
+            int freesrc,
+            [In()] [MarshalAs(UnmanagedType.LPStr)]
+                string type
+        );
+
+        /* anim refers to an IMG_Animation* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void IMG_FreeAnimation(nint anim);
+
+        /* IntPtr refers to an IMG_Animation*, src to an SDL_RWops* */
+        /* THIS IS A PUBLIC RWops FUNCTION! */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint IMG_LoadGIFAnimation_RW(nint src);
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiLL/ImGui2_mixer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiLL/ImGui2_mixer.cs
@@ -1,0 +1,667 @@
+#region License
+/* SDL2# - C# Wrapper for SDL2
+ *
+ * Copyright (c) 2013-2024 Ethan Lee.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software in a
+ * product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * Ethan "flibitijibibo" Lee <flibitijibibo@flibitijibibo.com>
+ *
+ */
+#endregion
+
+#region Using Statements
+using System;
+using System.Runtime.InteropServices;
+#endregion
+
+namespace AbstUI.ImGui.ImGuiLL
+{
+    public static class SDL_mixer
+    {
+        #region SDL2# Variables
+
+        /* Used by DllImport to load the native library. */
+        private const string nativeLibName = "SDL2_mixer";
+
+        #endregion
+
+        #region SDL_mixer.h
+
+        /* Similar to the headers, this is the version we're expecting to be
+		 * running with. You will likely want to check this somewhere in your
+		 * program!
+		 */
+        public const int SDL_MIXER_MAJOR_VERSION = 2;
+        public const int SDL_MIXER_MINOR_VERSION = 0;
+        public const int SDL_MIXER_PATCHLEVEL = 5;
+
+        /* In C, you can redefine this value before including SDL_mixer.h.
+		 * We're not going to allow this in SDL2#, since the value of this
+		 * variable is persistent and not dependent on preprocessor ordering.
+		 */
+        public const int MIX_CHANNELS = 8;
+
+        public static readonly int MIX_DEFAULT_FREQUENCY = 44100;
+        public static readonly ushort MIX_DEFAULT_FORMAT =
+            BitConverter.IsLittleEndian ? SDL.AUDIO_S16LSB : SDL.AUDIO_S16MSB;
+        public static readonly int MIX_DEFAULT_CHANNELS = 2;
+        public static readonly byte MIX_MAX_VOLUME = 128;
+
+        [Flags]
+        public enum MIX_InitFlags
+        {
+            MIX_INIT_FLAC = 0x00000001,
+            MIX_INIT_MOD = 0x00000002,
+            MIX_INIT_MP3 = 0x00000008,
+            MIX_INIT_OGG = 0x00000010,
+            MIX_INIT_MID = 0x00000020,
+            MIX_INIT_OPUS = 0x00000040
+        }
+
+        public struct MIX_Chunk
+        {
+            public int allocated;
+            public nint abuf; /* Uint8* */
+            public uint alen;
+            public byte volume;
+        }
+
+        public enum Mix_Fading
+        {
+            MIX_NO_FADING,
+            MIX_FADING_OUT,
+            MIX_FADING_IN
+        }
+
+        public enum Mix_MusicType
+        {
+            MUS_NONE,
+            MUS_CMD,
+            MUS_WAV,
+            MUS_MOD,
+            MUS_MID,
+            MUS_OGG,
+            MUS_MP3,
+            MUS_MP3_MAD_UNUSED,
+            MUS_FLAC,
+            MUS_MODPLUG_UNUSED,
+            MUS_OPUS
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void MixFuncDelegate(
+            nint udata, // void*
+            nint stream, // Uint8*
+            int len
+        );
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void Mix_EffectFunc_t(
+            int chan,
+            nint stream, // void*
+            int len,
+            nint udata // void*
+        );
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void Mix_EffectDone_t(
+            int chan,
+            nint udata // void*
+        );
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void MusicFinishedDelegate();
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void ChannelFinishedDelegate(int channel);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int SoundFontDelegate(
+            nint a, // const char*
+            nint b // void*
+        );
+
+        public static void SDL_MIXER_VERSION(out SDL.SDL_version X)
+        {
+            X.major = SDL_MIXER_MAJOR_VERSION;
+            X.minor = SDL_MIXER_MINOR_VERSION;
+            X.patch = SDL_MIXER_PATCHLEVEL;
+        }
+
+        [DllImport(nativeLibName, EntryPoint = "MIX_Linked_Version", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_MIX_Linked_Version();
+        public static SDL.SDL_version MIX_Linked_Version()
+        {
+            SDL.SDL_version result;
+            nint result_ptr = INTERNAL_MIX_Linked_Version();
+            result = SDL.PtrToStructure<SDL.SDL_version>(
+                result_ptr
+            );
+            return result;
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_Init(MIX_InitFlags flags);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Mix_Quit();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_OpenAudio(
+            int frequency,
+            ushort format,
+            int channels,
+            int chunksize
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_AllocateChannels(int numchans);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_QuerySpec(
+            out int frequency,
+            out ushort format,
+            out int channels
+        );
+
+        /* src refers to an SDL_RWops*, IntPtr to a Mix_Chunk* */
+        /* THIS IS A PUBLIC RWops FUNCTION! */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint Mix_LoadWAV_RW(
+            nint src,
+            int freesrc
+        );
+
+        /* IntPtr refers to a Mix_Chunk* */
+        /* This is an RWops macro in the C header. */
+        public static nint Mix_LoadWAV(string file)
+        {
+            nint rwops = SDL.SDL_RWFromFile(file, "rb");
+            return Mix_LoadWAV_RW(rwops, 1);
+        }
+
+        /* IntPtr refers to a Mix_Music* */
+        [DllImport(nativeLibName, EntryPoint = "Mix_LoadMUS", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_Mix_LoadMUS(
+            byte* file
+        );
+        public static unsafe nint Mix_LoadMUS(string file)
+        {
+            byte* utf8File = SDL.Utf8EncodeHeap(file);
+            nint handle = INTERNAL_Mix_LoadMUS(
+                utf8File
+            );
+            Marshal.FreeHGlobal((nint)utf8File);
+            return handle;
+        }
+
+        /* IntPtr refers to a Mix_Chunk* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint Mix_QuickLoad_WAV(
+            [In()] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1)]
+                byte[] mem
+        );
+
+        /* IntPtr refers to a Mix_Chunk* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint Mix_QuickLoad_RAW(
+            [In()] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeParamIndex = 1)]
+                byte[] mem,
+            uint len
+        );
+
+        /* chunk refers to a Mix_Chunk* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Mix_FreeChunk(nint chunk);
+
+        /* music refers to a Mix_Music* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Mix_FreeMusic(nint music);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_GetNumChunkDecoders();
+
+        [DllImport(nativeLibName, EntryPoint = "Mix_GetChunkDecoder", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_Mix_GetChunkDecoder(int index);
+        public static string Mix_GetChunkDecoder(int index)
+        {
+            return SDL.UTF8_ToManaged(
+                INTERNAL_Mix_GetChunkDecoder(index)
+            );
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_GetNumMusicDecoders();
+
+        [DllImport(nativeLibName, EntryPoint = "Mix_GetMusicDecoder", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_Mix_GetMusicDecoder(int index);
+        public static string Mix_GetMusicDecoder(int index)
+        {
+            return SDL.UTF8_ToManaged(
+                INTERNAL_Mix_GetMusicDecoder(index)
+            );
+        }
+
+        /* music refers to a Mix_Music* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Mix_MusicType Mix_GetMusicType(nint music);
+
+        /* music refers to a Mix_Music*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "Mix_GetMusicTitle", CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint INTERNAL_Mix_GetMusicTitle(nint music);
+        public static string Mix_GetMusicTitle(nint music)
+        {
+            return SDL.UTF8_ToManaged(
+                INTERNAL_Mix_GetMusicTitle(music)
+            );
+        }
+
+        /* music refers to a Mix_Music*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "Mix_GetMusicTitleTag", CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint INTERNAL_Mix_GetMusicTitleTag(nint music);
+        public static string Mix_GetMusicTitleTag(nint music)
+        {
+            return SDL.UTF8_ToManaged(
+                INTERNAL_Mix_GetMusicTitleTag(music)
+            );
+        }
+
+        /* music refers to a Mix_Music*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "Mix_GetMusicArtistTag", CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint INTERNAL_Mix_GetMusicArtistTag(nint music);
+        public static string Mix_GetMusicArtistTag(nint music)
+        {
+            return SDL.UTF8_ToManaged(
+                INTERNAL_Mix_GetMusicArtistTag(music)
+            );
+        }
+
+        /* music refers to a Mix_Music*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "Mix_GetMusicAlbumTag", CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint INTERNAL_Mix_GetMusicAlbumTag(nint music);
+        public static string Mix_GetMusicAlbumTag(nint music)
+        {
+            return SDL.UTF8_ToManaged(
+                INTERNAL_Mix_GetMusicAlbumTag(music)
+            );
+        }
+
+        /* music refers to a Mix_Music*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "Mix_GetMusicCopyrightTag", CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint INTERNAL_Mix_GetMusicCopyrightTag(nint music);
+        public static string Mix_GetMusicCopyrightTag(nint music)
+        {
+            return SDL.UTF8_ToManaged(
+                INTERNAL_Mix_GetMusicCopyrightTag(music)
+            );
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Mix_SetPostMix(
+            MixFuncDelegate mix_func,
+            nint arg // void*
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Mix_HookMusic(
+            MixFuncDelegate mix_func,
+            nint arg // void*
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Mix_HookMusicFinished(
+            MusicFinishedDelegate music_finished
+        );
+
+        /* IntPtr refers to a void* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint Mix_GetMusicHookData();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Mix_ChannelFinished(
+            ChannelFinishedDelegate channel_finished
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_RegisterEffect(
+            int chan,
+            Mix_EffectFunc_t f,
+            Mix_EffectDone_t d,
+            nint arg // void*
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_UnregisterEffect(
+            int channel,
+            Mix_EffectFunc_t f
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_UnregisterAllEffects(int channel);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_SetPanning(
+            int channel,
+            byte left,
+            byte right
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_SetPosition(
+            int channel,
+            short angle,
+            byte distance
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_SetDistance(int channel, byte distance);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_SetReverseStereo(int channel, int flip);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_ReserveChannels(int num);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_GroupChannel(int which, int tag);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_GroupChannels(int from, int to, int tag);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_GroupAvailable(int tag);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_GroupCount(int tag);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_GroupOldest(int tag);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_GroupNewer(int tag);
+
+        /* chunk refers to a Mix_Chunk* */
+        public static int Mix_PlayChannel(
+            int channel,
+            nint chunk,
+            int loops
+        )
+        {
+            return Mix_PlayChannelTimed(channel, chunk, loops, -1);
+        }
+
+        /* chunk refers to a Mix_Chunk* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_PlayChannelTimed(
+            int channel,
+            nint chunk,
+            int loops,
+            int ticks
+        );
+
+        /* music refers to a Mix_Music* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_PlayMusic(nint music, int loops);
+
+        /* music refers to a Mix_Music* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_FadeInMusic(
+            nint music,
+            int loops,
+            int ms
+        );
+
+        /* music refers to a Mix_Music* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_FadeInMusicPos(
+            nint music,
+            int loops,
+            int ms,
+            double position
+        );
+
+        /* chunk refers to a Mix_Chunk* */
+        public static int Mix_FadeInChannel(
+            int channel,
+            nint chunk,
+            int loops,
+            int ms
+        )
+        {
+            return Mix_FadeInChannelTimed(channel, chunk, loops, ms, -1);
+        }
+
+        /* chunk refers to a Mix_Chunk* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_FadeInChannelTimed(
+            int channel,
+            nint chunk,
+            int loops,
+            int ms,
+            int ticks
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_Volume(int channel, int volume);
+
+        /* chunk refers to a Mix_Chunk* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_VolumeChunk(
+            nint chunk,
+            int volume
+        );
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_VolumeMusic(int volume);
+
+        /* music refers to a Mix_Music*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_GetVolumeMusicStream(nint music);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_HaltChannel(int channel);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_HaltGroup(int tag);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_HaltMusic();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_ExpireChannel(int channel, int ticks);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_FadeOutChannel(int which, int ms);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_FadeOutGroup(int tag, int ms);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_FadeOutMusic(int ms);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Mix_Fading Mix_FadingMusic();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Mix_Fading Mix_FadingChannel(int which);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Mix_Pause(int channel);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Mix_Resume(int channel);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_Paused(int channel);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Mix_PauseMusic();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Mix_ResumeMusic();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Mix_RewindMusic();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_PausedMusic();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_SetMusicPosition(double position);
+
+        /* music refers to a Mix_Music*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern double Mix_GetMusicPosition(nint music);
+
+        /* music refers to a Mix_Music*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern double Mix_MusicDuration(nint music);
+
+        /* music refers to a Mix_Music*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern double Mix_GetMusicLoopStartTime(nint music);
+
+        /* music refers to a Mix_Music*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern double Mix_GetMusicLoopEndTime(nint music);
+
+        /* music refers to a Mix_Music*
+		 * Only available in 2.0.5 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern double Mix_GetMusicLoopLengthTime(nint music);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_Playing(int channel);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_PlayingMusic();
+
+        [DllImport(nativeLibName, EntryPoint = "Mix_SetMusicCMD", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe int INTERNAL_Mix_SetMusicCMD(
+            byte* command
+        );
+        public static unsafe int Mix_SetMusicCMD(string command)
+        {
+            byte* utf8Cmd = SDL.Utf8EncodeHeap(command);
+            int result = INTERNAL_Mix_SetMusicCMD(
+                utf8Cmd
+            );
+            Marshal.FreeHGlobal((nint)utf8Cmd);
+            return result;
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_SetSynchroValue(int value);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_GetSynchroValue();
+
+        [DllImport(nativeLibName, EntryPoint = "Mix_SetSoundFonts", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe int INTERNAL_Mix_SetSoundFonts(
+            byte* paths
+        );
+        public static unsafe int Mix_SetSoundFonts(string paths)
+        {
+            byte* utf8Paths = SDL.Utf8EncodeHeap(paths);
+            int result = INTERNAL_Mix_SetSoundFonts(
+                utf8Paths
+            );
+            Marshal.FreeHGlobal((nint)utf8Paths);
+            return result;
+        }
+
+        [DllImport(nativeLibName, EntryPoint = "Mix_GetSoundFonts", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_Mix_GetSoundFonts();
+        public static string Mix_GetSoundFonts()
+        {
+            return SDL.UTF8_ToManaged(
+                INTERNAL_Mix_GetSoundFonts()
+            );
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_EachSoundFont(
+            SoundFontDelegate function,
+            nint data // void*
+        );
+
+        /* Only available in 2.0.5 or later. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int Mix_SetTimidityCfg(
+            [In()] [MarshalAs(UnmanagedType.LPStr)]
+                string path
+        );
+
+        /* Only available in 2.0.5 or later. */
+        [DllImport(nativeLibName, EntryPoint = "Mix_GetTimidityCfg", CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint INTERNAL_Mix_GetTimidityCfg();
+        public static string Mix_GetTimidityCfg()
+        {
+            return SDL.UTF8_ToManaged(
+                INTERNAL_Mix_GetTimidityCfg()
+            );
+        }
+
+        /* IntPtr refers to a Mix_Chunk* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint Mix_GetChunk(int channel);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Mix_CloseAudio();
+
+        public static string Mix_GetError()
+        {
+            return SDL.SDL_GetError();
+        }
+
+        public static void Mix_SetError(string fmtAndArglist)
+        {
+            SDL.SDL_SetError(fmtAndArglist);
+        }
+
+        public static void Mix_ClearError()
+        {
+            SDL.SDL_ClearError();
+        }
+
+        #endregion
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiLL/ImGui2_ttf.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/ImGuiLL/ImGui2_ttf.cs
@@ -1,0 +1,777 @@
+#region License
+/* SDL2# - C# Wrapper for SDL2
+ *
+ * Copyright (c) 2013-2024 Ethan Lee.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software in a
+ * product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * Ethan "flibitijibibo" Lee <flibitijibibo@flibitijibibo.com>
+ *
+ */
+#endregion
+
+#region Using Statements
+using System;
+using System.Runtime.InteropServices;
+#endregion
+
+namespace AbstUI.ImGui.ImGuiLL
+{
+    public static class SDL_ttf
+    {
+        #region SDL2# Variables
+
+        /* Used by DllImport to load the native library. */
+        private const string nativeLibName = "SDL2_ttf";
+
+        #endregion
+
+        #region SDL_ttf.h
+
+        /* Similar to the headers, this is the version we're expecting to be
+		 * running with. You will likely want to check this somewhere in your
+		 * program!
+		 */
+        public const int SDL_TTF_MAJOR_VERSION = 2;
+        public const int SDL_TTF_MINOR_VERSION = 0;
+        public const int SDL_TTF_PATCHLEVEL = 16;
+
+        public const int UNICODE_BOM_NATIVE = 0xFEFF;
+        public const int UNICODE_BOM_SWAPPED = 0xFFFE;
+
+        public const int TTF_STYLE_NORMAL = 0x00;
+        public const int TTF_STYLE_BOLD = 0x01;
+        public const int TTF_STYLE_ITALIC = 0x02;
+        public const int TTF_STYLE_UNDERLINE = 0x04;
+        public const int TTF_STYLE_STRIKETHROUGH = 0x08;
+
+        public const int TTF_HINTING_NORMAL = 0;
+        public const int TTF_HINTING_LIGHT = 1;
+        public const int TTF_HINTING_MONO = 2;
+        public const int TTF_HINTING_NONE = 3;
+        public const int TTF_HINTING_LIGHT_SUBPIXEL = 4; /* >= 2.0.16 */
+
+        public static void SDL_TTF_VERSION(out SDL.SDL_version X)
+        {
+            X.major = SDL_TTF_MAJOR_VERSION;
+            X.minor = SDL_TTF_MINOR_VERSION;
+            X.patch = SDL_TTF_PATCHLEVEL;
+        }
+
+        [DllImport(nativeLibName, EntryPoint = "TTF_LinkedVersion", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_TTF_LinkedVersion();
+        public static SDL.SDL_version TTF_LinkedVersion()
+        {
+            SDL.SDL_version result;
+            nint result_ptr = INTERNAL_TTF_LinkedVersion();
+            result = SDL.PtrToStructure<SDL.SDL_version>(
+                result_ptr
+            );
+            return result;
+        }
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void TTF_ByteSwappedUNICODE(int swapped);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_Init();
+
+        /* IntPtr refers to a TTF_Font* */
+        [DllImport(nativeLibName, EntryPoint = "TTF_OpenFont", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_TTF_OpenFont(
+            byte* file,
+            int ptsize
+        );
+        public static unsafe nint TTF_OpenFont(string file, int ptsize)
+        {
+            byte* utf8File = SDL.Utf8EncodeHeap(file);
+            nint handle = INTERNAL_TTF_OpenFont(
+                utf8File,
+                ptsize
+            );
+            Marshal.FreeHGlobal((nint)utf8File);
+            return handle;
+        }
+
+        /* src refers to an SDL_RWops*, IntPtr to a TTF_Font* */
+        /* THIS IS A PUBLIC RWops FUNCTION! */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_OpenFontRW(
+            nint src,
+            int freesrc,
+            int ptsize
+        );
+
+        /* IntPtr refers to a TTF_Font* */
+        [DllImport(nativeLibName, EntryPoint = "TTF_OpenFontIndex", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_TTF_OpenFontIndex(
+            byte* file,
+            int ptsize,
+            long index
+        );
+        public static unsafe nint TTF_OpenFontIndex(
+            string file,
+            int ptsize,
+            long index
+        )
+        {
+            byte* utf8File = SDL.Utf8EncodeHeap(file);
+            nint handle = INTERNAL_TTF_OpenFontIndex(
+                utf8File,
+                ptsize,
+                index
+            );
+            Marshal.FreeHGlobal((nint)utf8File);
+            return handle;
+        }
+
+        /* src refers to an SDL_RWops*, IntPtr to a TTF_Font* */
+        /* THIS IS A PUBLIC RWops FUNCTION! */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_OpenFontIndexRW(
+            nint src,
+            int freesrc,
+            int ptsize,
+            long index
+        );
+
+        /* font refers to a TTF_Font*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_SetFontSize(
+            nint font,
+            int ptsize
+        );
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_GetFontStyle(nint font);
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void TTF_SetFontStyle(nint font, int style);
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_GetFontOutline(nint font);
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void TTF_SetFontOutline(nint font, int outline);
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_GetFontHinting(nint font);
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void TTF_SetFontHinting(nint font, int hinting);
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_FontHeight(nint font);
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_FontAscent(nint font);
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_FontDescent(nint font);
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_FontLineSkip(nint font);
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_GetFontKerning(nint font);
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void TTF_SetFontKerning(nint font, int allowed);
+
+        /* font refers to a TTF_Font*.
+		 * IntPtr is actually a C long! This ignores Win64!
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_FontFaces(nint font);
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_FontFaceIsFixedWidth(nint font);
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, EntryPoint = "TTF_FontFaceFamilyName", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_TTF_FontFaceFamilyName(
+            nint font
+        );
+        public static string TTF_FontFaceFamilyName(nint font)
+        {
+            return SDL.UTF8_ToManaged(
+                INTERNAL_TTF_FontFaceFamilyName(font)
+            );
+        }
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, EntryPoint = "TTF_FontFaceStyleName", CallingConvention = CallingConvention.Cdecl)]
+        private static extern nint INTERNAL_TTF_FontFaceStyleName(
+            nint font
+        );
+        public static string TTF_FontFaceStyleName(nint font)
+        {
+            return SDL.UTF8_ToManaged(
+                INTERNAL_TTF_FontFaceStyleName(font)
+            );
+        }
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_GlyphIsProvided(nint font, ushort ch);
+
+        /* font refers to a TTF_Font*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_GlyphIsProvided32(nint font, uint ch);
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_GlyphMetrics(
+            nint font,
+            ushort ch,
+            out int minx,
+            out int maxx,
+            out int miny,
+            out int maxy,
+            out int advance
+        );
+
+        /* font refers to a TTF_Font*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_GlyphMetrics32(
+            nint font,
+            uint ch,
+            out int minx,
+            out int maxx,
+            out int miny,
+            out int maxy,
+            out int advance
+        );
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_SizeText(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPStr)]
+                string text,
+            out int w,
+            out int h
+        );
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, EntryPoint = "TTF_SizeUTF8", CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int INTERNAL_TTF_SizeUTF8(
+            nint font,
+            byte* text,
+            out int w,
+            out int h
+        );
+        public static unsafe int TTF_SizeUTF8(
+            nint font,
+            string text,
+            out int w,
+            out int h
+        )
+        {
+            byte* utf8Text = SDL.Utf8EncodeHeap(text);
+            int result = INTERNAL_TTF_SizeUTF8(
+                font,
+                utf8Text,
+                out w,
+                out h
+            );
+            Marshal.FreeHGlobal((nint)utf8Text);
+            return result;
+        }
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_SizeUNICODE(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPWStr)]
+                string text,
+            out int w,
+            out int h
+        );
+
+        /* font refers to a TTF_Font*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_MeasureText(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPStr)]
+                string text,
+            int measure_width,
+            out int extent,
+            out int count
+        );
+
+        /* font refers to a TTF_Font*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "TTF_MeasureUTF8", CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int INTERNAL_TTF_MeasureUTF8(
+            nint font,
+            byte* text,
+            int measure_width,
+            out int extent,
+            out int count
+        );
+        public static unsafe int TTF_MeasureUTF8(
+            nint font,
+            string text,
+            int measure_width,
+            out int extent,
+            out int count
+        )
+        {
+            byte* utf8Text = SDL.Utf8EncodeHeap(text);
+            int result = INTERNAL_TTF_MeasureUTF8(
+                font,
+                utf8Text,
+                measure_width,
+                out extent,
+                out count
+            );
+            Marshal.FreeHGlobal((nint)utf8Text);
+            return result;
+        }
+
+        /* font refers to a TTF_Font*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_MeasureUNICODE(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPWStr)]
+                string text,
+            int measure_width,
+            out int extent,
+            out int count
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderText_Solid(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPStr)]
+                string text,
+            SDL.SDL_Color fg
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, EntryPoint = "TTF_RenderUTF8_Solid", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_TTF_RenderUTF8_Solid(
+            nint font,
+            byte* text,
+            SDL.SDL_Color fg
+        );
+        public static unsafe nint TTF_RenderUTF8_Solid(
+            nint font,
+            string text,
+            SDL.SDL_Color fg
+        )
+        {
+            byte* utf8Text = SDL.Utf8EncodeHeap(text);
+            nint result = INTERNAL_TTF_RenderUTF8_Solid(
+                font,
+                utf8Text,
+                fg
+            );
+            Marshal.FreeHGlobal((nint)utf8Text);
+            return result;
+        }
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderUNICODE_Solid(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPWStr)]
+                string text,
+            SDL.SDL_Color fg
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderText_Solid_Wrapped(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPStr)]
+                string text,
+            SDL.SDL_Color fg,
+            uint wrapLength
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "TTF_RenderUTF8_Solid_Wrapped", CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe nint INTERNAL_TTF_RenderUTF8_Solid_Wrapped(
+            nint font,
+            byte* text,
+            SDL.SDL_Color fg,
+            uint wrapLength
+        );
+        public static unsafe nint TTF_RenderUTF8_Solid_Wrapped(
+            nint font,
+            string text,
+            SDL.SDL_Color fg,
+            uint wrapLength
+        )
+        {
+            byte* utf8Text = SDL.Utf8EncodeHeap(text);
+            nint result = INTERNAL_TTF_RenderUTF8_Solid_Wrapped(
+                font,
+                utf8Text,
+                fg,
+                wrapLength
+            );
+            Marshal.FreeHGlobal((nint)utf8Text);
+            return result;
+        }
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderUNICODE_Solid_Wrapped(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPWStr)]
+                string text,
+            SDL.SDL_Color fg,
+            uint wrapLength
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderGlyph_Solid(
+            nint font,
+            ushort ch,
+            SDL.SDL_Color fg
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderGlyph32_Solid(
+            nint font,
+            uint ch,
+            SDL.SDL_Color fg
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderText_Shaded(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPStr)]
+                string text,
+            SDL.SDL_Color fg,
+            SDL.SDL_Color bg
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, EntryPoint = "TTF_RenderUTF8_Shaded", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_TTF_RenderUTF8_Shaded(
+            nint font,
+            byte* text,
+            SDL.SDL_Color fg,
+            SDL.SDL_Color bg
+        );
+        public static unsafe nint TTF_RenderUTF8_Shaded(
+            nint font,
+            string text,
+            SDL.SDL_Color fg,
+            SDL.SDL_Color bg
+        )
+        {
+            byte* utf8Text = SDL.Utf8EncodeHeap(text);
+            nint result = INTERNAL_TTF_RenderUTF8_Shaded(
+                font,
+                utf8Text,
+                fg,
+                bg
+            );
+            Marshal.FreeHGlobal((nint)utf8Text);
+            return result;
+        }
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderUNICODE_Shaded(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPWStr)]
+                string text,
+            SDL.SDL_Color fg,
+            SDL.SDL_Color bg
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderText_Shaded_Wrapped(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPStr)]
+                string text,
+            SDL.SDL_Color fg,
+            SDL.SDL_Color bg,
+            uint wrapLength
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, EntryPoint = "TTF_RenderUTF8_Shaded_Wrapped", CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe nint INTERNAL_TTF_RenderUTF8_Shaded_Wrapped(
+            nint font,
+            byte* text,
+            SDL.SDL_Color fg,
+            SDL.SDL_Color bg,
+            uint wrapLength
+        );
+        public static unsafe nint TTF_RenderUTF8_Shaded_Wrapped(
+            nint font,
+            string text,
+            SDL.SDL_Color fg,
+            SDL.SDL_Color bg,
+            uint wrapLength
+        )
+        {
+            byte* utf8Text = SDL.Utf8EncodeHeap(text);
+            nint result = INTERNAL_TTF_RenderUTF8_Shaded_Wrapped(
+                font,
+                utf8Text,
+                fg,
+                bg,
+                wrapLength
+            );
+            Marshal.FreeHGlobal((nint)utf8Text);
+            return result;
+        }
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderUNICODE_Shaded_Wrapped(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPWStr)]
+                string text,
+            SDL.SDL_Color fg,
+            SDL.SDL_Color bg,
+            uint wrapLength
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderGlyph_Shaded(
+            nint font,
+            ushort ch,
+            SDL.SDL_Color fg,
+            SDL.SDL_Color bg
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderGlyph32_Shaded(
+            nint font,
+            uint ch,
+            SDL.SDL_Color fg,
+            SDL.SDL_Color bg
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderText_Blended(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPStr)]
+                string text,
+            SDL.SDL_Color fg
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, EntryPoint = "TTF_RenderUTF8_Blended", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_TTF_RenderUTF8_Blended(
+            nint font,
+            byte* text,
+            SDL.SDL_Color fg
+        );
+        public static unsafe nint TTF_RenderUTF8_Blended(
+            nint font,
+            string text,
+            SDL.SDL_Color fg
+        )
+        {
+            byte* utf8Text = SDL.Utf8EncodeHeap(text);
+            nint result = INTERNAL_TTF_RenderUTF8_Blended(
+                font,
+                utf8Text,
+                fg
+            );
+            Marshal.FreeHGlobal((nint)utf8Text);
+            return result;
+        }
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderUNICODE_Blended(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPWStr)]
+                string text,
+            SDL.SDL_Color fg
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderText_Blended_Wrapped(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPStr)]
+                string text,
+            SDL.SDL_Color fg,
+            uint wrapped
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, EntryPoint = "TTF_RenderUTF8_Blended_Wrapped", CallingConvention = CallingConvention.Cdecl)]
+        private static extern unsafe nint INTERNAL_TTF_RenderUTF8_Blended_Wrapped(
+            nint font,
+            byte* text,
+            SDL.SDL_Color fg,
+            uint wrapped
+        );
+        public static unsafe nint TTF_RenderUTF8_Blended_Wrapped(
+            nint font,
+            string text,
+            SDL.SDL_Color fg,
+            uint wrapped
+        )
+        {
+            byte* utf8Text = SDL.Utf8EncodeHeap(text);
+            nint result = INTERNAL_TTF_RenderUTF8_Blended_Wrapped(
+                font,
+                utf8Text,
+                fg,
+                wrapped
+            );
+            Marshal.FreeHGlobal((nint)utf8Text);
+            return result;
+        }
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderUNICODE_Blended_Wrapped(
+            nint font,
+            [In()] [MarshalAs(UnmanagedType.LPWStr)]
+                string text,
+            SDL.SDL_Color fg,
+            uint wrapped
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderGlyph_Blended(
+            nint font,
+            ushort ch,
+            SDL.SDL_Color fg
+        );
+
+        /* IntPtr refers to an SDL_Surface*, font to a TTF_Font*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint TTF_RenderGlyph32_Blended(
+            nint font,
+            uint ch,
+            SDL.SDL_Color fg
+        );
+
+        /* Only available in 2.0.16 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_SetDirection(int direction);
+
+        /* Only available in 2.0.16 or higher. */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_SetScript(int script);
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void TTF_CloseFont(nint font);
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void TTF_Quit();
+
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_WasInit();
+
+        /* font refers to a TTF_Font* */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SDL_GetFontKerningSize(
+            nint font,
+            int prev_index,
+            int index
+        );
+
+        /* font refers to a TTF_Font*
+		 * Only available in 2.0.15 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_GetFontKerningSizeGlyphs(
+            nint font,
+            ushort previous_ch,
+            ushort ch
+        );
+
+        /* font refers to a TTF_Font*
+		 * Only available in 2.0.16 or higher.
+		 */
+        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int TTF_GetFontKerningSizeGlyphs32(
+            nint font,
+            ushort previous_ch,
+            ushort ch
+        );
+
+        public static string TTF_GetError()
+        {
+            return SDL.SDL_GetError();
+        }
+
+        public static void TTF_SetError(string fmtAndArglist)
+        {
+            SDL.SDL_SetError(fmtAndArglist);
+        }
+
+        #endregion
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Inputs/ImGuiKey.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Inputs/ImGuiKey.cs
@@ -1,0 +1,54 @@
+using AbstUI.Inputs;
+using AbstUI.ImGui.ImGuiLL;
+
+namespace AbstUI.ImGui.Inputs;
+
+public class ImGuiKey : IAbstFrameworkKey
+{
+    private readonly HashSet<SDL.SDL_Keycode> _keys = new();
+    private AbstKey? _lingoKey;
+    private string _lastKey = string.Empty;
+    private int _lastCode;
+
+    public void SetKeyObj(AbstKey key) => _lingoKey = key;
+
+    public void ProcessEvent(SDL.SDL_Event e)
+    {
+        if (e.type == SDL.SDL_EventType.SDL_KEYDOWN && e.key.repeat == 0)
+        {
+            _keys.Add(e.key.keysym.sym);
+            _lastCode = (int)e.key.keysym.sym;
+            _lastKey = SDL.SDL_GetKeyName(e.key.keysym.sym);
+            _lingoKey?.DoKeyDown();
+        }
+        else if (e.type == SDL.SDL_EventType.SDL_KEYUP)
+        {
+            _keys.Remove(e.key.keysym.sym);
+            _lastCode = (int)e.key.keysym.sym;
+            _lastKey = SDL.SDL_GetKeyName(e.key.keysym.sym);
+            _lingoKey?.DoKeyUp();
+        }
+    }
+
+    public bool CommandDown => (SDL.SDL_GetModState() & SDL.SDL_Keymod.KMOD_GUI) != 0;
+    public bool ControlDown => (SDL.SDL_GetModState() & SDL.SDL_Keymod.KMOD_CTRL) != 0;
+    public bool OptionDown => (SDL.SDL_GetModState() & SDL.SDL_Keymod.KMOD_ALT) != 0;
+    public bool ShiftDown => (SDL.SDL_GetModState() & SDL.SDL_Keymod.KMOD_SHIFT) != 0;
+
+    public bool KeyPressed(AbstUIKeyType key) => key switch
+    {
+        AbstUIKeyType.BACKSPACE => _keys.Contains(SDL.SDL_Keycode.SDLK_BACKSPACE),
+        AbstUIKeyType.ENTER or AbstUIKeyType.RETURN => _keys.Contains(SDL.SDL_Keycode.SDLK_RETURN),
+        AbstUIKeyType.QUOTE => _keys.Contains(SDL.SDL_Keycode.SDLK_QUOTE),
+        AbstUIKeyType.SPACE => _keys.Contains(SDL.SDL_Keycode.SDLK_SPACE),
+        AbstUIKeyType.TAB => _keys.Contains(SDL.SDL_Keycode.SDLK_TAB),
+        _ => false
+    };
+
+    public bool KeyPressed(char key) => _keys.Contains((SDL.SDL_Keycode)char.ToUpperInvariant(key));
+
+    public bool KeyPressed(int keyCode) => _keys.Contains((SDL.SDL_Keycode)keyCode);
+
+    public string Key => _lastKey;
+    public int KeyCode => _lastCode;
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Inputs/ImGuiMouse.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Inputs/ImGuiMouse.cs
@@ -1,0 +1,132 @@
+using AbstUI.Inputs;
+using AbstUI.Primitives;
+using AbstUI.ImGui.ImGuiLL;
+
+namespace AbstUI.ImGui.Inputs;
+public class ImGuiMouse<TAbstUIMouseEvent> : IAbstFrameworkMouse
+        where TAbstUIMouseEvent : AbstMouseEvent
+{
+    private Lazy<AbstMouse<TAbstUIMouseEvent>> _lingoMouse;
+    private bool _hidden;
+    protected nint _sdlCursor = nint.Zero;
+
+    public ImGuiMouse(Lazy<AbstMouse<TAbstUIMouseEvent>> mouse)
+    {
+        _lingoMouse = mouse;
+    }
+    ~ImGuiMouse()
+    {
+        if (_sdlCursor != nint.Zero)
+            SDL.SDL_FreeCursor(_sdlCursor);
+    }
+    public virtual void Release()
+    {
+        if (_sdlCursor != nint.Zero)
+        {
+            SDL.SDL_FreeCursor(_sdlCursor);
+            _sdlCursor = nint.Zero;
+        }
+    }
+    public void SetMouse(AbstMouse<TAbstUIMouseEvent> mouse) => _lingoMouse = new Lazy<AbstMouse<TAbstUIMouseEvent>>(() => mouse);
+
+    public void HideMouse(bool state)
+    {
+        _hidden = state;
+        SDL.SDL_ShowCursor(state ? 0 : 1);
+    }
+
+
+
+
+
+    public void ReplaceMouseObj(IAbstMouse lingoMouse)
+    {
+        _lingoMouse = new Lazy<AbstMouse<TAbstUIMouseEvent>>(() => (AbstMouse<TAbstUIMouseEvent>)lingoMouse);
+    }
+
+    public void ProcessEvent(SDL.SDL_Event e)
+    {
+        switch (e.type)
+        {
+            case SDL.SDL_EventType.SDL_MOUSEMOTION:
+                _lingoMouse.Value.MouseH = e.motion.x;
+                _lingoMouse.Value.MouseV = e.motion.y;
+                _lingoMouse.Value.DoMouseMove();
+                break;
+            case SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN:
+                _lingoMouse.Value.MouseH = e.button.x;
+                _lingoMouse.Value.MouseV = e.button.y;
+                if (e.button.button == SDL.SDL_BUTTON_LEFT)
+                {
+                    _lingoMouse.Value.MouseDown = true;
+                    _lingoMouse.Value.LeftMouseDown = true;
+                    _lingoMouse.Value.DoubleClick = e.button.clicks > 1;
+                }
+                else if (e.button.button == SDL.SDL_BUTTON_RIGHT)
+                {
+                    _lingoMouse.Value.RightMouseDown = true;
+                }
+                else if (e.button.button == SDL.SDL_BUTTON_MIDDLE)
+                {
+                    _lingoMouse.Value.MiddleMouseDown = true;
+                }
+                _lingoMouse.Value.DoMouseDown();
+                break;
+            case SDL.SDL_EventType.SDL_MOUSEBUTTONUP:
+                _lingoMouse.Value.MouseH = e.button.x;
+                _lingoMouse.Value.MouseV = e.button.y;
+                if (e.button.button == SDL.SDL_BUTTON_LEFT)
+                {
+                    _lingoMouse.Value.MouseDown = false;
+                    _lingoMouse.Value.LeftMouseDown = false;
+                }
+                else if (e.button.button == SDL.SDL_BUTTON_RIGHT)
+                {
+                    _lingoMouse.Value.RightMouseDown = false;
+                }
+                else if (e.button.button == SDL.SDL_BUTTON_MIDDLE)
+                {
+                    _lingoMouse.Value.MiddleMouseDown = false;
+                }
+                _lingoMouse.Value.DoMouseUp();
+                break;
+            case SDL.SDL_EventType.SDL_MOUSEWHEEL:
+                SDL.SDL_GetMouseState(out var x, out var y);
+                _lingoMouse.Value.MouseH = x;
+                _lingoMouse.Value.MouseV = y;
+                _lingoMouse.Value.DoMouseWheel(e.wheel.y);
+                break;
+        }
+    }
+    public virtual void SetCursor(AMouseCursor value)
+    {
+        SDL.SDL_SystemCursor sysCursor = value switch
+        {
+            AMouseCursor.Cross => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_CROSSHAIR,
+            AMouseCursor.Watch => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_WAIT,
+            AMouseCursor.IBeam => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_IBEAM,
+            AMouseCursor.SizeAll => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_SIZEALL,
+            AMouseCursor.SizeNWSE => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_SIZENWSE,
+            AMouseCursor.SizeNESW => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_SIZENESW,
+            AMouseCursor.SizeWE => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_SIZEWE,
+            AMouseCursor.SizeNS => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_SIZENS,
+            AMouseCursor.UpArrow => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_ARROW,
+            AMouseCursor.Blank => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_ARROW,
+            AMouseCursor.Finger => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_HAND,
+            AMouseCursor.Drag => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_SIZEALL,
+            AMouseCursor.Help => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_ARROW,
+            AMouseCursor.Wait => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_WAIT,
+            AMouseCursor.NotAllowed => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_NO,
+            _ => SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_ARROW
+        };
+
+        if (_sdlCursor != nint.Zero)
+            SDL.SDL_FreeCursor(_sdlCursor);
+
+        _sdlCursor = SDL.SDL_CreateSystemCursor(sysCursor);
+        SDL.SDL_SetCursor(_sdlCursor);
+    }
+
+
+
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/README.md
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/README.md
@@ -1,0 +1,3 @@
+# AbstUI.ImGui
+
+ImGui backend for the AbstUI framework, rendering the abstract UI components through ImGui.

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Styles/ImGuiFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Styles/ImGuiFontManager.cs
@@ -1,0 +1,151 @@
+using AbstUI.ImGui.ImGuiLL;
+using AbstUI.Styles;
+using ImGuiNET;
+
+namespace AbstUI.ImGui.Styles;
+
+public interface IImGuiFontLoadedByUser
+{
+    nint FontHandle { get; }
+    void Release();
+}
+public interface IAbstImGuiFont
+{
+    IImGuiFontLoadedByUser? Get(object fontUser, int fontSize);
+}
+public class ImGuiFontManager : IAbstFontManager
+{
+    private readonly List<(string Name, string FileName)> _fontsToLoad = new();
+    private readonly Dictionary<string, AbstImGuiFont> _loadedFonts = new();
+    public IAbstFontManager AddFont(string name, string pathAndName)
+    {
+        _fontsToLoad.Add((name, pathAndName));
+        return this;
+    }
+    public void LoadAll()
+    {
+        if (_loadedFonts.Count == 0)
+            _loadedFonts.Add("Tahoma", new AbstImGuiFont(this, "Tahoma", "Fonts\\Tahoma.ttf")); // default font
+        foreach (var font in _fontsToLoad)
+            _loadedFonts[font.Name] = new AbstImGuiFont(this, font.Name, font.FileName); // placeholder
+
+        _fontsToLoad.Clear();
+        InitFonts();
+
+    }
+    public T? Get<T>(string name) where T : class
+        => _loadedFonts.TryGetValue(name, out var f) ? f as T : null;
+    public IImGuiFontLoadedByUser GetTyped(object fontUser, string? name, int fontSize)
+    {
+        if (string.IsNullOrEmpty(name)) return _loadedFonts["Tahoma"].Get(fontUser, fontSize);
+        return _loadedFonts[name].Get(fontUser, fontSize);
+    }
+
+    public T GetDefaultFont<T>() where T : class
+        => _loadedFonts.TryGetValue("default", out var f) ? (f as T)! : throw new KeyNotFoundException("Default font not found");
+
+    public void SetDefaultFont<T>(T font) where T : class
+    {
+        if (font is not IAbstImGuiFont sdlFont)
+            throw new ArgumentException("Font must be of type IAbstImGuiFont", nameof(font));
+        _loadedFonts["default"] = (AbstImGuiFont)sdlFont;
+    }
+
+    public IEnumerable<string> GetAllNames() => _loadedFonts.Keys;
+
+
+
+    // SDL Fonts
+    private readonly Dictionary<int, ImFontPtr> _fonts = new();
+
+    public unsafe void InitFonts()
+    {
+        //var io = global::ImGuiNET.ImGui.GetIO();
+
+        //foreach (int size in new[] { 7, 8, 9, 10, 11, 12, 14, 16, 20, 24, 32 }) // etc
+        //{
+        //    var config = ImGuiNative.ImFontConfig_ImFontConfig(); // allocate native config
+        //    ImFontConfigPtr configPtr = new ImFontConfigPtr(config);
+        //    configPtr.SizePixels = size;
+        //    var font = io.Fonts.AddFontDefault(configPtr);
+        //    _fonts[size] = font;
+        //}
+        //io.Fonts.Build();
+    }
+
+    // TODO : use subscription based, add fontUser
+    public ImFontPtr? GetFont(int size)
+        => _fonts.TryGetValue(size, out var font) ? font : null;
+
+
+    private class AbstImGuiFont : IAbstImGuiFont
+    {
+        private Dictionary<int, LoadedFontWithSize> _loadedFontSizes = new();
+        public string FileName { get; private set; }
+        public string Name { get; private set; }
+
+        internal AbstImGuiFont(ImGuiFontManager fontManager, string name, string fontFileName)
+        {
+            FileName = fontFileName;
+            Name = name.Trim();
+        }
+
+
+        public IImGuiFontLoadedByUser Get(object fontUser, int fontSize)
+        {
+            if (!_loadedFontSizes.TryGetValue(fontSize, out var loadedFont))
+            {
+                loadedFont = new LoadedFontWithSize(FileName, fontSize, f => _loadedFontSizes.Remove(fontSize));
+                _loadedFontSizes[fontSize] = loadedFont;
+            }
+            return loadedFont.AddUser(fontUser);
+        }
+    }
+
+    private class LoadedFontWithSize
+    {
+        public nint FontHandle { get; set; }
+        private Dictionary<object, ImGuiLoadedFontByUser> _fontUsers = new();
+        private Action<LoadedFontWithSize> _onRemove;
+
+        public LoadedFontWithSize(string fileName, int fontSize, Action<LoadedFontWithSize> onRemove)
+        {
+            _onRemove = onRemove;
+            FontHandle = SDL_ttf.TTF_OpenFont(fileName, fontSize);
+        }
+
+        public IImGuiFontLoadedByUser AddUser(object user)
+        {
+            var subscription = new ImGuiLoadedFontByUser(FontHandle, f => RemoveUser(user));
+            _fontUsers.Add(user, subscription);
+            return subscription;
+        }
+        private void RemoveUser(object user)
+        {
+            _fontUsers.Remove(user);
+            if (_fontUsers.Count == 0)
+            {
+                _onRemove(this);
+                SDL_ttf.TTF_CloseFont(FontHandle);
+                FontHandle = nint.Zero;
+            }
+        }
+    }
+
+    private class ImGuiLoadedFontByUser : IImGuiFontLoadedByUser
+    {
+        private readonly nint _fontHandle;
+        private readonly Action<ImGuiLoadedFontByUser> _onRemove;
+
+        public ImGuiLoadedFontByUser(nint fontHandle, Action<ImGuiLoadedFontByUser> onRemove)
+        {
+            _fontHandle = fontHandle;
+            _onRemove = onRemove;
+        }
+
+        public nint FontHandle => _fontHandle;
+
+        public void Release() => _onRemove(this);
+    }
+
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Texts/ImGuiLabelExtensions.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Texts/ImGuiLabelExtensions.cs
@@ -1,0 +1,9 @@
+using AbstUI.Primitives;
+using AbstUI.Styles;
+
+namespace AbstUI.ImGui.Texts;
+
+public static class ImGuiLabelExtensions
+{
+
+}


### PR DESCRIPTION
## Summary
- duplicate AbstUI.SDL2 backend into new AbstUI.ImGui project
- add ImGui-specific package metadata and README
- rename namespaces, classes, and files from SDL to ImGui
- remove bundled native binaries and font assets and ignore them in git

## Testing
- `dotnet format -v diag WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a015e3bbc08332a47bad1c4dbab795