### PR TITLE
Add LingoKeyEvent and key event infrastructure

### DIFF
--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/Sprites/Behaviors/GameStopBehavior.cs
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/Sprites/Behaviors/GameStopBehavior.cs
@@ -53,7 +53,7 @@ namespace LingoEngine.Demo.TetriGrounds.Core.Sprites.Behaviors
             myTargetSprite = 4;
         }
 
-        public void KeyDown(ILingoKey key)
+        public void KeyDown(LingoKeyEvent key)
         {
             if (key.KeyPressed(35)) SendSprite<BgScriptBehavior>(myTargetSprite, s => s.PauseGame());
             if (key.KeyPressed(49)) SendSprite<BgScriptBehavior>(myTargetSprite, s => s.SpaceBar());

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Inputs/AbstKeyEvent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Inputs/AbstKeyEvent.cs
@@ -1,0 +1,66 @@
+namespace AbstUI.Inputs
+{
+    public enum AbstKeyEventType
+    {
+        KeyUp,
+        KeyDown
+    }
+
+    public class AbstKeyEvent
+    {
+        public IAbstKey AbstUIKey { get; }
+        public AbstKeyEventType Type { get; }
+        public bool ContinuePropation { get; set; } = true;
+
+        public bool CommandDown => AbstUIKey.CommandDown;
+        public bool ControlDown => AbstUIKey.ControlDown;
+        public bool OptionDown => AbstUIKey.OptionDown;
+        public bool ShiftDown => AbstUIKey.ShiftDown;
+        public string Key => AbstUIKey.Key;
+        public int KeyCode => AbstUIKey.KeyCode;
+
+        public bool KeyPressed(AbstUIKeyType key) => AbstUIKey.KeyPressed(key);
+        public bool KeyPressed(char key) => AbstUIKey.KeyPressed(key);
+        public bool KeyPressed(int keyCode) => AbstUIKey.KeyPressed(keyCode);
+
+        public AbstKeyEvent(IAbstKey key, AbstKeyEventType type)
+        {
+            AbstUIKey = key;
+            Type = type;
+        }
+    }
+
+    public interface IAbstKeyEventHandler<TAbstUIKeyEvent>
+        where TAbstUIKeyEvent : AbstKeyEvent
+    {
+        void RaiseKeyDown(TAbstUIKeyEvent key);
+        void RaiseKeyUp(TAbstUIKeyEvent key);
+    }
+
+    public interface IAbstKeyEventSubscription
+    {
+        void Release();
+    }
+
+    public class AbstKeyEventSubscription<TAbstUIKeyEvent> : IAbstKeyEventSubscription
+        where TAbstUIKeyEvent : AbstKeyEvent
+    {
+        private readonly IAbstKeyEventHandler<TAbstUIKeyEvent> _target;
+        private readonly Action<AbstKeyEventSubscription<TAbstUIKeyEvent>> _release;
+
+        public AbstKeyEventSubscription(IAbstKeyEventHandler<TAbstUIKeyEvent> target, Action<AbstKeyEventSubscription<TAbstUIKeyEvent>> release)
+        {
+            _target = target;
+            _release = release;
+        }
+
+        public void DoKeyDown(TAbstUIKeyEvent key) => _target.RaiseKeyDown(key);
+        public void DoKeyUp(TAbstUIKeyEvent key) => _target.RaiseKeyUp(key);
+
+        public void Release()
+        {
+            _release(this);
+        }
+    }
+}
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Inputs/IAbstKeyEventHandler.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Inputs/IAbstKeyEventHandler.cs
@@ -1,8 +1,0 @@
-﻿namespace AbstUI.Inputs
-{
-    public interface IAbstKeyEventHandler
-    {
-        void RaiseKeyDown(AbstKey lingoKey);
-        void RaiseKeyUp(AbstKey lingoKey);
-    }
-}

--- a/src/Director/LingoEngine.Director.Core/Scores/DirectorScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Scores/DirectorScoreWindow.cs
@@ -251,13 +251,13 @@ namespace LingoEngine.Director.Core.Scores
             Sprites2DContainer.CurrentFrameChanged(currentFrame);
         }
 
