### PR TITLE
Add RmlUi-based SDL2 input backend for AbstUI

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Bitmaps/SdlTexture2DExtensions.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Bitmaps/SdlTexture2DExtensions.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Runtime.InteropServices;
+using AbstUI.SDL2.SDLL;
+
+namespace AbstUI.SDL2.Bitmaps;
+
+public static class SdlTexture2DExtensions
+{
+    /// <summary>
+    /// Converts the SDL texture to a PNG and returns its Base64 representation.
+    /// </summary>
+    /// <param name="texture">Texture to encode.</param>
+    /// <param name="renderer">Renderer used to read the texture pixels.</param>
+    public static string ToPngBase64(this SdlTexture2D texture, nint renderer)
+    {
+        nint surface = texture.ToSurface(renderer, out int w, out int h);
+        try
+        {
+            int bufferSize = w * h * 4 + 1024; // raw pixel data + small overhead
+            nint buffer = Marshal.AllocHGlobal(bufferSize);
+            try
+            {
+                nint rw = SDL.SDL_RWFromMem(buffer, bufferSize);
+                if (rw == nint.Zero)
+                    throw new Exception(SDL.SDL_GetError());
+
+                try
+                {
+                    if (SDL_image.IMG_SavePNG_RW(surface, rw, 0) != 0)
+                        throw new Exception($"IMG_SavePNG_RW failed: {SDL_image.IMG_GetError()}");
+
+                    long size = SDL.SDL_RWtell(rw);
+                    byte[] bytes = new byte[size];
+                    Marshal.Copy(buffer, bytes, 0, (int)size);
+                    return Convert.ToBase64String(bytes);
+                }
+                finally
+                {
+                    SDL.SDL_FreeRW(rw);
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+        finally
+        {
+            SDL.SDL_FreeSurface(surface);
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/AbstUI.SDL2RmlUi.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/AbstUI.SDL2RmlUi.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Platforms>AnyCPU;x64;x86</Platforms>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet Packaging Metadata -->
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>AbstUI.SDL2RmlUi</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Emmanuel The Creator</Authors>
+    <Company>The Community</Company>
+    <Description>SDL2 backend using RmlUi.NET to provide advanced UI input components.</Description>
+    <RepositoryUrl>https://github.com/EmmanuelTheCreator/LingoEngine</RepositoryUrl>
+    <PackageTags>AbstUI SDL2 RmlUi</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="RmlUi.NET" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AbstUI.SDL2\AbstUI.SDL2.csproj" />
+  </ItemGroup>
+</Project>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Components/RmlUiButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Components/RmlUiButton.cs
@@ -1,0 +1,133 @@
+using AbstUI.Components;
+using AbstUI.Primitives;
+using AbstUI.SDL2.Bitmaps;
+using RmlUiNet;
+
+namespace AbstUI.SDL2RmlUi.Components;
+
+/// <summary>
+/// Button implementation backed by a RmlUi element.
+/// </summary>
+public class RmlUiButton : IAbstFrameworkButton, IDisposable
+{
+    private readonly Element _element;
+    private readonly nint _renderer;
+    private AMargin _margin;
+    private string _name = string.Empty;
+    private bool _visibility = true;
+    private float _width;
+    private float _height;
+    private event Action? _pressed;
+    private Element? _iconElement;
+    private IAbstTexture2D? _iconTexture;
+
+    public RmlUiButton(ElementDocument document, nint renderer)
+    {
+        // Create a <button> element and hook up the click event
+        _element = document.AppendChildTag("button");
+        _element.AddEventListener("click", _ => _pressed?.Invoke());
+        _renderer = renderer;
+    }
+
+    public object FrameworkNode => _element;
+
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            _name = value;
+            _element.SetAttribute("id", value);
+        }
+    }
+
+    public bool Visibility
+    {
+        get => _visibility;
+        set
+        {
+            _visibility = value;
+            _element.SetProperty("display", value ? "block" : "none");
+        }
+    }
+
+    public float Width
+    {
+        get => _width;
+        set
+        {
+            _width = value;
+            _element.SetProperty("width", $"{value}px");
+        }
+    }
+
+    public float Height
+    {
+        get => _height;
+        set
+        {
+            _height = value;
+            _element.SetProperty("height", $"{value}px");
+        }
+    }
+
+    public AMargin Margin
+    {
+        get => _margin;
+        set
+        {
+            _margin = value;
+            _element.SetProperty("margin", $"{value.Top}px {value.Right}px {value.Bottom}px {value.Left}px");
+        }
+    }
+
+    public string Text
+    {
+        get => _element.GetInnerRml();
+        set => _element.SetInnerRml(value);
+    }
+
+    public bool Enabled
+    {
+        get => !_element.HasAttribute("disabled");
+        set
+        {
+            if (value) _element.RemoveAttribute("disabled");
+            else _element.SetAttribute("disabled", "disabled");
+        }
+    }
+
+    public IAbstTexture2D? IconTexture
+    {
+        get => _iconTexture;
+        set
+        {
+            _iconTexture = value;
+
+            // Remove previous icon element if present
+            if (_iconElement != null)
+            {
+                _element.RemoveChild(_iconElement);
+                _iconElement = null;
+            }
+
+            // Only SDL2 textures are supported for now
+            if (value is SdlTexture2D tex)
+            {
+                var base64 = tex.ToPngBase64(_renderer);
+                _iconElement = _element.AppendChildTag("img");
+                _iconElement.SetAttribute("src", $"data:image/png;base64,{base64}");
+                _iconElement.SetAttribute("width", tex.Width.ToString());
+                _iconElement.SetAttribute("height", tex.Height.ToString());
+            }
+        }
+    }
+
+    public event Action? Pressed
+    {
+        add => _pressed += value;
+        remove => _pressed -= value;
+    }
+
+    public void Dispose() { }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Components/RmlUiInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Components/RmlUiInputText.cs
@@ -1,0 +1,226 @@
+using AbstUI.Components;
+using AbstUI.Primitives;
+using RmlUiNet;
+
+namespace AbstUI.SDL2RmlUi.Components;
+
+/// <summary>
+/// Single-line or multi-line text input implemented with RmlUi elements.
+/// </summary>
+public class RmlUiInputText : IAbstFrameworkInputText, IDisposable
+{
+    private readonly ElementDocument _document;
+    private Element _element;
+    private ElementFormControlInput? _input;
+    private ElementFormControlTextArea? _textarea;
+    private AMargin _margin;
+    private string _name = string.Empty;
+    private bool _visibility = true;
+    private float _width;
+    private float _height;
+    private float _x;
+    private float _y;
+    private bool _enabled = true;
+    private string _text = string.Empty;
+    private int _maxLength;
+    private string? _font;
+    private int _fontSize;
+    private bool _isMultiLine;
+    private event Action? _valueChanged;
+
+    public RmlUiInputText(ElementDocument document, bool multiLine)
+    {
+        _document = document;
+        _isMultiLine = multiLine;
+        InitElement(_isMultiLine);
+    }
+
+    private void InitElement(bool multiLine)
+    {
+        // remove existing element if reinitializing
+        if (_element != null)
+        {
+            var parent = _element.GetParentNode();
+            parent?.RemoveChild(_element);
+        }
+        _input = null;
+        _textarea = null;
+
+        if (multiLine)
+        {
+            _textarea = (ElementFormControlTextArea)_document.AppendChildTag("textarea");
+            _element = _textarea;
+        }
+        else
+        {
+            _input = (ElementFormControlInput)_document.AppendChildTag("input");
+            _element = _input;
+        }
+
+        // reapply stored properties
+        if (!string.IsNullOrEmpty(_name))
+            _element.SetAttribute("id", _name);
+        _element.SetProperty("display", _visibility ? "block" : "none");
+        _element.SetProperty("width", $"{_width}px");
+        _element.SetProperty("height", $"{_height}px");
+        _element.SetProperty("left", $"{_x}px");
+        _element.SetProperty("top", $"{_y}px");
+        _element.SetProperty("position", "absolute");
+        _element.SetProperty("margin", $"{_margin.Top}px {_margin.Right}px {_margin.Bottom}px {_margin.Left}px");
+        if (!_enabled) _element.SetAttribute("disabled", "disabled");
+        if (_maxLength != 0) _element.SetAttribute("maxlength", _maxLength.ToString());
+        if (!string.IsNullOrEmpty(_font)) _element.SetProperty("font-family", _font);
+        if (_fontSize != 0) _element.SetProperty("font-size", $"{_fontSize}px");
+
+        if (_input != null) _input.SetValue(_text);
+        else _textarea?.SetInnerRml(_text);
+
+        _element.AddEventListener("change", _ => _valueChanged?.Invoke());
+    }
+
+    public object FrameworkNode => _element;
+
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            _name = value;
+            _element.SetAttribute("id", value);
+        }
+    }
+
+    public bool Visibility
+    {
+        get => _visibility;
+        set
+        {
+            _visibility = value;
+            _element.SetProperty("display", value ? "block" : "none");
+        }
+    }
+
+    public float X
+    {
+        get => _x;
+        set
+        {
+            _x = value;
+            _element.SetProperty("left", $"{value}px");
+            _element.SetProperty("position", "absolute");
+        }
+    }
+
+    public float Y
+    {
+        get => _y;
+        set
+        {
+            _y = value;
+            _element.SetProperty("top", $"{value}px");
+            _element.SetProperty("position", "absolute");
+        }
+    }
+
+    public float Width
+    {
+        get => _width;
+        set
+        {
+            _width = value;
+            _element.SetProperty("width", $"{value}px");
+        }
+    }
+
+    public float Height
+    {
+        get => _height;
+        set
+        {
+            _height = value;
+            _element.SetProperty("height", $"{value}px");
+        }
+    }
+
+    public AMargin Margin
+    {
+        get => _margin;
+        set
+        {
+            _margin = value;
+            _element.SetProperty("margin", $"{value.Top}px {value.Right}px {value.Bottom}px {value.Left}px");
+        }
+    }
+
+    public bool Enabled
+    {
+        get => _enabled;
+        set
+        {
+            _enabled = value;
+            if (value) _element.RemoveAttribute("disabled");
+            else _element.SetAttribute("disabled", "disabled");
+        }
+    }
+
+    public string Text
+    {
+        get => _input != null ? _input.GetValue() : _textarea?.GetInnerRml() ?? string.Empty;
+        set
+        {
+            _text = value;
+            if (_input != null) _input.SetValue(value);
+            else _textarea?.SetInnerRml(value);
+            _valueChanged?.Invoke();
+        }
+    }
+
+    public int MaxLength
+    {
+        get => _maxLength;
+        set
+        {
+            _maxLength = value;
+            _element.SetAttribute("maxlength", value.ToString());
+        }
+    }
+
+    public string? Font
+    {
+        get => _font;
+        set
+        {
+            _font = value;
+            _element.SetProperty("font-family", value ?? string.Empty);
+        }
+    }
+
+    public int FontSize
+    {
+        get => _fontSize;
+        set
+        {
+            _fontSize = value;
+            _element.SetProperty("font-size", $"{value}px");
+        }
+    }
+
+    public bool IsMultiLine
+    {
+        get => _isMultiLine;
+        set
+        {
+            if (_isMultiLine == value) return;
+            _isMultiLine = value;
+            InitElement(_isMultiLine);
+        }
+    }
+
+    public event Action? ValueChanged
+    {
+        add => _valueChanged += value;
+        remove => _valueChanged -= value;
+    }
+
+    public void Dispose() { }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Inputs/RmlUiKey.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Inputs/RmlUiKey.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using AbstUI.Inputs;
+using RmlUiNet.Input;
+
+namespace AbstUI.SDL2RmlUi.Inputs;
+
+/// <summary>
+/// Keyboard handling using the RmlUi.NET context.
+/// </summary>
+public class RmlUiKey : IAbstFrameworkKey
+{
+    private readonly HashSet<KeyIdentifier> _keys = new();
+    private AbstKey? _lingoKey;
+    private string _lastKey = string.Empty;
+    private int _lastCode;
+    private KeyModifier _modifierState;
+
+    public void SetKeyObj(AbstKey key) => _lingoKey = key;
+
+    public void ProcessKeyDown(KeyIdentifier key, KeyModifier modifiers)
+    {
+        _keys.Add(key);
+        _modifierState = modifiers;
+        _lastCode = (int)key;
+        _lastKey = key.ToString();
+        _lingoKey?.DoKeyDown();
+    }
+
+    public void ProcessKeyUp(KeyIdentifier key, KeyModifier modifiers)
+    {
+        _keys.Remove(key);
+        _modifierState = modifiers;
+        _lastCode = (int)key;
+        _lastKey = key.ToString();
+        _lingoKey?.DoKeyUp();
+    }
+
+    public bool CommandDown => (_modifierState & KeyModifier.KM_META) != 0;
+    public bool ControlDown => (_modifierState & KeyModifier.KM_CTRL) != 0;
+    public bool OptionDown => (_modifierState & KeyModifier.KM_ALT) != 0;
+    public bool ShiftDown => (_modifierState & KeyModifier.KM_SHIFT) != 0;
+
+    public bool KeyPressed(AbstUIKeyType key) => key switch
+    {
+        AbstUIKeyType.BACKSPACE => _keys.Contains(KeyIdentifier.KI_BACK),
+        AbstUIKeyType.ENTER or AbstUIKeyType.RETURN => _keys.Contains(KeyIdentifier.KI_RETURN),
+        AbstUIKeyType.QUOTE => _keys.Contains(KeyIdentifier.KI_OEM_7),
+        AbstUIKeyType.SPACE => _keys.Contains(KeyIdentifier.KI_SPACE),
+        AbstUIKeyType.TAB => _keys.Contains(KeyIdentifier.KI_TAB),
+        _ => false
+    };
+
+    public bool KeyPressed(char key)
+    {
+        var c = char.ToUpperInvariant(key);
+        if (c >= 'A' && c <= 'Z')
+        {
+            var enumValue = (KeyIdentifier)((int)KeyIdentifier.KI_A + (c - 'A'));
+            return _keys.Contains(enumValue);
+        }
+        if (c >= '0' && c <= '9')
+        {
+            var enumValue = (KeyIdentifier)((int)KeyIdentifier.KI_0 + (c - '0'));
+            return _keys.Contains(enumValue);
+        }
+        return false;
+    }
+
+    public bool KeyPressed(int keyCode) => _keys.Contains((KeyIdentifier)keyCode);
+
+    public string Key => _lastKey;
+    public int KeyCode => _lastCode;
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Inputs/RmlUiMouse.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Inputs/RmlUiMouse.cs
@@ -1,0 +1,98 @@
+using System;
+using AbstUI.Inputs;
+using AbstUI.Primitives;
+using RmlUiNet;
+using RmlUiNet.Input;
+
+namespace AbstUI.SDL2RmlUi.Inputs;
+
+/// <summary>
+/// Mouse handling using the RmlUi.NET context.
+/// </summary>
+public class RmlUiMouse<TAbstUIMouseEvent> : IAbstFrameworkMouse
+    where TAbstUIMouseEvent : AbstMouseEvent
+{
+    private readonly Context _context;
+    private Lazy<AbstMouse<TAbstUIMouseEvent>> _lingoMouse;
+    private int _mouseX;
+    private int _mouseY;
+
+    public RmlUiMouse(Context context, Lazy<AbstMouse<TAbstUIMouseEvent>> mouse)
+    {
+        _context = context;
+        _lingoMouse = mouse;
+    }
+
+    public void HideMouse(bool state)
+    {
+        // RmlUi.NET does not expose cursor visibility control yet.
+    }
+
+    public void Release()
+    {
+        // nothing to release yet
+    }
+
+    public void ReplaceMouseObj(IAbstMouse lingoMouse)
+    {
+        _lingoMouse = new Lazy<AbstMouse<TAbstUIMouseEvent>>(() => (AbstMouse<TAbstUIMouseEvent>)lingoMouse);
+    }
+
+    public void ProcessMouseMove(int x, int y, KeyModifier modifiers)
+    {
+        _mouseX = x;
+        _mouseY = y;
+        _context.ProcessMouseMove(x, y, modifiers);
+        _lingoMouse.Value.MouseH = x;
+        _lingoMouse.Value.MouseV = y;
+        _lingoMouse.Value.DoMouseMove();
+    }
+
+    public void ProcessMouseButtonDown(int button, KeyModifier modifiers)
+    {
+        _context.ProcessMouseButtonDown(button, modifiers);
+        _lingoMouse.Value.MouseH = _mouseX;
+        _lingoMouse.Value.MouseV = _mouseY;
+        if (button == 0)
+        {
+            _lingoMouse.Value.MouseDown = true;
+            _lingoMouse.Value.LeftMouseDown = true;
+        }
+        else if (button == 1)
+        {
+            _lingoMouse.Value.RightMouseDown = true;
+        }
+        else if (button == 2)
+        {
+            _lingoMouse.Value.MiddleMouseDown = true;
+        }
+        _lingoMouse.Value.DoMouseDown();
+    }
+
+    public void ProcessMouseButtonUp(int button, KeyModifier modifiers)
+    {
+        _context.ProcessMouseButtonUp(button, modifiers);
+        _lingoMouse.Value.MouseH = _mouseX;
+        _lingoMouse.Value.MouseV = _mouseY;
+        if (button == 0)
+        {
+            _lingoMouse.Value.MouseDown = false;
+            _lingoMouse.Value.LeftMouseDown = false;
+        }
+        else if (button == 1)
+        {
+            _lingoMouse.Value.RightMouseDown = false;
+        }
+        else if (button == 2)
+        {
+            _lingoMouse.Value.MiddleMouseDown = false;
+        }
+        _lingoMouse.Value.DoMouseUp();
+    }
+
+    public void ProcessMouseWheel(Vector2f delta, KeyModifier modifiers)
+    {
+        _context.ProcessMouseWheel(delta, modifiers);
+        _lingoMouse.Value.DoMouseWheel((int)delta.Y);
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/README.md
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/README.md
@@ -1,0 +1,5 @@
+# AbstUI.SDL2RmlUi
+
+Backend for the AbstUI framework that augments the SDL2 implementation with input support powered by [RmlUi.NET](https://www.nuget.org/packages/RmlUi.NET).
+
+This project provides richer keyboard and mouse handling compared to the plain SDL2 backend and adds basic RmlUi-powered button and text input components.


### PR DESCRIPTION
## Summary
- add new AbstUI.SDL2RmlUi project referencing RmlUi.NET and existing SDL2 backend
- implement RmlUi-powered keyboard and mouse input handlers
- provide RmlUi-driven button and text input components
- render SDL2 textures inside RmlUi buttons and make text inputs rebuild when toggling multi-line mode
- encode SDL textures to PNG Base64 data URLs entirely in memory for fast embedding in RmlUi buttons

## Testing
- `dotnet format --no-restore WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --verify-no-changes --verbosity diagnostic` (warning: The reference assemblies for .NETFramework,Version=v4.8 were not found)
- `dotnet format --no-restore WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/AbstUI.SDL2RmlUi.csproj --verify-no-changes --verbosity diagnostic` (warning: The reference assemblies for .NETFramework,Version=v4.8 were not found)
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/AbstUI.SDL2RmlUi.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a2b65ab5748332b0ffbe4fbd5fb2e2