### PR TITLE
Initialize layout wrapper before position assignment and defer canvas renders

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
@@ -43,6 +43,7 @@ public class AbstBlazorComponentFactory : IAbstComponentFactory
 
         var wrapper = new AbstLayoutWrapper(content);
         var impl = new AbstBlazorLayoutWrapper(wrapper);
+        wrapper.Init(impl);
         if (x.HasValue) wrapper.X = x.Value;
         if (y.HasValue) wrapper.Y = y.Value;
         return wrapper;
@@ -201,6 +202,8 @@ public class AbstBlazorComponentFactory : IAbstComponentFactory
     public AbstMenu CreateMenu(string name)
     {
         var menu = new AbstMenu();
+        var impl = new AbstBlazorMenu(this, name);
+        menu.Init(impl);
         menu.Name = name;
         return menu;
     }
@@ -208,6 +211,8 @@ public class AbstBlazorComponentFactory : IAbstComponentFactory
     public AbstMenuItem CreateMenuItem(string name, string? shortcut = null)
     {
         var item = new AbstMenuItem();
+        var impl = new AbstBlazorMenuItem(this, name, shortcut);
+        item.Init(impl);
         item.Name = name;
         item.Shortcut = shortcut;
         return item;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
@@ -60,6 +60,8 @@
       <Compile Include="Components/AbstInputComponent.cs" />
         <Compile Include="Components/AbstBlazorTabContainer.cs" />
         <Compile Include="Components/AbstBlazorTabItem.cs" />
+        <Compile Include="Components/AbstBlazorMenu.cs" />
+        <Compile Include="Components/AbstBlazorMenuItem.cs" />
         <Compile Include="Inputs/BlazorMouse.cs" />
         <Compile Include="Inputs/BlazorKey.cs" />
         <Compile Include="AbstUIBlazorSetup.cs" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorGfxCanvas.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorGfxCanvas.cs
@@ -55,7 +55,7 @@ public partial class AbstBlazorGfxCanvas : AbstBlazorComponentBase, IAbstFramewo
         if (!_dirty)
         {
             _dirty = true;
-            _ = InvokeAsync(StateHasChanged);
+            RequestRender();
         }
     }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorMenu.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorMenu.cs
@@ -2,24 +2,28 @@ using System;
 using AbstUI.Components;
 using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components
+namespace AbstUI.Blazor.Components;
+
+internal class AbstBlazorMenu : IAbstFrameworkMenu, IDisposable
 {
-    internal class AbstBlazorMenu : AbstBlazorComponent, IAbstFrameworkMenu, IDisposable
+    public string Name { get; set; } = string.Empty;
+    public bool Visibility { get; set; } = true;
+    public float Width { get; set; }
+    public float Height { get; set; }
+    public AMargin Margin { get; set; } = AMargin.Zero;
+    public float X { get; set; }
+    public float Y { get; set; }
+    public object FrameworkNode => this;
+
+    public AbstBlazorMenu(AbstBlazorComponentFactory factory, string name)
     {
-        public AMargin Margin { get; set; } = AMargin.Zero;
-        public object FrameworkNode => this;
-
-        public AbstBlazorMenu(AbstBlazorComponentFactory factory, string name) : base(factory)
-        {
-            Name = name;
-        }
-
-        public void AddItem(IAbstFrameworkMenuItem item) { }
-        public void ClearItems() { }
-        public void PositionPopup(IAbstFrameworkButton button) { }
-        public void Popup() { }
-        public override void Dispose() => base.Dispose();
-
-        public override AbstBlazorRenderResult Render(AbstBlazorRenderContext context) => new AbstBlazorRenderResult();
+        Name = name;
     }
+
+    public void AddItem(IAbstFrameworkMenuItem item) { }
+    public void ClearItems() { }
+    public void PositionPopup(IAbstFrameworkButton button) { }
+    public void Popup() { }
+
+    public void Dispose() { }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorMenuItem.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorMenuItem.cs
@@ -1,25 +1,23 @@
 using System;
 using AbstUI.Components;
 
-namespace AbstUI.Blazor.Components
+namespace AbstUI.Blazor.Components;
+
+internal class AbstBlazorMenuItem : IAbstFrameworkMenuItem, IDisposable
 {
-    internal class AbstBlazorMenuItem : AbstBlazorComponent, IAbstFrameworkMenuItem, IDisposable
+    public string Name { get; set; } = string.Empty;
+    public bool Enabled { get; set; } = true;
+    public bool CheckMark { get; set; }
+    public string? Shortcut { get; set; }
+    public event Action? Activated;
+
+    public AbstBlazorMenuItem(AbstBlazorComponentFactory factory, string name, string? shortcut)
     {
-        public bool Enabled { get; set; } = true;
-        public bool CheckMark { get; set; }
-        public string? Shortcut { get; set; }
-        public event Action? Activated;
-        public object FrameworkNode => this;
-
-        public AbstBlazorMenuItem(AbstBlazorComponentFactory factory, string name, string? shortcut) : base(factory)
-        {
-            Name = name;
-            Shortcut = shortcut;
-        }
-
-        public void Invoke() => Activated?.Invoke();
-        public override void Dispose() => base.Dispose();
-
-        public override AbstBlazorRenderResult Render(AbstBlazorRenderContext context) => new AbstBlazorRenderResult();
+        Name = name;
+        Shortcut = shortcut;
     }
+
+    public void Invoke() => Activated?.Invoke();
+
+    public void Dispose() { }
 }


### PR DESCRIPTION
## Summary
- Initialize layout wrapper framework in `AbstBlazorComponentFactory` to prevent null references when setting position
- Guard `AbstBlazorGfxCanvas.MarkDirty` with `RequestRender` so rerenders only occur after the render handle is ready
- Initialize Blazor menu wrappers with their framework implementations before assigning names

## Testing
- ✅ `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --include Components/AbstBlazorMenu.cs Components/AbstBlazorMenuItem.cs AbstBlazorComponentFactory.cs --no-restore`
- ✅ `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/AbstUI.GfxVisualTest.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a3060232d08332a3385e412cca78f1