### PR TITLE
Implement HTML canvas drawing for Blazor

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorGfxCanvas.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorGfxCanvas.cs
@@ -1,7 +1,11 @@
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.Texts;
 
 namespace AbstUI.Blazor.Components;
 
@@ -9,14 +13,134 @@ public partial class AbstBlazorGfxCanvas : AbstBlazorComponentBase, IAbstFramewo
 {
     [Parameter] public bool Pixilated { get; set; }
 
-    public void Clear(AColor color) { }
-    public void SetPixel(APoint point, AColor color) { }
-    public void DrawLine(APoint start, APoint end, AColor color, float width = 1) { }
-    public void DrawRect(ARect rect, AColor color, bool filled = true, float width = 1) { }
-    public void DrawCircle(APoint center, float radius, AColor color, bool filled = true, float width = 1) { }
-    public void DrawArc(APoint center, float radius, float startDeg, float endDeg, int segments, AColor color, float width = 1) { }
-    public void DrawPolygon(IReadOnlyList<APoint> points, AColor color, bool filled = true, float width = 1) { }
-    public void DrawText(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, Texts.AbstTextAlignment alignment = default) { }
-    public void DrawPicture(byte[] data, int width, int height, APoint position, APixelFormat format) { }
-    public void DrawPicture(IAbstTexture2D texture, int width, int height, APoint position) { }
+    private ElementReference _canvasRef;
+    private IJSObjectReference? _module;
+    private IJSObjectReference? _context;
+
+    private readonly List<Func<IJSObjectReference, ValueTask>> _drawActions = new();
+    private AColor? _clearColor;
+    private bool _dirty;
+
+    protected override string BuildStyle()
+    {
+        var style = base.BuildStyle();
+        if (Pixilated)
+            style += "image-rendering:pixelated;";
+        return style;
+    }
+
+    [Inject] private IJSRuntime JS { get; set; } = default!;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_context == null)
+        {
+            _module ??= await JS.InvokeAsync<IJSObjectReference>("import", "./_content/AbstUI.Blazor/scripts/abstUIScripts.js");
+            _context = await _module.InvokeAsync<IJSObjectReference>("abstCanvas.getContext", _canvasRef, Pixilated);
+        }
+
+        if (_dirty && _context != null && _module != null)
+        {
+            if (_clearColor.HasValue)
+                await _module.InvokeVoidAsync("abstCanvas.clear", _context, ToCss(_clearColor.Value), Width, Height);
+            foreach (var action in _drawActions)
+                await action(_context);
+            _dirty = false;
+        }
+    }
+
+    private void MarkDirty()
+    {
+        if (!_dirty)
+        {
+            _dirty = true;
+            _ = InvokeAsync(StateHasChanged);
+        }
+    }
+
+    public void Clear(AColor color)
+    {
+        _drawActions.Clear();
+        _clearColor = color;
+        MarkDirty();
+    }
+
+    public void SetPixel(APoint point, AColor color)
+    {
+        _drawActions.Add(ctx => _module!.InvokeVoidAsync("abstCanvas.setPixel", ctx, point.X, point.Y, ToCss(color)));
+        MarkDirty();
+    }
+
+    public void DrawLine(APoint start, APoint end, AColor color, float width = 1)
+    {
+        _drawActions.Add(ctx => _module!.InvokeVoidAsync("abstCanvas.drawLine", ctx, start.X, start.Y, end.X, end.Y, ToCss(color), width));
+        MarkDirty();
+    }
+
+    public void DrawRect(ARect rect, AColor color, bool filled = true, float width = 1)
+    {
+        _drawActions.Add(ctx => _module!.InvokeVoidAsync("abstCanvas.drawRect", ctx, rect.Left, rect.Top, rect.Width, rect.Height, ToCss(color), filled, width));
+        MarkDirty();
+    }
+
+    public void DrawCircle(APoint center, float radius, AColor color, bool filled = true, float width = 1)
+    {
+        _drawActions.Add(ctx => _module!.InvokeVoidAsync("abstCanvas.drawCircle", ctx, center.X, center.Y, radius, ToCss(color), filled, width));
+        MarkDirty();
+    }
+
+    public void DrawArc(APoint center, float radius, float startDeg, float endDeg, int segments, AColor color, float width = 1)
+    {
+        _drawActions.Add(ctx => _module!.InvokeVoidAsync("abstCanvas.drawArc", ctx, center.X, center.Y, radius, startDeg, endDeg, ToCss(color), width));
+        MarkDirty();
+    }
+
+    public void DrawPolygon(IReadOnlyList<APoint> points, AColor color, bool filled = true, float width = 1)
+    {
+        if (points.Count == 0)
+            return;
+
+        var flat = new float[points.Count * 2];
+        for (int i = 0; i < points.Count; i++)
+        {
+            flat[i * 2] = points[i].X;
+            flat[i * 2 + 1] = points[i].Y;
+        }
+        _drawActions.Add(ctx => _module!.InvokeVoidAsync("abstCanvas.drawPolygon", ctx, flat, ToCss(color), filled, width));
+        MarkDirty();
+    }
+
+    public void DrawText(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, AbstTextAlignment alignment = default)
+    {
+        var col = ToCss(color ?? AColors.Black);
+        var align = alignment switch
+        {
+            AbstTextAlignment.Center => "center",
+            AbstTextAlignment.Right => "right",
+            _ => "left"
+        };
+        _drawActions.Add(ctx => _module!.InvokeVoidAsync("abstCanvas.drawText", ctx, position.X, position.Y, text, font, col, fontSize, align));
+        MarkDirty();
+    }
+
+    public void DrawPicture(byte[] data, int width, int height, APoint position, APixelFormat format)
+    {
+        _drawActions.Add(ctx => _module!.InvokeVoidAsync("abstCanvas.drawPictureData", ctx, data, width, height, position.X, position.Y));
+        MarkDirty();
+    }
+
+    public void DrawPicture(IAbstTexture2D texture, int width, int height, APoint position)
+    {
+        // Drawing from texture not yet supported in Blazor canvas backend.
+        MarkDirty();
+    }
+
+    public override void Dispose()
+    {
+        _drawActions.Clear();
+        base.Dispose();
+    }
+
+    private static string ToCss(AColor c)
+        => $"rgba({c.R},{c.G},{c.B},{c.A / 255f})";
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorGfxCanvas.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorGfxCanvas.razor
@@ -1,2 +1,2 @@
 @inherits AbstBlazorComponentBase
