### PR TITLE
feat: add framework dialog resolution

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Tools/LingoCSharpConverterPopup.cs
+++ b/src/Director/LingoEngine.Director.Core/Tools/LingoCSharpConverterPopup.cs
@@ -10,12 +10,12 @@ using TextCopy;
 
 namespace LingoEngine.Director.Core.Tools;
 
-public class LingoCSharpConverterPopup : ICommandHandler<OpenLingoCSharpConverterCommand>
+public class LingoCSharpConverterPopup : ICommandHandler<OpenLingoCSharpConverterCommand>, ILingoDialog
 {
-    private readonly IDirectorWindowManager _windowManager;
-    private readonly ILingoFrameworkFactory _factory;
+    protected readonly IDirectorWindowManager _windowManager;
+    protected readonly ILingoFrameworkFactory _factory;
 
-    private sealed class ViewModel
+    protected sealed class ViewModel
     {
         public string Lingo { get; set; } = string.Empty;
         public string CSharp { get; set; } = string.Empty;
@@ -29,15 +29,19 @@ public class LingoCSharpConverterPopup : ICommandHandler<OpenLingoCSharpConverte
 
     public bool CanExecute(OpenLingoCSharpConverterCommand command) => true;
 
-    public bool Handle(OpenLingoCSharpConverterCommand command)
+    public virtual bool Handle(OpenLingoCSharpConverterCommand command)
     {
         var vm = new ViewModel();
         var panel = BuildPanel(vm);
-        _windowManager.ShowCustomDialog("Lingo to C#", panel.Framework<IAbstFrameworkPanel>());
+        _windowManager.ShowCustomDialog<LingoCSharpConverterPopup>("Lingo to C#", panel.Framework<IAbstFrameworkPanel>(), this);
         return true;
     }
 
-    private AbstPanel BuildPanel(ViewModel vm)
+    public void Init(IDirFrameworkDialog framework)
+    {
+    }
+
+    protected AbstPanel BuildPanel(ViewModel vm)
     {
         var root = _factory.CreatePanel("LingoCSharpRoot");
         root.Width = 800;

--- a/src/Director/LingoEngine.Director.Core/Windowing/DirectorWindowManager.cs
+++ b/src/Director/LingoEngine.Director.Core/Windowing/DirectorWindowManager.cs
@@ -12,6 +12,8 @@ namespace LingoEngine.Director.Core.Windowing
         void SetActiveWindow(IDirectorWindowRegistration window);
         IDirectorWindowDialogReference? ShowConfirmDialog(string title, string message, Action<bool> onResult);
         IDirectorWindowDialogReference? ShowCustomDialog(string title, IAbstFrameworkPanel panel);
+        IDirectorWindowDialogReference? ShowCustomDialog<TDialog>(string title, IAbstFrameworkPanel panel, TDialog? lingoDialog = null)
+            where TDialog : class, ILingoDialog;
         IDirectorWindowDialogReference? ShowNotification(string message, DirUINotificationType type);
     }
     public interface IDirectorWindowRegistration
@@ -31,6 +33,8 @@ namespace LingoEngine.Director.Core.Windowing
         void SetActiveWindow(string windowCode);
         IDirectorWindowDialogReference? ShowConfirmDialog(string title, string message, Action<bool> onResult);
         IDirectorWindowDialogReference? ShowCustomDialog(string title, IAbstFrameworkPanel panel);
+        IDirectorWindowDialogReference? ShowCustomDialog<TDialog>(string title, IAbstFrameworkPanel panel, TDialog? lingoDialog = null)
+            where TDialog : class, ILingoDialog;
         IDirectorWindowDialogReference? ShowNotification(string message, DirUINotificationType type);
         void SetWindowSize(string windowCode, int stageWidth, int stageHeight);
     }
@@ -103,6 +107,10 @@ namespace LingoEngine.Director.Core.Windowing
 
         public IDirectorWindowDialogReference? ShowCustomDialog(string title, IAbstFrameworkPanel panel)
             => _frameworkWindowManager.ShowCustomDialog(title, panel);
+
+        public IDirectorWindowDialogReference? ShowCustomDialog<TDialog>(string title, IAbstFrameworkPanel panel, TDialog? lingoDialog = null)
+            where TDialog : class, ILingoDialog
+            => _frameworkWindowManager.ShowCustomDialog<TDialog>(title, panel, lingoDialog);
 
         public IDirectorWindowDialogReference? ShowNotification(string message, DirUINotificationType type)
             => _frameworkWindowManager.ShowNotification(message, type);

--- a/src/Director/LingoEngine.Director.Core/Windowing/IDirFrameworkDialog.cs
+++ b/src/Director/LingoEngine.Director.Core/Windowing/IDirFrameworkDialog.cs
@@ -1,0 +1,9 @@
+using LingoEngine.FrameworkCommunication;
+
+namespace LingoEngine.Director.Core.Windowing
+{
+    public interface IDirFrameworkDialog : IFrameworkFor<ILingoDialog>
+    {
+        void Init();
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Windowing/ILingoDialog.cs
+++ b/src/Director/LingoEngine.Director.Core/Windowing/ILingoDialog.cs
@@ -1,0 +1,6 @@
+namespace LingoEngine.Director.Core.Windowing;
+
+public interface ILingoDialog
+{
+    void Init(IDirFrameworkDialog framework);
+}

--- a/src/Director/LingoEngine.Director.Core/Windowing/LingoBaseFrameworkFactory.cs
+++ b/src/Director/LingoEngine.Director.Core/Windowing/LingoBaseFrameworkFactory.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using LingoEngine.Core;
+using LingoEngine.FrameworkCommunication;
+
+namespace LingoEngine.Director.Core.Windowing;
+
+/// <summary>
+/// Base factory capable of resolving framework-specific implementations
+/// for given Lingo types marked with <see cref="IFrameworkFor{T}"/>.
+/// </summary>
+public abstract class LingoBaseFrameworkFactory
+{
+    private readonly ILingoServiceProvider _serviceProvider;
+    private readonly Dictionary<Type, Type> _frameworkMap = new();
+
+    protected LingoBaseFrameworkFactory(ILingoServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public ILingoServiceProvider ServiceProvider => _serviceProvider;
+
+    /// <summary>
+    /// Scans the assembly of the derived factory for types implementing
+    /// <see cref="IFrameworkFor{T}"/> and caches their mapping.
+    /// </summary>
+    public void DiscoverInAssembly()
+        => DiscoverInAssembly(GetType().Assembly);
+
+    public void DiscoverInAssembly(Assembly assembly)
+    {
+        foreach (var type in assembly.GetTypes())
+        {
+            foreach (var iface in type.GetInterfaces())
+            {
+                if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IFrameworkFor<>))
+                {
+                    var lingoType = iface.GenericTypeArguments[0];
+                    _frameworkMap[lingoType] = type;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resolves the framework counterpart for the specified Lingo dialog.
+    /// </summary>
+    public TReturnType GetFrameworkFor<TReturnType>(ILingoDialog lingoDialog)
+    {
+        var lingoType = lingoDialog.GetType();
+        if (!_frameworkMap.TryGetValue(lingoType, out var frameworkType))
+            throw new InvalidOperationException($"No framework registered for {lingoType.Name}");
+
+        var instance = _serviceProvider.GetRequiredService(frameworkType);
+        return (TReturnType)instance;
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
@@ -1,6 +1,7 @@
 using Godot;
 using LingoEngine.Director.Core;
 using LingoEngine.LGodot;
+using LingoEngine.LGodot.Core;
 using Microsoft.Extensions.DependencyInjection;
 using LingoEngine.Director.LGodot.Gfx;
 using LingoEngine.Director.LGodot.Casts;
@@ -30,6 +31,7 @@ using LingoEngine.Director.LGodot.Styles;
 using LingoEngine.Director.LGodot.Projects;
 using LingoEngine.Projects;
 using AbstUI.LGodot.Styles;
+using LingoEngine.Director.LGodot.Tools;
 
 namespace LingoEngine.Director.LGodot
 {
@@ -57,9 +59,11 @@ namespace LingoEngine.Director.LGodot
                     s.AddSingleton<DirGodotPictureMemberEditorWindow>();
                     s.AddSingleton<DirGodotMainMenu>();
                     s.AddSingleton<DirGodotWindowManager>();
-                    s.AddSingleton<DirGodotWindowManager>();
                     s.AddSingleton<IDirFilePicker, GodotFilePicker>();
                     s.AddSingleton<IDirFolderPicker, GodotFolderPicker>();
+                    s.AddTransient<GodotLingoCSharpConverterPopup>();
+                    s.AddTransient<Window>();
+                    s.AddSingleton<DirGodotFrameworkFactory>();
                     s.AddSingleton<IDirectorIconManager>(p =>
                     {
                         var iconManager = new DirGodotIconManager(p.GetRequiredService<ILogger<DirGodotIconManager>>());
@@ -91,6 +95,7 @@ namespace LingoEngine.Director.LGodot
                     p.GetRequiredService<IAbstGodotStyleManager>().Register(AbstGodotThemeElementType.Tabs, styles.GetTabContainerTheme());
                     p.GetRequiredService<IAbstGodotStyleManager>().Register(AbstGodotThemeElementType.TabItem, styles.GetTabItemTheme());
                     p.GetRequiredService<IAbstGodotStyleManager>().Register(AbstGodotThemeElementType.PopupWindow, styles.GetPopupWindowTheme());
+                    p.GetRequiredService<DirGodotFrameworkFactory>().DiscoverInAssembly(typeof(GodotLingoCSharpConverterPopup).Assembly);
                     new LingoGodotDirectorRoot(p.GetRequiredService<LingoPlayer>(), p, p.GetRequiredService<LingoProjectSettings>());
                 });
             return engineRegistration;

--- a/src/Director/LingoEngine.Director.LGodot/Tools/GodotLingoCSharpConverterPopup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Tools/GodotLingoCSharpConverterPopup.cs
@@ -1,0 +1,13 @@
+using Godot;
+using LingoEngine.Director.Core.Windowing;
+using LingoEngine.Director.Core.Tools;
+using LingoEngine.FrameworkCommunication;
+
+namespace LingoEngine.Director.LGodot.Tools;
+
+public partial class GodotLingoCSharpConverterPopup : Window, IDirFrameworkDialog, IFrameworkFor<LingoCSharpConverterPopup>
+{
+    public void Init()
+    {
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/Windowing/DirGodotFrameworkFactory.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Windowing/DirGodotFrameworkFactory.cs
@@ -1,0 +1,11 @@
+using LingoEngine.Core;
+using LingoEngine.Director.Core.Windowing;
+
+namespace LingoEngine.Director.LGodot.Windowing;
+
+public class DirGodotFrameworkFactory : LingoBaseFrameworkFactory
+{
+    public DirGodotFrameworkFactory(ILingoServiceProvider serviceProvider) : base(serviceProvider)
+    {
+    }
+}

--- a/src/LingoEngine/FrameworkCommunication/IFrameworkFor.cs
+++ b/src/LingoEngine/FrameworkCommunication/IFrameworkFor.cs
@@ -1,0 +1,8 @@
+namespace LingoEngine.FrameworkCommunication
+{
+    /// <summary>
+    /// Marker interface linking a framework implementation to a Lingo type.
+    /// </summary>
+    /// <typeparam name="T">The Lingo type this framework implementation supports.</typeparam>
+    public interface IFrameworkFor<T> { }
+}


### PR DESCRIPTION
## Summary
- move framework mapping interface into core engine
- drop director dependency from Godot factory and project
- register a Godot-specific framework factory and use it for dialog resolution

## Testing
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/FrameworkCommunication/IFrameworkFor.cs -v diag`
- `dotnet format src/LingoEngine.LGodot/LingoEngine.LGodot.csproj --include src/LingoEngine.LGodot/Core/GodotFactory.cs src/LingoEngine.LGodot/LingoEngine.LGodot.csproj -v diag`
- `dotnet format src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj --include src/Director/LingoEngine.Director.Core/Windowing/IDirFrameworkDialog.cs src/Director/LingoEngine.Director.Core/Windowing/LingoBaseFrameworkFactory.cs -v diag`
- `dotnet format src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj --include src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs src/Director/LingoEngine.Director.LGodot/Windowing/DirGodotFrameworkFactory.cs src/Director/LingoEngine.Director.LGodot/Windowing/GodotWindowManager.cs src/Director/LingoEngine.Director.LGodot/Tools/GodotLingoCSharpConverterPopup.cs -v diag`
- `dotnet build src/LingoEngine/LingoEngine.csproj`
- `dotnet build src/LingoEngine.LGodot/LingoEngine.LGodot.csproj`
- `dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj`
- `dotnet build src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a2accd738883328cfc6fa7b7ac2853