### PR TITLE
Add game-specific license for AbstUI

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/LICENSE
+++ b/WillMoveToOwnRepo/AbstUI/LICENSE
@@ -1,0 +1,11 @@
+AbstUI Game License
+
+Copyright (c) 2025 Emmanuel The Creator
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this library and associated documentation files (the "Software"), to use, reproduce, and distribute the Software in games, including commercial games, subject to the following conditions:
+
+1. The name "Emmanuel The Creator" must appear in the credits of any game using the Software.
+2. Use of the Software in applications other than games requires prior written permission from the copyright holder.
+3. The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Summary
- add license for AbstUI that allows free use in games with credit
- fix creator name spacing in license

## Testing
- `dotnet test WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a2ab3184988332a8ec35329ff65964