### PR TITLE
Fix Blazor visual test rendering

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
@@ -37,6 +37,7 @@
     <ProjectReference Include="..\AbstUI\AbstUI.csproj" />
   </ItemGroup>
 
+  <!-- Explicitly include source files and generated Razor component code -->
   <ItemGroup>
     <Compile Remove="**/*.cs" />
     <Compile Include="AbstBlazorComponentFactory.cs" />
@@ -56,21 +57,23 @@
     <Compile Include="Components/AbstBlazorLayoutWrapper.cs" />
     <Compile Include="Components/AbstBlazorWrapPanel.cs" />
     <Compile Include="Components/AbstBlazorScrollContainer.cs" />
-      <Compile Include="Components/AbstBlazorGfxCanvas.cs" />
-      <Compile Include="Components/AbstInputComponent.cs" />
-        <Compile Include="Components/AbstBlazorTabContainer.cs" />
-        <Compile Include="Components/AbstBlazorTabItem.cs" />
-        <Compile Include="Components/AbstBlazorMenu.cs" />
-        <Compile Include="Components/AbstBlazorMenuItem.cs" />
-        <Compile Include="Inputs/BlazorMouse.cs" />
-        <Compile Include="Inputs/BlazorKey.cs" />
-        <Compile Include="AbstUIBlazorSetup.cs" />
-        <Compile Include="AbstUIScriptResolver.cs" />
-        <Compile Include="Bitmaps/AbstBlazorTexture2D.cs" />
-        <Compile Include="Bitmaps/BlazorImageTexture.cs" />
-        <Compile Include="Styles/AbstBlazorFontManager.cs" />
-        <Compile Include="Styles/AbstBlazorStyleManager.cs" />
-        <Compile Include="Primitives/AbstColorExtensions.cs" />
-      </ItemGroup>
+    <Compile Include="Components/AbstBlazorGfxCanvas.cs" />
+    <Compile Include="Components/AbstInputComponent.cs" />
+    <Compile Include="Components/AbstBlazorTabContainer.cs" />
+    <Compile Include="Components/AbstBlazorTabItem.cs" />
+    <Compile Include="Components/AbstBlazorMenu.cs" />
+    <Compile Include="Components/AbstBlazorMenuItem.cs" />
+    <Compile Include="Inputs/BlazorMouse.cs" />
+    <Compile Include="Inputs/BlazorKey.cs" />
+    <Compile Include="AbstUIBlazorSetup.cs" />
+    <Compile Include="AbstUIScriptResolver.cs" />
+    <Compile Include="Bitmaps/AbstBlazorTexture2D.cs" />
+    <Compile Include="Bitmaps/BlazorImageTexture.cs" />
+    <Compile Include="Styles/AbstBlazorFontManager.cs" />
+    <Compile Include="Styles/AbstBlazorStyleManager.cs" />
+    <Compile Include="Primitives/AbstColorExtensions.cs" />
+    <!-- Include generated Razor component code to ensure attributes like onclick are processed -->
+    <Compile Include="obj/**/*.razor.g.cs" />
+  </ItemGroup>
 
-  </Project>
+</Project>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorComponentBase.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorComponentBase.cs
@@ -39,15 +39,7 @@ public abstract class AbstBlazorComponentBase : ComponentBase, IAbstFrameworkLay
 
     public RenderFragment RenderFragment => builder =>
     {
-        builder.OpenComponent(0, GetType());
-        foreach (var prop in GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
-        {
-            if (prop.GetCustomAttribute<ParameterAttribute>() != null)
-            {
-                builder.AddAttribute(1, prop.Name, prop.GetValue(this));
-            }
-        }
-        builder.CloseComponent();
+        BuildRenderTree(builder);
     };
 
     protected virtual string BuildStyle()

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorLabel.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorLabel.razor
@@ -1,6 +1,15 @@
 @inherits AbstBlazorComponentBase
+@using AbstUI.Texts
 <span style="@StyleString">@Text</span>
 
 @code {
-    private string StyleString => BuildStyle() + $"color:{FontColor.ToHex()};font-size:{FontSize}px;";
+    private string StyleString => BuildStyle() +
+        $"color:{FontColor.ToHex()};font-size:{FontSize}px;text-align:{GetAlignment()};";
+
+    private string GetAlignment() => TextAlignment switch
+    {
+        AbstTextAlignment.Center => "center",
+        AbstTextAlignment.Right => "right",
+        _ => "left"
+    };
 }


### PR DESCRIPTION
## Summary
- Include generated Razor component sources so event handlers don't emit invalid `@onclick` attributes
- Support `TextAlignment` on Blazor labels

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorLabel.razor WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --verify-no-changes`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/AbstUI.GfxVisualTest.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a3167d7f1c83328a8df13fa7c668fe