### PR TITLE
Implement Blazor layout wrapper for AbstUI

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.Blazor.Components;
@@ -37,7 +38,11 @@ public class AbstBlazorComponentFactory : IAbstComponentFactory
     }
     public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y)
     {
+        if (content is IAbstLayoutNode)
+            throw new InvalidOperationException($"Content {content.Name} already supports layout wrapping is unnecessary.");
+
         var wrapper = new AbstLayoutWrapper(content);
+        var impl = new AbstBlazorLayoutWrapper(wrapper);
         if (x.HasValue) wrapper.X = x.Value;
         if (y.HasValue) wrapper.Y = y.Value;
         return wrapper;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Components/AbstBlazorItemList.cs" />
     <Compile Include="Components/AbstBlazorStateButton.cs" />
     <Compile Include="Components/AbstBlazorPanel.cs" />
+    <Compile Include="Components/AbstBlazorLayoutWrapper.cs" />
     <Compile Include="Components/AbstBlazorWrapPanel.cs" />
     <Compile Include="Components/AbstBlazorScrollContainer.cs" />
       <Compile Include="Components/AbstBlazorGfxCanvas.cs" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorLayoutWrapper.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorLayoutWrapper.cs
@@ -1,20 +1,29 @@
-﻿using AbstUI.Components;
+using Microsoft.AspNetCore.Components;
+using AbstUI.Components;
 using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components
+namespace AbstUI.Blazor.Components;
+
+public partial class AbstBlazorLayoutWrapper : AbstBlazorComponentBase, IAbstFrameworkLayoutWrapper
 {
+    private readonly RenderFragment? _contentFragment;
+    private readonly AbstLayoutWrapper _lingoLayoutWrapper;
+
+    public object FrameworkNode => this;
+
+    public AbstBlazorLayoutWrapper(AbstLayoutWrapper layoutWrapper)
     {
-        private AbstLayoutWrapper _lingoLayoutWrapper;
-        public object FrameworkNode => this;
+        _lingoLayoutWrapper = layoutWrapper;
+        _lingoLayoutWrapper.Init(this);
 
-        {
-            _lingoLayoutWrapper = layoutWrapper;
-            _lingoLayoutWrapper.Init(this);
-            var content = layoutWrapper.Content.FrameworkObj;
-        }
+        if (layoutWrapper.Content.FrameworkObj is AbstBlazorComponentBase component)
+            _contentFragment = component.RenderFragment;
+    }
 
-        public AMargin Margin { get; set; }
-
-        public override AbstBlazorRenderResult Render(AbstBlazorRenderContext context) => new AbstBlazorRenderResult();
+    private string BuildWrapperStyle()
+    {
+        var style = base.BuildStyle();
+        style += $"position:absolute;left:{X}px;top:{Y}px;";
+        return style;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorLayoutWrapper.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorLayoutWrapper.razor
@@ -1,0 +1,4 @@
+@inherits AbstBlazorComponentBase
+<div id="@Name" style="@BuildWrapperStyle()">
+    @_contentFragment
+</div>


### PR DESCRIPTION
## Summary
- add `AbstBlazorLayoutWrapper` for positioning non-layout components in Blazor
- wire `AbstBlazorComponentFactory` to create the new wrapper
- include wrapper in project build

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --no-restore` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a3022a42c883328c3f2d40eedb0e66