### PR TITLE
Add sprite movement conversion test and doc reference

### DIFF
--- a/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
@@ -308,6 +308,29 @@ end";
     }
 
     [Fact]
+    public void SpriteMoveAndExitFrameLoopAreConverted()
+    {
+        var lingo = @"on mouseDown me
+  sprite(me.spriteNum).locH = sprite(me.spriteNum).locH + 5
+end
+on exitFrame
+  go to the frame
+end";
+        var result = LingoToCSharpConverter.Convert(lingo);
+        var expected = string.Join('\n',
+            "public void MouseDown()",
+            "{",
+            "Sprite(SpriteNum).LocH = Sprite(SpriteNum).LocH + 5;",
+            "}",
+            "",
+            "public void ExitFrame()",
+            "{",
+            "_Movie.GoTo(_Movie.CurrentFrame);",
+            "}");
+        Assert.Equal(expected.Trim(), result.Trim());
+    }
+
+    [Fact]
     public void AccessModifierIsAppliedToHandlers()
     {
         var lingo = @"on test
@@ -465,7 +488,7 @@ end";
             Sprite = new LingoDatumNode(new LingoDatum(2)),
             Property = new LingoVarNode { VarName = "locH" }
         };
-        Assert.Equal("Sprite(2).locH", CSharpWriter.Write(spriteProp).Trim());
+        Assert.Equal("Sprite(2).LocH", CSharpWriter.Write(spriteProp).Trim());
 
         var menuItemProp = new LingoMenuItemPropExprNode
         {

--- a/src/LingoEngine.Lingo.Core/CSharpWriter.cs
+++ b/src/LingoEngine.Lingo.Core/CSharpWriter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using LingoEngine.Lingo.Core.Tokenizer;
 
@@ -168,6 +169,10 @@ public class CSharpWriter : ILingoAstVisitor
         {
             Append("_Movie.ActorList");
         }
+        else if (propLower == "frame")
+        {
+            Append("_Movie.CurrentFrame");
+        }
         else
         {
             Append($"/* the {node.Prop} */");
@@ -296,9 +301,16 @@ public class CSharpWriter : ILingoAstVisitor
 
     public void Visit(LingoObjPropExprNode node)
     {
-        node.Object.Accept(this);
-        Append(".");
-        node.Property.Accept(this);
+        if (node.Object is LingoVarNode objVar && objVar.VarName.Equals("me", StringComparison.OrdinalIgnoreCase) && node.Property is LingoVarNode propVar)
+        {
+            Append(char.ToUpperInvariant(propVar.VarName[0]) + propVar.VarName[1..]);
+        }
+        else
+        {
+            node.Object.Accept(this);
+            Append(".");
+            node.Property.Accept(this);
+        }
     }
 
     public void Visit(LingoPlayCmdStmtNode node)
@@ -400,7 +412,10 @@ public class CSharpWriter : ILingoAstVisitor
         Append("Sprite(");
         node.Sprite.Accept(this);
         Append(").");
-        node.Property.Accept(this);
+        if (node.Property is LingoVarNode propVar)
+            Append(char.ToUpperInvariant(propVar.VarName[0]) + propVar.VarName[1..]);
+        else
+            node.Property.Accept(this);
     }
 
     public void Visit(LingoChunkDeleteStmtNode node)
@@ -554,7 +569,13 @@ public class CSharpWriter : ILingoAstVisitor
         Append(")");
     }
 
-    public void Visit(LingoVarNode node) => Append(node.VarName);
+    public void Visit(LingoVarNode node)
+    {
+        if (node.VarName.Equals("me", StringComparison.OrdinalIgnoreCase))
+            Append("this");
+        else
+            Append(node.VarName);
+    }
 
     public void Visit(LingoBlockNode node)
     {

--- a/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
+++ b/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
@@ -1,8 +1,13 @@
+using System;
 using System.Collections.Generic;
 using LingoEngine.Lingo.Core.Tokenizer;
 
 namespace LingoEngine.Lingo.Core;
 
+/// <summary>
+/// Converts Lingo source into C# following the mapping rules documented at
+/// https://github.com/EmmanuelTheCreator/LingoEngine/blob/main/docs/Lingo_vs_CSharp.md.
+/// </summary>
 public static class LingoToCSharpConverter
 {
     public static string Convert(string lingoSource, string methodAccessModifier = "public")
@@ -188,7 +193,7 @@ public static class LingoToCSharpConverter
 
         int pos = idx + 4;
         if (pos >= tokens.Count) return false;
-        if (tokens[pos].Type != LingoTokenType.Identifier) return false;
+        if (tokens[pos].Type != LingoTokenType.Symbol) return false;
         string type = tokens[pos].Lexeme.ToLowerInvariant();
         string method = type switch
         {

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoTokenizer.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoTokenizer.cs
@@ -182,7 +182,7 @@ namespace LingoEngine.Lingo.Core.Tokenizer
                 '=' => MakeToken(LingoTokenType.Equals),
                 '<' => MakeToken(LingoTokenType.LessThan),
                 '>' => MakeToken(LingoTokenType.GreaterThan),
-                '#' => new LingoToken(LingoTokenType.Identifier, ReadIdentifier(), _line),
+                '#' => new LingoToken(LingoTokenType.Symbol, ReadIdentifier(), _line),
                 _ => MakeToken(LingoTokenType.Symbol)
             };
         }


### PR DESCRIPTION
## Summary
- note conversion guide in `LingoToCSharpConverter`
- handle sprite movement and frame loop snippet via token walk and AST
- add unit test covering sprite locH movement and frame loop

## Testing
- `dotnet format src/LingoEngine.Lingo.Core/LingoEngine.Lingo.Core.csproj --no-restore --include src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs src/LingoEngine.Lingo.Core/Tokenizer/LingoTokenizer.cs -v diag`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68a1598fa5308332adbc7c10065dfe0b