### PR TITLE
Optimize pixel loops by avoiding parallelism on small images

### DIFF
--- a/src/LingoEngine.LGodot/FilmLoops/LingoGodotFilmLoopMember.cs
+++ b/src/LingoEngine.LGodot/FilmLoops/LingoGodotFilmLoopMember.cs
@@ -4,6 +4,7 @@ using LingoEngine.FilmLoops;
 using LingoEngine.Primitives;
 using LingoEngine.Sprites;
 using LingoEngine.Members;
+using LingoEngine.Tools;
 using AbstUI.Primitives;
 using AbstUI.LGodot.Bitmaps;
 
@@ -83,19 +84,19 @@ namespace LingoEngine.LGodot.FilmLoops
                 }
                 if (srcImg == null)
                     continue;
-               
+
                 //DebugToDisk(srcImg, $"filmloop_{frame}/{i}_{info.Sprite2D.SpriteNum}_{info.Sprite2D.Member?.Name}");
 
                 srcImg = srcImg.GetRegion(new Rect2I(info.SrcX, info.SrcY, info.SrcW, info.SrcH));
                 if (info.DestW != info.SrcW || info.DestH != info.SrcH)
                     srcImg.Resize(info.DestW, info.DestH, Image.Interpolation.Bilinear);
-                                var m = info.Transform.Matrix;
+                var m = info.Transform.Matrix;
                 var transform = new Transform2D(
                     new Vector2(m.M11, m.M12),
                     new Vector2(m.M21, m.M22),
                     new Vector2(m.M31, m.M32));
                 BlendImage(image, srcImg, transform, info.Alpha);
-                
+
             }
 
             #region OLD
@@ -192,7 +193,8 @@ namespace LingoEngine.LGodot.FilmLoops
                 IntPtr destPtr = (IntPtr)pDestFixed;
                 IntPtr srcPtr = (IntPtr)pSrcFixed;
 
-                Parallel.For(minY, maxY, y =>
+                int totalPixels = (maxX - minX) * (maxY - minY);
+                ParallelHelper.For(minY, maxY, totalPixels, y =>
                 {
                     if ((uint)y >= (uint)destHeight) return;
 
@@ -279,7 +281,7 @@ namespace LingoEngine.LGodot.FilmLoops
             }
         }
 
-     
+
         #endregion
     }
 }

--- a/src/LingoEngine.SDL2/FilmLoops/SdlMemberFilmLoop.cs
+++ b/src/LingoEngine.SDL2/FilmLoops/SdlMemberFilmLoop.cs
@@ -10,6 +10,7 @@ using LingoEngine.Primitives;
 using LingoEngine.SDL2.Bitmaps;
 using LingoEngine.SDL2.Inputs;
 using LingoEngine.Sprites;
+using LingoEngine.Tools;
 
 namespace LingoEngine.SDL2.FilmLoops;
 
@@ -255,7 +256,8 @@ public class SdlMemberFilmLoop : ILingoFrameworkMemberFilmLoop, IDisposable
         byte* dpix = (byte*)dSurf.pixels;
         byte* spix = (byte*)sSurf.pixels;
 
-        Parallel.For(minY, maxY, y =>
+        int totalPixels = (maxX - minX) * (maxY - minY);
+        ParallelHelper.For(minY, maxY, totalPixels, y =>
         {
             if ((uint)y >= (uint)dSurf.h) return;
             byte* drow = dpix + y * dSurf.pitch;
@@ -279,7 +281,7 @@ public class SdlMemberFilmLoop : ILingoFrameworkMemberFilmLoop, IDisposable
             }
         });
 
-        UNLOCK:
+    UNLOCK:
         SDL.SDL_UnlockSurface(src);
         SDL.SDL_UnlockSurface(dest);
     }

--- a/src/LingoEngine.SDL2/Shapes/SdlMemberShape.cs
+++ b/src/LingoEngine.SDL2/Shapes/SdlMemberShape.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using LingoEngine.Primitives;
 using LingoEngine.Shapes;
 using LingoEngine.Sprites;
 using LingoEngine.Bitmaps;
+using LingoEngine.Tools;
 using AbstUI.Primitives;
 using AbstUI.SDL2;
 using AbstUI.SDL2.Bitmaps;
@@ -141,7 +141,8 @@ namespace LingoEngine.SDL2.Shapes
             float ry = h / 2f;
             float maxR = MathF.Max(rx, ry);
 
