### PR TITLE
feat(blazor): render sprites on canvas

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIScriptResolver.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIScriptResolver.cs
@@ -30,6 +30,12 @@ public class AbstUIScriptResolver : IAsyncDisposable
     public async ValueTask CanvasDisposeCanvas(ElementReference canvas)
         => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.disposeCanvas", canvas);
 
+    public async ValueTask CanvasAddToBody(ElementReference canvas)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.addCanvasToBody", canvas);
+
+    public async ValueTask CanvasSetVisible(ElementReference canvas, bool visible)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.setCanvasVisible", canvas, visible);
+
     public async ValueTask<IJSObjectReference> CanvasGetContext(ElementReference canvas, bool pixilated)
         => await (await GetModuleAsync()).InvokeAsync<IJSObjectReference>("abstCanvas.getContext", canvas, pixilated);
 
@@ -62,6 +68,9 @@ public class AbstUIScriptResolver : IAsyncDisposable
 
     public async ValueTask<byte[]> CanvasGetImageData(IJSObjectReference ctx, int width, int height)
         => await (await GetModuleAsync()).InvokeAsync<byte[]>("abstCanvas.getImageData", ctx, width, height);
+
+    public async ValueTask CanvasSetGlobalAlpha(IJSObjectReference ctx, double alpha)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.setGlobalAlpha", ctx, alpha);
 
     public async ValueTask SetCursor(string cursor)
         => await (await GetModuleAsync()).InvokeVoidAsync("AbstUIKey.setCursor", cursor);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
@@ -12,6 +12,14 @@ export class abstCanvas {
         }
     }
 