-<canvas width="@Width" height="@Height" style="@BuildStyle()"></canvas>
+<canvas @ref="_canvasRef" width="@Width" height="@Height" style="@BuildStyle()"></canvas>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorWindow.cs
@@ -68,9 +68,10 @@ internal class AbstBlazorWindow : AbstBlazorPanel, IAbstFrameworkWindow, IDispos
     }
 
 
-    // TODO :  Resize Blazor window.
     public void OnResize(int width, int height)
     {
+        Width = width;
+        Height = height;
         _lingoWindow.Resize(width, height);
     }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
@@ -1,0 +1,93 @@
+export class abstCanvas {
+    static getContext(canvas, pixilated) {
+        const ctx = canvas.getContext('2d');
+        if (pixilated) {
+            ctx.imageSmoothingEnabled = false;
+        }
+        return ctx;
+    }
+
+    static clear(ctx, color, width, height) {
+        ctx.fillStyle = color;
+        ctx.fillRect(0, 0, width, height);
+    }
+
+    static setPixel(ctx, x, y, color) {
+        ctx.fillStyle = color;
+        ctx.fillRect(x, y, 1, 1);
+    }
+
+    static drawLine(ctx, x1, y1, x2, y2, color, width) {
+        ctx.beginPath();
+        ctx.moveTo(x1, y1);
+        ctx.lineTo(x2, y2);
+        ctx.strokeStyle = color;
+        ctx.lineWidth = width;
+        ctx.stroke();
+    }
+
+    static drawRect(ctx, x, y, w, h, color, filled, width) {
+        if (filled) {
+            ctx.fillStyle = color;
+            ctx.fillRect(x, y, w, h);
+        } else {
+            ctx.strokeStyle = color;
+            ctx.lineWidth = width;
+            ctx.strokeRect(x, y, w, h);
+        }
+    }
+
+    static drawCircle(ctx, x, y, radius, color, filled, width) {
+        ctx.beginPath();
+        ctx.arc(x, y, radius, 0, Math.PI * 2);
+        if (filled) {
+            ctx.fillStyle = color;
+            ctx.fill();
+        } else {
+            ctx.strokeStyle = color;
+            ctx.lineWidth = width;
+            ctx.stroke();
+        }
+    }
+
+    static drawArc(ctx, x, y, radius, startDeg, endDeg, color, width) {
+        ctx.beginPath();
+        ctx.arc(x, y, radius, startDeg * Math.PI / 180, endDeg * Math.PI / 180);
+        ctx.strokeStyle = color;
+        ctx.lineWidth = width;
+        ctx.stroke();
+    }
+
+    static drawPolygon(ctx, points, color, filled, width) {
+        if (points.length < 4) return;
+        ctx.beginPath();
+        ctx.moveTo(points[0], points[1]);
+        for (let i = 2; i < points.length; i += 2) {
+            ctx.lineTo(points[i], points[i + 1]);
+        }
+        ctx.closePath();
+        if (filled) {
+            ctx.fillStyle = color;
+            ctx.fill();
+        } else {
+            ctx.strokeStyle = color;
+            ctx.lineWidth = width;
+            ctx.stroke();
+        }
+    }
+
+    static drawText(ctx, x, y, text, font, color, fontSize, alignment) {
+        ctx.fillStyle = color;
+        ctx.font = font || (fontSize + 'px sans-serif');
+        ctx.textAlign = alignment;
+        const lines = text.split('\n');
+        for (let i = 0; i < lines.length; i++) {
+            ctx.fillText(lines[i], x, y + i * fontSize);
+        }
+    }
+
+    static drawPictureData(ctx, data, width, height, x, y) {
+        const imgData = new ImageData(new Uint8ClampedArray(data), width, height);
+        ctx.putImageData(imgData, x, y);
+    }
+}


### PR DESCRIPTION
## Summary
- implement draw action queue for Blazor gfx canvas using HTML Canvas and JS interop
- add Razor markup reference and helper JavaScript module for canvas operations
- move canvas script into scripts folder, expose `abstCanvas` class, and support window resizing

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a158af4148833291169890eb6922ea