-        protected override void OnRaiseKeyDown(LingoKey lingoKey)
+        protected override void OnRaiseKeyDown(LingoKeyEvent lingoKey)
         {
             if (_movie != null && string.Equals(lingoKey.Key, "Delete", StringComparison.OrdinalIgnoreCase))
                 _spritesManager.DeleteSelected(_movie);
         }
 
-        protected override void OnRaiseKeyUp(LingoKey lingoKey) { }
+        protected override void OnRaiseKeyUp(LingoKeyEvent lingoKey) { }
 
         internal IDirectorWindowDialogReference? ShowConfirmDialog(string title, IAbstFrameworkPanel panel)
             => _windowManager.ShowCustomDialog(title, panel);

--- a/src/Director/LingoEngine.Director.Core/UI/DirectorMainMenu.cs
+++ b/src/Director/LingoEngine.Director.Core/UI/DirectorMainMenu.cs
@@ -4,6 +4,7 @@ using LingoEngine.Director.Core.Tools;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Movies;
 using LingoEngine.Inputs;
+using LingoEngine.Events;
 using System.Collections.Generic;
 using LingoEngine.Director.Core.Windowing;
 using LingoEngine.Director.Core.Icons;
@@ -108,7 +109,7 @@ namespace LingoEngine.Director.Core.UI
                 .AddButton("CompileButton", "", () => _commandManager.Handle(new CompileProjectCommand()), c => c.IconTexture = directorIconManager.Get(DirectorIcon.Script))
                 .AddVLine()
                 .AddButton("RewindButton", "", DoRewind, c => c.IconTexture = directorIconManager.Get(DirectorIcon.Rewind))
-                .AddStateButton("RewindButton", this, directorIconManager.Get(DirectorIcon.Stop), p => p.PlayPauseState, 
+                .AddStateButton("RewindButton", this, directorIconManager.Get(DirectorIcon.Stop), p => p.PlayPauseState,
                     c =>
                     {
                         c.TextureOff = directorIconManager.Get(DirectorIcon.Play);
@@ -222,8 +223,8 @@ namespace LingoEngine.Director.Core.UI
 
             var projectSettings = factory.CreateMenuItem("Project Settings");
             projectSettings.Activated += () => _windowManager.OpenWindow(DirectorMenuCodes.ProjectSettingsWindow);
-            _editMenu.AddItem(projectSettings); 
-            
+            _editMenu.AddItem(projectSettings);
+
             var cConverter = factory.CreateMenuItem("Lingo to # Converter");
             cConverter.Activated += () => _commandManager.Handle(new OpenLingoCSharpConverterCommand());
             _editMenu.AddItem(cConverter);
@@ -376,7 +377,7 @@ namespace LingoEngine.Director.Core.UI
             base.Dispose();
         }
 
-        protected override void OnRaiseKeyDown(LingoKey key)
+        protected override void OnRaiseKeyDown(LingoKeyEvent key)
         {
             var label = key.Key.ToUpperInvariant();
             bool ctrl = key.ControlDown;
@@ -394,6 +395,6 @@ namespace LingoEngine.Director.Core.UI
             }
         }
 
-        protected override void OnRaiseKeyUp(LingoKey key) { }
+        protected override void OnRaiseKeyUp(LingoKeyEvent key) { }
     }
 }

--- a/src/Director/LingoEngine.Director.Core/Windowing/DirectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Windowing/DirectorWindow.cs
@@ -1,6 +1,7 @@
 using AbstUI.Primitives;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Inputs;
+using LingoEngine.Events;
 
 namespace LingoEngine.Director.Core.Windowing;
 
@@ -54,21 +55,21 @@ public class DirectorWindow<TFrameworkWindow> : IDirectorWindow, IDisposable, IL
 
     public IDirFrameworkWindow FrameworkObj => _Framework;
 
-    public void RaiseKeyDown(LingoKey lingoKey)
+    public void RaiseKeyDown(LingoKeyEvent lingoKey)
     {
         if (IsActiveWindow)
             OnRaiseKeyDown(lingoKey);
     }
 
-    public void RaiseKeyUp(LingoKey lingoKey)
+    public void RaiseKeyUp(LingoKeyEvent lingoKey)
     {
         if (IsActiveWindow)
             OnRaiseKeyUp(lingoKey);
     }
 
-    protected virtual void OnRaiseKeyDown(LingoKey lingoKey) { }
+    protected virtual void OnRaiseKeyDown(LingoKeyEvent lingoKey) { }
 
