### PR TITLE
Generalize reversed Lingo method call syntax

### DIFF
--- a/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
@@ -547,4 +547,18 @@ end";
         var result = LingoToCSharpConverter.Convert(lingo);
         Assert.Contains("_movie.actorList.deleteOne", result);
     }
+
+    [Fact]
+    public void AppendActorListIsConverted()
+    {
+        var result = LingoToCSharpConverter.Convert("append the actorlist(me)");
+        Assert.Contains("_Movie.ActorList.Add(this)", result);
+    }
+
+    [Fact]
+    public void ReverseActorListIsConverted()
+    {
+        var result = LingoToCSharpConverter.Convert("reverse the actorlist(me)");
+        Assert.Contains("_Movie.ActorList.Reverse(this)", result);
+    }
 }

--- a/src/LingoEngine.Lingo.Core/CSharpWriter.cs
+++ b/src/LingoEngine.Lingo.Core/CSharpWriter.cs
@@ -301,9 +301,35 @@ public class CSharpWriter : ILingoAstVisitor
 
     public void Visit(LingoObjPropExprNode node)
     {
-        if (node.Object is LingoVarNode objVar && objVar.VarName.Equals("me", StringComparison.OrdinalIgnoreCase) && node.Property is LingoVarNode propVar)
+        if (node.Object is LingoVarNode objVar &&
+            objVar.VarName.Equals("me", StringComparison.OrdinalIgnoreCase) &&
+            node.Property is LingoVarNode propVar)
         {
             Append(char.ToUpperInvariant(propVar.VarName[0]) + propVar.VarName[1..]);
+            return;
+        }
+
+        if (node.Object is LingoTheExprNode theNode)
+        {
+            node.Object.Accept(this);
+            Append(".");
+            if (node.Property is LingoVarNode propVar2)
+            {
+                var name = propVar2.VarName;
+                if (theNode.Prop.Equals("actorlist", StringComparison.OrdinalIgnoreCase) &&
+                    name.Equals("append", StringComparison.OrdinalIgnoreCase))
+                {
+                    Append("Add");
+                }
+                else
+                {
+                    Append(char.ToUpperInvariant(name[0]) + name[1..]);
+                }
+            }
+            else
+            {
+                node.Property.Accept(this);
+            }
         }
         else
         {

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
@@ -115,8 +115,34 @@ namespace LingoEngine.Lingo.Core.Tokenizer
                     return new LingoSendSpriteStmtNode { Sprite = sprite, Message = message };
                 }
             }
-
             var expr = ParseExpression(false);
+            if (_currentToken.Type == LingoTokenType.The && expr is LingoVarNode methodVar)
+            {
+                AdvanceToken();
+                var propTok = Expect(LingoTokenType.Identifier);
+                LingoNode objExpr = new LingoTheExprNode { Prop = propTok.Lexeme };
+                while (Match(LingoTokenType.Dot))
+                {
+                    var pTok = Expect(LingoTokenType.Identifier);
+                    objExpr = new LingoObjPropExprNode
+                    {
+                        Object = objExpr,
+                        Property = new LingoVarNode { VarName = pTok.Lexeme }
+                    };
+                }
+                Expect(LingoTokenType.LeftParen);
+                var argExpr = ParseExpression();
+                Expect(LingoTokenType.RightParen);
+                return new LingoCallNode
+                {
+                    Callee = new LingoObjPropExprNode
+                    {
+                        Object = objExpr,
+                        Property = new LingoVarNode { VarName = methodVar.VarName }
+                    },
+                    Arguments = argExpr
+                };
+            }
             if (Match(LingoTokenType.Equals))
             {
                 var value = ParseExpression();


### PR DESCRIPTION
## Summary
- parse reversed `command the object(args)` patterns for arbitrary method calls
- translate reversed calls to standard object method invocations, mapping `append` on actor lists to `Add`
- cover reversed actor list calls with new regression tests

## Testing
- `dotnet format src/LingoEngine.Lingo.Core/LingoEngine.Lingo.Core.csproj --verify-no-changes`
- `dotnet format Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj --verify-no-changes`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a214579b9883328acc3479ac920c0a