### PR TITLE
Enable SDL2 visual test

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/Program.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/Program.cs
@@ -1,16 +1,13 @@
-//using AbstUI.SDL2;
-//using AbstUI.SDL2.Components;
-//using AbstUI.SDL2.Styles;
-//using LingoEngine.SDL2.GfxVisualTest;
-
-//using var rootContext = new TestSdlRootComponentContext();
+using AbstUI.SDL2;
 using AbstUI.SDL2.Styles;
+using LingoEngine.SDL2.GfxVisualTest;
 
+using var rootContext = new TestSdlRootComponentContext();
 var fontManager = new SdlFontManager();
-//fontManager.LoadAll();
-//var factory = new AbstSdlComponentFactory(rootContext, fontManager);
+fontManager.LoadAll();
+var factory = new AbstSdlComponentFactory(rootContext, fontManager);
 
-//var scroll = GfxTestScene.Build(factory);
-//rootContext.ComponentContainer.Activate(((dynamic)scroll.FrameworkObj).ComponentContext);
+var scroll = GfxTestScene.Build(factory);
+rootContext.ComponentContainer.Activate(((dynamic)scroll.FrameworkObj).ComponentContext);
 
-//rootContext.Run();
+rootContext.Run(factory);

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/TestSdlRootComponentContext.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/TestSdlRootComponentContext.cs
@@ -1,0 +1,99 @@
+using System;
+using AbstUI.Inputs;
+using AbstUI.Primitives;
+using AbstUI.SDL2;
+using AbstUI.SDL2.Inputs;
+using AbstUI.SDL2.SDLL;
+
+namespace LingoEngine.SDL2.GfxVisualTest;
+
+/// <summary>
+/// Minimal SDL2 environment for the AbstUI graphics visual test.
+/// Provides the <see cref="ISdlRootComponentContext"/> required by
+/// <see cref="AbstSdlComponentFactory"/> and runs a basic render loop.
+/// </summary>
+public sealed class TestSdlRootComponentContext : ISdlRootComponentContext, IDisposable
+{
+    private readonly SdlMouse<AbstMouseEvent> _sdlMouse;
+    private readonly SdlKey _sdlKey;
+    private readonly AbstMouse _abstMouse;
+    private readonly AbstKey _abstKey;
+
+    public nint Window { get; }
+    public nint Renderer { get; }
+
+    public AbstSDLComponentContainer ComponentContainer { get; }
+    public IAbstMouse AbstMouse => _abstMouse;
+    public IAbstKey AbstKey => _abstKey;
+    public SdlFocusManager FocusManager { get; }
+
+    public TestSdlRootComponentContext()
+    {
+        SDL.SDL_Init(SDL.SDL_INIT_VIDEO);
+        SDL_image.IMG_Init(SDL_image.IMG_InitFlags.IMG_INIT_PNG);
+
+        Window = SDL.SDL_CreateWindow(
+            "AbstUI SDL2 Visual Test",
+            SDL.SDL_WINDOWPOS_CENTERED,
+            SDL.SDL_WINDOWPOS_CENTERED,
+            800,
+            600,
+            SDL.SDL_WindowFlags.SDL_WINDOW_SHOWN);
+
+        Renderer = SDL.SDL_CreateRenderer(
+            Window,
+            -1,
+            SDL.SDL_RendererFlags.SDL_RENDERER_ACCELERATED);
+
+        FocusManager = new SdlFocusManager();
+        ComponentContainer = new AbstSDLComponentContainer(FocusManager);
+
+        _sdlMouse = new SdlMouse<AbstMouseEvent>(new Lazy<AbstMouse<AbstMouseEvent>>(() => _abstMouse));
+        _abstMouse = new AbstMouse(_sdlMouse);
+
+        _sdlKey = new SdlKey();
+        _abstKey = new AbstKey(_sdlKey);
+        _sdlKey.SetKeyObj(_abstKey);
+    }
+
+    /// <summary>
+    /// Runs a simple SDL2 loop until a key is pressed or the window is closed.
+    /// </summary>
+    public void Run(AbstSdlComponentFactory factory)
+    {
+        bool running = true;
+        while (running && !Console.KeyAvailable)
+        {
+            while (SDL.SDL_PollEvent(out var e) == 1)
+            {
+                if (e.type == SDL.SDL_EventType.SDL_QUIT)
+                    running = false;
+                _sdlKey.ProcessEvent(e);
+                _sdlMouse.ProcessEvent(e);
+                ComponentContainer.HandleEvent(e);
+            }
+
+            SDL.SDL_SetRenderDrawColor(Renderer, 0, 0, 0, 255);
+            SDL.SDL_RenderClear(Renderer);
+            ComponentContainer.Render(factory.CreateRenderContext());
+            SDL.SDL_RenderPresent(Renderer);
+
+            SDL.SDL_Delay(16);
+        }
+    }
+
+    public APoint GetWindowSize()
+    {
+        SDL.SDL_GetWindowSize(Window, out var w, out var h);
+        return new APoint(w, h);
+    }
+
+    public void Dispose()
+    {
+        SDL.SDL_DestroyRenderer(Renderer);
+        SDL.SDL_DestroyWindow(Window);
+        SDL_image.IMG_Quit();
+        SDL.SDL_Quit();
+    }
+}
+


### PR DESCRIPTION
## Summary
- hook up AbstUI.GfxVisualTest.SDL2 to shared GfxTestScene
- provide minimal SDL2 root context and render loop

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/AbstUI.GfxVisualTest.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a339b483208332a83becbeba013d2a