### PR TITLE
Implement Unity button component

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj
@@ -25,10 +25,10 @@
                 <None Include="README.md" Pack="true" PackagePath="" />
         </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
-		<PackageReference Include="UnityEngine" Version="1.0.0" />
-	</ItemGroup>
+        <ItemGroup>
+                <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+                <PackageReference Include="UnityEngine" Version="1.0.0" />
+        </ItemGroup>
 
 	<ItemGroup>
 	  <ProjectReference Include="..\AbstUI\AbstUI.csproj" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Bitmaps/UnityImageTexture.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Bitmaps/UnityImageTexture.cs
@@ -1,4 +1,5 @@
 using AbstUI.Primitives;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace AbstUI.LUnity.Bitmaps;
@@ -20,6 +21,13 @@ public class UnityTexture2D : IAbstTexture2D
     public int Height => Texture!.height;
 
     public bool IsDisposed => throw new NotImplementedException();
+
+    public Sprite? ToSprite()
+    {
+        if (Texture == null)
+            return null;
+        return Sprite.Create(Texture, new Rect(0, 0, Texture.width, Texture.height), new Vector2(0.5f, 0.5f));
+    }
 
 
     public IAbstUITextureUserSubscription AddUser(object user)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityButton.cs
@@ -1,6 +1,9 @@
 using System;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.LUnity.Bitmaps;
+using UnityEngine;
+using UnityEngine.UI;
 
 namespace AbstUI.LUnity.Components;
 
