### PR TITLE
Add dynamic component support for Blazor

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorComponentBase.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorComponentBase.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using AbstUI.Components;
 using AbstUI.Primitives;
@@ -41,6 +42,21 @@ public abstract class AbstBlazorComponentBase : ComponentBase, IAbstFrameworkLay
     {
         BuildRenderTree(builder);
     };
+
+    public static RenderFragment BuildFragment(Type componentType, IDictionary<string, object?>? parameters = null)
+        => builder =>
+        {
+            builder.OpenComponent(0, componentType);
+            if (parameters != null)
+            {
+                var seq = 1;
+                foreach (var (key, value) in parameters)
+                {
+                    builder.AddAttribute(seq++, key, value);
+                }
+            }
+            builder.CloseComponent();
+        };
 
     protected virtual string BuildStyle()
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorDynamicComponent.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorDynamicComponent.razor
@@ -1,0 +1,21 @@
+@inherits AbstBlazorComponentBase
+@using Microsoft.AspNetCore.Components
+@using System
+@using System.Collections.Generic
+
+<div id="@Name" style="@BuildStyle()">
+    @if (_fragment is not null)
+    {
+        @_fragment
+    }
+</div>
+
+@code {
+    private RenderFragment? _fragment;
+
+    public void SetComponent(Type componentType, IDictionary<string, object?>? parameters = null)
+    {
+        _fragment = BuildFragment(componentType, parameters);
+        RequestRender();
+    }
+}


### PR DESCRIPTION
## Summary
- add helper to build `RenderFragment` from component type and parameters
- introduce `AbstBlazorDynamicComponent` wrapper to render arbitrary components at runtime

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/AbstUI.GfxVisualTest.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a34b61f3bc83328baba0f1d098cc19