-    protected virtual void OnRaiseKeyUp(LingoKey lingoKey) { }
+    protected virtual void OnRaiseKeyUp(LingoKeyEvent lingoKey) { }
 
     public (float X, float Y) MouseGetAbolutePosition() => (Mouse.MouseH + Position.X, Mouse.MouseV + Position.Y);
 
@@ -87,7 +88,7 @@ public class DirectorWindow<TFrameworkWindow> : IDirectorWindow, IDisposable, IL
     {
         if (width < MinimumWidth) width = MinimumWidth;
         if (height < MinimumHeight) height = MinimumHeight;
-        OnResizing(firstLoad,width, height);
+        OnResizing(firstLoad, width, height);
     }
     protected virtual void OnResizing(bool firstLoad, int width, int height) { }
 }

--- a/src/LingoEngine/Events/LingoEventMediator.cs
+++ b/src/LingoEngine/Events/LingoEventMediator.cs
@@ -2,6 +2,7 @@
 using LingoEngine.Inputs.Events;
 using LingoEngine.Movies.Events;
 using LingoEngine.Sprites;
+using AbstUI.Inputs;
 
 namespace LingoEngine.Events
 {
@@ -148,8 +149,11 @@ namespace LingoEngine.Events
         internal void RaiseExitFrame() => _exitFrames.ForEach(x => x.ExitFrame());
         public void RaiseFocus() => _focuss.ForEach(x => x.Focus());
         public void RaiseBlur() => _blurs.ForEach(x => x.Blur());
-        public void RaiseKeyUp(LingoKey key) => _keyUps.ForEach(x => x.KeyUp(key));
-        public void RaiseKeyDown(LingoKey key) => _keyDowns.ForEach(x => x.KeyDown(key));
+        public void RaiseKeyUp(LingoKeyEvent key) => _keyUps.ForEach(x => x.KeyUp(key));
+        public void RaiseKeyDown(LingoKeyEvent key) => _keyDowns.ForEach(x => x.KeyDown(key));
+
+        void IAbstKeyEventHandler<LingoKeyEvent>.RaiseKeyDown(LingoKeyEvent key) => RaiseKeyDown(key);
+        void IAbstKeyEventHandler<LingoKeyEvent>.RaiseKeyUp(LingoKeyEvent key) => RaiseKeyUp(key);
 
 
     }

--- a/src/LingoEngine/Events/LingoKeyEvent.cs
+++ b/src/LingoEngine/Events/LingoKeyEvent.cs
@@ -1,0 +1,17 @@
+using AbstUI.Inputs;
+using LingoEngine.Inputs;
+
+namespace LingoEngine.Events
+{
+    public class LingoKeyEvent : AbstKeyEvent
+    {
+        public new LingoKey AbstUIKey { get; }
+
+        public LingoKeyEvent(LingoKey key, AbstKeyEventType type)
+            : base(key, type)
+        {
+            AbstUIKey = key;
+        }
+    }
+}
+

--- a/src/LingoEngine/Inputs/Events/IHasKeyDownEvent.cs
+++ b/src/LingoEngine/Inputs/Events/IHasKeyDownEvent.cs
@@ -1,9 +1,10 @@
-﻿using LingoEngine.Inputs;
+using LingoEngine.Events;
 
 namespace LingoEngine.Inputs.Events
 {
     public interface IHasKeyDownEvent
     {
-        void KeyDown(ILingoKey mouse);
+        void KeyDown(LingoKeyEvent key);
     }
 }
+

--- a/src/LingoEngine/Inputs/Events/IHasKeyUpEvent.cs
+++ b/src/LingoEngine/Inputs/Events/IHasKeyUpEvent.cs
@@ -1,7 +1,10 @@
-﻿namespace LingoEngine.Inputs.Events
+using LingoEngine.Events;
+
+namespace LingoEngine.Inputs.Events
 {
     public interface IHasKeyUpEvent
     {
-        void KeyUp(ILingoKey mouse);
+        void KeyUp(LingoKeyEvent key);
     }
 }
+

