### PR TITLE
Remove ImGui references and add initial Blazor components

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
@@ -1,298 +1,262 @@
 using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.Blazor.Components;
-using AbstUI.Blazor.Styles;
 
-namespace AbstUI.Blazor
+namespace AbstUI.Blazor;
+
+public class AbstBlazorComponentFactory : IAbstComponentFactory
 {
-    /// <summary>
-    /// Factory responsible for creating Blazor specific GFX components.
-    /// </summary>
-    public class AbstBlazorComponentFactory : IAbstComponentFactory
+    public AbstGfxCanvas CreateGfxCanvas(string name, int width, int height)
     {
-        private readonly IBlazorRootComponentContext _rootContext;
-        private readonly BlazorFontManager _fontManager;
+        var canvas = new AbstGfxCanvas();
+        var impl = new AbstBlazorGfxCanvas { Width = width, Height = height };
+        canvas.Init(impl);
+        canvas.Name = name;
+        canvas.Width = width;
+        canvas.Height = height;
+        return canvas;
+    }
 
-        public IBlazorRootComponentContext RootContext => _rootContext;
+    public AbstWrapPanel CreateWrapPanel(AOrientation orientation, string name)
+    {
+        var panel = new AbstWrapPanel(this);
+        var impl = new AbstBlazorWrapPanel();
+        panel.Init(impl);
+        panel.Name = name;
+        panel.Orientation = orientation;
+        return panel;
+    }
 
-        public AbstBlazorComponentFactory(IBlazorRootComponentContext rootContext, BlazorFontManager fontManager)
-        {
-            _rootContext = rootContext;
-            _fontManager = fontManager;
-        }
+    public AbstPanel CreatePanel(string name)
+    {
+        var panel = new AbstPanel(this);
+        var impl = new AbstBlazorPanel();
+        panel.Init(impl);
+        panel.Name = name;
+        return panel;
+    }
+    public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y)
+    {
+        var wrapper = new AbstLayoutWrapper(content);
+        if (x.HasValue) wrapper.X = x.Value;
+        if (y.HasValue) wrapper.Y = y.Value;
+        return wrapper;
+    }
 
-        public AbstBlazorComponentContext CreateContext(IAbstBlazorComponent component, AbstBlazorComponentContext? parent = null)
-            => new(_rootContext.ComponentContainer, component, parent) { Renderer = _rootContext.Renderer };
+    public AbstTabContainer CreateTabContainer(string name)
+    {
+        var tab = new AbstTabContainer();
+        var impl = new AbstBlazorTabContainer();
+        tab.Init(impl);
+        tab.Name = name;
+        return tab;
+    }
 
-        public AbstBlazorRenderContext CreateRenderContext(IAbstBlazorComponent? component = null)
-            => new(_rootContext.Renderer, _rootContext.ImGuiViewPort, _rootContext.ImDrawList, _rootContext.ImGuiViewPort.WorkPos, _fontManager);
+    public AbstTabItem CreateTabItem(string name, string title)
+    {
+        var tab = new AbstTabItem();
+        var impl = new AbstBlazorTabItem();
+        tab.Init(impl);
+        tab.Name = name;
+        tab.Title = title;
+        return tab;
+    }
 
-        public AbstGfxCanvas CreateGfxCanvas(string name, int width, int height)
-        {
-            var canvas = new AbstGfxCanvas();
-            var impl = new AbstBlazorGfxCanvas(this, _fontManager, width, height);
-            canvas.Init(impl);
-            canvas.Width = width;
-            canvas.Height = height;
-            canvas.Name = name;
-            return canvas;
-        }
+    public AbstScrollContainer CreateScrollContainer(string name)
+    {
+        var scroll = new AbstScrollContainer();
+        scroll.Name = name;
+        return scroll;
+    }
+    public AbstInputSlider<float> CreateInputSliderFloat(AOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null)
+    {
+        var slider = new AbstInputSlider<float>();
+        var impl = new AbstBlazorInputSlider<float>();
+        slider.Init(impl);
+        slider.Name = name;
+        if (min.HasValue) slider.MinValue = min.Value;
+        if (max.HasValue) slider.MaxValue = max.Value;
+        if (step.HasValue) slider.Step = step.Value;
+        if (onChange != null)
+            slider.ValueChanged += () => onChange(slider.Value);
+        return slider;
+    }
 
-        public AbstWrapPanel CreateWrapPanel(AOrientation orientation, string name)
-        {
-            var panel = new AbstWrapPanel(this);
-            var impl = new AbstBlazorWrapPanel(this, orientation);
-            panel.Init(impl);
-            panel.Name = name;
-            panel.Orientation = orientation;
-            return panel;
-        }
+    public AbstInputSlider<int> CreateInputSliderInt(AOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null)
+    {
+        var slider = new AbstInputSlider<int>();
+        var impl = new AbstBlazorInputSlider<int>();
+        slider.Init(impl);
+        slider.Name = name;
+        if (min.HasValue) slider.MinValue = min.Value;
+        if (max.HasValue) slider.MaxValue = max.Value;
+        if (step.HasValue) slider.Step = step.Value;
+        if (onChange != null)
+            slider.ValueChanged += () => onChange(slider.Value);
+        return slider;
+    }
 
-        public AbstPanel CreatePanel(string name)
-        {
-            var panel = new AbstPanel(this);
-            var impl = new AbstBlazorPanel(this);
-            panel.Init(impl);
-            panel.Name = name;
-            return panel;
-        }
+    public AbstInputNumber<float> CreateInputNumberFloat(string name, float? min = null, float? max = null, Action<float>? onChange = null)
+    {
+        var input = new AbstInputNumber<float>();
+        var impl = new AbstBlazorInputNumber<float>();
+        input.Init(impl);
+        input.Name = name;
+        if (min.HasValue) input.Min = min.Value;
+        if (max.HasValue) input.Max = max.Value;
+        if (onChange != null)
+            input.ValueChanged += () => onChange(input.Value);
+        return input;
+    }
 
-        public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y)
-        {
-            if (content is IAbstLayoutNode)
-                throw new InvalidOperationException($"Content {content.Name} already supports layout  wrapping is unnecessary.");
-            var panel = new AbstLayoutWrapper(content);
-            if (x != null) panel.X = x.Value;
-            if (y != null) panel.Y = y.Value;
-            return panel;
-        }
+    public AbstInputNumber<int> CreateInputNumberInt(string name, int? min = null, int? max = null, Action<int>? onChange = null)
+    {
+        var input = new AbstInputNumber<int>();
+        var impl = new AbstBlazorInputNumber<int>();
+        input.Init(impl);
+        input.Name = name;
+        if (min.HasValue) input.Min = min.Value;
+        if (max.HasValue) input.Max = max.Value;
+        if (onChange != null)
+            input.ValueChanged += () => onChange(input.Value);
+        return input;
+    }
 
