### PR TITLE
Implement SDL2 component rendering

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstSDLComponentContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstSDLComponentContainer.cs
@@ -7,6 +7,12 @@ public class AbstSDLComponentContainer
 {
     private readonly List<AbstSDLComponentContext> _allComponents = new();
     private readonly HashSet<AbstSDLComponentContext> _activeComponents = new();
+    private readonly SdlFocusManager _focusManager;
+
+    public AbstSDLComponentContainer(SdlFocusManager focusManager)
+    {
+        _focusManager = focusManager;
+    }
 
     internal void Register(AbstSDLComponentContext context) => _allComponents.Add(context);
     internal void Unregister(AbstSDLComponentContext context)
@@ -28,6 +34,9 @@ public class AbstSDLComponentContainer
 
     public void HandleEvent(SDL.SDL_Event e)
     {
+        if (e.type == SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN)
+            _focusManager.SetFocus(null);
+
         var evt = new AbstSDLEvent(e);
         foreach (var ctx in _activeComponents)
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstSdlComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstSdlComponentFactory.cs
@@ -14,6 +14,7 @@ namespace AbstUI.SDL2
         private readonly SdlFontManager _fontManager;
 
         public ISdlRootComponentContext RootContext => _rootContext;
+        public SdlFocusManager FocusManager => _rootContext.FocusManager;
 
         public AbstSdlComponentFactory(ISdlRootComponentContext rootContext, SdlFontManager fontManager)
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUISDLSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUISDLSetup.cs
@@ -10,7 +10,7 @@ namespace AbstUI.SDL2
         {
             services
                 .AddSingleton<IAbstFontManager, SdlFontManager>()
-                        ;
+                .AddSingleton<SdlFocusManager>();
 
             return services;
         }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdInputltemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdInputltemList.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Collections.Generic;
-using System.Numerics;
+using System.Runtime.InteropServices;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.SDL2.SDLL;
+using AbstUI.SDL2.Texts;
+using AbstUI.SDL2.Styles;
 
 namespace AbstUI.SDL2.Components
 {
-    internal class AbstSdInputltemList : AbstSdlComponent, IAbstFrameworkItemList, IDisposable
+    internal class AbstSdInputltemList : AbstSdlComponent, IAbstFrameworkItemList, IHandleSdlEvent, ISdlFocusable, IDisposable
     {
         public AbstSdInputltemList(AbstSdlComponentFactory factory) : base(factory)
         {
@@ -33,12 +36,149 @@ namespace AbstUI.SDL2.Components
             SelectedKey = null;
             SelectedValue = null;
         }
-        public override void Dispose() => base.Dispose();
+        private bool _focused;
+        public bool HasFocus => _focused;
+        public void SetFocus(bool focus) => _focused = focus;
+
+        private ISdlFontLoadedByUser? _font;
+        private SdlGlyphAtlas? _atlas;
+        private nint _texture;
+        private int _texW;
+        private int _texH;
+        private int _lineHeight;
+
+        private void EnsureResources(AbstSDLRenderContext ctx)
+        {
+            _font ??= ctx.SdlFontManager.GetTyped(this, null, 12);
+            _atlas ??= new SdlGlyphAtlas(ctx.Renderer, _font.FontHandle);
+            if (_lineHeight == 0)
+            {
+                int ascent = SDL_ttf.TTF_FontAscent(_font.FontHandle);
+                int descent = SDL_ttf.TTF_FontDescent(_font.FontHandle);
+                _lineHeight = ascent - descent + 4;
+            }
+        }
 
         public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
         {
             if (!Visibility) return default;
-            return default;
+
+            EnsureResources(context);
+            int w = (int)Width;
+            int h = (int)Height;
+            bool needRender = _texture == nint.Zero || _texW != w || _texH != h;
+            if (needRender)
+            {
+                if (_texture != nint.Zero)
+                    SDL.SDL_DestroyTexture(_texture);
+                _texture = SDL.SDL_CreateTexture(context.Renderer, SDL.SDL_PIXELFORMAT_RGBA8888,
+                    (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, w, h);
+                SDL.SDL_SetTextureBlendMode(_texture, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
+            }
+
+            SDL.SDL_SetRenderTarget(context.Renderer, _texture);
+            SDL.SDL_SetRenderDrawColor(context.Renderer, 255, 255, 255, 255);
+            SDL.SDL_RenderClear(context.Renderer);
+
+            int y = 0;
+            for (int i = 0; i < _items.Count && y < h; i++)
+            {
+                SDL.SDL_Rect rect = new SDL.SDL_Rect { x = 0, y = y, w = w, h = _lineHeight };
+                if (i == SelectedIndex)
+                {
+                    SDL.SDL_SetRenderDrawColor(context.Renderer, 0, 120, 215, 255);
+                    SDL.SDL_RenderFillRect(context.Renderer, ref rect);
+                    SDL.SDL_Color txt = new SDL.SDL_Color { r = 255, g = 255, b = 255, a = 255 };
+                    DrawItemText(_items[i].Value, 4, y, txt, context);
+                }
+                else
+                {
+                    SDL.SDL_SetRenderDrawColor(context.Renderer, 255, 255, 255, 255);
+                    SDL.SDL_RenderFillRect(context.Renderer, ref rect);
+                    SDL.SDL_SetRenderDrawColor(context.Renderer, 0, 0, 0, 255);
+                    SDL.SDL_RenderDrawRect(context.Renderer, ref rect);
+                    SDL.SDL_Color txt = new SDL.SDL_Color { r = 0, g = 0, b = 0, a = 255 };
+                    DrawItemText(_items[i].Value, 4, y, txt, context);
+                }
+                y += _lineHeight;
+            }
+
+            SDL.SDL_SetRenderTarget(context.Renderer, nint.Zero);
+            _texW = w;
+            _texH = h;
+            return _texture;
+        }
+
+        private void DrawItemText(string text, int x, int y, SDL.SDL_Color color, AbstSDLRenderContext ctx)
+        {
+            List<int> cps = new();
+            foreach (var r in text.EnumerateRunes()) cps.Add(r.Value);
+            var span = CollectionsMarshal.AsSpan(cps);
+            int baseline = y + _lineHeight - 4 - SDL_ttf.TTF_FontDescent(_font!.FontHandle);
+            _atlas!.DrawRun(span, x, baseline, color);
+        }
+
+        public void HandleEvent(AbstSDLEvent e)
+        {
+            if (!Enabled) return;
+            ref var ev = ref e.Event;
+            if (ev.type == SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN && ev.button.button == SDL.SDL_BUTTON_LEFT)
+            {
+                if (ev.button.x >= X && ev.button.x <= X + Width &&
+                    ev.button.y >= Y && ev.button.y <= Y + Height)
+                {
+                    Factory.FocusManager.SetFocus(this);
+                    int idx = (int)((ev.button.y - Y) / _lineHeight);
+                    if (idx >= 0 && idx < _items.Count)
+                    {
+                        SelectedIndex = idx;
+                        SelectedKey = _items[idx].Key;
+                        SelectedValue = _items[idx].Value;
+                        ValueChanged?.Invoke();
+                        ComponentContext.QueueRedraw(this);
+                        e.StopPropagation = true;
+                    }
+                }
+            }
+            else if (ev.type == SDL.SDL_EventType.SDL_KEYDOWN && _focused)
+            {
+                if (ev.key.keysym.sym == SDL.SDL_Keycode.SDLK_UP)
+                {
+                    if (SelectedIndex > 0)
+                    {
+                        SelectedIndex--;
+                        SelectedKey = _items[SelectedIndex].Key;
+                        SelectedValue = _items[SelectedIndex].Value;
+                        ValueChanged?.Invoke();
+                        ComponentContext.QueueRedraw(this);
+                    }
+                    e.StopPropagation = true;
+                }
+                else if (ev.key.keysym.sym == SDL.SDL_Keycode.SDLK_DOWN)
+                {
+                    if (SelectedIndex < _items.Count - 1)
+                    {
+                        SelectedIndex++;
+                        SelectedKey = _items[SelectedIndex].Key;
+                        SelectedValue = _items[SelectedIndex].Value;
+                        ValueChanged?.Invoke();
+                        ComponentContext.QueueRedraw(this);
+                    }
+                    e.StopPropagation = true;
+                }
+            }
+        }
+
+        public override void Dispose()
+        {
+            if (_texture != nint.Zero)
+            {
+                SDL.SDL_DestroyTexture(_texture);
+                _texture = nint.Zero;
+            }
+            _font?.Release();
+            _atlas?.Dispose();
+            base.Dispose();
         }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlButton.cs
@@ -1,11 +1,16 @@
 using System;
-using System.Numerics;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.SDL2;
+using AbstUI.SDL2.SDLL;
+using AbstUI.SDL2.Texts;
+using AbstUI.SDL2.Styles;
 
 namespace AbstUI.SDL2.Components
 {
-    internal class AbstSdlButton : AbstSdlComponent, IAbstFrameworkButton, IDisposable
+    internal class AbstSdlButton : AbstSdlComponent, IAbstFrameworkButton, IHandleSdlEvent, ISdlFocusable, IDisposable
     {
         public AbstSdlButton(AbstSdlComponentFactory factory) : base(factory)
         {
@@ -19,13 +24,109 @@ namespace AbstUI.SDL2.Components
 
         public event Action? Pressed;
 
+        private ISdlFontLoadedByUser? _font;
+        private SdlGlyphAtlas? _atlas;
+        private nint _texture;
+        private string _renderedText = string.Empty;
+        private int _texW;
+        private int _texH;
+        private bool _pressed;
+        private bool _focused;
+
+        private void EnsureResources(AbstSDLRenderContext ctx)
+        {
+            _font ??= ctx.SdlFontManager.GetTyped(this, null, 12);
+            _atlas ??= new SdlGlyphAtlas(ctx.Renderer, _font.FontHandle);
+        }
+
         public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
         {
             if (!Visibility) return default;
-            return default;
+
+            EnsureResources(context);
+            int w = (int)Width;
+            int h = (int)Height;
+            if (_texture == nint.Zero || _texW != w || _texH != h || _renderedText != Text)
+            {
+                if (_texture != nint.Zero)
+                    SDL.SDL_DestroyTexture(_texture);
+                _texture = SDL.SDL_CreateTexture(context.Renderer, SDL.SDL_PIXELFORMAT_RGBA8888,
+                    (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, w, h);
+                SDL.SDL_SetTextureBlendMode(_texture, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
+
+                SDL.SDL_SetRenderTarget(context.Renderer, _texture);
+
+                SDL.SDL_SetRenderDrawColor(context.Renderer, 200, 200, 200, 255);
+                SDL.SDL_RenderClear(context.Renderer);
+                SDL.SDL_SetRenderDrawColor(context.Renderer, 0, 0, 0, 255);
+                SDL.SDL_Rect rect = new SDL.SDL_Rect { x = 0, y = 0, w = w, h = h };
+                SDL.SDL_RenderDrawRect(context.Renderer, ref rect);
+
+                if (!string.IsNullOrEmpty(Text))
+                {
+                    List<int> cps = new();
+                    foreach (var r in Text.EnumerateRunes()) cps.Add(r.Value);
+                    var span = CollectionsMarshal.AsSpan(cps);
+                    int ascent = SDL_ttf.TTF_FontAscent(_font!.FontHandle);
+                    int descent = SDL_ttf.TTF_FontDescent(_font.FontHandle);
+                    int tw = _atlas!.MeasureWidth(span);
+                    int th = ascent - descent;
+                    int baseline = (h - th) / 2 + ascent;
+                    int tx = (w - tw) / 2;
+                    _atlas.DrawRun(span, tx, baseline, new SDL.SDL_Color { r = 0, g = 0, b = 0, a = 255 });
+                }
+
+                SDL.SDL_SetRenderTarget(context.Renderer, nint.Zero);
+                _renderedText = Text;
+                _texW = w;
+                _texH = h;
+            }
+
+            return _texture;
         }
 
+        public void HandleEvent(AbstSDLEvent e)
+        {
+            if (!Enabled) return;
+            ref var ev = ref e.Event;
+            switch (ev.type)
+            {
+                case SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN:
+                    if (ev.button.button == SDL.SDL_BUTTON_LEFT && HitTest(ev.button.x, ev.button.y))
+                    {
+                        Factory.FocusManager.SetFocus(this);
+                        _pressed = true;
+                        e.StopPropagation = true;
+                    }
+                    break;
+                case SDL.SDL_EventType.SDL_MOUSEBUTTONUP:
+                    if (_pressed && ev.button.button == SDL.SDL_BUTTON_LEFT)
+                    {
+                        if (HitTest(ev.button.x, ev.button.y))
+                            Pressed?.Invoke();
+                        _pressed = false;
+                        e.StopPropagation = true;
+                    }
+                    break;
+            }
+        }
+
+        private bool HitTest(int mx, int my)
+            => mx >= X && mx <= X + Width && my >= Y && my <= Y + Height;
+
+        public bool HasFocus => _focused;
+
+        public void SetFocus(bool focus) => _focused = focus;
+
         public void Invoke() => Pressed?.Invoke();
-        public override void Dispose() => base.Dispose();
+
+        public override void Dispose()
+        {
+            if (_texture != nint.Zero)
+                SDL.SDL_DestroyTexture(_texture);
+            _font?.Release();
+            _atlas?.Dispose();
+            base.Dispose();
+        }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlColorPicker.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlColorPicker.cs
@@ -2,10 +2,11 @@ using System;
 using System.Numerics;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.SDL2;
 
 namespace AbstUI.SDL2.Components
 {
-    internal class AbstSdlColorPicker : AbstSdlComponent, IAbstFrameworkColorPicker, IDisposable
+    internal class AbstSdlColorPicker : AbstSdlComponent, IAbstFrameworkColorPicker, ISdlFocusable, IDisposable
     {
         public AbstSdlColorPicker(AbstSdlComponentFactory factory) : base(factory)
         {
@@ -14,6 +15,7 @@ namespace AbstUI.SDL2.Components
         public AMargin Margin { get; set; } = AMargin.Zero;
 
         private AColor _color;
+        private bool _focused;
         public AColor Color
         {
             get => _color;
@@ -29,6 +31,9 @@ namespace AbstUI.SDL2.Components
 
         public event Action? ValueChanged;
         public object FrameworkNode => this;
+
+        public bool HasFocus => _focused;
+        public void SetFocus(bool focus) => _focused = focus;
 
         public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlComponent.cs
@@ -10,9 +10,12 @@ public abstract class AbstSdlComponent : IAbstSDLComponent, IDisposable
 {
     protected AbstSdlComponent(AbstSdlComponentFactory factory)
     {
+        Factory = factory;
         ComponentContext = factory.CreateContext(this);
         ComponentContext.Visible = _visibility;
     }
+
+    protected AbstSdlComponentFactory Factory { get; }
 
     public AbstSDLComponentContext ComponentContext { get; }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputCheckbox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputCheckbox.cs
@@ -2,16 +2,19 @@ using System;
 using System.Numerics;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.SDL2;
+using AbstUI.SDL2.SDLL;
 
 namespace AbstUI.SDL2.Components
 {
-    internal class AbstSdlInputCheckbox : AbstSdlComponent, IAbstFrameworkInputCheckbox, IDisposable
+    internal class AbstSdlInputCheckbox : AbstSdlComponent, IAbstFrameworkInputCheckbox, IHandleSdlEvent, ISdlFocusable, IDisposable
     {
         public AbstSdlInputCheckbox(AbstSdlComponentFactory factory) : base(factory)
         {
         }
         public bool Enabled { get; set; } = true;
         private bool _checked;
+        private bool _focused;
         public bool Checked
         {
             get => _checked;
@@ -27,6 +30,24 @@ namespace AbstUI.SDL2.Components
         public AMargin Margin { get; set; } = AMargin.Zero;
         public event Action? ValueChanged;
         public object FrameworkNode => this;
+
+        public void HandleEvent(AbstSDLEvent e)
+        {
+            if (!Enabled) return;
+            ref var ev = ref e.Event;
+            if (ev.type == SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN && ev.button.button == SDL.SDL_BUTTON_LEFT &&
+                HitTest(ev.button.x, ev.button.y))
+            {
+                Factory.FocusManager.SetFocus(this);
+                Checked = !Checked;
+                e.StopPropagation = true;
+            }
+        }
+
+        private bool HitTest(int x, int y) => x >= X && x <= X + Width && y >= Y && y <= Y + Height;
+
+        public bool HasFocus => _focused;
+        public void SetFocus(bool focus) => _focused = focus;
 
         public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputCombobox.cs
@@ -3,16 +3,19 @@ using System.Collections.Generic;
 using System.Numerics;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.SDL2;
+using AbstUI.SDL2.SDLL;
 
 namespace AbstUI.SDL2.Components
 {
-    internal class AbstSdlInputCombobox : AbstSdlComponent, IAbstFrameworkInputCombobox, IDisposable
+    internal class AbstSdlInputCombobox : AbstSdlComponent, IAbstFrameworkInputCombobox, IHandleSdlEvent, ISdlFocusable, IDisposable
     {
         public AbstSdlInputCombobox(AbstSdlComponentFactory factory) : base(factory)
         {
         }
         public bool Enabled { get; set; } = true;
         public AMargin Margin { get; set; } = AMargin.Zero;
+        private bool _focused;
 
         private readonly List<KeyValuePair<string, string>> _items = new();
         public IReadOnlyList<KeyValuePair<string, string>> Items => _items;
@@ -34,6 +37,23 @@ namespace AbstUI.SDL2.Components
             SelectedKey = null;
             SelectedValue = null;
         }
+
+        public void HandleEvent(AbstSDLEvent e)
+        {
+            if (!Enabled) return;
+            ref var ev = ref e.Event;
+            if (ev.type == SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN && ev.button.button == SDL.SDL_BUTTON_LEFT &&
+                HitTest(ev.button.x, ev.button.y))
+            {
+                Factory.FocusManager.SetFocus(this);
+                e.StopPropagation = true;
+            }
+        }
+
+        private bool HitTest(int x, int y) => x >= X && x <= X + Width && y >= Y && y <= Y + Height;
+
+        public bool HasFocus => _focused;
+        public void SetFocus(bool focus) => _focused = focus;
 
         public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputNumber.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputNumber.cs
@@ -7,7 +7,7 @@ using AbstUI.SDL2.SDLL;
 
 namespace AbstUI.SDL2.Components;
 
-internal class AbstSdlInputNumber<TValue> : AbstSdlComponent, IAbstFrameworkInputNumber<TValue>, IHandleSdlEvent, IDisposable
+internal class AbstSdlInputNumber<TValue> : AbstSdlComponent, IAbstFrameworkInputNumber<TValue>, IHandleSdlEvent, ISdlFocusable, IDisposable
 #if NET48
     where TValue : struct
 #else
@@ -132,5 +132,9 @@ internal class AbstSdlInputNumber<TValue> : AbstSdlComponent, IAbstFrameworkInpu
         base.Dispose();
         _textInput.Dispose();
     }
+
+    public bool HasFocus => _textInput.HasFocus;
+
+    public void SetFocus(bool focus) => _textInput.SetFocus(focus);
 }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputSlider.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputSlider.cs
@@ -2,10 +2,12 @@ using System;
 using System.Numerics;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.SDL2;
+using AbstUI.SDL2.SDLL;
 
 namespace AbstUI.SDL2.Components
 {
-    internal class AbstSdlInputSlider<TValue> : AbstSdlComponent, IAbstFrameworkInputSlider<TValue>, IDisposable where TValue : struct
+    internal class AbstSdlInputSlider<TValue> : AbstSdlComponent, IAbstFrameworkInputSlider<TValue>, IHandleSdlEvent, ISdlFocusable, IDisposable where TValue : struct
     {
         public AbstSdlInputSlider(AbstSdlComponentFactory factory) : base(factory)
         {
@@ -13,6 +15,7 @@ namespace AbstUI.SDL2.Components
         public AMargin Margin { get; set; } = AMargin.Zero;
         public bool Enabled { get; set; } = true;
         private TValue _value = default!;
+        private bool _focused;
         public TValue Value
         {
             get => _value;
@@ -30,6 +33,23 @@ namespace AbstUI.SDL2.Components
         public TValue Step { get; set; } = default!;
         public event Action? ValueChanged;
         public object FrameworkNode => this;
+
+        public void HandleEvent(AbstSDLEvent e)
+        {
+            if (!Enabled) return;
+            ref var ev = ref e.Event;
+            if (ev.type == SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN && ev.button.button == SDL.SDL_BUTTON_LEFT &&
+                HitTest(ev.button.x, ev.button.y))
+            {
+                Factory.FocusManager.SetFocus(this);
+                e.StopPropagation = true;
+            }
+        }
+
+        private bool HitTest(int x, int y) => x >= X && x <= X + Width && y >= Y && y <= Y + Height;
+
+        public bool HasFocus => _focused;
+        public void SetFocus(bool focus) => _focused = focus;
 
         public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputText.cs
@@ -11,7 +11,7 @@ using AbstUI.SDL2.Styles;
 
 namespace AbstUI.SDL2.Components
 {
-    internal class AbstSdlInputText : AbstSdlComponent, IAbstFrameworkInputText, IHandleSdlEvent, IDisposable
+    internal class AbstSdlInputText : AbstSdlComponent, IAbstFrameworkInputText, IHandleSdlEvent, ISdlFocusable, IDisposable
     {
         private readonly bool _multiLine;
         private readonly List<int> _codepoints = new();
@@ -49,6 +49,12 @@ namespace AbstUI.SDL2.Components
         public bool IsMultiLine { get; set; }
 
         public bool HasFocus => _focused;
+        public void SetFocus(bool focus)
+        {
+            _focused = focus;
+            if (focus)
+                _blinkStart = SDL.SDL_GetTicks();
+        }
 
         public event Action? ValueChanged;
 
@@ -69,7 +75,7 @@ namespace AbstUI.SDL2.Components
             switch (ev.type)
             {
                 case SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN:
-                    _focused = true;
+                    Factory.FocusManager.SetFocus(this);
                     _caret = _codepoints.Count;
                     e.StopPropagation = true;
                     break;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlScrollContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlScrollContainer.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Numerics;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.SDL2.SDLL;
 
 namespace AbstUI.SDL2.Components
 {
-    internal class AbstSdlScrollContainer : AbstSdlComponent, IAbstFrameworkScrollContainer, IDisposable
+    internal class AbstSdlScrollContainer : AbstSdlComponent, IAbstFrameworkScrollContainer, IHandleSdlEvent, IDisposable
     {
         public AbstSdlScrollContainer(AbstSdlComponentFactory factory) : base(factory)
         {
@@ -32,17 +32,147 @@ namespace AbstUI.SDL2.Components
 
         public IEnumerable<IAbstFrameworkLayoutNode> GetItems() => _children.ToArray();
 
+        private nint _texture;
+        private int _texW;
+        private int _texH;
+        private float _lastScrollH;
+        private float _lastScrollV;
+        private bool _dragV;
+        private bool _dragH;
+        private int _dragStartX;
+        private int _dragStartY;
+        private float _scrollStartH;
+        private float _scrollStartV;
+
         public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
         {
             if (!Visibility) return default;
-            return default;
+
+            int w = (int)Width;
+            int h = (int)Height;
+            const int sbSize = 16;
+
+            bool needRender = _texture == nint.Zero || _texW != w || _texH != h ||
+                               _lastScrollH != ScrollHorizontal || _lastScrollV != ScrollVertical;
+            if (needRender)
+            {
+                if (_texture != nint.Zero)
+                    SDL.SDL_DestroyTexture(_texture);
+                _texture = SDL.SDL_CreateTexture(context.Renderer, SDL.SDL_PIXELFORMAT_RGBA8888,
+                    (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, w, h);
+                SDL.SDL_SetTextureBlendMode(_texture, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
+
+                SDL.SDL_SetRenderTarget(context.Renderer, _texture);
+                SDL.SDL_SetRenderDrawColor(context.Renderer, 255, 255, 255, 255);
+                SDL.SDL_RenderClear(context.Renderer);
+
+                if (ClipContents)
+                {
+                    SDL.SDL_Rect clip = new SDL.SDL_Rect { x = 0, y = 0, w = w - sbSize, h = h - sbSize };
+                    SDL.SDL_RenderSetClipRect(context.Renderer, ref clip);
+                }
+
+                foreach (var child in _children)
+                {
+                    if (child.FrameworkNode is AbstSdlComponent comp)
+                    {
+                        var ctx = comp.ComponentContext;
+                        var oldOffX = ctx.OffsetX;
+                        var oldOffY = ctx.OffsetY;
+                        ctx.OffsetX += -X - ScrollHorizontal;
+                        ctx.OffsetY += -Y - ScrollVertical;
+                        ctx.RenderToTexture(context);
+                        ctx.OffsetX = oldOffX;
+                        ctx.OffsetY = oldOffY;
+                    }
+                }
+
+                if (ClipContents)
+                    SDL.SDL_RenderSetClipRect(context.Renderer, nint.Zero);
+
+                SDL.SDL_SetRenderDrawColor(context.Renderer, 200, 200, 200, 255);
+                SDL.SDL_Rect vbar = new SDL.SDL_Rect { x = w - sbSize, y = 0, w = sbSize, h = h - sbSize };
+                SDL.SDL_RenderFillRect(context.Renderer, ref vbar);
+                SDL.SDL_Rect hbar = new SDL.SDL_Rect { x = 0, y = h - sbSize, w = w - sbSize, h = sbSize };
+                SDL.SDL_RenderFillRect(context.Renderer, ref hbar);
+                SDL.SDL_Rect corner = new SDL.SDL_Rect { x = w - sbSize, y = h - sbSize, w = sbSize, h = sbSize };
+                SDL.SDL_RenderFillRect(context.Renderer, ref corner);
+
+                SDL.SDL_SetRenderDrawColor(context.Renderer, 160, 160, 160, 255);
+                SDL.SDL_RenderDrawRect(context.Renderer, ref vbar);
+                SDL.SDL_RenderDrawRect(context.Renderer, ref hbar);
+                SDL.SDL_RenderDrawRect(context.Renderer, ref corner);
+
+                SDL.SDL_SetRenderTarget(context.Renderer, nint.Zero);
+
+                _texW = w;
+                _texH = h;
+                _lastScrollH = ScrollHorizontal;
+                _lastScrollV = ScrollVertical;
+            }
+
+            return _texture;
         }
 
-
+        public void HandleEvent(AbstSDLEvent e)
+        {
+            ref var ev = ref e.Event;
+            const int sbSize = 16;
+            if (ev.type == SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN && ev.button.button == SDL.SDL_BUTTON_LEFT)
+            {
+                int lx = ev.button.x - (int)X;
+                int ly = ev.button.y - (int)Y;
+                if (lx >= Width - sbSize && ly < Height - sbSize)
+                {
+                    _dragV = true;
+                    _dragStartY = ev.button.y;
+                    _scrollStartV = ScrollVertical;
+                    e.StopPropagation = true;
+                }
+                else if (ly >= Height - sbSize && lx < Width - sbSize)
+                {
+                    _dragH = true;
+                    _dragStartX = ev.button.x;
+                    _scrollStartH = ScrollHorizontal;
+                    e.StopPropagation = true;
+                }
+            }
+            else if (ev.type == SDL.SDL_EventType.SDL_MOUSEBUTTONUP && ev.button.button == SDL.SDL_BUTTON_LEFT)
+            {
+                _dragV = _dragH = false;
+            }
+            else if (ev.type == SDL.SDL_EventType.SDL_MOUSEMOTION)
+            {
+                if (_dragV)
+                {
+                    ScrollVertical = _scrollStartV + (ev.motion.y - _dragStartY);
+                    ComponentContext.QueueRedraw(this);
+                    e.StopPropagation = true;
+                }
+                else if (_dragH)
+                {
+                    ScrollHorizontal = _scrollStartH + (ev.motion.x - _dragStartX);
+                    ComponentContext.QueueRedraw(this);
+                    e.StopPropagation = true;
+                }
+            }
+            else if (ev.type == SDL.SDL_EventType.SDL_MOUSEWHEEL)
+            {
+                ScrollVertical -= ev.wheel.y * 20;
+                ScrollHorizontal -= ev.wheel.x * 20;
+                ComponentContext.QueueRedraw(this);
+                e.StopPropagation = true;
+            }
+        }
 
         public override void Dispose()
         {
             _children.Clear();
+            if (_texture != nint.Zero)
+            {
+                SDL.SDL_DestroyTexture(_texture);
+                _texture = nint.Zero;
+            }
             base.Dispose();
         }
     }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlSpinBox.cs
@@ -6,7 +6,7 @@ using AbstUI.SDL2.SDLL;
 
 namespace AbstUI.SDL2.Components;
 
-internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IHandleSdlEvent, IDisposable
+internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IHandleSdlEvent, ISdlFocusable, IDisposable
 {
     private readonly AbstSdlInputNumber<float> _number;
     private const int ButtonWidth = 16;
@@ -128,5 +128,9 @@ internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IHandle
         base.Dispose();
         _number.Dispose();
     }
+
+    public bool HasFocus => _number.HasFocus;
+
+    public void SetFocus(bool focus) => _number.SetFocus(focus);
 }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlStateButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlStateButton.cs
@@ -1,17 +1,19 @@
 using System.Numerics;
 using AbstUI.Primitives;
 using AbstUI.Components;
+using AbstUI.SDL2;
 using AbstUI.SDL2.Bitmaps;
 using AbstUI.SDL2.SDLL;
 
 namespace AbstUI.SDL2.Components
 {
-    internal class AbstSdlStateButton : AbstSdlComponent, IAbstFrameworkStateButton, IDisposable
+    internal class AbstSdlStateButton : AbstSdlComponent, IAbstFrameworkStateButton, ISdlFocusable, IDisposable
     {
         private nint _textureOnPtr;
         private IAbstTexture2D? _textureOn;
         private nint _textureOffPtr;
         private IAbstTexture2D? _textureOff;
+        private bool _focused;
 
         public AbstSdlStateButton(AbstSdlComponentFactory factory) : base(factory)
         {
@@ -91,5 +93,9 @@ namespace AbstUI.SDL2.Components
             }
             base.Dispose();
         }
+
+        public bool HasFocus => _focused;
+
+        public void SetFocus(bool focus) => _focused = focus;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlTabContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlTabContainer.cs
@@ -1,15 +1,20 @@
 using System;
 using System.Collections.Generic;
-using System.Numerics;
+using System.Runtime.InteropServices;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.SDL2;
+using AbstUI.SDL2.SDLL;
+using AbstUI.SDL2.Texts;
+using AbstUI.SDL2.Styles;
 
 namespace AbstUI.SDL2.Components
 {
-    public class AbstSdlTabContainer : AbstSdlComponent, IAbstFrameworkTabContainer, IDisposable
+    public class AbstSdlTabContainer : AbstSdlComponent, IAbstFrameworkTabContainer, IHandleSdlEvent, ISdlFocusable, IDisposable
     {
         private readonly List<IAbstFrameworkTabItem> _children = new();
         private int _selectedIndex = -1;
+        private bool _focused;
 
         public AMargin Margin { get; set; } = AMargin.Zero;
         public object FrameworkNode => this;
@@ -54,15 +59,126 @@ namespace AbstUI.SDL2.Components
                 _selectedIndex = idx;
         }
 
+        private ISdlFontLoadedByUser? _font;
+        private SdlGlyphAtlas? _atlas;
+        private nint _texture;
+        private int _texW;
+        private int _texH;
+        private readonly List<SDL.SDL_Rect> _tabRects = new();
+
+        private void EnsureResources(AbstSDLRenderContext ctx)
+        {
+            _font ??= ctx.SdlFontManager.GetTyped(this, null, 12);
+            _atlas ??= new SdlGlyphAtlas(ctx.Renderer, _font.FontHandle);
+        }
+
         public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
         {
             if (!Visibility) return default;
-            return default;
+
+            EnsureResources(context);
+            int w = (int)Width;
+            int h = (int)Height;
+            int tabHeight = 20;
+
+            bool needRender = _texture == nint.Zero || _texW != w || _texH != h;
+            if (needRender)
+            {
+                if (_texture != nint.Zero)
+                    SDL.SDL_DestroyTexture(_texture);
+                _texture = SDL.SDL_CreateTexture(context.Renderer, SDL.SDL_PIXELFORMAT_RGBA8888,
+                    (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, w, h);
+                SDL.SDL_SetTextureBlendMode(_texture, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
+            }
+
+            SDL.SDL_SetRenderTarget(context.Renderer, _texture);
+            SDL.SDL_SetRenderDrawColor(context.Renderer, 255, 255, 255, 255);
+            SDL.SDL_RenderClear(context.Renderer);
+
+            _tabRects.Clear();
+            int x = 0;
+            for (int i = 0; i < _children.Count; i++)
+            {
+                var tab = _children[i];
+                List<int> cps = new();
+                foreach (var r in tab.Title.EnumerateRunes()) cps.Add(r.Value);
+                var span = CollectionsMarshal.AsSpan(cps);
+                int ascent = SDL_ttf.TTF_FontAscent(_font!.FontHandle);
+                int descent = SDL_ttf.TTF_FontDescent(_font.FontHandle);
+                int tw = _atlas!.MeasureWidth(span) + 10;
+                int th = ascent - descent + 4;
+                int tabW = Math.Max(tw, 60);
+                SDL.SDL_Rect rect = new SDL.SDL_Rect { x = x, y = 0, w = tabW, h = tabHeight };
+                _tabRects.Add(rect);
+                if (i == _selectedIndex)
+                    SDL.SDL_SetRenderDrawColor(context.Renderer, 220, 220, 220, 255);
+                else
+                    SDL.SDL_SetRenderDrawColor(context.Renderer, 180, 180, 180, 255);
+                SDL.SDL_RenderFillRect(context.Renderer, ref rect);
+                SDL.SDL_SetRenderDrawColor(context.Renderer, 0, 0, 0, 255);
+                SDL.SDL_RenderDrawRect(context.Renderer, ref rect);
+                int baseline = rect.y + (tabHeight - th) / 2 + ascent;
+                int tx = rect.x + (tabW - (tw - 10)) / 2;
+                _atlas.DrawRun(span, tx, baseline, new SDL.SDL_Color { r = 0, g = 0, b = 0, a = 255 });
+                x += tabW;
+            }
+
+            if (_selectedIndex >= 0 && _selectedIndex < _children.Count)
+            {
+                var tab = _children[_selectedIndex];
+                if (tab.Content?.FrameworkObj.FrameworkNode is AbstSdlComponent comp)
+                {
+                    var ctx = comp.ComponentContext;
+                    var oldOffX = ctx.OffsetX;
+                    var oldOffY = ctx.OffsetY;
+                    ctx.OffsetX += -X;
+                    ctx.OffsetY += -Y - tabHeight;
+                    ctx.RenderToTexture(context);
+                    ctx.OffsetX = oldOffX;
+                    ctx.OffsetY = oldOffY;
+                }
+            }
+
+            SDL.SDL_SetRenderTarget(context.Renderer, nint.Zero);
+            _texW = w;
+            _texH = h;
+            return _texture;
         }
+
+        public void HandleEvent(AbstSDLEvent e)
+        {
+            ref var ev = ref e.Event;
+            if (ev.type == SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN && ev.button.button == SDL.SDL_BUTTON_LEFT)
+            {
+                for (int i = 0; i < _tabRects.Count; i++)
+                {
+                    var r = _tabRects[i];
+                    if (ev.button.x >= r.x && ev.button.x <= r.x + r.w &&
+                        ev.button.y >= r.y && ev.button.y <= r.y + r.h)
+                    {
+                        _selectedIndex = i;
+                        Factory.FocusManager.SetFocus(this);
+                        e.StopPropagation = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        public bool HasFocus => _focused;
+
+        public void SetFocus(bool focus) => _focused = focus;
 
         public override void Dispose()
         {
             ClearTabs();
+            if (_texture != nint.Zero)
+            {
+                SDL.SDL_DestroyTexture(_texture);
+                _texture = nint.Zero;
+            }
+            _font?.Release();
+            _atlas?.Dispose();
             base.Dispose();
         }
     }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/ISdlFocusable.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/ISdlFocusable.cs
@@ -1,0 +1,7 @@
+namespace AbstUI.SDL2;
+
+public interface ISdlFocusable
+{
+    bool HasFocus { get; }
+    void SetFocus(bool focus);
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/ISdlRootComponentContext.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/ISdlRootComponentContext.cs
@@ -9,6 +9,7 @@ public interface ISdlRootComponentContext
     nint Renderer { get; }
     IAbstMouse AbstMouse { get; }
     IAbstKey AbstKey { get; }
+    SdlFocusManager FocusManager { get; }
 
     APoint GetWindowSize();
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/SdlFocusManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/SdlFocusManager.cs
@@ -1,0 +1,29 @@
+namespace AbstUI.SDL2;
+
+/// <summary>
+/// Manages which SDL component currently owns keyboard focus.
+/// Instances are registered through dependency injection and shared
+/// via the root context.
+/// </summary>
+public class SdlFocusManager
+{
+    private ISdlFocusable? _focused;
+
+    /// <summary>
+    /// Assigns focus to the given component, notifying the previous
+    /// and new targets accordingly.
+    /// </summary>
+    public void SetFocus(ISdlFocusable? component)
+    {
+        if (_focused == component)
+            return;
+        _focused?.SetFocus(false);
+        _focused = component;
+        _focused?.SetFocus(true);
+    }
+
+    /// <summary>
+    /// Gets the currently focused component.
+    /// </summary>
+    public ISdlFocusable? Focused => _focused;
+}

--- a/src/LingoEngine.SDL2/AbstUISdlRootContext.cs
+++ b/src/LingoEngine.SDL2/AbstUISdlRootContext.cs
@@ -10,7 +10,7 @@ using AbstUI.SDL2;
 public abstract class AbstUISdlRootContext<TMouse> : IDisposable
      where TMouse : IAbstMouse
 {
-    
+
     public nint Window { get; }
     public nint Renderer { get; }
 
@@ -19,20 +19,20 @@ public abstract class AbstUISdlRootContext<TMouse> : IDisposable
 
     public IAbstKey AbstKey { get; protected set; }
     public IAbstMouse AbstMouse { get; set; }
-   
-    
 
-    public AbstSDLComponentContainer ComponentContainer { get; } = new();
+    public SdlFocusManager FocusManager { get; }
+    public AbstSDLComponentContainer ComponentContainer { get; }
     internal LingoSdlFactory Factory { get; set; } = null!;
 
-  
-    public AbstUISdlRootContext(nint window, nint renderer)
+    public AbstUISdlRootContext(nint window, nint renderer, SdlFocusManager focusManager)
     {
         Window = window;
         Renderer = renderer;
+        FocusManager = focusManager;
+        ComponentContainer = new AbstSDLComponentContainer(focusManager);
     }
-   
-   
+
+
 
 
 

--- a/src/LingoEngine.SDL2/SdlRootContext.cs
+++ b/src/LingoEngine.SDL2/SdlRootContext.cs
@@ -17,7 +17,7 @@ public class SdlRootContext : AbstUISdlRootContext<LingoMouse>, ISdlRootComponen
     private LingoPlayer _lPlayer;
     public LingoDebugOverlay DebugOverlay { get; set; }
 
-    public SdlRootContext(nint window, nint renderer) : base(window, renderer)
+    public SdlRootContext(nint window, nint renderer, SdlFocusManager focusManager) : base(window, renderer, focusManager)
     {
         _sdlMouse = new LingoSdlMouse(new Lazy<AbstMouse<LingoMouseEvent>>(() => (LingoMouse)AbstMouse));
         Mouse = _sdlMouse;

--- a/src/LingoEngine.SDL2/SdlSetup.cs
+++ b/src/LingoEngine.SDL2/SdlSetup.cs
@@ -49,18 +49,17 @@ public static class SdlSetup
     public static ILingoEngineRegistration WithLingoSdlEngine(this ILingoEngineRegistration reg, nint sdlWindow, nint sdlRenderer, Action<LingoSdlFactory>? setup = null)
     {
         LingoEngineGlobal.RunFramework = AbstEngineRunFramework.SDL2;
-        var rootContext = new SdlRootContext(sdlWindow, sdlRenderer);
-        RegisterServices(reg, setup, rootContext);
+        RegisterServices(reg, setup, sdlWindow, sdlRenderer);
         return reg;
     }
 
-    private static void RegisterServices(ILingoEngineRegistration reg, Action<LingoSdlFactory>? setup, SdlRootContext rootContext)
+    private static void RegisterServices(ILingoEngineRegistration reg, Action<LingoSdlFactory>? setup, nint sdlWindow, nint sdlRenderer)
     {
         reg
             .ServicesMain(s => s
-                    .AddSingleton<ILingoFrameworkFactory, LingoSdlFactory>()
                     .WithAbstUISdl()
-                    .AddSingleton(rootContext)
+                    .AddSingleton(provider => new SdlRootContext(sdlWindow, sdlRenderer, provider.GetRequiredService<SdlFocusManager>()))
+                    .AddSingleton<ILingoFrameworkFactory, LingoSdlFactory>()
                 ).WithFrameworkFactory(setup);
     }
 }


### PR DESCRIPTION
## Summary
- inject focus manager through dependency injection and expose it via the SDL root context
- wire tabs, buttons, and input widgets into the focus system
- clear focus on external clicks through the SDL component container

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --verbosity diagnostic`
- `dotnet format src/LingoEngine.SDL2/LingoEngine.SDL2.csproj --verbosity diagnostic --include src/LingoEngine.SDL2/AbstUISdlRootContext.cs src/LingoEngine.SDL2/SdlRootContext.cs src/LingoEngine.SDL2/SdlSetup.cs`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/AbstUI.GfxVisualTest.SDL2.csproj`
- `dotnet build src/LingoEngine.SDL2/LingoEngine.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a3154f376c833295ccf132443d59c5