### PR TITLE
Use Bootstrap modals for Blazor windows

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorPanel.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorPanel.razor
@@ -1,5 +1,5 @@
 @inherits AbstBlazorComponentBase
-<div style="@($"{BuildStyle()}{BuildPanelStyle()}")">
+<div id="@Name" style="@($"{BuildStyle()}{BuildPanelStyle()}")">
     @foreach (var fragment in _fragments)
     {
         @fragment

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
@@ -97,3 +97,19 @@ export class AbstUIKey {
         document.body.style.cursor = cursor;
     }
 }
+
+export class AbstUIWindow {
+    static showBootstrapModal(id) {
+        const el = document.getElementById(id);
+        if (!el) return;
+        const modal = bootstrap.Modal.getOrCreateInstance(el);
+        modal.show();
+    }
+
+    static hideBootstrapModal(id) {
+        const el = document.getElementById(id);
+        if (!el) return;
+        const modal = bootstrap.Modal.getOrCreateInstance(el);
+        modal.hide();
+    }
+}

--- a/src/LingoEngine.Blazor/BlazorWindowManager.cs
+++ b/src/LingoEngine.Blazor/BlazorWindowManager.cs
@@ -1,0 +1,39 @@
+using Microsoft.JSInterop;
+
+namespace LingoEngine.Blazor;
+
+public interface IBlazorWindowManager
+{
+    void ShowWindow(string id);
+    void HideWindow(string id);
+}
+
+public class BlazorWindowManager : IBlazorWindowManager
+{
+    private readonly IJSRuntime _js;
+    private IJSObjectReference? _module;
+
+    public BlazorWindowManager(IJSRuntime js)
+    {
+        _js = js;
+    }
+
+    private void EnsureModule()
+    {
+        _module ??= _js.InvokeAsync<IJSObjectReference>("import", "./_content/AbstUI.Blazor/scripts/abstUIScripts.js")
+                     .AsTask().GetAwaiter().GetResult();
+    }
+
+    public void ShowWindow(string id)
+    {
+        EnsureModule();
+        _module!.InvokeVoidAsync("AbstUIWindow.showBootstrapModal", id);
+    }
+
+    public void HideWindow(string id)
+    {
+        EnsureModule();
+        _module!.InvokeVoidAsync("AbstUIWindow.hideBootstrapModal", id);
+    }
+}
+


### PR DESCRIPTION
## Summary
- wrap Bootstrap modal helpers in a dedicated AbstUIWindow JS class
- invoke class-based helpers from AbstBlazorWindow and BlazorWindowManager

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --verbosity diagnostic`
- `dotnet format src/LingoEngine.Blazor/LingoEngine.Blazor.csproj --verbosity diagnostic`
- `dotnet test WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`
- `dotnet test src/LingoEngine.Blazor/LingoEngine.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a16e35f97083329741484c8358b532