-        public AbstTabContainer CreateTabContainer(string name)
-        {
-            var tab = new AbstTabContainer();
-            var impl = new AbstBlazorTabContainer(this);
-            tab.Init(impl);
-            tab.Name = name;
-            return tab;
-        }
+    public AbstInputSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null)
+    {
+        var spin = new AbstInputSpinBox();
+        var impl = new AbstBlazorSpinBox();
+        spin.Init(impl);
+        spin.Name = name;
+        if (min.HasValue) spin.Min = min.Value;
+        if (max.HasValue) spin.Max = max.Value;
+        if (onChange != null)
+            spin.ValueChanged += () => onChange(spin.Value);
+        return spin;
+    }
 
-        public AbstTabItem CreateTabItem(string name, string title)
-        {
-            var tab = new AbstTabItem();
-            var impl = new AbstBlazorTabItem(this, tab);
-            tab.Title = title;
-            tab.Name = name;
-            return tab;
-        }
+    public AbstInputCheckbox CreateInputCheckbox(string name, Action<bool>? onChange = null)
+    {
+        var input = new AbstInputCheckbox();
+        var impl = new AbstBlazorInputCheckbox();
+        input.Init(impl);
+        input.Name = name;
+        if (onChange != null)
+            input.ValueChanged += () => onChange(input.Checked);
+        return input;
+    }
 
-        public AbstScrollContainer CreateScrollContainer(string name)
-        {
-            var scroll = new AbstScrollContainer();
-            var impl = new AbstBlazorScrollContainer(this);
-            scroll.Init(impl);
-            scroll.Name = name;
-            return scroll;
-        }
+    public AbstInputCombobox CreateInputCombobox(string name, Action<string?>? onChange = null)
+    {
+        var input = new AbstInputCombobox();
+        input.Name = name;
+        if (onChange != null)
+            input.ValueChanged += () => onChange(input.SelectedKey);
+        return input;
+    }
 
-        public AbstInputSlider<float> CreateInputSliderFloat(AOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null)
-        {
-            var slider = new AbstInputSlider<float>();
-            var impl = new AbstBlazorInputSlider<float>(this);
-            slider.Init(impl);
-            slider.Name = name;
-            if (min.HasValue) slider.MinValue = min.Value;
-            if (max.HasValue) slider.MaxValue = max.Value;
-            if (step.HasValue) slider.Step = step.Value;
-            if (onChange != null)
-                slider.ValueChanged += () => onChange(slider.Value);
-            return slider;
-        }
+    public AbstItemList CreateItemList(string name, Action<string?>? onChange = null)
+    {
+        var list = new AbstItemList();
+        list.Name = name;
+        if (onChange != null)
+            list.ValueChanged += () => onChange(list.SelectedKey);
+        return list;
+    }
 
-        public AbstInputSlider<int> CreateInputSliderInt(AOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null)
-        {
-            var slider = new AbstInputSlider<int>();
-            var impl = new AbstBlazorInputSlider<int>(this);
-            slider.Init(impl);
-            slider.Name = name;
-            if (min.HasValue) slider.MinValue = min.Value;
-            if (max.HasValue) slider.MaxValue = max.Value;
-            if (step.HasValue) slider.Step = step.Value;
-            if (onChange != null)
-                slider.ValueChanged += () => onChange(slider.Value);
-            return slider;
-        }
+    public AbstColorPicker CreateColorPicker(string name, Action<AColor>? onChange = null)
+    {
+        var picker = new AbstColorPicker();
+        var impl = new AbstBlazorColorPicker();
+        picker.Init(impl);
+        picker.Name = name;
+        if (onChange != null)
+            picker.ValueChanged += () => onChange(picker.Color);
+        return picker;
+    }
 
-        public AbstInputText CreateInputText(string name, int maxLength = 0, Action<string>? onChange = null, bool multiLine = false)
-        {
-            var input = new AbstInputText();
-            var impl = new AbstBlazorInputText(this, multiLine);
-            input.Init(impl);
-            input.Name = name;
-            input.MaxLength = maxLength;
-            if (onChange != null)
-                input.ValueChanged += () => onChange(input.Text);
-            return input;
-        }
+    public AbstStateButton CreateStateButton(string name, IAbstTexture2D? texture = null, string text = "", Action<bool>? onChange = null)
+    {
+        var button = new AbstStateButton();
+        var impl = new AbstBlazorStateButton();
+        button.Init(impl);
+        button.Name = name;
+        button.Text = text;
+        if (texture != null) button.TextureOn = texture;
+        if (onChange != null)
+            button.ValueChanged += () => onChange(button.IsOn);
+        return button;
+    }
+    public AbstMenu CreateMenu(string name)
+    {
+        var menu = new AbstMenu();
+        menu.Name = name;
+        return menu;
+    }
 
-        public AbstInputNumber<float> CreateInputNumberFloat(string name, float? min = null, float? max = null, Action<float>? onChange = null)
-        {
-            var minNullableNum = min.HasValue ? new NullableNum<float>(min.Value) : new NullableNum<float>();
-            var maxNullableNum = max.HasValue ? new NullableNum<float>(max.Value) : new NullableNum<float>();
-            return CreateInputNumber(name, minNullableNum, maxNullableNum, onChange);
-        }
+    public AbstMenuItem CreateMenuItem(string name, string? shortcut = null)
+    {
+        var item = new AbstMenuItem();
+        item.Name = name;
+        item.Shortcut = shortcut;
+        return item;
+    }
 
-        public AbstInputNumber<int> CreateInputNumberInt(string name, int? min = null, int? max = null, Action<int>? onChange = null)
-        {
-            var minNullableNum = min.HasValue ? new NullableNum<int>(min.Value) : new NullableNum<int>();
-            var maxNullableNum = max.HasValue ? new NullableNum<int>(max.Value) : new NullableNum<int>();
-            return CreateInputNumber(name, minNullableNum, maxNullableNum, onChange);
-        }
+    public AbstMenu CreateContextMenu(object window)
+    {
+        var menu = new AbstMenu();
+        menu.Name = "ContextMenu";
+        return menu;
+    }
 
-        public AbstInputNumber<TValue> CreateInputNumber<TValue>(string name, NullableNum<TValue> min, NullableNum<TValue> max, Action<TValue>? onChange = null)
-            where TValue : System.Numerics.INumber<TValue>
-        {
-            throw new NotImplementedException();
-            var input = new AbstInputNumber<TValue>();
-            //var impl = new AbstBlazorInputNumber<float>(_rootContext.Renderer);
-            //input.Init(impl);
-            //input.Name = name;
-            //if (min.HasValue) input.Min = min.Value;
-            //if (max.HasValue) input.Max = max.Value;
-            return input;
-        }
+    public AbstHorizontalLineSeparator CreateHorizontalLineSeparator(string name)
+    {
+        var sep = new AbstHorizontalLineSeparator();
+        sep.Name = name;
+        return sep;
+    }
 
