### PR TITLE
Add basic Blazor members and ink rendering

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
@@ -57,6 +57,7 @@
         <Compile Include="Inputs/BlazorMouse.cs" />
         <Compile Include="Inputs/BlazorKey.cs" />
         <Compile Include="AbstUIBlazorSetup.cs" />
+        <Compile Include="AbstUIScriptResolver.cs" />
         <Compile Include="Bitmaps/AbstBlazorTexture2D.cs" />
         <Compile Include="Bitmaps/BlazorImageTexture.cs" />
         <Compile Include="Styles/AbstBlazorFontManager.cs" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIBlazorSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIBlazorSetup.cs
@@ -10,7 +10,8 @@ public static class AbstUIBlazorSetup
     {
         services
             .AddSingleton<IAbstFontManager, AbstBlazorFontManager>()
-            .AddSingleton<IAbstBlazorStyleManager, AbstBlazorStyleManager>();
+            .AddSingleton<IAbstBlazorStyleManager, AbstBlazorStyleManager>()
+            .AddSingleton<AbstUIScriptResolver>();
         return services;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIScriptResolver.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIScriptResolver.cs
@@ -1,0 +1,84 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace AbstUI.Blazor;
+
+/// <summary>
+/// Provides access to the JavaScript helper module used by AbstUI.
+/// The resolver loads the underlying ES module on first use and
+/// exposes strongly typed proxies for all exported functions so that
+/// consumers do not have to deal with <see cref="IJSObjectReference"/>
+/// directly.
+/// </summary>
+public class AbstUIScriptResolver : IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private Task<IJSObjectReference>? _moduleTask;
+
+    public AbstUIScriptResolver(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    private Task<IJSObjectReference> GetModuleAsync()
+        => _moduleTask ??= _jsRuntime.InvokeAsync<IJSObjectReference>(
+            "import", "./_content/AbstUI.Blazor/scripts/abstUIScripts.js").AsTask();
+
+    public async ValueTask<ElementReference> CanvasCreateCanvas(int width, int height)
+        => await (await GetModuleAsync()).InvokeAsync<ElementReference>("abstCanvas.createCanvas", width, height);
+
+    public async ValueTask CanvasDisposeCanvas(ElementReference canvas)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.disposeCanvas", canvas);
+
+    public async ValueTask<IJSObjectReference> CanvasGetContext(ElementReference canvas, bool pixilated)
+        => await (await GetModuleAsync()).InvokeAsync<IJSObjectReference>("abstCanvas.getContext", canvas, pixilated);
+
+    public async ValueTask CanvasClear(IJSObjectReference ctx, string color, int width, int height)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.clear", ctx, color, width, height);
+
+    public async ValueTask CanvasSetPixel(IJSObjectReference ctx, int x, int y, string color)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.setPixel", ctx, x, y, color);
+
+    public async ValueTask CanvasDrawLine(IJSObjectReference ctx, double x1, double y1, double x2, double y2, string color, int width)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.drawLine", ctx, x1, y1, x2, y2, color, width);
+
+    public async ValueTask CanvasDrawRect(IJSObjectReference ctx, double x, double y, double w, double h, string color, bool filled, int width)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.drawRect", ctx, x, y, w, h, color, filled, width);
+
+    public async ValueTask CanvasDrawCircle(IJSObjectReference ctx, double x, double y, double radius, string color, bool filled, int width)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.drawCircle", ctx, x, y, radius, color, filled, width);
+
+    public async ValueTask CanvasDrawArc(IJSObjectReference ctx, double x, double y, double radius, double startDeg, double endDeg, string color, int width)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.drawArc", ctx, x, y, radius, startDeg, endDeg, color, width);
+
+    public async ValueTask CanvasDrawPolygon(IJSObjectReference ctx, double[] points, string color, bool filled, int width)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.drawPolygon", ctx, points, color, filled, width);
+
+    public async ValueTask CanvasDrawText(IJSObjectReference ctx, double x, double y, string text, string font, string color, int fontSize, string alignment)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.drawText", ctx, x, y, text, font, color, fontSize, alignment);
+
+    public async ValueTask CanvasDrawPictureData(IJSObjectReference ctx, byte[] data, int width, int height, int x, int y)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.drawPictureData", ctx, data, width, height, x, y);
+
+    public async ValueTask<byte[]> CanvasGetImageData(IJSObjectReference ctx, int width, int height)
+        => await (await GetModuleAsync()).InvokeAsync<byte[]>("abstCanvas.getImageData", ctx, width, height);
+
+    public async ValueTask SetCursor(string cursor)
+        => await (await GetModuleAsync()).InvokeVoidAsync("AbstUIKey.setCursor", cursor);
+
+    public async ValueTask ShowBootstrapModal(string id)
+        => await (await GetModuleAsync()).InvokeVoidAsync("AbstUIWindow.showBootstrapModal", id);
+
+    public async ValueTask HideBootstrapModal(string id)
+        => await (await GetModuleAsync()).InvokeVoidAsync("AbstUIWindow.hideBootstrapModal", id);
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_moduleTask is not null && _moduleTask.IsCompletedSuccessfully)
+        {
+            var module = await _moduleTask;
+            await module.DisposeAsync();
+        }
+    }
+}
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Bitmaps/AbstBlazorTexture2D.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Bitmaps/AbstBlazorTexture2D.cs
@@ -1,6 +1,7 @@
 using AbstUI.Primitives;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using AbstUI.Blazor;
 
 namespace AbstUI.Blazor.Bitmaps;
 