+    static addCanvasToBody(canvas) {
+        document.body.appendChild(canvas);
+    }
+
+    static setCanvasVisible(canvas, visible) {
+        canvas.style.display = visible ? 'block' : 'none';
+    }
+
     static getContext(canvas, pixilated) {
         const ctx = canvas.getContext('2d');
         if (pixilated) {
@@ -106,6 +114,10 @@ export class abstCanvas {
 
     static getImageData(ctx, width, height) {
         return ctx.getImageData(0, 0, width, height).data;
+    }
+
+    static setGlobalAlpha(ctx, alpha) {
+        ctx.globalAlpha = alpha;
     }
 }
 

--- a/src/LingoEngine.Blazor/BlazorFactory.cs
+++ b/src/LingoEngine.Blazor/BlazorFactory.cs
@@ -1,7 +1,15 @@
 using System;
+using System.Collections.Generic;
+using AbstUI.Blazor;
 using AbstUI.Components;
+using AbstUI.Inputs;
 using AbstUI.Primitives;
 using LingoEngine.Bitmaps;
+using LingoEngine.Blazor.Inputs;
+using LingoEngine.Blazor.Movies;
+using LingoEngine.Blazor.Sprites;
+using LingoEngine.Blazor.Stages;
+using LingoEngine.Blazor.FilmLoops;
 using LingoEngine.Casts;
 using LingoEngine.Core;
 using LingoEngine.FrameworkCommunication;
@@ -14,18 +22,89 @@ using LingoEngine.Sounds;
 using LingoEngine.Sprites;
 using LingoEngine.Stages;
 using LingoEngine.Texts;
+using LingoEngine.Events;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
 
 namespace LingoEngine.Blazor;
 
-public class BlazorFactory : ILingoFrameworkFactory
+/// <summary>
+/// Factory responsible for creating Blazor backed framework objects.
+/// Only a subset of the factory is implemented, enough for stage, movie and
+/// sprite handling which is required by the current tests.
+/// </summary>
+public class BlazorFactory : ILingoFrameworkFactory, IDisposable
 {
-    public BlazorFactory(ILingoServiceProvider services) { }
-    public LingoStage CreateStage(LingoPlayer lingoPlayer) => throw new NotImplementedException();
-    public LingoMovie AddMovie(LingoStage stage, LingoMovie lingoMovie) => throw new NotImplementedException();
+    private readonly ILingoServiceProvider _services;
+    private readonly List<IDisposable> _disposables = new();
+    private readonly IAbstComponentFactory _gfxFactory = new AbstBlazorComponentFactory();
+
+    public BlazorFactory(ILingoServiceProvider services)
+    {
+        _services = services;
+    }
+
+    public LingoStage CreateStage(LingoPlayer lingoPlayer)
+    {
+        var impl = new LingoBlazorStage((LingoClock)lingoPlayer.Clock);
+        var stage = new LingoStage(impl);
+        impl.Init(stage);
+        _disposables.Add(impl);
+        return stage;
+    }
+
+    public LingoMovie AddMovie(LingoStage stage, LingoMovie lingoMovie)
+    {
+        var blazorStage = stage.Framework<LingoBlazorStage>();
+        var scripts = _services.GetRequiredService<AbstUIScriptResolver>();
+        var impl = new LingoBlazorMovie(blazorStage, lingoMovie, m => _disposables.Remove(m), scripts);
+        lingoMovie.Init(impl);
+        _disposables.Add(impl);
+        return lingoMovie;
+    }
+
+    public LingoSprite2D CreateSprite2D(ILingoMovie movie, Action<LingoSprite2D> onRemoveMe)
+    {
+        var lingoMovie = (LingoMovie)movie;
+        var sprite = new LingoSprite2D(lingoMovie.GetEnvironment(), movie);
+        sprite.SetOnRemoveMe(onRemoveMe);
+        lingoMovie.Framework<LingoBlazorMovie>().CreateSprite(sprite);
+        return sprite;
+    }
+
+    public LingoStageMouse CreateMouse(LingoStage stage)
+    {
+        var js = _services.GetRequiredService<IJSRuntime>();
+        var scripts = _services.GetRequiredService<AbstUIScriptResolver>();
+        var mouseImpl = new LingoBlazorMouse(new Lazy<AbstMouse<LingoMouseEvent>>(() => null!), js, scripts);
+        var mouse = new LingoStageMouse(stage, mouseImpl);
+        mouseImpl.SetMouse(mouse);
+        return mouse;
+    }
+
+    public LingoKey CreateKey()
+    {
+        var impl = new LingoBlazorKey();
+        var key = new LingoKey(impl);
+        impl.SetKeyObj(key);
+        return key;
+    }
+
+    // The remaining factory methods are not yet required for the Blazor
+    // backend. They will be implemented as the Blazor integration evolves.
     public T CreateMember<T>(ILingoCast cast, int numberInCast, string name = "") where T : LingoMember => throw new NotImplementedException();
     public LingoMemberBitmap CreateMemberBitmap(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
     public LingoMemberSound CreateMemberSound(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
-    public LingoFilmLoopMember CreateMemberFilmLoop(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
+    public LingoFilmLoopMember CreateMemberFilmLoop(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default)
+    {
+        var js = _services.GetRequiredService<IJSRuntime>();
+        var scripts = _services.GetRequiredService<AbstUIScriptResolver>();
+        var impl = new LingoBlazorMemberFilmLoop(js, scripts);
+        var member = new LingoFilmLoopMember(impl, (LingoCast)cast, numberInCast, name, fileName ?? string.Empty, regPoint);
+        impl.Init(member);
+        _disposables.Add(impl);
+        return member;
+    }
     public LingoMemberShape CreateMemberShape(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
     public LingoMemberField CreateMemberField(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
     public LingoMemberText CreateMemberText(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
@@ -33,35 +112,38 @@ public class BlazorFactory : ILingoFrameworkFactory
     public LingoMember CreateEmpty(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
     public LingoSound CreateSound(ILingoCastLibsContainer castLibsContainer) => throw new NotImplementedException();
     public LingoSoundChannel CreateSoundChannel(int number) => throw new NotImplementedException();
-    public LingoStageMouse CreateMouse(LingoStage stage) => throw new NotImplementedException();
-    public LingoKey CreateKey() => throw new NotImplementedException();
-    public AbstGfxCanvas CreateGfxCanvas(string name, int width, int height) => throw new NotImplementedException();
-    public AbstWrapPanel CreateWrapPanel(AOrientation orientation, string name) => throw new NotImplementedException();
-    public AbstPanel CreatePanel(string name) => throw new NotImplementedException();
-    public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y) => throw new NotImplementedException();
-    public AbstTabContainer CreateTabContainer(string name) => throw new NotImplementedException();
-    public AbstTabItem CreateTabItem(string name, string title) => throw new NotImplementedException();
-    public AbstScrollContainer CreateScrollContainer(string name) => throw new NotImplementedException();
-    public AbstInputSlider<float> CreateInputSliderFloat(AOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null) => throw new NotImplementedException();
-    public AbstInputSlider<int> CreateInputSliderInt(AOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null) => throw new NotImplementedException();
-    public AbstInputText CreateInputText(string name, int maxLength = 0, Action<string>? onChange = null, bool multiLine = false) => throw new NotImplementedException();
-    public AbstInputNumber<float> CreateInputNumberFloat(string name, float? min = null, float? max = null, Action<float>? onChange = null) => throw new NotImplementedException();
-    public AbstInputNumber<int> CreateInputNumberInt(string name, int? min = null, int? max = null, Action<int>? onChange = null) => throw new NotImplementedException();
-    public AbstInputSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null) => throw new NotImplementedException();
-    public AbstInputCheckbox CreateInputCheckbox(string name, Action<bool>? onChange = null) => throw new NotImplementedException();
-    public AbstInputCombobox CreateInputCombobox(string name, Action<string?>? onChange = null) => throw new NotImplementedException();
-    public AbstItemList CreateItemList(string name, Action<string?>? onChange = null) => throw new NotImplementedException();
-    public AbstColorPicker CreateColorPicker(string name, Action<AColor>? onChange = null) => throw new NotImplementedException();
-    public AbstLabel CreateLabel(string name, string text = "") => throw new NotImplementedException();
-    public AbstButton CreateButton(string name, string text = "") => throw new NotImplementedException();
-    public AbstStateButton CreateStateButton(string name, IAbstTexture2D? texture = null, string text = "", Action<bool>? onChange = null) => throw new NotImplementedException();
-    public AbstMenu CreateMenu(string name) => throw new NotImplementedException();
-    public AbstMenuItem CreateMenuItem(string name, string? shortcut = null) => throw new NotImplementedException();
-    public AbstMenu CreateContextMenu(object window) => throw new NotImplementedException();
-    public AbstHorizontalLineSeparator CreateHorizontalLineSeparator(string name) => throw new NotImplementedException();
-    public AbstVerticalLineSeparator CreateVerticalLineSeparator(string name) => throw new NotImplementedException();
-    public AbstWindow CreateWindow(string name, string title = "") => throw new NotImplementedException();
-    public LingoSprite2D CreateSprite2D(ILingoMovie movie, Action<LingoSprite2D> onRemoveMe) => throw new NotImplementedException();
+    public AbstGfxCanvas CreateGfxCanvas(string name, int width, int height) => _gfxFactory.CreateGfxCanvas(name, width, height);
+    public AbstWrapPanel CreateWrapPanel(AOrientation orientation, string name) => _gfxFactory.CreateWrapPanel(orientation, name);
+    public AbstPanel CreatePanel(string name) => _gfxFactory.CreatePanel(name);
+    public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y) => _gfxFactory.CreateLayoutWrapper(content, x, y);
+    public AbstTabContainer CreateTabContainer(string name) => _gfxFactory.CreateTabContainer(name);
+    public AbstTabItem CreateTabItem(string name, string title) => _gfxFactory.CreateTabItem(name, title);
+    public AbstScrollContainer CreateScrollContainer(string name) => _gfxFactory.CreateScrollContainer(name);
+    public AbstInputSlider<float> CreateInputSliderFloat(AOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null) => _gfxFactory.CreateInputSliderFloat(orientation, name, min, max, step, onChange);
+    public AbstInputSlider<int> CreateInputSliderInt(AOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null) => _gfxFactory.CreateInputSliderInt(orientation, name, min, max, step, onChange);
+    public AbstInputText CreateInputText(string name, int maxLength = 0, Action<string>? onChange = null, bool multiLine = false) => _gfxFactory.CreateInputText(name, maxLength, onChange, multiLine);
+    public AbstInputNumber<float> CreateInputNumberFloat(string name, float? min = null, float? max = null, Action<float>? onChange = null) => _gfxFactory.CreateInputNumberFloat(name, min, max, onChange);
+    public AbstInputNumber<int> CreateInputNumberInt(string name, int? min = null, int? max = null, Action<int>? onChange = null) => _gfxFactory.CreateInputNumberInt(name, min, max, onChange);
+    public AbstInputSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null) => _gfxFactory.CreateSpinBox(name, min, max, onChange);
+    public AbstInputCheckbox CreateInputCheckbox(string name, Action<bool>? onChange = null) => _gfxFactory.CreateInputCheckbox(name, onChange);
+    public AbstInputCombobox CreateInputCombobox(string name, Action<string?>? onChange = null) => _gfxFactory.CreateInputCombobox(name, onChange);
+    public AbstItemList CreateItemList(string name, Action<string?>? onChange = null) => _gfxFactory.CreateItemList(name, onChange);
+    public AbstColorPicker CreateColorPicker(string name, Action<AColor>? onChange = null) => _gfxFactory.CreateColorPicker(name, onChange);
+    public AbstLabel CreateLabel(string name, string text = "") => _gfxFactory.CreateLabel(name, text);
+    public AbstButton CreateButton(string name, string text = "") => _gfxFactory.CreateButton(name, text);
+    public AbstStateButton CreateStateButton(string name, IAbstTexture2D? texture = null, string text = "", Action<bool>? onChange = null) => _gfxFactory.CreateStateButton(name, texture, text, onChange);
+    public AbstMenu CreateMenu(string name) => _gfxFactory.CreateMenu(name);
+    public AbstMenuItem CreateMenuItem(string name, string? shortcut = null) => _gfxFactory.CreateMenuItem(name, shortcut);
+    public AbstMenu CreateContextMenu(object window) => _gfxFactory.CreateContextMenu(window);
+    public AbstHorizontalLineSeparator CreateHorizontalLineSeparator(string name) => _gfxFactory.CreateHorizontalLineSeparator(name);
+    public AbstVerticalLineSeparator CreateVerticalLineSeparator(string name) => _gfxFactory.CreateVerticalLineSeparator(name);
+    public AbstWindow CreateWindow(string name, string title = "") => _gfxFactory.CreateWindow(name, title);
     public T CreateBehavior<T>(LingoMovie lingoMovie) where T : LingoSpriteBehavior => throw new NotImplementedException();
     public T CreateMovieScript<T>(LingoMovie lingoMovie) where T : LingoMovieScript => throw new NotImplementedException();
+
+    public void Dispose()
+    {
+        foreach (var d in _disposables)
+            d.Dispose();
+    }
 }

--- a/src/LingoEngine.Blazor/FilmLoops/LingoBlazorMemberFilmLoop.cs
+++ b/src/LingoEngine.Blazor/FilmLoops/LingoBlazorMemberFilmLoop.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Blazor;
+using AbstUI.Blazor.Bitmaps;
+using AbstUI.Primitives;
+using LingoEngine.Bitmaps;
+using LingoEngine.FilmLoops;
+using LingoEngine.Members;
+using LingoEngine.Primitives;
+using LingoEngine.Sprites;
+using Microsoft.JSInterop;
+
+namespace LingoEngine.Blazor.FilmLoops;
+
+/// <summary>
+/// Blazor framework implementation for film loop members. It composes the
+/// active layers into an off-screen canvas and exposes the resulting texture
+/// to sprites.
+/// </summary>
+public class LingoBlazorMemberFilmLoop : ILingoFrameworkMemberFilmLoop, IDisposable
+{
+    private readonly IJSRuntime _js;
+    private readonly AbstUIScriptResolver _scripts;
+    private LingoFilmLoopMember _member = null!;
+    private AbstBlazorTexture2D? _texture;
+
+    public bool IsLoaded { get; private set; }
+    public byte[]? Media { get; set; }
+    public LingoFilmLoopFraming Framing { get; set; } = LingoFilmLoopFraming.Auto;
+    public bool Loop { get; set; } = true;
+    public APoint Offset { get; private set; }
+    public IAbstTexture2D? TextureLingo => _texture;
+
+    public LingoBlazorMemberFilmLoop(IJSRuntime js, AbstUIScriptResolver scripts)
+    {
+        _js = js;
+        _scripts = scripts;
+    }
+
+    internal void Init(LingoFilmLoopMember member)
+    {
+        _member = member;
+    }
+
+    public void Preload()
+    {
+        IsLoaded = true;
+    }
+
+    public void Unload()
+    {
+        IsLoaded = false;
+        _texture?.Dispose();
+        _texture = null;
+    }
+
+    public void Erase()
+    {
+        Media = null;
+        Unload();
+    }
+
+    public void ImportFileInto() { }
+    public void CopyToClipboard() { }
+    public void PasteClipboardInto() { }
+    public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
+
+    public IAbstTexture2D? RenderToTexture(LingoInkType ink, AColor transparentColor)
+        => _texture;
+
+    public IAbstTexture2D ComposeTexture(ILingoSprite2DLight hostSprite, IReadOnlyList<LingoSprite2DVirtual> layers, int frame)
+    {
+        var prep = LingoFilmLoopComposer.Prepare(_member, Framing, layers);
+        Offset = prep.Offset;
+        int width = prep.Width;
+        int height = prep.Height;
+
+        var tex = AbstBlazorTexture2D.CreateAsync(_js, width, height).GetAwaiter().GetResult();
+        var ctx = _scripts.CanvasGetContext(tex.Canvas, true).GetAwaiter().GetResult();
+        _scripts.CanvasClear(ctx, "rgba(0,0,0,0)", width, height).GetAwaiter().GetResult();
+
+        foreach (var info in prep.Layers)
+        {
+            AbstBlazorTexture2D? srcTex = null;
+            if (info.Sprite2D.Member is ILingoMemberWithTexture memberWithTexture)
+            {
+                srcTex = memberWithTexture.RenderToTexture(info.Ink, info.BackColor) as AbstBlazorTexture2D;
+            }
+            else if (info.Sprite2D.Texture is AbstBlazorTexture2D existing)
+            {
+                srcTex = existing;
+            }
+            if (srcTex == null)
+                continue;
+
+            var m = info.Transform.Matrix;
+            ctx.InvokeVoidAsync("save").GetAwaiter().GetResult();
+            ctx.InvokeVoidAsync("setTransform", m.M11, m.M12, m.M21, m.M22, m.M31, m.M32).GetAwaiter().GetResult();
+            _scripts.CanvasSetGlobalAlpha(ctx, info.Alpha).GetAwaiter().GetResult();
+            ctx.InvokeVoidAsync("drawImage", srcTex.Canvas, info.SrcX, info.SrcY, info.SrcW, info.SrcH, 0, 0, info.DestW, info.DestH).GetAwaiter().GetResult();
+            ctx.InvokeVoidAsync("restore").GetAwaiter().GetResult();
+        }
+
+        _texture = tex;
+        return tex;
+    }
+
+    public void Dispose() => _texture?.Dispose();
+}

--- a/src/LingoEngine.Blazor/Movies/LingoBlazorMovie.cs
+++ b/src/LingoEngine.Blazor/Movies/LingoBlazorMovie.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AbstUI.Blazor;
+using AbstUI.Blazor.Primitives;
+using AbstUI.Blazor.Bitmaps;
+using AbstUI.Primitives;
+using LingoEngine.Blazor.Sprites;
+using LingoEngine.Blazor.Stages;
+using LingoEngine.Movies;
+using LingoEngine.Sprites;
+using Microsoft.JSInterop;
+using Microsoft.AspNetCore.Components;
+
+namespace LingoEngine.Blazor.Movies;
+
+/// <summary>
+/// Lightweight movie container for the Blazor backend. It keeps track of
+/// sprites and exposes basic lifecycle hooks used by the engine.
+/// </summary>
+public class LingoBlazorMovie : ILingoFrameworkMovie, IDisposable
+{
+    private readonly LingoBlazorStage _stage;
+    private readonly Action<LingoBlazorMovie> _remove;
+    private readonly HashSet<LingoBlazorSprite2D> _drawnSprites = new();
+    private readonly HashSet<LingoBlazorSprite2D> _allSprites = new();
+    private readonly AbstUIScriptResolver _scripts;
+    private readonly int _width;
+    private readonly int _height;
+    private ElementReference _canvas;
+    private IJSObjectReference? _ctx;
+
+    public LingoBlazorMovie(LingoBlazorStage stage, LingoMovie movie, Action<LingoBlazorMovie> remove, AbstUIScriptResolver scripts)
+    {
+        _stage = stage;
+        _remove = remove;
+        _scripts = scripts;
+        _width = stage.LingoStage.Width;
+        _height = stage.LingoStage.Height;
+        _canvas = _scripts.CanvasCreateCanvas(_width, _height).GetAwaiter().GetResult();
+        _scripts.CanvasAddToBody(_canvas).GetAwaiter().GetResult();
+        _ctx = _scripts.CanvasGetContext(_canvas, true).GetAwaiter().GetResult();
+        _scripts.CanvasSetVisible(_canvas, false).GetAwaiter().GetResult();
+    }
+
+    internal void Show()
+    {
+        _stage.ShowMovie(this);
+        _scripts.CanvasSetVisible(_canvas, true).GetAwaiter().GetResult();
+    }
+
+    internal void Hide()
+    {
+        _scripts.CanvasSetVisible(_canvas, false).GetAwaiter().GetResult();
+        _stage.HideMovie(this);
+    }
+
+    public void UpdateStage()
+    {
+        if (_ctx == null) return;
+        _scripts.CanvasClear(_ctx, _stage.LingoStage.BackgroundColor.ToCss(), _width, _height).GetAwaiter().GetResult();
+        foreach (var s in _drawnSprites.OrderBy(s => s.ZIndex))
+        {
+            if (s.Texture is not AbstBlazorTexture2D tex) continue;
+            var drawW = s.DesiredWidth > 0 ? s.DesiredWidth : s.Width;
+            var drawH = s.DesiredHeight > 0 ? s.DesiredHeight : s.Height;
+            var x = s.X - s.RegPoint.X;
+            var y = s.Y - s.RegPoint.Y;
+            _ctx.InvokeVoidAsync("drawImage", tex.Canvas, x, y, drawW, drawH).GetAwaiter().GetResult();
+            s.Update();
+        }
+    }
+
+    internal void CreateSprite<T>(T lingoSprite) where T : LingoSprite2D
+    {
+        var sprite = new LingoBlazorSprite2D(lingoSprite,
+            s => _drawnSprites.Add(s),
+            s => _drawnSprites.Remove(s),
+            s => { _drawnSprites.Remove(s); _allSprites.Remove(s); });
+        _allSprites.Add(sprite);
+    }
+
+    public void RemoveMe()
+    {
+        _remove(this);
+    }
+
+    public APoint GetGlobalMousePosition() => (0, 0);
+
+    public void Dispose()
+    {
+        Hide();
+        _scripts.CanvasDisposeCanvas(_canvas).GetAwaiter().GetResult();
+        RemoveMe();
+    }
+}

--- a/src/LingoEngine.Blazor/Sprites/LingoBlazorSprite2D.cs
+++ b/src/LingoEngine.Blazor/Sprites/LingoBlazorSprite2D.cs
@@ -1,0 +1,122 @@
+using System;
+using AbstUI.Primitives;
+using LingoEngine.Bitmaps;
+using LingoEngine.Sprites;
+
+namespace LingoEngine.Blazor.Sprites;
+
+/// <summary>
+/// Simple sprite implementation for the Blazor backend. It stores sprite
+/// properties and notifies the movie about visibility changes but does not
+/// perform actual rendering.
+/// </summary>
+public class LingoBlazorSprite2D : ILingoFrameworkSprite, IDisposable
+{
+    private readonly Action<LingoBlazorSprite2D> _show;
+    private readonly Action<LingoBlazorSprite2D> _hide;
+    private readonly Action<LingoBlazorSprite2D> _remove;
+    private readonly LingoSprite2D _lingoSprite;
+    private IAbstTexture2D? _texture;
+
+    internal bool IsDirty { get; set; } = true;
+    internal bool IsDirtyMember { get; set; } = true;
+
+    public LingoBlazorSprite2D(LingoSprite2D sprite,
+        Action<LingoBlazorSprite2D> show,
+        Action<LingoBlazorSprite2D> hide,
+        Action<LingoBlazorSprite2D> remove)
+    {
+        _show = show;
+        _hide = hide;
+        _remove = remove;
+        _lingoSprite = sprite;
+        sprite.Init(this);
+        ZIndex = sprite.SpriteNum;
+        DirectToStage = sprite.DirectToStage;
+        Ink = sprite.Ink;
+    }
+
+    public bool Visibility
+    {
+        get => _visible;
+        set
+        {
+            _visible = value;
+            if (value) _show(this); else _hide(this);
+            IsDirty = true;
+        }
+    }
+    private bool _visible;
+
+    private float _blend = 1f;
+    public float Blend { get => _blend; set { _blend = value; IsDirty = true; } }
+    private float _x;
+    public float X { get => _x; set { _x = value; IsDirty = true; } }
+    private float _y;
+    public float Y { get => _y; set { _y = value; IsDirty = true; } }
+    public float Width { get; private set; }
+    public float Height { get; private set; }
+    private string _name = string.Empty;
+    public string Name { get => _name; set { _name = value; IsDirty = true; } }
+    private APoint _regPoint;
+    public APoint RegPoint { get => _regPoint; set { _regPoint = value; IsDirty = true; } }
+    private float _desiredHeight;
+    public float DesiredHeight { get => _desiredHeight; set { _desiredHeight = value; IsDirty = true; } }
+    private float _desiredWidth;
+    public float DesiredWidth { get => _desiredWidth; set { _desiredWidth = value; IsDirty = true; } }
+    private int _zIndex;
+    public int ZIndex { get => _zIndex; set { _zIndex = value; IsDirty = true; } }
+    private float _rotation;
+    public float Rotation { get => _rotation; set { _rotation = value; IsDirty = true; } }
+    private float _skew;
+    public float Skew { get => _skew; set { _skew = value; IsDirty = true; } }
+    private bool _flipH;
+    public bool FlipH { get => _flipH; set { _flipH = value; IsDirty = true; } }
+    private bool _flipV;
+    public bool FlipV { get => _flipV; set { _flipV = value; IsDirty = true; } }
+    private bool _directToStage;
+    public bool DirectToStage { get => _directToStage; set { _directToStage = value; IsDirty = true; } }
+    private int _ink;
+    public int Ink { get => _ink; set { _ink = value; IsDirty = true; } }
+
+    public void MemberChanged()
+    {
+        if (_lingoSprite.Member is { } member)
+        {
+            if (Width == 0 || Height == 0)
+            {
+                Width = member.Width;
+                Height = member.Height;
+            }
+            IsDirtyMember = true;
+        }
+    }
+
+    public void RemoveMe() => _remove(this);
+    public void Show() => Visibility = true;
+    public void Hide() => Visibility = false;
+    public void SetPosition(APoint point) { X = point.X; Y = point.Y; }
+    public void ApplyMemberChangesOnStepFrame() { }
+
+    public void SetTexture(IAbstTexture2D texture)
+    {
+        _texture = texture;
+        if (Width == 0 || Height == 0)
+        {
+            Width = texture.Width;
+            Height = texture.Height;
+        }
+        _lingoSprite.FWTextureHasChanged(texture);
+        IsDirtyMember = true;
+    }
+
+    internal void Update()
+    {
+        IsDirty = false;
+        IsDirtyMember = false;
+    }
+
+    internal IAbstTexture2D? Texture => _texture;
+
+    public void Dispose() => _remove(this);
+}

--- a/src/LingoEngine.Blazor/Stages/LingoBlazorStage.cs
+++ b/src/LingoEngine.Blazor/Stages/LingoBlazorStage.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using LingoEngine.Core;
+using LingoEngine.Movies;
+using LingoEngine.Stages;
+using LingoEngine.Blazor.Movies;
+
+namespace LingoEngine.Blazor.Stages;
+
+/// <summary>
+/// Minimal Blazor stage implementation. It tracks movies and delegates
+/// activation to the engine without providing a concrete rendering surface.
+/// </summary>
+public class LingoBlazorStage : ILingoFrameworkStage, IDisposable
+{
+    private readonly LingoClock _clock;
+    private readonly HashSet<LingoBlazorMovie> _movies = new();
+    private LingoBlazorMovie? _activeMovie;
+    private LingoStage _stage = null!;
+
+    public LingoStage LingoStage => _stage;
+
+    public float Scale { get; set; } = 1f;
+
+    public LingoBlazorStage(LingoClock clock)
+    {
+        _clock = clock;
+    }
+
+    internal void Init(LingoStage stage)
+    {
+        _stage = stage;
+    }
+
+    internal void ShowMovie(LingoBlazorMovie movie)
+    {
+        _movies.Add(movie);
+    }
+
+    internal void HideMovie(LingoBlazorMovie movie)
+    {
+        _movies.Remove(movie);
+    }
+
+    /// <inheritdoc />
+    public void SetActiveMovie(LingoMovie? lingoMovie)
+    {
+        _activeMovie?.Hide();
+        if (lingoMovie == null)
+        {
+            _activeMovie = null;
+            return;
+        }
+        var movie = lingoMovie.Framework<LingoBlazorMovie>();
+        _activeMovie = movie;
+        movie.Show();
+    }
+
+    /// <inheritdoc />
+    public void ApplyPropertyChanges() { }
+
+    public void Dispose()
+    {
+        foreach (var m in _movies)
+            m.Dispose();
+        _movies.Clear();
+    }
+}


### PR DESCRIPTION
## Summary
- track Blazor sprite property changes with dirty flags and safe dimension updates
- render active movie sprites onto a DOM canvas via JS interop
- extend script resolver and factory to manage canvas lifecycle and visibility
- compose film loop member layers into off-screen canvas textures

## Testing
- `dotnet format src/LingoEngine.Blazor/LingoEngine.Blazor.csproj` (Unable to fix CA1416)
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj` (Unable to fix BL0005)
- `dotnet build src/LingoEngine.Blazor/LingoEngine.Blazor.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a2b86e65408332b8445a462e72c59b