### PR TITLE
Replace System.Drawing with ImageSharp in Blazor

### DIFF
--- a/src/LingoEngine.Blazor/LingoEngine.Blazor.csproj
+++ b/src/LingoEngine.Blazor/LingoEngine.Blazor.csproj
@@ -25,6 +25,6 @@
     <ProjectReference Include="..\LingoEngine\LingoEngine.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Use ImageSharp to load bitmap data in Blazor member instead of System.Drawing
- Swap System.Drawing.Common dependency for SixLabors.ImageSharp

## Testing
- `dotnet format src/LingoEngine.Blazor/LingoEngine.Blazor.csproj -v diag --verify-no-changes`
- `dotnet build src/LingoEngine.Blazor/LingoEngine.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a2d4dea8d08332ab05d065ae136b94