### PR TITLE
Implement basic SDL2 input widgets

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstSDLComponentContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstSDLComponentContainer.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using AbstUI.SDL2.SDLL;
+
 namespace AbstUI.SDL2;
 
 public class AbstSDLComponentContainer
@@ -21,6 +23,46 @@ public class AbstSDLComponentContainer
         foreach (var ctx in _activeComponents)
         {
             ctx.RenderToTexture(renderContext);
+        }
+    }
+
+    public void HandleEvent(SDL.SDL_Event e)
+    {
+        var evt = new AbstSDLEvent(e);
+        foreach (var ctx in _activeComponents)
+        {
+            if (ctx.Component is not IHandleSdlEvent handler)
+                continue;
+
+            bool inside = true;
+            switch (evt.Event.type)
+            {
+                case SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN:
+                case SDL.SDL_EventType.SDL_MOUSEBUTTONUP:
+                    var bx = evt.Event.button.x;
+                    var by = evt.Event.button.y;
+                    inside = bx >= ctx.X && bx <= ctx.X + ctx.TargetWidth &&
+                             by >= ctx.Y && by <= ctx.Y + ctx.TargetHeight;
+                    break;
+                case SDL.SDL_EventType.SDL_MOUSEMOTION:
+                    var mx = evt.Event.motion.x;
+                    var my = evt.Event.motion.y;
+                    inside = mx >= ctx.X && mx <= ctx.X + ctx.TargetWidth &&
+                             my >= ctx.Y && my <= ctx.Y + ctx.TargetHeight;
+                    break;
+                case SDL.SDL_EventType.SDL_MOUSEWHEEL:
+                    SDL.SDL_GetMouseState(out var wx, out var wy);
+                    inside = wx >= ctx.X && wx <= ctx.X + ctx.TargetWidth &&
+                             wy >= ctx.Y && wy <= ctx.Y + ctx.TargetHeight;
+                    break;
+            }
+
+            if (inside)
+            {
+                handler.HandleEvent(evt);
+                if (evt.StopPropagation)
+                    break;
+            }
         }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstSDLEvent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstSDLEvent.cs
@@ -1,0 +1,14 @@
+using AbstUI.SDL2.SDLL;
+
+namespace AbstUI.SDL2;
+
+public class AbstSDLEvent
+{
+    public SDL.SDL_Event Event;
+    public bool StopPropagation;
+
+    public AbstSDLEvent(SDL.SDL_Event e)
+    {
+        Event = e;
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputText.cs
@@ -1,15 +1,31 @@
 using System;
-using System.Numerics;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.SDL2;
+using AbstUI.SDL2.SDLL;
+using AbstUI.SDL2.Texts;
+using AbstUI.SDL2.Styles;
 
 namespace AbstUI.SDL2.Components
 {
-    internal class AbstSdlInputText : AbstSdlComponent, IAbstFrameworkInputText, IDisposable
+    internal class AbstSdlInputText : AbstSdlComponent, IAbstFrameworkInputText, IHandleSdlEvent, IDisposable
     {
+        private readonly bool _multiLine;
+        private readonly List<int> _codepoints = new();
+        private int _caret;
+        private bool _focused;
+        private uint _blinkStart;
+        private ISdlFontLoadedByUser? _font;
+        private SdlGlyphAtlas? _atlas;
+
         public AbstSdlInputText(AbstSdlComponentFactory factory, bool multiLine) : base(factory)
         {
+            _multiLine = multiLine;
         }
+
         public bool Enabled { get; set; } = true;
         private string _text = string.Empty;
         public string Text
@@ -17,11 +33,11 @@ namespace AbstUI.SDL2.Components
             get => _text;
             set
             {
-                if (_text != value)
-                {
-                    _text = value;
-                    ValueChanged?.Invoke();
-                }
+                _text = value ?? string.Empty;
+                _codepoints.Clear();
+                foreach (var r in value.EnumerateRunes()) _codepoints.Add(r.Value);
+                _caret = _codepoints.Count;
+                ValueChanged?.Invoke();
             }
         }
         public int MaxLength { get; set; }
@@ -32,15 +48,134 @@ namespace AbstUI.SDL2.Components
 
         public bool IsMultiLine { get; set; }
 
+        public bool HasFocus => _focused;
+
         public event Action? ValueChanged;
+
+        private void EnsureResources(AbstSDLRenderContext ctx)
+        {
+            if (_font == null)
+            {
+                _font = ctx.SdlFontManager.GetTyped(this, Font, FontSize);
+                _atlas = new SdlGlyphAtlas(ctx.Renderer, _font.FontHandle);
+            }
+        }
+
+        public void HandleEvent(AbstSDLEvent e)
+        {
+            if (!Enabled) return;
+            ref var ev = ref e.Event;
+
+            switch (ev.type)
+            {
+                case SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN:
+                    _focused = true;
+                    _caret = _codepoints.Count;
+                    e.StopPropagation = true;
+                    break;
+                case SDL.SDL_EventType.SDL_TEXTINPUT:
+                    if (!_focused) break;
+                    unsafe
+                    {
+                        fixed (byte* p = ev.text.text)
+                        {
+                            string s = SDL.UTF8_ToManaged((nint)p, false)!;
+                            foreach (var r in s.EnumerateRunes())
+                            {
+                                if (MaxLength > 0 && _codepoints.Count >= MaxLength) break;
+                                _codepoints.Insert(_caret, r.Value);
+                                _caret++;
+                            }
+                        }
+                    }
+                    _text = string.Concat(_codepoints.ConvertAll(cp => char.ConvertFromUtf32(cp)));
+                    ValueChanged?.Invoke();
+                    e.StopPropagation = true;
+                    break;
+                case SDL.SDL_EventType.SDL_KEYDOWN:
+                    if (!_focused) break;
+                    var key = ev.key.keysym.sym;
+                    if (key == SDL.SDL_Keycode.SDLK_BACKSPACE)
+                    {
+                        if (_caret > 0)
+                        {
+                            _codepoints.RemoveAt(_caret - 1);
+                            _caret--;
+                            _text = string.Concat(_codepoints.ConvertAll(cp => char.ConvertFromUtf32(cp)));
+                            ValueChanged?.Invoke();
+                        }
+                        e.StopPropagation = true;
+                    }
+                    else if (key == SDL.SDL_Keycode.SDLK_DELETE)
+                    {
+                        if (_caret < _codepoints.Count)
+                        {
+                            _codepoints.RemoveAt(_caret);
+                            _text = string.Concat(_codepoints.ConvertAll(cp => char.ConvertFromUtf32(cp)));
+                            ValueChanged?.Invoke();
+                        }
+                        e.StopPropagation = true;
+                    }
+                    else if (key == SDL.SDL_Keycode.SDLK_LEFT)
+                    {
+                        if (_caret > 0) _caret--;
+                        e.StopPropagation = true;
+                    }
+                    else if (key == SDL.SDL_Keycode.SDLK_RIGHT)
+                    {
+                        if (_caret < _codepoints.Count) _caret++;
+                        e.StopPropagation = true;
+                    }
+                    break;
+            }
+        }
 
         public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
         {
             if (!Visibility) return default;
-            return default;
+
+            EnsureResources(context);
+            var renderer = context.Renderer;
+
+            SDL.SDL_Rect rect = new SDL.SDL_Rect
+            {
+                x = (int)X,
+                y = (int)Y,
+                w = (int)Width,
+                h = (int)Height
+            };
+            SDL.SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+            SDL.SDL_RenderFillRect(renderer, ref rect);
+            SDL.SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+            SDL.SDL_RenderDrawRect(renderer, ref rect);
+
+            if (_atlas == null || _font == null) return default;
+
+            int ascent = SDL_ttf.TTF_FontAscent(_font.FontHandle);
+            int baseline = (int)Y + (int)Height / 2 + ascent / 2;
+
+            _atlas.DrawRun(CollectionsMarshal.AsSpan(_codepoints), (int)X + 4, baseline,
+                new SDL.SDL_Color { r = 0, g = 0, b = 0, a = 255 });
+
+            if (_focused)
+            {
+                uint ticks = SDL.SDL_GetTicks();
+                if ((ticks - _blinkStart) > 1000) { _blinkStart = ticks; }
+                if (((ticks - _blinkStart) / 500) % 2 == 0)
+                {
+                    int caretX = (int)X + 4 + _atlas.MeasureWidth(CollectionsMarshal.AsSpan(_codepoints).Slice(0, _caret));
+                    SDL.SDL_RenderDrawLine(renderer, caretX, (int)Y + 2, caretX, (int)(Y + Height) - 2);
+                }
+            }
+
+            return AbstSDLRenderResult.RequireRender();
         }
 
-
-        public override void Dispose() => base.Dispose();
+        public override void Dispose()
+        {
+            base.Dispose();
+            _font?.Release();
+            _atlas?.Dispose();
+        }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlSpinBox.cs
@@ -1,42 +1,132 @@
 using System;
-using System.Numerics;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.SDL2;
+using AbstUI.SDL2.SDLL;
 
-namespace AbstUI.SDL2.Components
+namespace AbstUI.SDL2.Components;
+
+internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IHandleSdlEvent, IDisposable
 {
-    internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IDisposable
+    private readonly AbstSdlInputNumber<float> _number;
+    private const int ButtonWidth = 16;
+
+    public AbstSdlSpinBox(AbstSdlComponentFactory factory) : base(factory)
     {
-        public AbstSdlSpinBox(AbstSdlComponentFactory factory) : base(factory)
+        _number = new AbstSdlInputNumber<float>(factory);
+        _number.ValueChanged += () => ValueChanged?.Invoke();
+    }
+
+    public bool Enabled { get; set; } = true;
+
+    public float Value
+    {
+        get => _number.Value;
+        set => _number.Value = value;
+    }
+
+    public float Min
+    {
+        get => _number.Min;
+        set => _number.Min = value;
+    }
+
+    public float Max
+    {
+        get => _number.Max;
+        set => _number.Max = value;
+    }
+
+    public float Step
+    {
+        get => _number.Step;
+        set => _number.Step = value;
+    }
+
+    public AMargin Margin { get; set; } = AMargin.Zero;
+    public object FrameworkNode => this;
+    public event Action? ValueChanged;
+
+    public void HandleEvent(AbstSDLEvent e)
+    {
+        if (!Enabled) return;
+
+        SDL.SDL_GetMouseState(out var mx, out var my);
+
+        ref var ev = ref e.Event;
+
+        if (ev.type == SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN)
         {
-        }
-        public bool Enabled { get; set; } = true;
-        private float _value;
-        public float Value
-        {
-            get => _value;
-            set
+            var upRect = GetUpRect();
+            var downRect = GetDownRect();
+            if (PointInRect(mx, my, upRect))
             {
-                if (_value != value)
-                {
-                    _value = value;
-                    ValueChanged?.Invoke();
-                }
+                Value += Step;
+                e.StopPropagation = true;
+                return;
+            }
+            if (PointInRect(mx, my, downRect))
+            {
+                Value -= Step;
+                e.StopPropagation = true;
+                return;
             }
         }
-        public float Min { get; set; }
-        public float Max { get; set; }
-        public AMargin Margin { get; set; } = AMargin.Zero;
-        public object FrameworkNode => this;
 
-        public event Action? ValueChanged;
+        _number.HandleEvent(e);
+    }
 
-        public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
-        {
-            if (!Visibility) return default;
-            return default;
-        }
+    private SDL.SDL_Rect GetUpRect() => new SDL.SDL_Rect
+    {
+        x = (int)(X + Width - ButtonWidth),
+        y = (int)Y,
+        w = ButtonWidth,
+        h = (int)Height / 2
+    };
 
-        public override void Dispose() => base.Dispose();
+    private SDL.SDL_Rect GetDownRect() => new SDL.SDL_Rect
+    {
+        x = (int)(X + Width - ButtonWidth),
+        y = (int)Y + (int)Height / 2,
+        w = ButtonWidth,
+        h = (int)Height / 2
+    };
+
+    private static bool PointInRect(int x, int y, SDL.SDL_Rect r)
+        => x >= r.x && x < r.x + r.w && y >= r.y && y < r.y + r.h;
+
+    public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
+    {
+        if (!Visibility) return default;
+
+        _number.X = X;
+        _number.Y = Y;
+        _number.Width = Width - ButtonWidth;
+        _number.Height = Height;
+        _number.Render(context);
+
+        var renderer = context.Renderer;
+        var up = GetUpRect();
+        var down = GetDownRect();
+        SDL.SDL_SetRenderDrawColor(renderer, 200, 200, 200, 255);
+        SDL.SDL_RenderFillRect(renderer, ref up);
+        SDL.SDL_RenderFillRect(renderer, ref down);
+        SDL.SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+        SDL.SDL_RenderDrawRect(renderer, ref up);
+        SDL.SDL_RenderDrawRect(renderer, ref down);
+        // simple triangles
+        SDL.SDL_RenderDrawLine(renderer, up.x + up.w / 2, up.y + 3, up.x + 3, up.y + up.h - 3);
+        SDL.SDL_RenderDrawLine(renderer, up.x + up.w / 2, up.y + 3, up.x + up.w - 3, up.y + up.h - 3);
+        SDL.SDL_RenderDrawLine(renderer, down.x + 3, down.y + 3, down.x + down.w / 2, down.y + down.h - 3);
+        SDL.SDL_RenderDrawLine(renderer, down.x + down.w - 3, down.y + 3, down.x + down.w / 2, down.y + down.h - 3);
+
+        return AbstSDLRenderResult.RequireRender();
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        _number.Dispose();
     }
 }
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/IHandleSdlEvent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/IHandleSdlEvent.cs
@@ -1,0 +1,6 @@
+namespace AbstUI.SDL2;
+
+internal interface IHandleSdlEvent
+{
+    void HandleEvent(AbstSDLEvent e);
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Texts/SdlGlyphAtlas.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Texts/SdlGlyphAtlas.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using AbstUI.SDL2.SDLL;
+
+namespace AbstUI.SDL2.Texts;
+
+internal sealed class SdlGlyphAtlas : IDisposable
+{
+    private readonly nint _renderer;
+    private readonly nint _font;
+    private readonly int _width;
+    private readonly int _height;
+    private readonly nint _surface;
+    private readonly nint _texture;
+
+    private int _nextX;
+    private int _nextY;
+    private int _rowHeight;
+
+    private struct Glyph
+    {
+        public SDL.SDL_Rect Rect;
+        public int Advance;
+        public int MinX;
+        public int MaxY;
+    }
+
+    private readonly Dictionary<int, Glyph> _glyphs = new();
+
+    public SdlGlyphAtlas(nint renderer, nint font, int width = 1024, int height = 1024)
+    {
+        _renderer = renderer;
+        _font = font;
+        _width = width;
+        _height = height;
+        _surface = SDL.SDL_CreateRGBSurfaceWithFormat(0, width, height, 32, SDL.SDL_PIXELFORMAT_RGBA8888);
+        _texture = SDL.SDL_CreateTexture(renderer, SDL.SDL_PIXELFORMAT_RGBA8888,
+            (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_STATIC, width, height);
+        SDL.SDL_SetTextureBlendMode(_texture, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
+    }
+
+    public void EnsureGlyph(int codepoint)
+    {
+        if (_glyphs.ContainsKey(codepoint))
+            return;
+
+        SDL.SDL_Color white = new SDL.SDL_Color { r = 255, g = 255, b = 255, a = 255 };
+        nint glyphSurface = SDL_ttf.TTF_RenderGlyph32_Blended(_font, (uint)codepoint, white);
+        if (glyphSurface == nint.Zero)
+            return;
+
+        SDL.SDL_Surface surf = Marshal.PtrToStructure<SDL.SDL_Surface>(glyphSurface);
+        int w = surf.w;
+        int h = surf.h;
+
+        if (_nextX + w >= _width)
+        {
+            _nextX = 0;
+            _nextY += _rowHeight;
+            _rowHeight = 0;
+        }
+
+        if (_nextY + h >= _height)
+        {
+            SDL.SDL_FreeSurface(glyphSurface);
+            return; // atlas full
+        }
+
+        SDL.SDL_Rect dest = new SDL.SDL_Rect { x = _nextX, y = _nextY, w = w, h = h };
+        SDL.SDL_BlitSurface(glyphSurface, IntPtr.Zero, _surface, ref dest);
+        SDL.SDL_UpdateTexture(_texture, ref dest, surf.pixels, surf.pitch);
+        SDL.SDL_FreeSurface(glyphSurface);
+
+        SDL_ttf.TTF_GlyphMetrics32(_font, (uint)codepoint, out int minx, out _, out _, out int maxy, out int advance);
+
+        _glyphs[codepoint] = new Glyph
+        {
+            Rect = dest,
+            Advance = advance,
+            MinX = minx,
+            MaxY = maxy
+        };
+
+        _nextX += w;
+        _rowHeight = Math.Max(_rowHeight, h);
+    }
+
+    public void DrawRun(ReadOnlySpan<int> run, int x, int baselineY, SDL.SDL_Color color)
+    {
+        SDL.SDL_SetTextureColorMod(_texture, color.r, color.g, color.b);
+        SDL.SDL_SetTextureAlphaMod(_texture, color.a);
+
+        foreach (var cp in run)
+        {
+            EnsureGlyph(cp);
+            if (!_glyphs.TryGetValue(cp, out var g))
+                continue;
+
+            SDL.SDL_Rect src = g.Rect;
+            SDL.SDL_Rect dst = new SDL.SDL_Rect
+            {
+                x = x + g.MinX,
+                y = baselineY - g.MaxY,
+                w = src.w,
+                h = src.h
+            };
+            SDL.SDL_RenderCopy(_renderer, _texture, ref src, ref dst);
+            x += g.Advance;
+        }
+    }
+
+    public int MeasureWidth(ReadOnlySpan<int> run)
+    {
+        int w = 0;
+        foreach (var cp in run)
+        {
+            EnsureGlyph(cp);
+            if (_glyphs.TryGetValue(cp, out var g))
+                w += g.Advance;
+        }
+        return w;
+    }
+
+    public void Dispose()
+    {
+        SDL.SDL_DestroyTexture(_texture);
+        SDL.SDL_FreeSurface(_surface);
+    }
+}
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Texts/SdlLabelExtensions.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Texts/SdlLabelExtensions.cs
@@ -5,5 +5,5 @@ namespace AbstUI.SDL2.Texts;
 
 public static class SdlLabelExtensions
 {
-   
+
 }

--- a/src/LingoEngine.SDL2/SdlRootContext.cs
+++ b/src/LingoEngine.SDL2/SdlRootContext.cs
@@ -49,6 +49,7 @@ public class SdlRootContext : AbstUISdlRootContext<LingoMouse>, ISdlRootComponen
                     running = false;
                 Key.ProcessEvent(e);
                 _sdlMouse.ProcessEvent(e);
+                Factory.ComponentContainer.HandleEvent(e);
             }
             uint now = SDL.SDL_GetTicks();
             float delta = (now - last) / 1000f;


### PR DESCRIPTION
## Summary
- add SDL2 glyph atlas for cached text rendering
- implement SDL2 input text with caret and basic editing
- add numeric input and spin box controls
- clamp SDL2 input handling to component bounds
- route SDL events through component container
- introduce stoppable SDL event wrapper to halt propagation
- drop ref usage from SDL event wrapper for cleaner handler APIs

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --verify-no-changes --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstSDLEvent.cs --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/IHandleSdlEvent.cs --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstSDLComponentContainer.cs --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputText.cs --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputNumber.cs --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlSpinBox.cs -v minimal`
- `dotnet format src/LingoEngine.SDL2/LingoEngine.SDL2.csproj --verify-no-changes --include src/LingoEngine.SDL2/SdlRootContext.cs -v minimal`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/AbstUI.GfxVisualTest.SDL2.csproj`
- `dotnet build src/LingoEngine.SDL2/LingoEngine.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a3003925f083329f7c3da5c00cd5af