### PR TITLE
Expose SDL canvas for RmlUi and add rendering bridge

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlGfxCanvas.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlGfxCanvas.cs
@@ -9,7 +9,7 @@ using AbstUI.SDL2.SDLL;
 
 namespace AbstUI.SDL2.Components
 {
-    internal class AbstSdlGfxCanvas : AbstSdlComponent, IAbstFrameworkGfxCanvas, IDisposable
+    public class AbstSdlGfxCanvas : AbstSdlComponent, IAbstFrameworkGfxCanvas, IDisposable
     {
         public AMargin Margin { get; set; } = AMargin.Zero;
 
@@ -20,7 +20,7 @@ namespace AbstUI.SDL2.Components
         private nint _texture;
         private readonly List<Action> _drawActions = new();
         private AColor? _clearColor;
-        private bool _dirty;
+        protected bool _dirty;
         public object FrameworkNode => this;
         public nint Texture => _texture;
 
@@ -72,7 +72,7 @@ namespace AbstUI.SDL2.Components
         }
 
 
-        private void MarkDirty() => _dirty = true;
+        protected void MarkDirty() => _dirty = true;
 
         public void Clear(AColor color)
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Components/RmlUiGfxCanvas.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Components/RmlUiGfxCanvas.cs
@@ -1,0 +1,116 @@
+using AbstUI.Primitives;
+using AbstUI.Styles;
+using AbstUI.SDL2;
+using AbstUI.SDL2.Components;
+using AbstUI.SDL2.Bitmaps;
+using RmlUiNet;
+
+namespace AbstUI.SDL2RmlUi.Components;
+
+/// <summary>
+/// Gfx canvas implementation that renders its SDL texture into a RmlUi image element.
+/// </summary>
+public class RmlUiGfxCanvas : AbstSdlGfxCanvas
+{
+    private readonly Element _element;
+    private readonly nint _renderer;
+
+    public RmlUiGfxCanvas(
+        AbstSdlComponentFactory factory,
+        IAbstFontManager fontManager,
+        ElementDocument document,
+        nint renderer,
+        int width,
+        int height) : base(factory, fontManager, width, height)
+    {
+        _renderer = renderer;
+        _element = document.AppendChildTag("img");
+        _element.SetAttribute("width", width.ToString());
+        _element.SetAttribute("height", height.ToString());
+        _element.SetProperty("display", "block");
+        _element.SetProperty("position", "absolute");
+    }
+
+    public new object FrameworkNode => _element;
+
+    public new float X
+    {
+        get => base.X;
+        set
+        {
+            base.X = value;
+            _element.SetProperty("left", $"{value}px");
+        }
+    }
+
+    public new float Y
+    {
+        get => base.Y;
+        set
+        {
+            base.Y = value;
+            _element.SetProperty("top", $"{value}px");
+        }
+    }
+
+    public new float Width
+    {
+        get => base.Width;
+        set
+        {
+            base.Width = value;
+            _element.SetAttribute("width", ((int)value).ToString());
+        }
+    }
+
+    public new float Height
+    {
+        get => base.Height;
+        set
+        {
+            base.Height = value;
+            _element.SetAttribute("height", ((int)value).ToString());
+        }
+    }
+
+    public new bool Visibility
+    {
+        get => base.Visibility;
+        set
+        {
+            base.Visibility = value;
+            _element.SetProperty("display", value ? "block" : "none");
+        }
+    }
+
+    public new AMargin Margin
+    {
+        get => base.Margin;
+        set
+        {
+            base.Margin = value;
+            _element.SetProperty("margin", $"{value.Top}px {value.Right}px {value.Bottom}px {value.Left}px");
+        }
+    }
+
+    public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
+    {
+        var wasDirty = _dirty;
+        var texture = base.Render(context);
+        nint texHandle = (nint)texture;
+        if (wasDirty && texHandle != nint.Zero)
+        {
+            var tex = new SdlTexture2D(texHandle, (int)Width, (int)Height);
+            var base64 = tex.ToPngBase64(context.Renderer);
+            _element.SetAttribute("src", $"data:image/png;base64,{base64}");
+        }
+        return texture;
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        _element.GetParentNode()?.RemoveChild(_element);
+    }
+}
+


### PR DESCRIPTION
## Summary
- make `AbstSdlGfxCanvas` public with a protected dirty flag to allow reuse
- add `RmlUiGfxCanvas` that extends the SDL canvas and displays its texture via a RmlUi `<img>` element

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/AbstUI.SDL2RmlUi.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a2f508f5b08332b7dc79368646e716