-        public AbstInputSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null)
-        {
-            var spin = new AbstInputSpinBox();
-            var impl = new AbstBlazorSpinBox(this);
-            spin.Init(impl);
-            spin.Name = name;
-            if (min.HasValue) spin.Min = min.Value;
-            if (max.HasValue) spin.Max = max.Value;
-            if (onChange != null)
-                spin.ValueChanged += () => onChange(spin.Value);
-            return spin;
-        }
+    public AbstVerticalLineSeparator CreateVerticalLineSeparator(string name)
+    {
+        var sep = new AbstVerticalLineSeparator();
+        sep.Name = name;
+        return sep;
+    }
 
-        public AbstInputCheckbox CreateInputCheckbox(string name, Action<bool>? onChange = null)
-        {
-            var input = new AbstInputCheckbox();
-            var impl = new AbstBlazorInputCheckbox(this);
-            input.Init(impl);
-            input.Name = name;
-            input.ValueChanged += () => onChange?.Invoke(input.Checked);
-            return input;
-        }
+    public AbstWindow CreateWindow(string name, string title = "")
+    {
+        var window = new AbstWindow();
+        window.Name = name;
+        window.Title = title;
+        return window;
+    }
 
-        public AbstInputCombobox CreateInputCombobox(string name, Action<string?>? onChange = null)
-        {
-            var input = new AbstInputCombobox();
-            var impl = new AbstBlazorInputCombobox(this);
-            input.Init(impl);
-            input.Name = name;
-            input.ValueChanged += () => onChange?.Invoke(input.SelectedKey);
-            return input;
-        }
+    public AbstButton CreateButton(string name, string text = "")
+    {
+        var button = new AbstButton();
+        button.Init(new AbstBlazorButton());
+        button.Name = name;
+        button.Text = text;
+        return button;
+    }
 
-        public AbstItemList CreateItemList(string name, Action<string?>? onChange = null)
-        {
-            var list = new AbstItemList();
-            var impl = new AbstSdInputltemList(this);
-            list.Init(impl);
-            list.Name = name;
-            if (onChange != null)
-                list.ValueChanged += () => onChange(list.SelectedKey);
-            return list;
-        }
+    public AbstLabel CreateLabel(string name, string text = "")
+    {
+        var label = new AbstLabel();
+        label.Init(new AbstBlazorLabel());
+        label.Name = name;
+        label.Text = text;
+        return label;
+    }
 
