### PR TITLE
Show Blazor GfxTestScene on homepage

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/AbstUI.GfxVisualTest.Blazor.csproj
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/AbstUI.GfxVisualTest.Blazor.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\AbstUI.Blazor\AbstUI.Blazor.csproj" />
     <ProjectReference Include="..\..\src\AbstUI\AbstUI.csproj" />
+    <ProjectReference Include="..\AbstUI.GfxVisualTest\AbstUI.GfxVisualTest.csproj" />
   </ItemGroup>
 
 </Project>

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/Pages/Home.razor
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/Pages/Home.razor
@@ -1,7 +1,25 @@
-﻿@page "/"
+@page "/"
+@using Microsoft.AspNetCore.Components
+@using AbstUI.Blazor
+@using AbstUI.Blazor.Components
+@using AbstUI.Components
+@using LingoEngine.SDL2.GfxVisualTest
 
 <PageTitle>Home</PageTitle>
 
-<h1>Hello, world!</h1>
+@if (_scene is not null)
+{
+    @_scene
+}
 
-Welcome to your new app.
+@code {
+    private RenderFragment? _scene;
+
+    protected override void OnInitialized()
+    {
+        var factory = new AbstBlazorComponentFactory();
+        var scroll = (AbstScrollContainer)GfxTestScene.Build(factory);
+        var impl = (AbstBlazorComponentBase)scroll.Framework<IAbstFrameworkScrollContainer>();
+        _scene = impl.RenderFragment;
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/Program.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using AbstUI.Blazor;
 
 namespace AbstUI.GfxVisualTest.Blazor
 {
@@ -12,6 +13,7 @@ namespace AbstUI.GfxVisualTest.Blazor
             builder.RootComponents.Add<HeadOutlet>("head::after");
 
             builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+            builder.Services.WithAbstUIBlazor();
 
             await builder.Build().RunAsync();
         }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
@@ -65,6 +65,8 @@ public class AbstBlazorComponentFactory : IAbstComponentFactory
     public AbstScrollContainer CreateScrollContainer(string name)
     {
         var scroll = new AbstScrollContainer();
+        var impl = new AbstBlazorScrollContainer();
+        scroll.Init(impl);
         scroll.Name = name;
         return scroll;
     }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Components/AbstBlazorStateButton.cs" />
     <Compile Include="Components/AbstBlazorPanel.cs" />
     <Compile Include="Components/AbstBlazorWrapPanel.cs" />
+    <Compile Include="Components/AbstBlazorScrollContainer.cs" />
       <Compile Include="Components/AbstBlazorGfxCanvas.cs" />
       <Compile Include="Components/AbstInputComponent.cs" />
         <Compile Include="Components/AbstBlazorTabContainer.cs" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorScrollContainer.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorScrollContainer.razor
@@ -1,0 +1,7 @@
+@inherits AbstBlazorComponentBase
+<div id="@Name" style="@BuildStyle()">
+    @foreach (var fragment in _fragments)
+    {
+        @fragment
+    }
+</div>


### PR DESCRIPTION
## Summary
- register AbstUI services in Blazor visual test app
- render `GfxTestScene` scroll container on home page
- reference common test scene project
- add `AbstBlazorScrollContainer` component and wire it into factory
- use the new scroll container on the home page

## Testing
- `dotnet format --verify-no-changes WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj -v diag`
- `dotnet format --verify-no-changes WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/AbstUI.GfxVisualTest.Blazor.csproj -v diag`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/AbstUI.GfxVisualTest.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a2eb88ade083328b6d6958c2406f5e