--- a/src/LingoEngine/Inputs/ILingoKeyEventHandler.cs
+++ b/src/LingoEngine/Inputs/ILingoKeyEventHandler.cs
@@ -1,8 +1,12 @@
-﻿namespace LingoEngine.Inputs
+using AbstUI.Inputs;
+using LingoEngine.Events;
+
+namespace LingoEngine.Inputs
 {
-    public interface ILingoKeyEventHandler
+    public interface ILingoKeyEventHandler : IAbstKeyEventHandler<LingoKeyEvent>
     {
-        void RaiseKeyDown(LingoKey lingoKey);
-        void RaiseKeyUp(LingoKey lingoKey);
+        new void RaiseKeyDown(LingoKeyEvent lingoKey);
+        new void RaiseKeyUp(LingoKeyEvent lingoKey);
     }
 }
+

--- a/src/LingoEngine/Inputs/LingoJoystickKeyboard.cs
+++ b/src/LingoEngine/Inputs/LingoJoystickKeyboard.cs
@@ -18,7 +18,7 @@ namespace LingoEngine.Inputs
         private readonly int _cols;
         private readonly AbstWindow _window;
         private readonly AbstGfxCanvas _canvas;
-        
+
         private readonly IAbstMouseSubscription _mouseDownSub;
         private readonly IAbstMouseSubscription _mouseMoveSub;
         private int _selectedRow;
@@ -121,8 +121,8 @@ namespace LingoEngine.Inputs
             ((ILingoKey)_window.Key).Subscribe(this);
             ApplyWindowChrome();
             DrawKeyboard();
-            _window.Width = width + Margin*2;
-            _window.Height = height+ Margin*2;
+            _window.Width = width + Margin * 2;
+            _window.Height = height + Margin * 2;
             _window.BackgroundColor = BackgroundColor;
         }
         public void Dispose()
@@ -205,8 +205,8 @@ namespace LingoEngine.Inputs
             {
                 for (int c = 0; c < _layout[r].Length; c++)
                 {
-                    var x = c * (CellSize + CellSpacing) ;
-                    var y = r * (CellSize + CellSpacing) ;
+                    var x = c * (CellSize + CellSpacing);
+                    var y = r * (CellSize + CellSpacing);
                     var key = _layout[r][c];
                     var selected = r == _selectedRow && c == _selectedCol;
                     if (selected && SelectedBackgroundColor.HasValue)
@@ -273,7 +273,7 @@ namespace LingoEngine.Inputs
             if (key == "ENTER")
             {
                 EnterPressed?.Invoke();
-            } 
+            }
             else if (key == "ESC")
             {
                 Close();
@@ -303,8 +303,8 @@ namespace LingoEngine.Inputs
             DrawKeyboard();
         }
 
-        void ILingoKeyEventHandler.RaiseKeyUp(LingoKey key) { }
-        void ILingoKeyEventHandler.RaiseKeyDown(LingoKey key)
+        void ILingoKeyEventHandler.RaiseKeyUp(LingoKeyEvent key) { }
+        void ILingoKeyEventHandler.RaiseKeyDown(LingoKeyEvent key)
         {
             if (!_window.Visibility) return;
             if (!(_enableKeyNumbers || _enableKeyLetters || _enableKeySpecial)) return;
@@ -349,6 +349,10 @@ namespace LingoEngine.Inputs
             }
         }
 
+        void IAbstKeyEventHandler<LingoKeyEvent>.RaiseKeyDown(LingoKeyEvent key) => ((ILingoKeyEventHandler)this).RaiseKeyDown(key);
+        void IAbstKeyEventHandler<LingoKeyEvent>.RaiseKeyUp(LingoKeyEvent key) => ((ILingoKeyEventHandler)this).RaiseKeyUp(key);
+
+
         private void OnMouseMove(LingoMouseEvent e)
         {
             //Console.WriteLine($"Mouse moved: {e.MouseH}, {e.MouseV}");  
@@ -392,7 +396,7 @@ namespace LingoEngine.Inputs
         /// <summary>Closes the keyboard popup window.</summary>
         public void Close() => _window.Hide();
 
-       
+
     }
 }
 

--- a/src/LingoEngine/Inputs/LingoKey.cs
+++ b/src/LingoEngine/Inputs/LingoKey.cs
@@ -1,4 +1,5 @@
 using AbstUI.Inputs;
