### PR TITLE
Add Lingo syntax highlighter to Godot converter popup

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Styles/DirectorColors.cs
+++ b/src/Director/LingoEngine.Director.Core/Styles/DirectorColors.cs
@@ -102,5 +102,11 @@ namespace LingoEngine.Director.Core.Styles
         public static AColor BG_TopMenu = new AColor(240, 240, 240); // Background color of the top menu bar
 
 
+        // Code Highlighting
+        public static AColor CodeKeyword = new AColor(77, 77, 255); // Blue
+        public static AColor CodeLiteral = new AColor(80, 80, 80); // Dark gray
+        public static AColor CodeComment = new AColor(139, 0, 0); // Dark red
+        public static AColor CodeBuiltIn = new AColor(0, 128, 0); // Green
+
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/Tools/GodotLingoCSharpConverterPopup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Tools/GodotLingoCSharpConverterPopup.cs
@@ -1,7 +1,9 @@
 using Godot;
 using LingoEngine.Director.Core.Windowing;
 using LingoEngine.Director.Core.Tools;
+using LingoEngine.Director.Core.Styles;
 using LingoEngine.FrameworkCommunication;
+using AbstUI.LGodot.Primitives;
 
 namespace LingoEngine.Director.LGodot.Tools;
 
@@ -9,5 +11,34 @@ public partial class GodotLingoCSharpConverterPopup : Window, IDirFrameworkDialo
 {
     public void Init()
     {
+        var lingoEdit = FindChild("LingoText", recursive: true, owned: false) as TextEdit;
+        if (lingoEdit == null)
+            return;
+
+        var highlighter = new CodeHighlighter();
+
+        var keywordColor = DirectorColors.CodeKeyword.ToGodotColor();
+        foreach (var word in new[]
+        {
+            "property","on","if","then","else","me","or","and","true","false","repeat","with","end","to","return","while","the","new"
+        })
+            highlighter.AddKeywordColor(word, keywordColor);
+
+        var builtInColor = DirectorColors.CodeBuiltIn.ToGodotColor();
+        foreach (var word in new[]
+        {
+            "_movie","actorlist","deleteOne","member","preload","append","membernum","sprite","spritenum","getpos","deleteone","addprop","sendsprite","voidp","frame","go","exit","line","value","cursor","sound","puppet","script","count","getpos","handler","getNetText","stepFrame","beginsprite","endsprite","startmovie","stopmovie","mouseup","mousedown","mouseenter","mouseleave","neterror","nettextresult","locH","locV","locZ","blend","ink","mouseH","mouseV","_key","keypressed","controldown","shiftdown","point","loc","in","alert","void","char","length","text","string"
+        })
+            highlighter.AddKeywordColor(word, builtInColor);
+
+        var literalColor = DirectorColors.CodeLiteral.ToGodotColor();
+        highlighter.NumberColor = literalColor;
+
+        highlighter.AddColorRegion("--", "\n", DirectorColors.CodeComment.ToGodotColor());
+        highlighter.AddColorRegion("\"", "\"", literalColor);
+        highlighter.AddColorRegion("#", " ", builtInColor);
+        highlighter.AddColorRegion("#", "\n", builtInColor);
+
+        lingoEdit.SyntaxHighlighter = highlighter;
     }
 }


### PR DESCRIPTION
## Summary
- add syntax highlighting colors for Lingo code
- apply keyword and built-in highlighting to Lingo input in Godot converter popup

## Testing
- `dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj`
- `dotnet build src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj` *(fails: Unable to load shared library 'SDL2')*

------
https://chatgpt.com/codex/tasks/task_e_68a32f7d638c8332b0574c402577960a