### PR TITLE
Add Unity UI components and factory support

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj
@@ -34,7 +34,4 @@
 	  <ProjectReference Include="..\AbstUI\AbstUI.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <Folder Include="Components\" />
-	</ItemGroup>
 </Project>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUIUnitySetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUIUnitySetup.cs
@@ -1,4 +1,5 @@
 ﻿using AbstUI.LUnity.Styles;
+using AbstUI.Components;
 using AbstUI.Styles;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -10,7 +11,7 @@ namespace AbstUI.LUnity
         {
             services
                 .AddSingleton<IAbstFontManager, UnityFontManager>()
-                        ;
+                .AddSingleton<IAbstComponentFactory, AbstUnityComponentFactory>();
 
             return services;
         }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUnityComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUnityComponentFactory.cs
@@ -1,0 +1,156 @@
+using System;
+using AbstUI.Components;
+using AbstUI.Primitives;
+using AbstUI.LUnity.Components;
+
+namespace AbstUI.LUnity;
+
+/// <summary>
+/// Factory creating Unity-based AbstUI components.
+/// </summary>
+public class AbstUnityComponentFactory : IAbstComponentFactory
+{
+    public AbstGfxCanvas CreateGfxCanvas(string name, int width, int height) => throw new NotImplementedException();
+
+    public AbstWrapPanel CreateWrapPanel(AOrientation orientation, string name)
+    {
+        var panel = new AbstWrapPanel(this);
+        var impl = new AbstUnityWrapPanel(orientation);
+        panel.Init(impl);
+        panel.Name = name;
+        panel.Orientation = orientation;
+        return panel;
+    }
+
+    public AbstPanel CreatePanel(string name)
+    {
+        var panel = new AbstPanel(this);
+        var impl = new AbstUnityPanel();
+        panel.Init(impl);
+        panel.Name = name;
+        return panel;
+    }
+
+    public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y)
+    {
+        var wrapper = new AbstLayoutWrapper(content);
+        var impl = new AbstUnityLayoutWrapper();
+        wrapper.Init(impl);
+        if (x.HasValue) wrapper.X = x.Value;
+        if (y.HasValue) wrapper.Y = y.Value;
+        return wrapper;
+    }
+
+    public AbstTabContainer CreateTabContainer(string name)
+    {
+        var container = new AbstTabContainer();
+        var impl = new AbstUnityTabContainer();
+        container.Init(impl);
+        container.Name = name;
+        return container;
+    }
+
+    public AbstTabItem CreateTabItem(string name, string title)
+    {
+        var tab = new AbstTabItem();
+        var impl = new AbstUnityTabItem();
+        tab.Init(impl);
+        tab.Name = name;
+        tab.Title = title;
+        return tab;
+    }
+
+    public AbstScrollContainer CreateScrollContainer(string name)
+    {
+        var scroll = new AbstScrollContainer();
+        var impl = new AbstUnityScrollContainer();
+        scroll.Init(impl);
+        scroll.Name = name;
+        return scroll;
+    }
+
+    public AbstInputSlider<float> CreateInputSliderFloat(AOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null) => throw new NotImplementedException();
+
+    public AbstInputSlider<int> CreateInputSliderInt(AOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null) => throw new NotImplementedException();
+
+    public AbstInputText CreateInputText(string name, int maxLength = 0, Action<string>? onChange = null, bool multiLine = false)
+    {
+        var input = new AbstInputText();
+        var impl = new AbstUnityInputText
+        {
+            MaxLength = maxLength,
+            IsMultiLine = multiLine
+        };
+        if (onChange != null)
+            impl.ValueChanged += () => onChange(impl.Text);
+        input.Init(impl);
+        input.Name = name;
+        return input;
+    }
+
+    public AbstInputNumber<float> CreateInputNumberFloat(string name, float? min = null, float? max = null, Action<float>? onChange = null) => throw new NotImplementedException();
+
+    public AbstInputNumber<int> CreateInputNumberInt(string name, int? min = null, int? max = null, Action<int>? onChange = null) => throw new NotImplementedException();
+
+    public AbstInputSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null) => throw new NotImplementedException();
+
+    public AbstInputCheckbox CreateInputCheckbox(string name, Action<bool>? onChange = null)
+    {
+        var input = new AbstInputCheckbox();
+        var impl = new AbstUnityInputCheckbox();
+        if (onChange != null)
+            impl.ValueChanged += () => onChange(impl.Checked);
+        input.Init(impl);
+        input.Name = name;
+        return input;
+    }
+
+    public AbstInputCombobox CreateInputCombobox(string name, Action<string?>? onChange = null)
+    {
+        var input = new AbstInputCombobox();
+        var impl = new AbstUnityInputCombobox();
+        if (onChange != null)
+            impl.ValueChanged += () => onChange(impl.SelectedValue);
+        input.Init(impl);
+        input.Name = name;
+        return input;
+    }
+
+    public AbstItemList CreateItemList(string name, Action<string?>? onChange = null) => throw new NotImplementedException();
+
+    public AbstColorPicker CreateColorPicker(string name, Action<AColor>? onChange = null) => throw new NotImplementedException();
+
+    public AbstLabel CreateLabel(string name, string text = "")
+    {
+        var label = new AbstLabel();
+        var impl = new AbstUnityLabel();
+        label.Init(impl);
+        label.Name = name;
+        label.Text = text;
+        return label;
+    }
+
+    public AbstButton CreateButton(string name, string text = "")
+    {
+        var button = new AbstButton();
+        var impl = new AbstUnityButton();
+        button.Init(impl);
+        button.Name = name;
+        button.Text = text;
+        return button;
+    }
+
+    public AbstStateButton CreateStateButton(string name, IAbstTexture2D? texture = null, string text = "", Action<bool>? onChange = null) => throw new NotImplementedException();
+
+    public AbstMenu CreateMenu(string name) => throw new NotImplementedException();
+
+    public AbstMenuItem CreateMenuItem(string name, string? shortcut = null) => throw new NotImplementedException();
+
+    public AbstMenu CreateContextMenu(object window) => throw new NotImplementedException();
+
+    public AbstHorizontalLineSeparator CreateHorizontalLineSeparator(string name) => throw new NotImplementedException();
+
+    public AbstVerticalLineSeparator CreateVerticalLineSeparator(string name) => throw new NotImplementedException();
+
+    public AbstWindow CreateWindow(string name, string title = "") => throw new NotImplementedException();
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityButton.cs
@@ -1,0 +1,19 @@
+using System;
+using AbstUI.Components;
+using AbstUI.Primitives;
+
+namespace AbstUI.LUnity.Components;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkButton"/>.
+/// </summary>
+internal class AbstUnityButton : AbstUnityComponent, IAbstFrameworkButton
+{
+    public string Text { get; set; } = string.Empty;
+    public bool Enabled { get; set; } = true;
+    public IAbstTexture2D? IconTexture { get; set; }
+
+    public event Action? Pressed;
+
+    public void Invoke() => Pressed?.Invoke();
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityComponent.cs
@@ -1,0 +1,45 @@
+using AbstUI.Components;
+using AbstUI.Primitives;
+using UnityEngine;
+
+namespace AbstUI.LUnity.Components;
+
+/// <summary>
+/// Base Unity component providing common node properties.
+/// </summary>
+internal class AbstUnityComponent : IAbstFrameworkLayoutNode
+{
+    protected readonly GameObject GameObject;
+
+    public AbstUnityComponent()
+    {
+        GameObject = new GameObject();
+    }
+
+    public string Name
+    {
+        get => GameObject.name;
+        set => GameObject.name = value;
+    }
+
+    public bool Visibility
+    {
+        get => GameObject.activeSelf;
+        set => GameObject.SetActive(value);
+    }
+
+    public float Width { get; set; }
+    public float Height { get; set; }
+
+    public AMargin Margin { get; set; } = AMargin.Zero;
+
+    public float X { get; set; }
+    public float Y { get; set; }
+
+    public object FrameworkNode => GameObject;
+
+    public virtual void Dispose()
+    {
+        UnityEngine.Object.Destroy(GameObject);
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityInputCheckbox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityInputCheckbox.cs
@@ -1,0 +1,26 @@
+using System;
+using AbstUI.Components;
+
+namespace AbstUI.LUnity.Components;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkInputCheckbox"/>.
+/// </summary>
+internal class AbstUnityInputCheckbox : AbstUnityComponent, IAbstFrameworkInputCheckbox
+{
+    public bool Enabled { get; set; } = true;
+
+    private bool _checked;
+    public bool Checked
+    {
+        get => _checked;
+        set
+        {
+            if (_checked == value) return;
+            _checked = value;
+            ValueChanged?.Invoke();
+        }
+    }
+
+    public event Action? ValueChanged;
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityInputCombobox.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Components;
+
+namespace AbstUI.LUnity.Components;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkInputCombobox"/>.
+/// </summary>
+internal class AbstUnityInputCombobox : AbstUnityComponent, IAbstFrameworkInputCombobox
+{
+    public bool Enabled { get; set; } = true;
+    private readonly List<KeyValuePair<string, string>> _items = new();
+    public IReadOnlyList<KeyValuePair<string, string>> Items => _items;
+
+    public int SelectedIndex { get; set; } = -1;
+    public string? SelectedKey { get; set; }
+    public string? SelectedValue { get; set; }
+
+    public event Action? ValueChanged;
+
+    public void AddItem(string key, string value)
+    {
+        _items.Add(new KeyValuePair<string, string>(key, value));
+    }
+
+    public void ClearItems()
+    {
+        _items.Clear();
+        SelectedIndex = -1;
+        SelectedKey = null;
+        SelectedValue = null;
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityInputText.cs
@@ -1,0 +1,31 @@
+using System;
+using AbstUI.Components;
+
+namespace AbstUI.LUnity.Components;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkInputText"/>.
+/// </summary>
+internal class AbstUnityInputText : AbstUnityComponent, IAbstFrameworkInputText
+{
+    public bool Enabled { get; set; } = true;
+
+    private string _text = string.Empty;
+    public string Text
+    {
+        get => _text;
+        set
+        {
+            if (_text == value) return;
+            _text = value;
+            ValueChanged?.Invoke();
+        }
+    }
+
+    public int MaxLength { get; set; }
+    public string? Font { get; set; }
+    public int FontSize { get; set; }
+    public bool IsMultiLine { get; set; }
+
+    public event Action? ValueChanged;
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityLabel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityLabel.cs
@@ -1,0 +1,19 @@
+using AbstUI.Components;
+using AbstUI.Primitives;
+using AbstUI.Texts;
+
+namespace AbstUI.LUnity.Components;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkLabel"/>.
+/// </summary>
+internal class AbstUnityLabel : AbstUnityComponent, IAbstFrameworkLabel
+{
+    public string Text { get; set; } = string.Empty;
+    public int FontSize { get; set; } = 12;
+    public string? Font { get; set; }
+    public AColor FontColor { get; set; } = new AColor(255, 255, 255);
+    public int LineHeight { get; set; } = 1;
+    public ATextWrapMode WrapMode { get; set; } = ATextWrapMode.Off;
+    public AbstTextAlignment TextAlignment { get; set; } = AbstTextAlignment.Left;
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityLayoutWrapper.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityLayoutWrapper.cs
@@ -1,0 +1,10 @@
+using AbstUI.Components;
+
+namespace AbstUI.LUnity.Components;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkLayoutWrapper"/>.
+/// </summary>
+internal class AbstUnityLayoutWrapper : AbstUnityComponent, IAbstFrameworkLayoutWrapper
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityPanel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityPanel.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using AbstUI.Components;
+using AbstUI.Primitives;
+using UnityEngine;
+
+namespace AbstUI.LUnity.Components;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkPanel"/>.
+/// </summary>
+internal class AbstUnityPanel : AbstUnityComponent, IAbstFrameworkPanel
+{
+    private readonly List<IAbstFrameworkLayoutNode> _children = new();
+
+    public AColor? BackgroundColor { get; set; }
+    public AColor? BorderColor { get; set; }
+    public float BorderWidth { get; set; }
+
+    public void AddItem(IAbstFrameworkLayoutNode child)
+    {
+        _children.Add(child);
+        if (child.FrameworkNode is GameObject go)
+            go.transform.parent = GameObject.transform;
+    }
+
+    public IEnumerable<IAbstFrameworkLayoutNode> GetItems() => _children;
+
+    public void RemoveAll()
+    {
+        foreach (var child in _children.ToArray())
+            RemoveItem(child);
+    }
+
+    public void RemoveItem(IAbstFrameworkLayoutNode child)
+    {
+        _children.Remove(child);
+        if (child.FrameworkNode is GameObject go)
+            go.transform.parent = null;
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityScrollContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityScrollContainer.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using AbstUI.Components;
+using UnityEngine;
+
+namespace AbstUI.LUnity.Components;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkScrollContainer"/>.
+/// </summary>
+internal class AbstUnityScrollContainer : AbstUnityComponent, IAbstFrameworkScrollContainer
+{
+    private readonly List<IAbstFrameworkLayoutNode> _children = new();
+
+    public float ScrollHorizontal { get; set; }
+    public float ScrollVertical { get; set; }
+    public bool ClipContents { get; set; }
+
+    public void AddItem(IAbstFrameworkLayoutNode child)
+    {
+        _children.Add(child);
+        if (child.FrameworkNode is GameObject go)
+            go.transform.parent = GameObject.transform;
+    }
+
+    public void RemoveItem(IAbstFrameworkLayoutNode child)
+    {
+        _children.Remove(child);
+        if (child.FrameworkNode is GameObject go)
+            go.transform.parent = null;
+    }
+
+    public IEnumerable<IAbstFrameworkLayoutNode> GetItems() => _children;
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityTabContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityTabContainer.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Components;
+using AbstUI.Primitives;
+using UnityEngine;
+
+namespace AbstUI.LUnity.Components;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkTabContainer"/>.
+/// </summary>
+internal class AbstUnityTabContainer : AbstUnityComponent, IAbstFrameworkTabContainer
+{
+    private readonly List<IAbstFrameworkTabItem> _tabs = new();
+    private int _selectedIndex = -1;
+
+    public string SelectedTabName =>
+        _selectedIndex >= 0 && _selectedIndex < _tabs.Count ? _tabs[_selectedIndex].Title : string.Empty;
+
+    public void AddTab(IAbstFrameworkTabItem content)
+    {
+        _tabs.Add(content);
+        if (content.FrameworkNode is GameObject go)
+            go.transform.parent = GameObject.transform;
+        if (_selectedIndex == -1)
+            _selectedIndex = 0;
+    }
+
+    public void RemoveTab(IAbstFrameworkTabItem content)
+    {
+        var idx = _tabs.IndexOf(content);
+        if (idx >= 0)
+        {
+            _tabs.RemoveAt(idx);
+            if (content.FrameworkNode is GameObject go)
+                go.transform.parent = null;
+            if (_selectedIndex >= _tabs.Count)
+                _selectedIndex = _tabs.Count - 1;
+        }
+    }
+
+    public IEnumerable<IAbstFrameworkTabItem> GetTabs() => _tabs.ToArray();
+
+    public void ClearTabs()
+    {
+        foreach (var tab in _tabs.ToArray())
+            RemoveTab(tab);
+        _tabs.Clear();
+        _selectedIndex = -1;
+    }
+
+    public void SelectTabByName(string tabName)
+    {
+        var idx = _tabs.FindIndex(t => t.Title == tabName);
+        if (idx >= 0)
+            _selectedIndex = idx;
+    }
+}
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkTabItem"/>.
+/// </summary>
+internal class AbstUnityTabItem : AbstUnityComponent, IAbstFrameworkTabItem
+{
+    private IAbstNode? _content;
+
+    public string Title { get; set; } = string.Empty;
+
+    public IAbstNode? Content
+    {
+        get => _content;
+        set
+        {
+            if (_content == value) return;
+            if (_content?.FrameworkObj.FrameworkNode is GameObject oldGo)
+                oldGo.transform.parent = null;
+            _content = value;
+            if (_content?.FrameworkObj.FrameworkNode is GameObject newGo)
+                newGo.transform.parent = GameObject.transform;
+        }
+    }
+
+    public float TopHeight { get; set; }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityWrapPanel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityWrapPanel.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using AbstUI.Components;
+using AbstUI.Primitives;
+using UnityEngine;
+
+namespace AbstUI.LUnity.Components;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkWrapPanel"/>.
+/// </summary>
+internal class AbstUnityWrapPanel : AbstUnityComponent, IAbstFrameworkWrapPanel
+{
+    private readonly List<IAbstFrameworkNode> _children = new();
+
+    public AbstUnityWrapPanel(AOrientation orientation)
+    {
+        Orientation = orientation;
+        ItemMargin = new APoint(0, 0);
+    }
+
+    public AOrientation Orientation { get; set; }
+
+    public APoint ItemMargin { get; set; }
+
+    public void AddItem(IAbstFrameworkNode child)
+    {
+        _children.Add(child);
+        if (child.FrameworkNode is GameObject go)
+            go.transform.parent = GameObject.transform;
+    }
+
+    public void RemoveItem(IAbstFrameworkNode child)
+    {
+        _children.Remove(child);
+        if (child.FrameworkNode is GameObject go)
+            go.transform.parent = null;
+    }
+
+    public IEnumerable<IAbstFrameworkNode> GetItems() => _children;
+
+    public IAbstFrameworkNode? GetItem(int index)
+        => index >= 0 && index < _children.Count ? _children[index] : null;
+
+    public void RemoveAll()
+    {
+        foreach (var child in _children.ToArray())
+            RemoveItem(child);
+    }
+}
+

--- a/src/LingoEngine.Unity/Core/UnityFactory.cs
+++ b/src/LingoEngine.Unity/Core/UnityFactory.cs
@@ -25,6 +25,7 @@ using AbstUI.Styles;
 using Microsoft.Extensions.DependencyInjection;
 using AbstUI.Primitives;
 using AbstUI.Components;
+using AbstUI.LUnity;
 using System.Numerics;
 
 namespace LingoEngine.Unity.Core;
@@ -33,11 +34,15 @@ public class UnityFactory : ILingoFrameworkFactory, IDisposable
 {
     private readonly List<IDisposable> _disposables = new();
     private readonly ILingoServiceProvider _serviceProvider;
+    private readonly AbstUnityComponentFactory _gfxFactory;
 
     public UnityFactory(ILingoServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider;
+        _gfxFactory = new AbstUnityComponentFactory();
     }
+
+    public IAbstComponentFactory GfxFactory => _gfxFactory;
 
     public LingoStage CreateStage(LingoPlayer lingoPlayer)
     {
@@ -147,26 +152,27 @@ public class UnityFactory : ILingoFrameworkFactory, IDisposable
     }
 
     #region Gfx
-    public AbstGfxCanvas CreateGfxCanvas(string name, int width, int height) => throw new NotImplementedException();
-    public AbstWrapPanel CreateWrapPanel(AOrientation orientation, string name) => throw new NotImplementedException();
-    public AbstPanel CreatePanel(string name) => throw new NotImplementedException();
-    public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y) => throw new NotImplementedException();
-    public AbstTabContainer CreateTabContainer(string name) => throw new NotImplementedException();
-    public AbstTabItem CreateTabItem(string name, string title) => throw new NotImplementedException();
-    public AbstScrollContainer CreateScrollContainer(string name) => throw new NotImplementedException();
+    public AbstGfxCanvas CreateGfxCanvas(string name, int width, int height) => _gfxFactory.CreateGfxCanvas(name, width, height);
+    public AbstWrapPanel CreateWrapPanel(AOrientation orientation, string name) => _gfxFactory.CreateWrapPanel(orientation, name);
+    public AbstPanel CreatePanel(string name) => _gfxFactory.CreatePanel(name);
+    public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y) => _gfxFactory.CreateLayoutWrapper(content, x, y);
+    public AbstTabContainer CreateTabContainer(string name) => _gfxFactory.CreateTabContainer(name);
+    public AbstTabItem CreateTabItem(string name, string title) => _gfxFactory.CreateTabItem(name, title);
+    public AbstScrollContainer CreateScrollContainer(string name) => _gfxFactory.CreateScrollContainer(name);
     public AbstInputSlider<float> CreateInputSliderFloat(AOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null) => throw new NotImplementedException();
     public AbstInputSlider<int> CreateInputSliderInt(AOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null) => throw new NotImplementedException();
-    public AbstInputText CreateInputText(string name, int maxLength = 0, Action<string>? onChange = null, bool multiLine = false) => throw new NotImplementedException();
+    public AbstInputText CreateInputText(string name, int maxLength = 0, Action<string>? onChange = null, bool multiLine = false)
+        => _gfxFactory.CreateInputText(name, maxLength, onChange, multiLine);
     public AbstInputNumber<float> CreateInputNumberFloat(string name, float? min = null, float? max = null, Action<float>? onChange = null) => throw new NotImplementedException();
     public AbstInputNumber<int> CreateInputNumberInt(string name, int? min = null, int? max = null, Action<int>? onChange = null) => throw new NotImplementedException();
     public AbstInputNumber<TValue> CreateInputNumber<TValue>(string name, NullableNum<TValue> min, NullableNum<TValue> max, Action<TValue>? onChange = null) where TValue : System.Numerics.INumber<TValue> => throw new NotImplementedException();
     public AbstInputSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null) => throw new NotImplementedException();
-    public AbstInputCheckbox CreateInputCheckbox(string name, Action<bool>? onChange = null) => throw new NotImplementedException();
-    public AbstInputCombobox CreateInputCombobox(string name, Action<string?>? onChange = null) => throw new NotImplementedException();
+    public AbstInputCheckbox CreateInputCheckbox(string name, Action<bool>? onChange = null) => _gfxFactory.CreateInputCheckbox(name, onChange);
+    public AbstInputCombobox CreateInputCombobox(string name, Action<string?>? onChange = null) => _gfxFactory.CreateInputCombobox(name, onChange);
     public AbstItemList CreateItemList(string name, Action<string?>? onChange = null) => throw new NotImplementedException();
     public AbstColorPicker CreateColorPicker(string name, Action<AColor>? onChange = null) => throw new NotImplementedException();
-    public AbstLabel CreateLabel(string name, string text = "") => throw new NotImplementedException();
-    public AbstButton CreateButton(string name, string text = "") => throw new NotImplementedException();
+    public AbstLabel CreateLabel(string name, string text = "") => _gfxFactory.CreateLabel(name, text);
+    public AbstButton CreateButton(string name, string text = "") => _gfxFactory.CreateButton(name, text);
     public AbstStateButton CreateStateButton(string name, IAbstTexture2D? texture = null, string text = "", Action<bool>? onChange = null) => throw new NotImplementedException();
     public AbstMenu CreateMenu(string name) => throw new NotImplementedException();
     public AbstMenuItem CreateMenuItem(string name, string? shortcut = null) => throw new NotImplementedException();

--- a/src/LingoEngine.Unity/Stages/UnityStageContainer.cs
+++ b/src/LingoEngine.Unity/Stages/UnityStageContainer.cs
@@ -1,0 +1,38 @@
+using LingoEngine.Stages;
+using UnityEngine;
+
+namespace LingoEngine.Unity.Stages;
+
+/// <summary>
+/// Unity implementation of <see cref="ILingoFrameworkStageContainer"/>.
+/// Hosts the stage inside a dedicated GameObject.
+/// </summary>
+public class UnityStageContainer : ILingoFrameworkStageContainer
+{
+    private readonly GameObject _container;
+    private UnityStage? _stage;
+
+    public UnityStageContainer()
+    {
+        _container = new GameObject("StageContainer");
+    }
+
+    /// <summary>Root GameObject containing the stage.</summary>
+    public GameObject Container => _container;
+
+    public void SetStage(ILingoFrameworkStage stage)
+    {
+        _stage = stage as UnityStage;
+        if (_stage != null)
+            _stage.transform.parent = _container.transform;
+    }
+
+    /// <summary>Adjusts the scale of the current stage.</summary>
+    public void SetScale(float scale)
+    {
+        if (_stage != null)
+        {
+            _stage.Scale = scale;
+        }
+    }
+}

--- a/src/LingoEngine.Unity/UnityLingoSetup.cs
+++ b/src/LingoEngine.Unity/UnityLingoSetup.cs
@@ -5,6 +5,8 @@ using LingoEngine.Unity.Core;
 using AbstUI.Core;
 using AbstUI.LUnity;
 using LingoEngine.Core;
+using LingoEngine.Stages;
+using LingoEngine.Unity.Stages;
 
 namespace LingoEngine.Unity;
 
@@ -15,6 +17,7 @@ public static class UnityLingoSetup
         LingoEngineGlobal.RunFramework = AbstEngineRunFramework.Unity;
         reg.ServicesMain(s => s
                 .AddSingleton<ILingoFrameworkFactory, UnityFactory>()
+                .AddSingleton<ILingoFrameworkStageContainer, UnityStageContainer>()
                 .WithAbstUIUnity()
             )
            .WithFrameworkFactory(setup);


### PR DESCRIPTION
## Summary
- add Unity wrap panel component and integrate into AbstUI factory
- delegate panel, layout wrapper, label, button, tab, scroll container and text input creation through Unity factory
- parent Unity stages under a container GameObject for scaling
- implement Unity tab container, tab item, checkbox, combobox, scroll container and text input components

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj`
- `dotnet format src/LingoEngine.Unity/LingoEngine.Unity.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj`
- `dotnet build src/LingoEngine.Unity/LingoEngine.Unity.csproj`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj` *(fails: SDL2 shared library missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c8fb9adc8332b7e2c303b6e79027