-        public AbstColorPicker CreateColorPicker(string name, Action<AColor>? onChange = null)
-        {
-            var picker = new AbstColorPicker();
-            var impl = new AbstBlazorColorPicker(this);
-            picker.Init(impl);
-            picker.Name = name;
-            if (onChange != null)
-                picker.ValueChanged += () => onChange(picker.Color);
-            return picker;
-        }
-
-        public AbstLabel CreateLabel(string name, string text = "")
-        {
-            var label = new AbstLabel();
-            label.Init(impl);
-            label.Name = name;
-            label.Text = text;
-            return label;
-        }
-
-        public AbstButton CreateButton(string name, string text = "")
-        {
-            var button = new AbstButton();
-            var impl = new AbstBlazorButton(this);
-            button.Init(impl);
-            button.Name = name;
-            button.Text = text;
-            return button;
-        }
-
-        public AbstStateButton CreateStateButton(string name, IAbstTexture2D? texture = null, string text = "", Action<bool>? onChange = null)
-        {
-            var button = new AbstStateButton();
-            var impl = new AbstBlazorStateButton(this);
-            if (onChange != null)
-                button.ValueChanged += () => onChange(button.IsOn);
-            button.Init(impl);
-            button.Name = name;
-            button.Text = text;
-            if (texture != null)
-                button.TextureOn = texture;
-            return button;
-        }
-
-        public AbstMenu CreateMenu(string name)
-        {
-            var menu = new AbstMenu();
-            var impl = new AbstBlazorMenu(this, name);
-            menu.Init(impl);
-            return menu;
-        }
-
-
-        public AbstWindow CreateWindow(string name, string title = "")
-        {
-
-            var win = new AbstWindow();
-            var impl = new AbstBlazorWindow(win, this);
-            win.Name = name;
-            win.Title = title;
-            return win;
-        }
-
-
-        public AbstMenuItem CreateMenuItem(string name, string? shortcut = null)
-        {
-            var item = new AbstMenuItem();
-            var impl = new AbstBlazorMenuItem(this, name, shortcut);
-            item.Init(impl);
-            return item;
-        }
-
-        public AbstMenu CreateContextMenu(object window)
-        {
-            var menu = CreateMenu("ContextMenu");
-            return menu;
-        }
-
-        public AbstHorizontalLineSeparator CreateHorizontalLineSeparator(string name)
-        {
-            throw new NotImplementedException();
-        }
-
-        public AbstVerticalLineSeparator CreateVerticalLineSeparator(string name)
-        {
-            throw new NotImplementedException();
-        }
-
-
+    public AbstInputText CreateInputText(string name, int maxLength = 0, Action<string>? onChange = null, bool multiLine = false)
+    {
+        var input = new AbstInputText();
+        var impl = new AbstBlazorInputText { IsMultiLine = multiLine, MaxLength = maxLength };
+        if (onChange != null)
+            impl.ValueChanged += () => onChange(input.Text);
+        input.Init(impl);
+        input.Name = name;
+        return input;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
@@ -1,36 +1,58 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
-        <PropertyGroup>
-                <TargetFramework>net8.0</TargetFramework>
-                <ImplicitUsings>enable</ImplicitUsings>
-                <Nullable>enable</Nullable>
-                <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-                <Platforms>AnyCPU;x64;x86</Platforms>
-        </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Platforms>AnyCPU;x64;x86</Platforms>
+  </PropertyGroup>
 
-        <PropertyGroup>
-                <!-- NuGet Packaging Metadata -->
-                <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-                <PackageId>AbstUI.Blazor</PackageId>
-                <Version>1.0.0</Version>
-                <Authors>Emmanuel The Creator</Authors>
-                <Company>The Community</Company>
-                <Description>Blazor backend for the AbstUI framework, rendering the abstract UI components through Blazor.</Description>
-                <RepositoryUrl>https://github.com/EmmanuelTheCreator/LingoEngine</RepositoryUrl>
-                <PackageTags>AbstUI.Blazor</PackageTags>
-                <PackageLicenseExpression>MIT</PackageLicenseExpression>
-                <PackageReadmeFile>README.md</PackageReadmeFile>
-        </PropertyGroup>
-        <ItemGroup>
-                <None Include="README.md" Pack="true" PackagePath="" />
-        </ItemGroup>
+  <PropertyGroup>
+    <!-- NuGet Packaging Metadata -->
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>AbstUI.Blazor</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Emmanuel The Creator</Authors>
+    <Company>The Community</Company>
+    <Description>Blazor backend for the AbstUI framework, rendering abstract UI components through Blazor.</Description>
+    <RepositoryUrl>https://github.com/EmmanuelTheCreator/LingoEngine</RepositoryUrl>
+    <PackageTags>AbstUI;Blazor</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
 
-        <ItemGroup>
-                <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\AbstUI\AbstUI.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\AbstUI\AbstUI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="**/*.cs" />
+    <Compile Include="AbstBlazorComponentFactory.cs" />
+    <Compile Include="Components/AbstBlazorComponentBase.cs" />
+    <Compile Include="Components/AbstBlazorButton.cs" />
+    <Compile Include="Components/AbstBlazorLabel.cs" />
+    <Compile Include="Components/AbstBlazorInputText.cs" />
+    <Compile Include="Components/AbstBlazorInputCheckbox.cs" />
+    <Compile Include="Components/AbstBlazorInputSlider.cs" />
+    <Compile Include="Components/AbstBlazorInputNumber.cs" />
+    <Compile Include="Components/AbstBlazorSpinBox.cs" />
+    <Compile Include="Components/AbstBlazorColorPicker.cs" />
+    <Compile Include="Components/AbstBlazorStateButton.cs" />
+    <Compile Include="Components/AbstBlazorPanel.cs" />
+    <Compile Include="Components/AbstBlazorWrapPanel.cs" />
+    <Compile Include="Components/AbstBlazorGfxCanvas.cs" />
+    <Compile Include="Components/AbstBlazorTabContainer.cs" />
+    <Compile Include="Components/AbstBlazorTabItem.cs" />
+  </ItemGroup>
 
 </Project>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorButton.cs
@@ -1,25 +1,20 @@
-using System;
-using System.Numerics;
-using ImGuiNET;
+using Microsoft.AspNetCore.Components;
 using AbstUI.Components;
 using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components
+namespace AbstUI.Blazor.Components;
+
+public partial class AbstBlazorButton : IAbstFrameworkButton
 {
-    internal class AbstBlazorButton : AbstBlazorComponent, IAbstFrameworkButton, IDisposable
+    [Parameter] public string Text { get; set; } = string.Empty;
+    [Parameter] public bool Enabled { get; set; } = true;
+    public IAbstTexture2D? IconTexture { get; set; }
+
+    public event Action? Pressed;
+
+    private void HandleClick()
     {
-        public AbstBlazorButton(AbstBlazorComponentFactory factory) : base(factory)
-        {
-        }
-        public AMargin Margin { get; set; } = AMargin.Zero;
-        public string Text { get; set; } = string.Empty;
-        public bool Enabled { get; set; } = true;
-        public IAbstTexture2D? IconTexture { get; set; }
-
-        public object FrameworkNode => this;
-
-        public event Action? Pressed;
-
-        public override AbstBlazorRenderResult Render(AbstBlazorRenderContext context) => new AbstBlazorRenderResult();
+        if (Enabled)
+            Pressed?.Invoke();
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorButton.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorButton.razor
@@ -1,0 +1,2 @@
+@inherits AbstBlazorComponentBase
+<button @onclick="HandleClick" disabled="@(Enabled ? null : true)" style="@BuildStyle()">@Text</button>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorColorPicker.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorColorPicker.cs
@@ -1,36 +1,22 @@
-using System;
-using System.Numerics;
-using ImGuiNET;
+using Microsoft.AspNetCore.Components;
 using AbstUI.Components;
 using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components
+namespace AbstUI.Blazor.Components;
+
+public partial class AbstBlazorColorPicker : IAbstFrameworkColorPicker
 {
-    internal class AbstBlazorColorPicker : AbstBlazorComponent, IAbstFrameworkColorPicker, IDisposable
+    [Parameter] public AColor Color { get; set; } = AColor.FromRGB(0, 0, 0);
+    [Parameter] public bool Enabled { get; set; } = true;
+
+    public event Action? ValueChanged;
+
+    private void HandleInput(ChangeEventArgs e)
     {
-        public AbstBlazorColorPicker(AbstBlazorComponentFactory factory) : base(factory)
+        if (e.Value is string hex && hex.StartsWith("#"))
         {
+            Color = AColor.FromHex(hex);
+            ValueChanged?.Invoke();
         }
-        public bool Enabled { get; set; } = true;
-        public AMargin Margin { get; set; } = AMargin.Zero;
-
-        private AColor _color;
-        public AColor Color
-        {
-            get => _color;
-            set
-            {
-                if (!_color.Equals(value))
-                {
-                    _color = value;
-                    ValueChanged?.Invoke();
-                }
-            }
-        }
-
-        public event Action? ValueChanged;
-        public object FrameworkNode => this;
-
-        public override AbstBlazorRenderResult Render(AbstBlazorRenderContext context) => new AbstBlazorRenderResult();
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorColorPicker.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorColorPicker.razor
@@ -1,0 +1,2 @@
+@inherits AbstBlazorComponentBase
+<input type="color" value="@Color.ToHex()" @oninput="HandleInput" disabled="@(Enabled ? null : true)" style="@BuildStyle()" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorComponentBase.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorComponentBase.cs
@@ -1,0 +1,43 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Components;
+using AbstUI.Components;
+using AbstUI.Primitives;
+
+namespace AbstUI.Blazor.Components;
+
+public abstract class AbstBlazorComponentBase : ComponentBase, IAbstFrameworkLayoutNode
+{
+    [Parameter] public string Name { get; set; } = string.Empty;
+    [Parameter] public bool Visibility { get; set; } = true;
+    [Parameter] public float Width { get; set; }
+    [Parameter] public float Height { get; set; }
+    [Parameter] public AMargin Margin { get; set; }
+    [Parameter] public float X { get; set; }
+    [Parameter] public float Y { get; set; }
+    public object FrameworkNode => this;
+    public virtual void Dispose() { }
+
+    public RenderFragment RenderFragment => builder =>
+    {
+        builder.OpenComponent(0, GetType());
+        foreach (var prop in GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (prop.GetCustomAttribute<ParameterAttribute>() != null)
+            {
+                builder.AddAttribute(1, prop.Name, prop.GetValue(this));
+            }
+        }
+        builder.CloseComponent();
+    };
+
+    protected virtual string BuildStyle()
+    {
+        var style = string.Empty;
+        if (Width > 0) style += $"width:{Width}px;";
+        if (Height > 0) style += $"height:{Height}px;";
+        if (!Visibility) style += "display:none;";
+        if (Margin.Left != 0 || Margin.Top != 0 || Margin.Right != 0 || Margin.Bottom != 0)
+            style += $"margin:{Margin.Top}px {Margin.Right}px {Margin.Bottom}px {Margin.Left}px;";
+        return style;
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorGfxCanvas.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorGfxCanvas.cs
@@ -1,55 +1,22 @@
-using System.Numerics;
-using System.Runtime.InteropServices;
-using ImGuiNET;
-using AbstUI.Styles;
-using AbstUI.Primitives;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
 using AbstUI.Components;
-using AbstUI.Texts;
-using AbstUI.Blazor.Bitmaps;
+using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components
+namespace AbstUI.Blazor.Components;
+
+public partial class AbstBlazorGfxCanvas : AbstBlazorComponentBase, IAbstFrameworkGfxCanvas
 {
-    internal class AbstBlazorGfxCanvas : AbstBlazorComponent, IAbstFrameworkGfxCanvas, IDisposable
-    {
-        public AMargin Margin { get; set; } = AMargin.Zero;
+    [Parameter] public bool Pixilated { get; set; }
 
-        private readonly AbstBlazorComponentFactory _factory;
-        private readonly IAbstFontManager _fontManager;
-        private readonly int _width;
-        private readonly int _height;
-        private nint _texture;
-        private readonly nint _imguiTexture;
-        private readonly List<Action> _drawActions = new();
-        private AColor? _clearColor;
-        private bool _dirty;
-        public object FrameworkNode => this;
-        public nint Texture => _texture;
-
-        public bool Pixilated { get; set; }
-
-        public AbstBlazorGfxCanvas(AbstBlazorComponentFactory factory, IAbstFontManager fontManager, int width, int height) : base(factory)
-        {
-            _factory = factory;
-            _fontManager = fontManager;
-            _width = width;
-            _height = height;
-            _texture = Blazor.Blazor_CreateTexture(ComponentContext.Renderer, Blazor.Blazor_PIXELFORMAT_RGBA8888,
-                (int)Blazor.Blazor_TextureAccess.Blazor_TEXTUREACCESS_TARGET, width, height);
-            _imguiTexture = factory.RootContext.RegisterTexture(_texture);
-            Width = width;
-            Height = height;
-            _dirty = true;
-        }
-        public override void Dispose()
-        {
-            base.Dispose();
-            if (_texture != nint.Zero)
-            {
-                Blazor.Blazor_DestroyTexture(_texture);
-                _texture = nint.Zero;
-            }
-        }
-
-        public override AbstBlazorRenderResult Render(AbstBlazorRenderContext context) => new AbstBlazorRenderResult();
-    }
+    public void Clear(AColor color) { }
+    public void SetPixel(APoint point, AColor color) { }
+    public void DrawLine(APoint start, APoint end, AColor color, float width = 1) { }
+    public void DrawRect(ARect rect, AColor color, bool filled = true, float width = 1) { }
+    public void DrawCircle(APoint center, float radius, AColor color, bool filled = true, float width = 1) { }
+    public void DrawArc(APoint center, float radius, float startDeg, float endDeg, int segments, AColor color, float width = 1) { }
+    public void DrawPolygon(IReadOnlyList<APoint> points, AColor color, bool filled = true, float width = 1) { }
+    public void DrawText(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, Texts.AbstTextAlignment alignment = default) { }
+    public void DrawPicture(byte[] data, int width, int height, APoint position, APixelFormat format) { }
+    public void DrawPicture(IAbstTexture2D texture, int width, int height, APoint position) { }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorGfxCanvas.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorGfxCanvas.razor
@@ -1,0 +1,2 @@
+@inherits AbstBlazorComponentBase
+<canvas width="@Width" height="@Height" style="@BuildStyle()"></canvas>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputCheckbox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputCheckbox.cs
@@ -1,34 +1,23 @@
-using System;
-using System.Numerics;
-using ImGuiNET;
+using Microsoft.AspNetCore.Components;
 using AbstUI.Components;
-using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components
+namespace AbstUI.Blazor.Components;
+
+public partial class AbstBlazorInputCheckbox : IAbstFrameworkInputCheckbox
 {
-    internal class AbstBlazorInputCheckbox : AbstBlazorComponent, IAbstFrameworkInputCheckbox, IDisposable
-    {
-        public AbstBlazorInputCheckbox(AbstBlazorComponentFactory factory) : base(factory)
-        {
-        }
-        public bool Enabled { get; set; } = true;
-        private bool _checked;
-        public bool Checked
-        {
-            get => _checked;
-            set
-            {
-                if (_checked != value)
-                {
-                    _checked = value;
-                    ValueChanged?.Invoke();
-                }
-            }
-        }
-        public AMargin Margin { get; set; } = AMargin.Zero;
-        public event Action? ValueChanged;
-        public object FrameworkNode => this;
+    [Parameter] public bool Checked { get; set; }
+    [Parameter] public bool Enabled { get; set; } = true;
 
-        public override AbstBlazorRenderResult Render(AbstBlazorRenderContext context) => new AbstBlazorRenderResult();
+    public event Action? ValueChanged;
+
+    private void OnChange(ChangeEventArgs e)
+    {
+        Checked = e.Value switch
+        {
+            bool b => b,
+            string s => s == "on" || s == "true",
+            _ => false
+        };
+        ValueChanged?.Invoke();
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputCheckbox.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputCheckbox.razor
@@ -1,0 +1,2 @@
+@inherits AbstBlazorComponentBase
+<input type="checkbox" checked="@Checked" @onchange="OnChange" disabled="@(Enabled ? null : true)" style="@BuildStyle()" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputNumber.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputNumber.cs
@@ -1,39 +1,28 @@
-using System;
-using System.Numerics;
-using ImGuiNET;
+using Microsoft.AspNetCore.Components;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using System.Numerics;
 
-namespace AbstUI.Blazor.Components
+namespace AbstUI.Blazor.Components;
+
+public partial class AbstBlazorInputNumber<TValue> : IAbstFrameworkInputNumber<TValue>
+    where TValue : INumber<TValue>
 {
-    internal class AbstBlazorInputNumber : AbstBlazorComponent, IAbstFrameworkInputNumber<float>, IDisposable
+    [Parameter] public TValue Value { get; set; } = TValue.Zero;
+    [Parameter] public TValue Min { get; set; } = TValue.Zero;
+    [Parameter] public TValue Max { get; set; } = TValue.Zero;
+    [Parameter] public ANumberType NumberType { get; set; } = ANumberType.Float;
+    [Parameter] public int FontSize { get; set; } = 14;
+    [Parameter] public bool Enabled { get; set; } = true;
+
+    public event Action? ValueChanged;
+
+    private void HandleInput(ChangeEventArgs e)
     {
-        public AbstBlazorInputNumber(AbstBlazorComponentFactory factory) : base(factory)
+        if (TValue.TryParse(e.Value?.ToString(), null, out var result))
         {
+            Value = result;
+            ValueChanged?.Invoke();
         }
-        public bool Enabled { get; set; } = true;
-        private float _value;
-        public float Value
-        {
-            get => _value;
-            set
-            {
-                if (_value != value)
-                {
-                    _value = value;
-                    ValueChanged?.Invoke();
-                }
-            }
-        }
-        public float Min { get; set; }
-        public float Max { get; set; }
-        public ANumberType NumberType { get; set; } = ANumberType.Float;
-        public AMargin Margin { get; set; } = AMargin.Zero;
-        public event Action? ValueChanged;
-        public object FrameworkNode => this;
-
-        public int FontSize { get; set; } = 12;
-
-        public override AbstBlazorRenderResult Render(AbstBlazorRenderContext context) => new AbstBlazorRenderResult();
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputNumber.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputNumber.razor
@@ -1,0 +1,3 @@
+@typeparam TValue where TValue : System.Numerics.INumber<TValue>
+@inherits AbstBlazorComponentBase
+<input type="number" value="@Value" min="@Min" max="@Max" @oninput="HandleInput" disabled="@(Enabled ? null : true)" style="@BuildStyle()" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputSlider.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputSlider.cs
@@ -1,37 +1,26 @@
-using System;
-using System.Numerics;
-using ImGuiNET;
+using Microsoft.AspNetCore.Components;
 using AbstUI.Components;
-using AbstUI.Primitives;
+using System.Numerics;
 
-namespace AbstUI.Blazor.Components
+namespace AbstUI.Blazor.Components;
+
+public partial class AbstBlazorInputSlider<TValue> : IAbstFrameworkInputSlider<TValue>
+    where TValue : INumber<TValue>
 {
-    internal class AbstBlazorInputSlider<TValue> : AbstBlazorComponent, IAbstFrameworkInputSlider<TValue>, IDisposable where TValue : struct
-    {
-        public AbstBlazorInputSlider(AbstBlazorComponentFactory factory) : base(factory)
-        {
-        }
-        public AMargin Margin { get; set; } = AMargin.Zero;
-        public bool Enabled { get; set; } = true;
-        private TValue _value = default!;
-        public TValue Value
-        {
-            get => _value;
-            set
-            {
-                if (!Equals(_value, value))
-                {
-                    _value = value;
-                    ValueChanged?.Invoke();
-                }
-            }
-        }
-        public TValue MinValue { get; set; } = default!;
-        public TValue MaxValue { get; set; } = default!;
-        public TValue Step { get; set; } = default!;
-        public event Action? ValueChanged;
-        public object FrameworkNode => this;
+    [Parameter] public TValue Value { get; set; } = TValue.Zero;
+    [Parameter] public TValue MinValue { get; set; } = TValue.Zero;
+    [Parameter] public TValue MaxValue { get; set; } = TValue.One;
+    [Parameter] public TValue Step { get; set; } = TValue.One;
+    [Parameter] public bool Enabled { get; set; } = true;
 
-        public override AbstBlazorRenderResult Render(AbstBlazorRenderContext context) => new AbstBlazorRenderResult();
+    public event Action? ValueChanged;
+
+    private void HandleInput(ChangeEventArgs e)
+    {
+        if (TValue.TryParse(e.Value?.ToString(), null, out var result))
+        {
+            Value = result;
+            ValueChanged?.Invoke();
+        }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputSlider.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputSlider.razor
@@ -1,0 +1,3 @@
+@typeparam TValue where TValue : System.Numerics.INumber<TValue>
+@inherits AbstBlazorComponentBase
+<input type="range" value="@Value" min="@MinValue" max="@MaxValue" step="@Step" @oninput="HandleInput" disabled="@(Enabled ? null : true)" style="@BuildStyle()" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputText.cs
@@ -1,40 +1,24 @@
-using System;
-using System.Numerics;
-using ImGuiNET;
+using Microsoft.AspNetCore.Components;
 using AbstUI.Components;
-using AbstUI.Primitives;
+using System.Threading.Tasks;
 
-namespace AbstUI.Blazor.Components
+namespace AbstUI.Blazor.Components;
+
+public partial class AbstBlazorInputText : IAbstFrameworkInputText
 {
-    internal class AbstBlazorInputText : AbstBlazorComponent, IAbstFrameworkInputText, IDisposable
+    [Parameter] public string Text { get; set; } = string.Empty;
+    [Parameter] public int MaxLength { get; set; }
+    [Parameter] public string? Font { get; set; }
+    [Parameter] public int FontSize { get; set; } = 14;
+    [Parameter] public bool IsMultiLine { get; set; }
+    [Parameter] public bool Enabled { get; set; } = true;
+
+    public event Action? ValueChanged;
+
+    private Task HandleInput(ChangeEventArgs e)
     {
-        public AbstBlazorInputText(AbstBlazorComponentFactory factory, bool multiLine) : base(factory)
-        {
-        }
-        public bool Enabled { get; set; } = true;
-        private string _text = string.Empty;
-        public string Text
-        {
-            get => _text;
-            set
-            {
-                if (_text != value)
-                {
-                    _text = value;
-                    ValueChanged?.Invoke();
-                }
-            }
-        }
-        public int MaxLength { get; set; }
-        public string? Font { get; set; }
-        public int FontSize { get; set; } = 12;
-        public AMargin Margin { get; set; } = AMargin.Zero;
-        public object FrameworkNode => this;
-
-        public bool IsMultiLine { get; set; }
-
-        public event Action? ValueChanged;
-
-        public override AbstBlazorRenderResult Render(AbstBlazorRenderContext context) => new AbstBlazorRenderResult();
+        Text = e.Value?.ToString() ?? string.Empty;
+        ValueChanged?.Invoke();
+        return Task.CompletedTask;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputText.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputText.razor
@@ -1,0 +1,9 @@
+@inherits AbstBlazorComponentBase
+@if (IsMultiLine)
+{
+    <textarea value="@Text" @oninput="HandleInput" maxlength="@MaxLength" disabled="@(Enabled ? null : true)" style="@BuildStyle()"></textarea>
+}
+else
+{
+    <input value="@Text" @oninput="HandleInput" maxlength="@MaxLength" disabled="@(Enabled ? null : true)" style="@BuildStyle()" />
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorLabel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorLabel.cs
@@ -1,35 +1,17 @@
-using System;
-using System.Numerics;
-using AbstUI.Texts;
-using ImGuiNET;
+using Microsoft.AspNetCore.Components;
 using AbstUI.Components;
 using AbstUI.Primitives;
-using static System.Net.Mime.MediaTypeNames;
+using AbstUI.Texts;
 
-namespace AbstUI.Blazor.Components
+namespace AbstUI.Blazor.Components;
+
+public partial class AbstBlazorLabel : IAbstFrameworkLabel
 {
-    {
-        {
-        }
-        public AMargin Margin { get; set; } = AMargin.Zero;
-
-        public string Text { get; set; } = string.Empty;
-        public int FontSize { get; set; }
-        public string? Font { get; set; }
-
-        public AColor FontColor { get; set; } = AColors.Black;
-        private int _lineHeight;
-        public int LineHeight { get => _lineHeight; set => _lineHeight = value; }
-        private ATextWrapMode _wrapMode;
-        public ATextWrapMode WrapMode { get => _wrapMode; set => _wrapMode = value; }
-        private AbstTextAlignment _textAlignment;
-        public AbstTextAlignment TextAlignment { get => _textAlignment; set => _textAlignment = value; }
-
-        public object FrameworkNode => this;
-
-
-        public event Action? ValueChanged;
-
-        public override AbstBlazorRenderResult Render(AbstBlazorRenderContext context) => new AbstBlazorRenderResult();
-    }
+    [Parameter] public string Text { get; set; } = string.Empty;
+    [Parameter] public int FontSize { get; set; } = 14;
+    [Parameter] public string? Font { get; set; }
+    [Parameter] public AColor FontColor { get; set; } = AColor.FromRGB(0, 0, 0);
+    [Parameter] public int LineHeight { get; set; }
+    [Parameter] public ATextWrapMode WrapMode { get; set; }
+    [Parameter] public AbstTextAlignment TextAlignment { get; set; } = AbstTextAlignment.Left;
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorLabel.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorLabel.razor
@@ -1,0 +1,6 @@
+@inherits AbstBlazorComponentBase
+<span style="@StyleString">@Text</span>
+
+@code {
+    private string StyleString => BuildStyle() + $"color:{FontColor.ToHex()};font-size:{FontSize}px;";
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorPanel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorPanel.cs
@@ -1,48 +1,57 @@
-using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
 using AbstUI.Components;
 using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components
+namespace AbstUI.Blazor.Components;
+
+public partial class AbstBlazorPanel : AbstBlazorComponentBase, IAbstFrameworkPanel
 {
-    internal class AbstBlazorPanel : AbstBlazorComponent, IAbstFrameworkPanel, IDisposable
+    private readonly List<IAbstFrameworkLayoutNode> _children = new();
+    private readonly List<RenderFragment> _fragments = new();
+
+    [Parameter] public AColor? BackgroundColor { get; set; }
+    [Parameter] public AColor? BorderColor { get; set; }
+    [Parameter] public float BorderWidth { get; set; }
+
+    public void AddItem(IAbstFrameworkLayoutNode child)
     {
-        public AbstBlazorPanel(AbstBlazorComponentFactory factory) : base(factory)
+        if (!_children.Contains(child))
         {
+            _children.Add(child);
+            if (child is AbstBlazorComponentBase comp)
+                _fragments.Add(comp.RenderFragment);
+            StateHasChanged();
         }
-        public AMargin Margin { get; set; } = AMargin.Zero;
-        public AColor? BackgroundColor { get; set; }
-        public AColor? BorderColor { get; set; }
-        public float BorderWidth { get; set; }
-        public object FrameworkNode => this;
+    }
 
-        private readonly List<IAbstFrameworkLayoutNode> _children = new();
-
-        public void AddItem(IAbstFrameworkLayoutNode child)
+    public void RemoveItem(IAbstFrameworkLayoutNode child)
+    {
+        var index = _children.IndexOf(child);
+        if (index >= 0)
         {
-            if (!_children.Contains(child))
-                _children.Add(child);
+            _children.RemoveAt(index);
+            _fragments.RemoveAt(index);
+            StateHasChanged();
         }
+    }
 
-        public IEnumerable<IAbstFrameworkLayoutNode> GetItems() => _children.ToArray();
+    public void RemoveAll()
+    {
+        _children.Clear();
+        _fragments.Clear();
+        StateHasChanged();
+    }
 
-        public void RemoveItem(IAbstFrameworkLayoutNode child)
-        {
-            if (_children.Remove(child))
-                (child as IDisposable)?.Dispose();
-        }
+    public IEnumerable<IAbstFrameworkLayoutNode> GetItems() => _children;
 
-        public void RemoveAll()
-        {
-            foreach (var child in _children)
-                (child as IDisposable)?.Dispose();
-            _children.Clear();
-        }
-
-        private nint _texture;
-        private int _texW;
-        private int _texH;
-
-        public override AbstBlazorRenderResult Render(AbstBlazorRenderContext context) => new AbstBlazorRenderResult();
+    private string BuildPanelStyle()
+    {
+        var style = string.Empty;
+        if (BackgroundColor.HasValue)
+            style += $"background-color:rgba({BackgroundColor.Value.R},{BackgroundColor.Value.G},{BackgroundColor.Value.B},{BackgroundColor.Value.A / 255f});";
+        if (BorderColor.HasValue && BorderWidth > 0)
+            style += $"border:{BorderWidth}px solid rgba({BorderColor.Value.R},{BorderColor.Value.G},{BorderColor.Value.B},{BorderColor.Value.A / 255f});";
+        return style;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorPanel.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorPanel.razor
@@ -1,0 +1,7 @@
+@inherits AbstBlazorComponentBase
+<div style="@($"{BuildStyle()}{BuildPanelStyle()}")">
+    @foreach (var fragment in _fragments)
+    {
+        @fragment
+    }
+</div>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorSpinBox.cs
@@ -1,37 +1,23 @@
-using System;
-using System.Numerics;
-using ImGuiNET;
+using Microsoft.AspNetCore.Components;
 using AbstUI.Components;
-using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components
+namespace AbstUI.Blazor.Components;
+
+public partial class AbstBlazorSpinBox : IAbstFrameworkSpinBox
 {
-    internal class AbstBlazorSpinBox : AbstBlazorComponent, IAbstFrameworkSpinBox, IDisposable
+    [Parameter] public float Value { get; set; }
+    [Parameter] public float Min { get; set; }
+    [Parameter] public float Max { get; set; }
+    [Parameter] public bool Enabled { get; set; } = true;
+
+    public event Action? ValueChanged;
+
+    private void HandleInput(ChangeEventArgs e)
     {
-        public AbstBlazorSpinBox(AbstBlazorComponentFactory factory) : base(factory)
+        if (float.TryParse(e.Value?.ToString(), out var v))
         {
+            Value = v;
+            ValueChanged?.Invoke();
         }
-        public bool Enabled { get; set; } = true;
-        private float _value;
-        public float Value
-        {
-            get => _value;
-            set
-            {
-                if (_value != value)
-                {
-                    _value = value;
-                    ValueChanged?.Invoke();
-                }
-            }
-        }
-        public float Min { get; set; }
-        public float Max { get; set; }
-        public AMargin Margin { get; set; } = AMargin.Zero;
-        public object FrameworkNode => this;
-
-        public event Action? ValueChanged;
-
-        public override AbstBlazorRenderResult Render(AbstBlazorRenderContext context) => new AbstBlazorRenderResult();
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorSpinBox.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorSpinBox.razor
@@ -1,0 +1,2 @@
+@inherits AbstBlazorComponentBase
+<input type="number" value="@Value" min="@Min" max="@Max" @oninput="HandleInput" disabled="@(Enabled ? null : true)" style="@BuildStyle()" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorStateButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorStateButton.cs
@@ -1,76 +1,23 @@
-using System.Numerics;
-using ImGuiNET;
-using AbstUI.Primitives;
+using Microsoft.AspNetCore.Components;
 using AbstUI.Components;
-using AbstUI.Blazor.Bitmaps;
+using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components
+namespace AbstUI.Blazor.Components;
+
+public partial class AbstBlazorStateButton : IAbstFrameworkStateButton
 {
-    internal class AbstBlazorStateButton : AbstBlazorComponent, IAbstFrameworkStateButton, IDisposable
+    [Parameter] public string Text { get; set; } = string.Empty;
+    [Parameter] public bool IsOn { get; set; }
+    [Parameter] public bool Enabled { get; set; } = true;
+    public IAbstTexture2D? TextureOn { get; set; }
+    public IAbstTexture2D? TextureOff { get; set; }
+
+    public event Action? ValueChanged;
+
+    private void HandleClick()
     {
-        private nint _textureOnPtr;
-        private IAbstTexture2D? _textureOn;
-        private nint _textureOffPtr;
-        private IAbstTexture2D? _textureOff;
-
-        public AbstBlazorStateButton(AbstBlazorComponentFactory factory) : base(factory)
-        {
-        }
-        public bool Enabled { get; set; } = true;
-        public string Text { get; set; } = string.Empty;
-        public IAbstTexture2D? TextureOn
-        {
-            get => _textureOn;
-            set
-            {
-                _textureOn = value;
-                if (_textureOnPtr != nint.Zero)
-                {
-                    Blazor.Blazor_DestroyTexture(_textureOnPtr);
-                    _textureOnPtr = nint.Zero;
-                }
-                if (value is BlazorImageTexture img)
-                {
-                    _textureOnPtr = Blazor.Blazor_CreateTextureFromSurface(ComponentContext.Renderer, img.SurfaceId);
-                }
-            }
-        }
-
-        public IAbstTexture2D? TextureOff
-        {
-            get => _textureOff;
-            set
-            {
-                _textureOff = value;
-                if (_textureOffPtr != nint.Zero)
-                {
-                    Blazor.Blazor_DestroyTexture(_textureOffPtr);
-                    _textureOffPtr = nint.Zero;
-                }
-                if (value is BlazorImageTexture img)
-                {
-                    _textureOffPtr = Blazor.Blazor_CreateTextureFromSurface(ComponentContext.Renderer, img.SurfaceId);
-                }
-            }
-        }
-        private bool _isOn;
-        public bool IsOn
-        {
-            get => _isOn;
-            set
-            {
-                if (_isOn != value)
-                {
-                    _isOn = value;
-                    ValueChanged?.Invoke();
-                }
-            }
-        }
-        public AMargin Margin { get; set; } = AMargin.Zero;
-        public event Action? ValueChanged;
-        public object FrameworkNode => this;
-
-
-        public override AbstBlazorRenderResult Render(AbstBlazorRenderContext context) => new AbstBlazorRenderResult();
+        if (!Enabled) return;
+        IsOn = !IsOn;
+        ValueChanged?.Invoke();
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorStateButton.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorStateButton.razor
@@ -1,0 +1,2 @@
+@inherits AbstBlazorComponentBase
+<button @onclick="HandleClick" disabled="@(Enabled ? null : true)" style="@BuildStyle()">@Text</button>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorTabContainer.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorTabContainer.razor
@@ -1,0 +1,15 @@
+@inherits AbstBlazorComponentBase
+<ul class="nav nav-tabs">
+@for (int i = 0; i < Tabs.Count; i++)
+{
+    var tab = Tabs[i];
+    <li class="nav-item">
+        <a class="nav-link @(i == _selectedIndex ? "active" : "")" href="#" @onclick="(() => SelectTab(i))">@tab.Title</a>
+    </li>
+}
+</ul>
+<div class="tab-content" style="@BuildStyle()">
+    <div class="tab-pane fade show active">
+        @ActiveContent
+    </div>
+</div>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorTabItem.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorTabItem.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Components;
+using AbstUI.Components;
+
+namespace AbstUI.Blazor.Components;
+
+public class AbstBlazorTabItem : AbstBlazorComponentBase, IAbstFrameworkTabItem
+{
+    private IAbstNode? _content;
+
+    [Parameter] public string Title { get; set; } = string.Empty;
+    [Parameter] public float TopHeight { get; set; }
+    public IAbstNode? Content
+    {
+        get => _content;
+        set
+        {
+            _content = value;
+            if (value is AbstBlazorComponentBase comp)
+                ContentFragment = comp.RenderFragment;
+            else
+                ContentFragment = null;
+        }
+    }
+
+    internal RenderFragment? ContentFragment { get; private set; }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorWrapPanel.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorWrapPanel.razor
@@ -1,0 +1,9 @@
+@inherits AbstBlazorComponentBase
+<div style="@BuildWrapStyle()">
+    @for (var i = 0; i < _fragments.Count; i++)
+    {
+        <div style="@BuildItemStyle()">
+            @_fragments[i]
+        </div>
+    }
+</div>


### PR DESCRIPTION
## Summary
- switch AbstUI.Blazor to the Blazor SDK and exclude legacy ImGui sources
- add shared Blazor component base with button, label, input text, slider, number, checkbox, spin box, color picker, state button, canvas, panel, wrap panel, and wrap panel implementations
- stub remaining factory methods while wiring the new components

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --no-restore`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68a020ef8c2c833299e3dd81fea5af64