@@ -9,11 +12,58 @@ namespace AbstUI.LUnity.Components;
 /// </summary>
 internal class AbstUnityButton : AbstUnityComponent, IAbstFrameworkButton
 {
-    public string Text { get; set; } = string.Empty;
-    public bool Enabled { get; set; } = true;
-    public IAbstTexture2D? IconTexture { get; set; }
+    private readonly Button _button;
+    private readonly Image _image;
+    private readonly Text _textComponent;
+    private string _text = string.Empty;
+    private IAbstTexture2D? _iconTexture;
+
+    public AbstUnityButton() : base(CreateGameObject(out var textComponent))
+    {
+        _textComponent = textComponent;
+        _button = GameObject.GetComponent<Button>();
+        _image = GameObject.GetComponent<Image>();
+        _button.onClick.AddListener(() => Pressed?.Invoke());
+    }
+
+    private static GameObject CreateGameObject(out Text text)
+    {
+        var go = new GameObject("Button");
+        go.AddComponent<Image>();
+        go.AddComponent<Button>();
+        var textGo = new GameObject("Text");
+        textGo.transform.parent = go.transform;
+        text = textGo.AddComponent<Text>();
+        return go;
+    }
+
+    public string Text
+    {
+        get => _text;
+        set
+        {
+            _text = value;
+            _textComponent.text = value;
+        }
+    }
+
+    public bool Enabled
+    {
+        get => _button.interactable;
+        set => _button.interactable = value;
+    }
+
+    public IAbstTexture2D? IconTexture
+    {
+        get => _iconTexture;
+        set
+        {
+            _iconTexture = value;
+            _image.sprite = value is UnityTexture2D tex ? tex.ToSprite() : null;
+        }
+    }
 
     public event Action? Pressed;
 
-    public void Invoke() => Pressed?.Invoke();
+    public void Invoke() => _button.onClick.Invoke();
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityComponent.cs
@@ -11,9 +11,9 @@ internal class AbstUnityComponent : IAbstFrameworkLayoutNode
 {
     protected readonly GameObject GameObject;
 
-    public AbstUnityComponent()
+    protected AbstUnityComponent(GameObject? gameObject = null)
     {
-        GameObject = new GameObject();
+        GameObject = gameObject ?? new GameObject();
     }
 
     public string Name
@@ -28,13 +28,61 @@ internal class AbstUnityComponent : IAbstFrameworkLayoutNode
         set => GameObject.SetActive(value);
     }
 
-    public float Width { get; set; }
-    public float Height { get; set; }
+    private float _width;
+    private float _height;
+
+    public float Width
+    {
+        get => _width;
+        set
+        {
+            _width = value;
+            var scale = GameObject.transform.localScale;
+            scale.x = value;
+            GameObject.transform.localScale = scale;
+        }
+    }
+
+    public float Height
+    {
+        get => _height;
+        set
+        {
+            _height = value;
+            var scale = GameObject.transform.localScale;
+            scale.y = value;
+            GameObject.transform.localScale = scale;
+        }
+    }
 
     public AMargin Margin { get; set; } = AMargin.Zero;
 
-    public float X { get; set; }
-    public float Y { get; set; }
+    private float _x;
+    private float _y;
+
+    public float X
+    {
+        get => _x;
+        set
+        {
+            _x = value;
+            var pos = GameObject.transform.position;
+            pos.x = value;
+            GameObject.transform.position = pos;
+        }
+    }
+
+    public float Y
+    {
+        get => _y;
+        set
+        {
+            _y = value;
+            var pos = GameObject.transform.position;
+            pos.y = value;
+            GameObject.transform.position = pos;
+        }
+    }
 
     public object FrameworkNode => GameObject;
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityInputText.cs
@@ -1,5 +1,7 @@
 using System;
 using AbstUI.Components;
+using UnityEngine;
+using UnityEngine.UI;
 
 namespace AbstUI.LUnity.Components;
 
@@ -8,9 +10,43 @@ namespace AbstUI.LUnity.Components;
 /// </summary>
 internal class AbstUnityInputText : AbstUnityComponent, IAbstFrameworkInputText
 {
-    public bool Enabled { get; set; } = true;
-
+    private readonly InputField _inputField;
+    private readonly Text _textComponent;
     private string _text = string.Empty;
+
+    public AbstUnityInputText() : base(CreateGameObject(out var input, out var text))
+    {
+        _inputField = input;
+        _textComponent = text;
+        _inputField.onValueChanged.AddListener(OnValueChanged);
+    }
+
+    private static GameObject CreateGameObject(out InputField input, out Text text)
+    {
+        var go = new GameObject("InputField");
+        go.AddComponent<Image>();
+        input = go.AddComponent<InputField>();
+        var textGo = new GameObject("Text");
+        textGo.transform.parent = go.transform;
+        text = textGo.AddComponent<Text>();
+        input.textComponent = text;
+        return go;
+    }
+
+    private void OnValueChanged(string value)
+    {
+        if (_text == value) return;
+        _text = value;
+        _textComponent.text = value;
+        ValueChanged?.Invoke();
+    }
+
+    public bool Enabled
+    {
+        get => _inputField.interactable;
+        set => _inputField.interactable = value;
+    }
+
     public string Text
     {
         get => _text;
@@ -18,14 +54,27 @@ internal class AbstUnityInputText : AbstUnityComponent, IAbstFrameworkInputText
         {
             if (_text == value) return;
             _text = value;
+            _inputField.text = value;
+            _textComponent.text = value;
             ValueChanged?.Invoke();
         }
     }
 
-    public int MaxLength { get; set; }
+    public int MaxLength
+    {
+        get => _inputField.characterLimit;
+        set => _inputField.characterLimit = value;
+    }
+
     public string? Font { get; set; }
+
     public int FontSize { get; set; }
-    public bool IsMultiLine { get; set; }
+
+    public bool IsMultiLine
+    {
+        get => _inputField.lineType != InputField.LineType.SingleLine;
+        set => _inputField.lineType = value ? InputField.LineType.MultiLineNewline : InputField.LineType.SingleLine;
+    }
 
     public event Action? ValueChanged;
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/UnityUIStubs.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/UnityUIStubs.cs
@@ -1,0 +1,53 @@
+namespace UnityEngine.UI;
+
+using System;
+using UnityEngine;
+
+public class Image : MonoBehaviour
+{
+    public Sprite? sprite { get; set; }
+}
+
+public class Button : MonoBehaviour
+{
+    public class ButtonClickedEvent
+    {
+        private event Action? _handlers;
+        public void AddListener(Action handler) => _handlers += handler;
+        public void RemoveListener(Action handler) => _handlers -= handler;
+        public void Invoke() => _handlers?.Invoke();
+    }
+
+    public bool interactable { get; set; } = true;
+    public ButtonClickedEvent onClick { get; } = new();
+}
+
+public class Text : MonoBehaviour
+{
+    public string text { get; set; } = string.Empty;
+}
+
+public class InputField : MonoBehaviour
+{
+    public class SubmitEvent
+    {
+        private event Action<string>? _handlers;
+        public void AddListener(Action<string> handler) => _handlers += handler;
+        public void RemoveListener(Action<string> handler) => _handlers -= handler;
+        public void Invoke(string value) => _handlers?.Invoke(value);
+    }
+
+    public enum LineType
+    {
+        SingleLine,
+        MultiLineNewline,
+        MultiLineSubmit
+    }
+
+    public bool interactable { get; set; } = true;
+    public string text { get; set; } = string.Empty;
+    public int characterLimit { get; set; }
+    public LineType lineType { get; set; } = LineType.SingleLine;
+    public Text? textComponent { get; set; }
+    public SubmitEvent onValueChanged { get; } = new();
+}


### PR DESCRIPTION
## Summary
- allow Unity components to supply custom GameObjects
- add AbstUnityButton backed by a Unity UI Button
- stub UnityEngine.UI Image, Button, Text, and InputField for compilation
- render button text and convert icon textures to sprites via UnityTexture2D.ToSprite
- link layout size and position to underlying Unity GameObject transforms
- add AbstUnityInputText built on Unity InputField with text change notifications and multi-line support

## Testing
- `dotnet format src/AbstUI.LUnity/AbstUI.LUnity.csproj`
- `dotnet build src/AbstUI.LUnity/AbstUI.LUnity.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68a2e95f382c8332aff1929703f16253