-            Parallel.For(0, h, y =>
+            int totalPixels = w * h;
+            ParallelHelper.For(0, h, totalPixels, y =>
             {
                 for (int x = 0; x < w; x++)
                 {
@@ -198,7 +199,8 @@ namespace LingoEngine.SDL2.Shapes
             SDL.SDL_LockSurface(_surface);
             byte* pix = (byte*)_surfacePtr.pixels;
             int pitch = _surfacePtr.pitch;
-            Parallel.For(0, h, y =>
+            int totalPixels = w * h;
+            ParallelHelper.For(0, h, totalPixels, y =>
             {
                 for (int x = 0; x < w; x++)
                 {
@@ -251,7 +253,7 @@ namespace LingoEngine.SDL2.Shapes
                 if (e2 >= dy) { err += dy; x0 += sx; }
                 if (e2 <= dx) { err += dx; y0 += sy; }
             }
-        } 
+        }
         #endregion
 
 

--- a/src/LingoEngine/Tools/InkPreRenderer.cs
+++ b/src/LingoEngine/Tools/InkPreRenderer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Security.Cryptography;
-using System.Threading.Tasks;
 using AbstUI.Primitives;
 using LingoEngine.Primitives;
 
@@ -46,7 +45,7 @@ namespace LingoEngine.Tools
             {
                 case LingoInkType.BackgroundTransparent:
                 case LingoInkType.Matte:
-                    Parallel.For(0, pixelCount, idx =>
+                    ParallelHelper.For(0, pixelCount, pixelCount, idx =>
                     {
                         int i = idx * 4;
                         if (result[i] == transparentColor.R &&
@@ -58,7 +57,7 @@ namespace LingoEngine.Tools
                     });
                     break;
                 case LingoInkType.Blend:
-                    Parallel.For(0, pixelCount, idx =>
+                    ParallelHelper.For(0, pixelCount, pixelCount, idx =>
                     {
                         int i = idx * 4;
                         byte a = result[i + 3];
@@ -71,7 +70,7 @@ namespace LingoEngine.Tools
                 case LingoInkType.Reverse:
                 case LingoInkType.NotCopy:
                 case LingoInkType.NotReverse:
-                    Parallel.For(0, pixelCount, idx =>
+                    ParallelHelper.For(0, pixelCount, pixelCount, idx =>
                     {
                         int i = idx * 4;
                         result[i] = (byte)(255 - result[i]);
@@ -81,14 +80,14 @@ namespace LingoEngine.Tools
                     break;
                 case LingoInkType.Ghost:
                 case LingoInkType.NotGhost:
-                    Parallel.For(0, pixelCount, idx =>
+                    ParallelHelper.For(0, pixelCount, pixelCount, idx =>
                     {
                         int i = idx * 4;
                         result[i + 3] = (byte)(result[i + 3] / 2);
                     });
                     break;
                 case LingoInkType.Mask:
-                    Parallel.For(0, pixelCount, idx =>
+                    ParallelHelper.For(0, pixelCount, pixelCount, idx =>
                     {
                         int i = idx * 4;
                         result[i] = (byte)(255 - result[i]);
@@ -98,7 +97,7 @@ namespace LingoEngine.Tools
                     });
                     break;
                 case LingoInkType.NotTransparent:
-                    Parallel.For(0, pixelCount, idx =>
+                    ParallelHelper.For(0, pixelCount, pixelCount, idx =>
                     {
                         int i = idx * 4;
                         result[i + 3] = 255;
@@ -114,10 +113,10 @@ namespace LingoEngine.Tools
             var inkKey = ink;
             switch (ink)
             {
-                case LingoInkType.BackgroundTransparent:return LingoInkType.Matte;
+                case LingoInkType.BackgroundTransparent: return LingoInkType.Matte;
                 case LingoInkType.Reverse:
                 case LingoInkType.NotCopy:
-                case LingoInkType.NotReverse:return LingoInkType.Reverse;
+                case LingoInkType.NotReverse: return LingoInkType.Reverse;
                 case LingoInkType.Ghost:
                 case LingoInkType.NotGhost: return LingoInkType.Ghost;
                 default:

--- a/src/LingoEngine/Tools/ParallelHelper.cs
+++ b/src/LingoEngine/Tools/ParallelHelper.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading.Tasks;
+
+namespace LingoEngine.Tools
+{
+    /// <summary>
+    /// Helper utilities for conditional parallel execution based on workload size.
+    /// </summary>
+    public static class ParallelHelper
+    {
+        /// <summary>
+        /// Minimum number of pixels required before parallel execution is used.
+        /// </summary>
+        public const int MinParallelPixels = 640 * 480;
+
+        /// <summary>
+        /// Executes <see cref="body"/> either sequentially or in parallel depending on
+        /// <paramref name="totalPixels"/>. If the work is smaller than
+        /// <see cref="MinParallelPixels"/>, a simple loop is used to avoid the overhead of
+        /// <c>Parallel.For</c>.
+        /// </summary>
+        /// <param name="fromInclusive">Start index (inclusive).</param>
+        /// <param name="toExclusive">End index (exclusive).</param>
+        /// <param name="totalPixels">Approximate total work size in pixels.</param>
+        /// <param name="body">Delegate to execute for each index.</param>
+        public static void For(int fromInclusive, int toExclusive, int totalPixels, Action<int> body)
+        {
+            if (totalPixels >= MinParallelPixels)
+            {
+                Parallel.For(fromInclusive, toExclusive, body);
+            }
+            else
+            {
+                for (int i = fromInclusive; i < toExclusive; i++)
+                {
+                    body(i);
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- avoid Parallel.For overhead for small workloads via new ParallelHelper
- use conditional parallelism in InkPreRenderer and engine renderers

## Testing
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj` *(fails: Unable to load shared library 'SDL2')*


------
https://chatgpt.com/codex/tasks/task_e_68a3437a254483328f74ab9d224ce3f9