### PR TITLE
Add text color support to input text components

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorInputText.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Components;
 using AbstUI.Components;
 using System.Threading.Tasks;
+using AbstUI.Primitives;
 
 namespace AbstUI.Blazor.Components;
 
@@ -12,8 +13,16 @@ public partial class AbstBlazorInputText : IAbstFrameworkInputText
     [Parameter] public int FontSize { get; set; } = 14;
     [Parameter] public bool IsMultiLine { get; set; }
     [Parameter] public bool Enabled { get; set; } = true;
+    [Parameter] public AColor TextColor { get; set; } = AColors.Black;
 
     public event Action? ValueChanged;
+
+    protected override string BuildStyle()
+    {
+        var style = base.BuildStyle();
+        style += $"color:{TextColor.ToHex()};";
+        return style;
+    }
 
     private Task HandleInput(ChangeEventArgs e)
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputText.cs
@@ -30,6 +30,7 @@ namespace AbstUI.ImGui.Components
         public int FontSize { get; set; } = 12;
         public AMargin Margin { get; set; } = AMargin.Zero;
         public object FrameworkNode => this;
+        public AColor TextColor { get; set; } = AColors.Black;
 
         public bool IsMultiLine { get; set; }
 
@@ -45,6 +46,7 @@ namespace AbstUI.ImGui.Components
             if (Width > 0) global::ImGuiNET.ImGui.SetNextItemWidth(Width);
 
             global::ImGuiNET.ImGui.PushID(Name);
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.Text, TextColor.ToImGuiColor());
             if (!Enabled) global::ImGuiNET.ImGui.BeginDisabled();
 
             uint cap = MaxLength > 0 ? (uint)MaxLength : 1024u;
@@ -52,6 +54,7 @@ namespace AbstUI.ImGui.Components
                 ValueChanged?.Invoke();
 
             if (!Enabled) global::ImGuiNET.ImGui.EndDisabled();
+            global::ImGuiNET.ImGui.PopStyleColor();
             global::ImGuiNET.ImGui.PopID();
             return AbstImGuiRenderResult.RequireRender();
         }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/AbstGodotInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/AbstGodotInputText.cs
@@ -3,6 +3,7 @@ using Godot;
 using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.Styles;
+using AbstUI.LGodot.Primitives;
 
 namespace AbstUI.LGodot.Components
 {
@@ -23,7 +24,7 @@ namespace AbstUI.LGodot.Components
 
         private float _wantedWidth = 10;
         private float _wantedHeight = 10;
-        private Color _fontColor = Colors.Black;
+        private AColor _textColor = AColors.Black;
         private bool _isMultiLine;
         public object FrameworkNode => _control;
 
@@ -32,7 +33,7 @@ namespace AbstUI.LGodot.Components
             _onChange = onChange;
             _fontManager = fontManager;
             IsMultiLine = multiLine;
-            _control= InitControl(multiLine);
+            _control = InitControl(multiLine);
 
             input.Init(this);
         }
@@ -218,15 +219,15 @@ namespace AbstUI.LGodot.Components
             }
         }
 
-      
 
-        public Color FontColor
+
+        public AColor TextColor
         {
-            get => _fontColor;
+            get => _textColor;
             set
             {
-                _fontColor = value;
-                _control.AddThemeColorOverride("font_color", _fontColor);
+                _textColor = value;
+                _control.AddThemeColorOverride("font_color", _textColor.ToGodotColor());
             }
         }
 
@@ -243,7 +244,7 @@ namespace AbstUI.LGodot.Components
             }
         }
 
-       
+
 
         public bool IsMultiLine
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputText.cs
@@ -45,6 +45,7 @@ namespace AbstUI.SDL2.Components
         public int FontSize { get; set; } = 12;
         public AMargin Margin { get; set; } = AMargin.Zero;
         public object FrameworkNode => this;
+        public AColor TextColor { get; set; } = AColors.Black;
 
         public bool IsMultiLine { get; set; }
 