+using LingoEngine.Events;
 namespace LingoEngine.Inputs
 {
     /// <summary>
@@ -23,14 +24,9 @@ namespace LingoEngine.Inputs
         private HashSet<ILingoKeyEventHandler> _subscriptionsLingo = new();
         private readonly ILingoFrameworkKey _frameworkObjLingo;
 
-        public LingoKey(ILingoFrameworkKey frameworkObj):base(frameworkObj)
+        public LingoKey(ILingoFrameworkKey frameworkObj) : base(frameworkObj)
         {
             _frameworkObjLingo = frameworkObj;
-        }
-
-        protected override void DoOnAll(Action<IAbstKeyEventHandler> action)
-        {
-            base.DoOnAll(action);
         }
 
         ///// <summary>
@@ -43,14 +39,16 @@ namespace LingoEngine.Inputs
 
         public override void DoKeyUp()
         {
-            base.DoOnAll(x => x.RaiseKeyUp(this));
-            DoOnAllLingo(x => x.RaiseKeyUp(this));
+            var ev = new LingoKeyEvent(this, AbstKeyEventType.KeyUp);
+            base.DoOnAll(x => x.RaiseKeyUp(ev));
+            DoOnAllLingo(x => x.RaiseKeyUp(ev));
         }
 
         public override void DoKeyDown()
         {
-            base.DoOnAll(x => x.RaiseKeyDown(this));
-            DoOnAllLingo(x => x.RaiseKeyDown(this));
+            var ev = new LingoKeyEvent(this, AbstKeyEventType.KeyDown);
+            base.DoOnAll(x => x.RaiseKeyDown(ev));
+            DoOnAllLingo(x => x.RaiseKeyDown(ev));
         }
 
         private void DoOnAllLingo(Action<ILingoKeyEventHandler> action)
@@ -72,6 +70,6 @@ namespace LingoEngine.Inputs
             _subscriptionsLingo.Remove(handler);
             return this;
         }
-        
+
     }
 }

--- a/src/LingoEngine/Tempos/LingoTempoSprite.cs
+++ b/src/LingoEngine/Tempos/LingoTempoSprite.cs
@@ -54,13 +54,13 @@ public class LingoTempoSprite : LingoSprite
     /// </summary>
     public int CuePoint { get; set; }
 
-    private class WaitForInputSubscription : IHasMouseDownEvent, IHasKeyDownEvent
-    {
-        private readonly LingoTempoSprite _owner;
-        public WaitForInputSubscription(LingoTempoSprite owner) => _owner = owner;
-        public void MouseDown(LingoMouseEvent mouse) => _owner.Resume();
-        public void KeyDown(ILingoKey key) => _owner.Resume();
-    }
+        private class WaitForInputSubscription : IHasMouseDownEvent, IHasKeyDownEvent
+        {
+            private readonly LingoTempoSprite _owner;
+            public WaitForInputSubscription(LingoTempoSprite owner) => _owner = owner;
+            public void MouseDown(LingoMouseEvent mouse) => _owner.Resume();
+            public void KeyDown(LingoKeyEvent key) => _owner.Resume();
+        }
 
     private WaitForInputSubscription? _waitForInputSubscription;
     public LingoTempoSprite(ILingoMovieEnvironment environment, Action<LingoTempoSprite> removeMe) : base(environment.Events)


### PR DESCRIPTION
## Summary
- align AbstKeyEvent naming with mouse events and add generic handler subscriptions
- wire LingoKeyEvent through handlers and mediator using generic key events
- update director window classes and joystick keyboard for new key event signatures

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI/Inputs/AbstKey.cs WillMoveToOwnRepo/AbstUI/src/AbstUI/Inputs/AbstKeyEvent.cs -v diag`
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/Events/LingoEventMediator.cs src/LingoEngine/Events/LingoKeyEvent.cs src/LingoEngine/Inputs/ILingoKeyEventHandler.cs src/LingoEngine/Inputs/LingoJoystickKeyboard.cs src/LingoEngine/Inputs/LingoKey.cs -v diag`
- `dotnet format src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj --include src/Director/LingoEngine.Director.Core/Scores/DirectorScoreWindow.cs src/Director/LingoEngine.Director.Core/UI/DirectorMainMenu.cs src/Director/LingoEngine.Director.Core/Windowing/DirectorWindow.cs -v diag`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a208c50cdc83329b3dd117d8e01be3