### PR TITLE
Add initial Blazor project scaffolding

### DIFF
--- a/LingoEngine.sln
+++ b/LingoEngine.sln
@@ -49,6 +49,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.SDL2.GfxVisualT
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.Unity", "src\LingoEngine.Unity\LingoEngine.Unity.csproj", "{6CE8AADE-1B0F-4BC0-B33F-8572E9463411}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LingoEngine.Blazor", "src\LingoEngine.Blazor\LingoEngine.Blazor.csproj", "{420CB027-B956-4614-A358-C6C9FC72513D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -403,6 +405,24 @@ Global
 		{6CE8AADE-1B0F-4BC0-B33F-8572E9463411}.ExportRelease|x64.Build.0 = Debug|Any CPU
 		{6CE8AADE-1B0F-4BC0-B33F-8572E9463411}.ExportRelease|x86.ActiveCfg = Debug|Any CPU
 		{6CE8AADE-1B0F-4BC0-B33F-8572E9463411}.ExportRelease|x86.Build.0 = Debug|Any CPU
+		{420CB027-B956-4614-A358-C6C9FC72513D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{420CB027-B956-4614-A358-C6C9FC72513D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{420CB027-B956-4614-A358-C6C9FC72513D}.Debug|x64.ActiveCfg = Debug|x64
+		{420CB027-B956-4614-A358-C6C9FC72513D}.Debug|x64.Build.0 = Debug|x64
+		{420CB027-B956-4614-A358-C6C9FC72513D}.Debug|x86.ActiveCfg = Debug|x86
+		{420CB027-B956-4614-A358-C6C9FC72513D}.Debug|x86.Build.0 = Debug|x86
+		{420CB027-B956-4614-A358-C6C9FC72513D}.ExportDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{420CB027-B956-4614-A358-C6C9FC72513D}.ExportDebug|Any CPU.Build.0 = Debug|Any CPU
+		{420CB027-B956-4614-A358-C6C9FC72513D}.ExportDebug|x64.ActiveCfg = Debug|x64
+		{420CB027-B956-4614-A358-C6C9FC72513D}.ExportDebug|x64.Build.0 = Debug|x64
+		{420CB027-B956-4614-A358-C6C9FC72513D}.ExportDebug|x86.ActiveCfg = Debug|x86
+		{420CB027-B956-4614-A358-C6C9FC72513D}.ExportDebug|x86.Build.0 = Debug|x86
+		{420CB027-B956-4614-A358-C6C9FC72513D}.ExportRelease|Any CPU.ActiveCfg = Debug|Any CPU
+		{420CB027-B956-4614-A358-C6C9FC72513D}.ExportRelease|Any CPU.Build.0 = Debug|Any CPU
+		{420CB027-B956-4614-A358-C6C9FC72513D}.ExportRelease|x64.ActiveCfg = Debug|x64
+		{420CB027-B956-4614-A358-C6C9FC72513D}.ExportRelease|x64.Build.0 = Debug|x64
+		{420CB027-B956-4614-A358-C6C9FC72513D}.ExportRelease|x86.ActiveCfg = Debug|x86
+		{420CB027-B956-4614-A358-C6C9FC72513D}.ExportRelease|x86.Build.0 = Debug|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/LingoEngine.Blazor/BlazorRootContext.cs
+++ b/src/LingoEngine.Blazor/BlazorRootContext.cs
@@ -1,0 +1,27 @@
+using System;
+using AbstUI.Inputs;
+using LingoEngine.Blazor.Inputs;
+using LingoEngine.Inputs;
+using AbstUI.Primitives;
+
+namespace LingoEngine.Blazor;
+
+public abstract class BlazorRootContext<TMouse> : IDisposable
+    where TMouse : IAbstMouse
+{
+    public LingoBlazorKey Key { get; set; } = null!;
+    public IAbstFrameworkMouse Mouse { get; set; } = null!;
+
+    public IAbstKey AbstKey { get; protected set; } = null!;
+    public IAbstMouse AbstMouse { get; set; } = null!;
+
+    protected BlazorRootContext()
+    {
+    }
+
+    public virtual APoint GetWindowSize() => new APoint(0, 0);
+
+    public virtual void Dispose()
+    {
+    }
+}

--- a/src/LingoEngine.Blazor/Inputs/LingoBlazorKey.cs
+++ b/src/LingoEngine.Blazor/Inputs/LingoBlazorKey.cs
@@ -1,0 +1,18 @@
+using AbstUI.Inputs;
+using LingoEngine.Inputs;
+
+namespace LingoEngine.Blazor.Inputs;
+
+public class LingoBlazorKey : ILingoFrameworkKey
+{
+    public bool CommandDown => false;
+    public bool ControlDown => false;
+    public bool OptionDown => false;
+    public bool ShiftDown => false;
+    public string Key => string.Empty;
+    public int KeyCode => 0;
+
+    public bool KeyPressed(AbstUIKeyType key) => false;
+    public bool KeyPressed(char key) => false;
+    public bool KeyPressed(int keyCode) => false;
+}

--- a/src/LingoEngine.Blazor/Inputs/LingoBlazorMouse.cs
+++ b/src/LingoEngine.Blazor/Inputs/LingoBlazorMouse.cs
@@ -1,0 +1,42 @@
+using AbstUI.Inputs;
+using AbstUI.Primitives;
+using LingoEngine.Bitmaps;
+using LingoEngine.Events;
+using LingoEngine.Inputs;
+
+namespace LingoEngine.Blazor.Inputs;
+
+public class LingoBlazorMouse : ILingoFrameworkMouse
+{
+    private Lazy<AbstMouse<LingoMouseEvent>> _lingoMouse;
+
+    public LingoBlazorMouse(Lazy<AbstMouse<LingoMouseEvent>> mouse)
+    {
+        _lingoMouse = mouse;
+    }
+
+    public void HideMouse(bool state)
+    {
+        // Blazor integration pending
+    }
+
+    public void Release()
+    {
+        // cleanup resources if needed
+    }
+
+    public void ReplaceMouseObj(IAbstMouse lingoMouse)
+    {
+        _lingoMouse = new Lazy<AbstMouse<LingoMouseEvent>>(() => (AbstMouse<LingoMouseEvent>)lingoMouse);
+    }
+
+    public void SetCursor(AMouseCursor cursorType)
+    {
+        // TODO: set system cursor when Blazor backend is available
+    }
+
+    public void SetCursor(LingoMemberBitmap? image)
+    {
+        // TODO: implement custom cursor images for Blazor
+    }
+}

--- a/src/LingoEngine.Blazor/LingoEngine.Blazor.csproj
+++ b/src/LingoEngine.Blazor/LingoEngine.Blazor.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Platforms>AnyCPU;x64;x86</Platforms>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!-- NuGet Packaging Metadata -->
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>LingoEngine.Blazor</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Emmanuel The Creator</Authors>
+    <Company>The Community</Company>
+    <Description>Blazor backend integration for LingoEngine.</Description>
+    <RepositoryUrl>https://github.com/EmmanuelTheCreator/LingoEngine</RepositoryUrl>
+    <PackageTags>LingoEngine;Blazor</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\..\WillMoveToOwnRepo\AbstUI\src\AbstUI\AbstUI.csproj" />
+    <ProjectReference Include="..\LingoEngine\LingoEngine.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add LingoEngine.Blazor project using Razor SDK and packaging metadata
- stub out root context, key, and mouse classes for future Blazor integration

## Testing
- `dotnet build src/LingoEngine.Blazor/LingoEngine.Blazor.csproj`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`
- `dotnet format src/LingoEngine.Blazor/LingoEngine.Blazor.csproj` *(failed: The server disconnected unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68a02f8b8fb88332947efa714e17a391