@@ -33,6 +34,14 @@ public class AbstBlazorTexture2D : IAbstTexture2D
         return new AbstBlazorTexture2D(jsRuntime, canvas, width, height, name);
     }
 
+    public static async Task<AbstBlazorTexture2D> CreateFromPixelDataAsync(IJSRuntime jsRuntime, AbstUIScriptResolver scripts, byte[] data, int width, int height, string name = "")
+    {
+        var tex = await CreateAsync(jsRuntime, width, height, name);
+        var ctx = await scripts.CanvasGetContext(tex.Canvas, false);
+        await scripts.CanvasDrawPictureData(ctx, data, width, height, 0, 0);
+        return tex;
+    }
+
     public IAbstUITextureUserSubscription AddUser(object user)
     {
         if (IsDisposed)
@@ -55,6 +64,12 @@ public class AbstBlazorTexture2D : IAbstTexture2D
             return;
         IsDisposed = true;
         _ = _jsRuntime.InvokeVoidAsync("abstCanvas.disposeCanvas", Canvas);
+    }
+
+    public async Task<byte[]> GetPixelDataAsync(AbstUIScriptResolver scripts)
+    {
+        var ctx = await scripts.CanvasGetContext(Canvas, false);
+        return await scripts.CanvasGetImageData(ctx, Width, Height);
     }
 
     private class TextureSubscription : IAbstUITextureUserSubscription

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
@@ -103,6 +103,10 @@ export class abstCanvas {
         const imgData = new ImageData(new Uint8ClampedArray(data), width, height);
         ctx.putImageData(imgData, x, y);
     }