@@ -155,7 +156,7 @@ namespace AbstUI.SDL2.Components
             int baseline = (int)Y + (int)Height / 2 + ascent / 2;
 
             _atlas.DrawRun(CollectionsMarshal.AsSpan(_codepoints), (int)X + 4, baseline,
-                new SDL.SDL_Color { r = 0, g = 0, b = 0, a = 255 });
+                TextColor.ToSDLColor());
 
             if (_focused)
             {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/SdlColorExtensions.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/SdlColorExtensions.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using AbstUI.Primitives;
+using AbstUI.SDL2.SDLL;
 
 namespace AbstUI.SDL2;
 
@@ -11,4 +12,8 @@ public static class SdlColorExtensions
     /// <summary>Converts a <see cref="AColor"/> to a normalized <see cref="Vector4"/>.</summary>
     public static Vector4 ToVector4(this AColor color)
         => new(color.R / 255f, color.G / 255f, color.B / 255f, color.A / 255f);
+
+    /// <summary>Converts a <see cref="AColor"/> to an <see cref="SDL.SDL_Color"/>.</summary>
+    public static SDL.SDL_Color ToSDLColor(this AColor color)
+        => new() { r = color.R, g = color.G, b = color.B, a = color.A };
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Components/RmlUiInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Components/RmlUiInputText.cs
@@ -25,6 +25,7 @@ public class RmlUiInputText : IAbstFrameworkInputText, IDisposable
     private int _maxLength;
     private string? _font;
     private int _fontSize;
+    private AColor _textColor = AColors.Black;
     private bool _isMultiLine;
     private event Action? _valueChanged;
 
@@ -71,6 +72,7 @@ public class RmlUiInputText : IAbstFrameworkInputText, IDisposable
         if (_maxLength != 0) _element.SetAttribute("maxlength", _maxLength.ToString());
         if (!string.IsNullOrEmpty(_font)) _element.SetProperty("font-family", _font);
         if (_fontSize != 0) _element.SetProperty("font-size", $"{_fontSize}px");
+        _element.SetProperty("color", _textColor.ToHex());
 
         if (_input != null) _input.SetValue(_text);
         else _textarea?.SetInnerRml(_text);
@@ -202,6 +204,16 @@ public class RmlUiInputText : IAbstFrameworkInputText, IDisposable
         {
             _fontSize = value;
             _element.SetProperty("font-size", $"{value}px");
+        }
+    }
+
+    public AColor TextColor
+    {
+        get => _textColor;
+        set
+        {
+            _textColor = value;
+            _element.SetProperty("color", value.ToHex());
         }
     }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/AbstInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/AbstInputText.cs
@@ -1,3 +1,5 @@
+using AbstUI.Primitives;
+
 namespace AbstUI.Components
 {
     /// <summary>
@@ -10,6 +12,7 @@ namespace AbstUI.Components
         public int MaxLength { get => _framework.MaxLength; set => _framework.MaxLength = value; }
         public string? Font { get => _framework.Font; set => _framework.Font = value; }
         public int FontSize { get => _framework.FontSize; set => _framework.FontSize = value; }
+        public AColor TextColor { get => _framework.TextColor; set => _framework.TextColor = value; }
         public bool IsMultiLine { get => _framework.IsMultiLine; set => _framework.IsMultiLine = value; }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/IAbstFrameworkInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/IAbstFrameworkInputText.cs
@@ -1,3 +1,5 @@
+using AbstUI.Primitives;
+
 namespace AbstUI.Components
 {
     /// <summary>
@@ -9,6 +11,10 @@ namespace AbstUI.Components
         int MaxLength { get; set; }
         string? Font { get; set; }
         int FontSize { get; set; }
+        /// <summary>
+        /// Gets or sets the color of the text.
+        /// </summary>
+        AColor TextColor { get; set; }
         bool IsMultiLine { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- allow specifying text color on AbstInputText
- implement text color for Blazor, ImGui, Godot, SDL2 and SDL2RmlUi backends
- add SDL color conversion extension and apply it in SDL input text

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --verbosity diagnostic`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a31854dc8c83328ab41b013675bb64