+
+    static getImageData(ctx, width, height) {
+        return ctx.getImageData(0, 0, width, height).data;
+    }
 }
 
 export class AbstUIKey {

--- a/src/LingoEngine.Blazor/Bitmaps/LingoBlazorMemberBitmap.cs
+++ b/src/LingoEngine.Blazor/Bitmaps/LingoBlazorMemberBitmap.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using AbstUI.Blazor;
+using AbstUI.Blazor.Bitmaps;
+using AbstUI.Primitives;
+using LingoEngine.Bitmaps;
+using LingoEngine.Blazor.Util;
+using LingoEngine.Primitives;
+using LingoEngine.Sprites;
+using LingoEngine.Tools;
+using AbstUI.Tools;
+using Microsoft.JSInterop;
+
+namespace LingoEngine.Blazor.Bitmaps;
+
+/// <summary>
+/// Minimal Blazor implementation of a bitmap cast member.
+/// Currently provides basic file loading and metadata extraction so the
+/// member can participate in the engine without a rendering backend.
+/// </summary>
+public class LingoBlazorMemberBitmap : ILingoFrameworkMemberBitmap, IDisposable
+{
+    private LingoMemberBitmap _member = null!;
+    private readonly IJSRuntime _js;
+    private readonly AbstUIScriptResolver _scripts;
+    private readonly HttpClient _httpClient;
+    private readonly Dictionary<LingoSprite2D, IAbstUITextureUserSubscription> _spriteSubscriptions = new();
+    private byte[]? _pixelData;
+    private int _stride;
+    private AbstBlazorTexture2D? _texture;
+    private readonly Dictionary<LingoInkType, AbstBlazorTexture2D> _inkTextures = new();
+
+    public byte[]? ImageData { get; private set; }
+    public string Format { get; private set; } = "image/unknown";
+    public int Width { get; private set; }
+    public int Height { get; private set; }
+    public bool IsLoaded { get; private set; }
+    public IAbstTexture2D? TextureLingo => _texture;
+
+    public LingoBlazorMemberBitmap(IJSRuntime js, AbstUIScriptResolver scripts, HttpClient httpClient)
+    {
+        _js = js;
+        _scripts = scripts;
+        _httpClient = httpClient;
+    }
+
+    internal void Init(LingoMemberBitmap member)
+    {
+        _member = member;
+        if (!string.IsNullOrEmpty(member.FileName))
+            Format = MimeHelper.GetMimeType(member.FileName);
+    }
+
+    public void Preload()
+    {
+        if (IsLoaded)
+            return;
+        if (!string.IsNullOrEmpty(_member.FileName))
+        {
+            try
+            {
+                var bytes = _httpClient.GetByteArrayAsync(_member.FileName).GetAwaiter().GetResult();
+                SetImageData(bytes);
+            }
+            catch { }
+        }
+        IsLoaded = true;
+    }
+
+    public void Unload()
+    {
+        IsLoaded = false;
+        _pixelData = null;
+        _stride = 0;
+        ClearCache();
+    }
+
+    public void Erase()
+    {
+        Unload();
+        ImageData = null;
+    }
+
+    public void CopyToClipboard() { }
+    public void ImportFileInto() { }
+    public void PasteClipboardInto() { }
+    public void ReleaseFromSprite(LingoSprite2D lingoSprite)
+    {
+        if (_spriteSubscriptions.TryGetValue(lingoSprite, out var sub))
+        {
+            sub.Release();
+            _spriteSubscriptions.Remove(lingoSprite);
+        }
+    }
+
+    internal void TrackSpriteUsage(LingoSprite2D sprite)
+    {
+        if (_texture == null)
+            return;
+        if (!_spriteSubscriptions.ContainsKey(sprite))
+            _spriteSubscriptions[sprite] = _texture.AddUser(sprite);
+    }
+
+    public void SetImageData(byte[] bytes)
+    {
+        ImageData = bytes;
+        try
+        {
+            using var ms = new MemoryStream(bytes);
+            using var img = Image.FromStream(ms);
+            Width = img.Width;
+            Height = img.Height;
+            var rect = new Rectangle(0, 0, Width, Height);
+            using var bmp = new Bitmap(img);
+            var data = bmp.LockBits(rect, ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+            int rowBytes = Width * 4;
+            _stride = rowBytes;
+            _pixelData = new byte[rowBytes * Height];
+            for (int y = 0; y < Height; y++)
+            {
+                var src = data.Scan0 + y * data.Stride;
+                Marshal.Copy(src, _pixelData, y * rowBytes, rowBytes);
+            }
+            bmp.UnlockBits(data);
+            // Convert BGRA -> RGBA
+            for (int i = 0; i < _pixelData.Length; i += 4)
+            {
+                (_pixelData[i], _pixelData[i + 2]) = (_pixelData[i + 2], _pixelData[i]);
+            }
+        }
+        catch { }
+        _member.Size = bytes.Length;
+        _member.Width = Width;
+        _member.Height = Height;
+    }
+
+    public bool IsPixelTransparent(int x, int y)
+        => PixelDataUtils.IsTransparent(_pixelData, _stride, Width, Height, x, y);
+
+    public IAbstTexture2D? RenderToTexture(LingoInkType ink, AColor transparentColor)
+    {
+        if (_pixelData == null)
+            return null;
+
+        if (!InkPreRenderer.CanHandle(ink))
+        {
+            _texture ??= AbstBlazorTexture2D.CreateFromPixelDataAsync(_js, _scripts, _pixelData, Width, Height)
+                .GetAwaiter().GetResult();
+            return _texture;
+        }
+
+        var inkKey = InkPreRenderer.GetInkCacheKey(ink);
+        if (_inkTextures.TryGetValue(inkKey, out var tex))
+            return tex;
+
+        var data = InkPreRenderer.Apply(_pixelData, ink, transparentColor);
+        var newTex = AbstBlazorTexture2D.CreateFromPixelDataAsync(_js, _scripts, data, Width, Height)
+            .GetAwaiter().GetResult();
+        _inkTextures[inkKey] = newTex;
+        return newTex;
+    }
+
+    private void ClearCache()
+    {
+        _texture?.Dispose();
+        _texture = null;
+        foreach (var tex in _inkTextures.Values)
+            tex.Dispose();
+        _inkTextures.Clear();
+    }
+
+    public void Dispose() => ClearCache();
+}
+

--- a/src/LingoEngine.Blazor/ColorPalettes/LingoBlazorMemberColorPalette.cs
+++ b/src/LingoEngine.Blazor/ColorPalettes/LingoBlazorMemberColorPalette.cs
@@ -1,0 +1,19 @@
+using LingoEngine.ColorPalettes;
+using LingoEngine.Members;
+using LingoEngine.Sprites;
+using LingoEngine.Blazor.Core;
+
+namespace LingoEngine.Blazor.ColorPalettes;
+
+/// <summary>
+/// Blazor placeholder implementation for color palette members.
+/// </summary>
+public class LingoBlazorMemberColorPalette : BlazorFrameworkMemberEmpty
+{
+    private LingoColorPaletteMember _member = null!;
+
+    internal void Init(LingoColorPaletteMember member)
+    {
+        _member = member;
+    }
+}

--- a/src/LingoEngine.Blazor/Core/BlazorFrameworkMemberEmpty.cs
+++ b/src/LingoEngine.Blazor/Core/BlazorFrameworkMemberEmpty.cs
@@ -1,0 +1,20 @@
+using LingoEngine.Members;
+using LingoEngine.Sprites;
+
+namespace LingoEngine.Blazor.Core;
+
+/// <summary>
+/// Minimal backend implementation for member types that require no platform features.
+/// </summary>
+public class BlazorFrameworkMemberEmpty : ILingoFrameworkMemberEmpty
+{
+    public bool IsLoaded => true;
+
+    public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
+    public void CopyToClipboard() { }
+    public void Erase() { }
+    public void ImportFileInto() { }
+    public void PasteClipboardInto() { }
+    public void Preload() { }
+    public void Unload() { }
+}

--- a/src/LingoEngine.Blazor/Inputs/LingoBlazorKey.cs
+++ b/src/LingoEngine.Blazor/Inputs/LingoBlazorKey.cs
@@ -1,18 +1,13 @@
-using AbstUI.Inputs;
+using AbstUI.Blazor.Inputs;
 using LingoEngine.Inputs;
 
 namespace LingoEngine.Blazor.Inputs;
 
-public class LingoBlazorKey : ILingoFrameworkKey
+/// <summary>
+/// Blazor implementation of <see cref="ILingoFrameworkKey"/> leveraging the
+/// generic <see cref="BlazorKey"/> from AbstUI.
+/// </summary>
+public class LingoBlazorKey : BlazorKey, ILingoFrameworkKey
 {
-    public bool CommandDown => false;
-    public bool ControlDown => false;
-    public bool OptionDown => false;
-    public bool ShiftDown => false;
-    public string Key => string.Empty;
-    public int KeyCode => 0;
-
-    public bool KeyPressed(AbstUIKeyType key) => false;
-    public bool KeyPressed(char key) => false;
-    public bool KeyPressed(int keyCode) => false;
 }
+

--- a/src/LingoEngine.Blazor/LingoEngine.Blazor.csproj
+++ b/src/LingoEngine.Blazor/LingoEngine.Blazor.csproj
@@ -21,6 +21,10 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\..\WillMoveToOwnRepo\AbstUI\src\AbstUI\AbstUI.csproj" />
+    <ProjectReference Include="..\..\WillMoveToOwnRepo\AbstUI\src\AbstUI.Blazor\AbstUI.Blazor.csproj" />
     <ProjectReference Include="..\LingoEngine\LingoEngine.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/LingoEngine.Blazor/Shapes/LingoBlazorMemberShape.cs
+++ b/src/LingoEngine.Blazor/Shapes/LingoBlazorMemberShape.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Linq;
+using AbstUI.Blazor;
+using AbstUI.Blazor.Bitmaps;
+using AbstUI.Blazor.Primitives;
+using AbstUI.Primitives;
+using LingoEngine.Bitmaps;
+using LingoEngine.Blazor.Util;
+using LingoEngine.Primitives;
+using LingoEngine.Shapes;
+using LingoEngine.Sprites;
+using Microsoft.JSInterop;
+
+namespace LingoEngine.Blazor.Shapes;
+
+/// <summary>
+/// Basic Blazor implementation of a vector shape member. It draws the shape
+/// onto an off-screen canvas using JavaScript interop and exposes it as a
+/// texture when requested.
+/// </summary>
+public class LingoBlazorMemberShape : ILingoFrameworkMemberShape, IDisposable
+{
+    private readonly IJSRuntime _js;
+    private readonly AbstUIScriptResolver _scripts;
+    private AbstBlazorTexture2D? _texture;
+    private byte[]? _pixelData;
+    private int _stride;
+    private LingoMemberShape _member = null!;
+
+    public LingoList<APoint> VertexList { get; } = new();
+    public LingoShapeType ShapeType { get; set; } = LingoShapeType.Rectangle;
+    public AColor FillColor { get; set; } = AColor.FromRGB(255, 255, 255);
+    public AColor EndColor { get; set; } = AColor.FromRGB(255, 255, 255);
+    public AColor StrokeColor { get; set; } = AColor.FromRGB(0, 0, 0);
+    public int StrokeWidth { get; set; } = 1;
+    public float Width { get; set; }
+    public float Height { get; set; }
+    public bool Closed { get; set; } = true;
+    public bool AntiAlias { get; set; } = true;
+    public bool Filled { get; set; } = true;
+    public bool IsLoaded { get; private set; }
+    public IAbstTexture2D? TextureLingo => _texture;
+
+    public LingoBlazorMemberShape(IJSRuntime js, AbstUIScriptResolver scripts)
+    {
+        _js = js;
+        _scripts = scripts;
+    }
+
+    internal void Init(LingoMemberShape member) => _member = member;
+
+    public void Preload()
+    {
+        if (IsLoaded)
+            return;
+        int w = Math.Max(1, (int)Width);
+        int h = Math.Max(1, (int)Height);
+        _texture = AbstBlazorTexture2D.CreateAsync(_js, w, h).GetAwaiter().GetResult();
+        var ctx = _scripts.CanvasGetContext(_texture.Canvas, !AntiAlias).GetAwaiter().GetResult();
+        string fill = FillColor.ToCss();
+        string stroke = StrokeColor.ToCss();
+        switch (ShapeType)
+        {
+            case LingoShapeType.Rectangle:
+                _scripts.CanvasDrawRect(ctx, 0, 0, w, h, Filled ? fill : stroke, Filled, StrokeWidth)
+                        .GetAwaiter().GetResult();
+                break;
+            case LingoShapeType.Oval:
+                int radius = Math.Min(w, h) / 2;
+                _scripts.CanvasDrawCircle(ctx, w / 2, h / 2, radius, Filled ? fill : stroke, Filled, StrokeWidth)
+                        .GetAwaiter().GetResult();
+                break;
+            case LingoShapeType.Line:
+                if (VertexList.Count >= 2)
+                    _scripts.CanvasDrawLine(ctx,
+                        VertexList[0].X, VertexList[0].Y,
+                        VertexList[1].X, VertexList[1].Y, stroke, StrokeWidth)
+                        .GetAwaiter().GetResult();
+                break;
+            case LingoShapeType.PolyLine:
+                if (VertexList.Count >= 2)
+                {
+                    var pts = VertexList.SelectMany(p => new double[] { p.X, p.Y }).ToArray();
+                    _scripts.CanvasDrawPolygon(ctx, pts, stroke, Filled, StrokeWidth)
+                            .GetAwaiter().GetResult();
+                }
+                break;
+            case LingoShapeType.RoundRect:
+                _scripts.CanvasDrawRect(ctx, 0, 0, w, h, Filled ? fill : stroke, Filled, StrokeWidth)
+                        .GetAwaiter().GetResult();
+                break;
+        }
+        _pixelData = _texture.GetPixelDataAsync(_scripts).GetAwaiter().GetResult();
+        _stride = w * 4;
+        IsLoaded = true;
+    }
+
+    public void Unload()
+    {
+        _texture?.Dispose();
+        _texture = null;
+        IsLoaded = false;
+    }
+
+    public void Erase()
+    {
+        Unload();
+        VertexList.Clear();
+    }
+
+    public void CopyToClipboard() { }
+    public void ImportFileInto() { }
+    public void PasteClipboardInto() { }
+    public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
+
+    public bool IsPixelTransparent(int x, int y)
+        => PixelDataUtils.IsTransparent(_pixelData, _stride, (int)Width, (int)Height, x, y);
+
+    public IAbstTexture2D? RenderToTexture(LingoInkType ink, AColor transparentColor) => _texture;
+
+    public void Dispose() => Unload();
+}
+

--- a/src/LingoEngine.Blazor/Sounds/LingoBlazorMemberSound.cs
+++ b/src/LingoEngine.Blazor/Sounds/LingoBlazorMemberSound.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Net.Http;
+using LingoEngine.Sounds;
+using LingoEngine.Sprites;
+
+namespace LingoEngine.Blazor.Sounds;
+
+/// <summary>
+/// Minimal Blazor implementation for sound cast members.
+/// </summary>
+public class LingoBlazorMemberSound : ILingoFrameworkMemberSound, IDisposable
+{
+    private readonly HttpClient _httpClient;
+    private LingoMemberSound _member = null!;
+    private byte[]? _data;
+
+    public bool Stereo { get; private set; }
+    public double Length { get; private set; }
+    public bool IsLoaded { get; private set; }
+
+    public LingoBlazorMemberSound(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    internal void Init(LingoMemberSound member)
+    {
+        _member = member;
+    }
+
+    public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
+    public void CopyToClipboard() { }
+    public void ImportFileInto() { }
+    public void PasteClipboardInto() { }
+
+    public void Erase() => Unload();
+
+    public void Preload()
+    {
+        if (IsLoaded)
+            return;
+        if (!string.IsNullOrEmpty(_member.FileName))
+        {
+            try
+            {
+                _data = _httpClient.GetByteArrayAsync(_member.FileName).GetAwaiter().GetResult();
+                _member.Size = _data.Length;
+                Length = _data.Length / 44100.0;
+                Stereo = true;
+            }
+            catch { }
+        }
+        IsLoaded = true;
+    }
+
+    public void Unload()
+    {
+        IsLoaded = false;
+        Stereo = false;
+        Length = 0;
+        _data = null;
+    }
+
+    public void Dispose() => Unload();
+}

--- a/src/LingoEngine.Blazor/Texts/LingoBlazorMemberField.cs
+++ b/src/LingoEngine.Blazor/Texts/LingoBlazorMemberField.cs
@@ -1,0 +1,15 @@
+using AbstUI.Blazor;
+using LingoEngine.Texts;
+using LingoEngine.Texts.FrameworkCommunication;
+using Microsoft.JSInterop;
+
+namespace LingoEngine.Blazor.Texts;
+
+/// <summary>
+/// Blazor implementation for field members, reusing the text base logic.
+/// </summary>
+public class LingoBlazorMemberField : LingoBlazorMemberTextBase<LingoMemberField>, ILingoFrameworkMemberField
+{
+    public LingoBlazorMemberField(IJSRuntime js, AbstUIScriptResolver scripts) : base(js, scripts) { }
+}
+

--- a/src/LingoEngine.Blazor/Texts/LingoBlazorMemberText.cs
+++ b/src/LingoEngine.Blazor/Texts/LingoBlazorMemberText.cs
@@ -1,0 +1,15 @@
+using AbstUI.Blazor;
+using LingoEngine.Texts;
+using LingoEngine.Texts.FrameworkCommunication;
+using Microsoft.JSInterop;
+
+namespace LingoEngine.Blazor.Texts;
+
+/// <summary>
+/// Concrete Blazor text member implementation.
+/// </summary>
+public class LingoBlazorMemberText : LingoBlazorMemberTextBase<LingoMemberText>, ILingoFrameworkMemberText
+{
+    public LingoBlazorMemberText(IJSRuntime js, AbstUIScriptResolver scripts) : base(js, scripts) { }
+}
+

--- a/src/LingoEngine.Blazor/Texts/LingoBlazorMemberTextBase.cs
+++ b/src/LingoEngine.Blazor/Texts/LingoBlazorMemberTextBase.cs
@@ -1,0 +1,250 @@
+using System;
+using System.IO;
+using AbstUI.Blazor;
+using AbstUI.Blazor.Bitmaps;
+using AbstUI.Blazor.Primitives;
+using AbstUI.Primitives;
+using AbstUI.Texts;
+using LingoEngine.Bitmaps;
+using LingoEngine.Primitives;
+using LingoEngine.Sprites;
+using LingoEngine.Texts;
+using LingoEngine.Texts.FrameworkCommunication;
+using Microsoft.JSInterop;
+
+namespace LingoEngine.Blazor.Texts;
+
+/// <summary>
+/// Basic Blazor implementation for text-based cast members. It renders the
+/// text onto an off-screen canvas using JavaScript and exposes it as a texture
+/// for the Lingo runtime.
+/// </summary>
+public abstract class LingoBlazorMemberTextBase<TText> : ILingoFrameworkMemberTextBase, IDisposable where TText : ILingoMemberTextBase
+{
+    protected TText _lingoMemberText = default!;
+    private readonly IJSRuntime _js;
+    private readonly AbstUIScriptResolver _scripts;
+    private AbstBlazorTexture2D? _texture;
+    private bool _dirty;
+
+    private string _text = string.Empty;
+    private bool _wordWrap;
+    private int _scrollTop;
+    private string _fontName = string.Empty;
+    private int _fontSize = 12;
+    private LingoTextStyle _fontStyle;
+    private AColor _textColor = AColor.FromRGB(0, 0, 0);
+    private AbstTextAlignment _alignment;
+    private int _margin;
+    private int _width;
+    private int _height;
+
+    public LingoBlazorMemberTextBase(IJSRuntime js, AbstUIScriptResolver scripts)
+    {
+        _js = js;
+        _scripts = scripts;
+    }
+
+    internal void Init(TText member) => _lingoMemberText = member;
+
+    public bool IsDirty => _dirty;
+    public string Text
+    {
+        get => _text;
+        set
+        {
+            if (_text != value)
+            {
+                _text = value;
+                _dirty = true;
+            }
+        }
+    }
+    public bool WordWrap
+    {
+        get => _wordWrap;
+        set
+        {
+            if (_wordWrap != value)
+            {
+                _wordWrap = value;
+                _dirty = true;
+            }
+        }
+    }
+    public int ScrollTop
+    {
+        get => _scrollTop;
+        set
+        {
+            if (_scrollTop != value)
+            {
+                _scrollTop = value;
+                _dirty = true;
+            }
+        }
+    }
+    public string FontName
+    {
+        get => _fontName;
+        set
+        {
+            if (_fontName != value)
+            {
+                _fontName = value;
+                _dirty = true;
+            }
+        }
+    }
+    public int FontSize
+    {
+        get => _fontSize;
+        set
+        {
+            if (_fontSize != value)
+            {
+                _fontSize = value;
+                _dirty = true;
+            }
+        }
+    }
+    public LingoTextStyle FontStyle
+    {
+        get => _fontStyle;
+        set
+        {
+            if (_fontStyle != value)
+            {
+                _fontStyle = value;
+                _dirty = true;
+            }
+        }
+    }
+    public AColor TextColor
+    {
+        get => _textColor;
+        set
+        {
+            if (!_textColor.Equals(value))
+            {
+                _textColor = value;
+                _dirty = true;
+            }
+        }
+    }
+    public AbstTextAlignment Alignment
+    {
+        get => _alignment;
+        set
+        {
+            if (_alignment != value)
+            {
+                _alignment = value;
+                _dirty = true;
+            }
+        }
+    }
+    public int Margin
+    {
+        get => _margin;
+        set
+        {
+            if (_margin != value)
+            {
+                _margin = value;
+                _dirty = true;
+            }
+        }
+    }
+    public bool IsLoaded { get; private set; }
+    public int Width
+    {
+        get => _width;
+        set
+        {
+            if (_width != value)
+            {
+                _width = value;
+                _dirty = true;
+            }
+        }
+    }
+    public int Height
+    {
+        get => _height;
+        set
+        {
+            if (_height != value)
+            {
+                _height = value;
+                _dirty = true;
+            }
+        }
+    }
+    public IAbstTexture2D? TextureLingo => _texture;
+
+    public void Copy(string text) => _js.InvokeVoidAsync("navigator.clipboard.writeText", text).AsTask().GetAwaiter().GetResult();
+
+    public string PasteClipboard() => _js.InvokeAsync<string>("navigator.clipboard.readText").AsTask().GetAwaiter().GetResult();
+
+    public string ReadText() => File.Exists(_lingoMemberText.FileName) ? File.ReadAllText(_lingoMemberText.FileName) : string.Empty;
+
+    public string ReadTextRtf()
+    {
+        var rtf = Path.ChangeExtension(_lingoMemberText.FileName, ".rtf");
+        return File.Exists(rtf) ? File.ReadAllText(rtf) : string.Empty;
+    }
+
+    public void CopyToClipboard() => Copy(Text);
+
+    public void Erase()
+    {
+        Unload();
+        Text = string.Empty;
+    }
+
+    public void ImportFileInto() { }
+
+    public void PasteClipboardInto() => Text = PasteClipboard();
+
+    public void Preload() => IsLoaded = true;
+
+    public void Unload()
+    {
+        IsLoaded = false;
+        _texture?.Dispose();
+        _texture = null;
+    }
+
+    public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
+
+    public bool IsPixelTransparent(int x, int y) => false;
+
+    public IAbstTexture2D? RenderToTexture(LingoInkType ink, AColor transparentColor)
+    {
+        int lines = Math.Max(1, Text.Split('\n').Length);
+        int w = Width > 0 ? Width : Math.Max(1, Text.Length * FontSize / 2 + Margin * 2);
+        int h = Height > 0 ? Height : FontSize * lines + Margin * 2;
+        Width = w;
+        Height = h;
+
+        _texture?.Dispose();
+        _texture = AbstBlazorTexture2D.CreateAsync(_js, w, h).GetAwaiter().GetResult();
+        var ctx = _scripts.CanvasGetContext(_texture.Canvas, false).GetAwaiter().GetResult();
+
+        string color = TextColor.ToCss();
+        string align = Alignment switch
+        {
+            AbstTextAlignment.Center => "center",
+            AbstTextAlignment.Right => "right",
+            _ => "left"
+        };
+        _scripts.CanvasDrawText(ctx, Margin, Margin + FontSize, Text, FontName, color, FontSize, align).GetAwaiter().GetResult();
+        IsLoaded = true;
+        _dirty = false;
+        return _texture;
+    }
+
+    public void Dispose() => Unload();
+}
+

--- a/src/LingoEngine.Blazor/Transitions/LingoBlazorMemberTransition.cs
+++ b/src/LingoEngine.Blazor/Transitions/LingoBlazorMemberTransition.cs
@@ -1,0 +1,19 @@
+using LingoEngine.Members;
+using LingoEngine.Sprites;
+using LingoEngine.Transitions;
+using LingoEngine.Blazor.Core;
+
+namespace LingoEngine.Blazor.Transitions;
+
+/// <summary>
+/// Blazor placeholder implementation for transition members.
+/// </summary>
+public class LingoBlazorMemberTransition : BlazorFrameworkMemberEmpty
+{
+    private LingoTransitionMember _member = null!;
+
+    internal void Init(LingoTransitionMember member)
+    {
+        _member = member;
+    }
+}

--- a/src/LingoEngine.Blazor/Util/PixelDataUtils.cs
+++ b/src/LingoEngine.Blazor/Util/PixelDataUtils.cs
@@ -1,0 +1,12 @@
+namespace LingoEngine.Blazor.Util;
+
+internal static class PixelDataUtils
+{
+    public static bool IsTransparent(byte[]? data, int stride, int width, int height, int x, int y)
+    {
+        if (data == null || x < 0 || y < 0 || x >= width || y >= height)
+            return false;
+        int index = y * stride + x * 4 + 3; // alpha channel
+        return data[index] == 0;
+    }
+}


### PR DESCRIPTION
## Summary
- convert bitmap data to RGBA and cache ink-rendered textures for Blazor members
- add minimal Blazor implementations for color palette, transition, and sound members
- provide a reusable empty-member base for Blazor

## Testing
- `dotnet format src/LingoEngine.Blazor/LingoEngine.Blazor.csproj -v diag`
- `dotnet build src/LingoEngine.Blazor/LingoEngine.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a2196242a08332928e49c177fb3697