### PR TITLE
Improve Lingo to C# conversion

### DIFF
--- a/Test/LingoEngine.Lingo.Core.Tests/ClassGenerationTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/ClassGenerationTests.cs
@@ -144,5 +144,45 @@ end",
         Assert.Contains("return new BehaviorPropertyDescriptionList()", result);
         Assert.Contains(".Add(this, x => x.myStartMembernum, \"My Start membernum:\", 0)", result);
         Assert.Contains(".Add(this, x => x.myFunction, \"function to execute:\", \"70\")", result);
+        Assert.Contains("public int myStartMembernum = 0;", result);
+        Assert.Contains("public string myFunction = \"70\";", result);
+    }
+
+    [Fact]
+    public void PropertyDeclarationsBecomeFields()
+    {
+        var file = new LingoScriptFile
+        {
+            Name = "MyVars",
+            Source = @"property myVar1, myVar2
+on startMovie
+end",
+            Type = LingoScriptType.Behavior
+        };
+        var result = _converter.ConvertClass(file);
+        Assert.Contains("public object myVar1;", result);
+        Assert.Contains("public object myVar2;", result);
+    }
+
+    [Fact]
+    public void PropertyTypesAreInferredFromAssignments()
+    {
+        var file = new LingoScriptFile
+        {
+            Name = "InferTypes",
+            Source = @"property a, b, c, d
+on startMovie
+  a = 1
+  b = ""hi""
+  c = member(""foo"").text
+  d = false
+end",
+            Type = LingoScriptType.Behavior
+        };
+        var result = _converter.ConvertClass(file);
+        Assert.Contains("public int a;", result);
+        Assert.Contains("public string b;", result);
+        Assert.Contains("public string c;", result);
+        Assert.Contains("public bool d;", result);
     }
 }

--- a/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
@@ -213,6 +213,37 @@ public class LingoToCSharpConverterTests
     }
 
     [Fact]
+    public void CommentLinesArePreserved()
+    {
+        var lingo = string.Join('\n', "-- test", "put 1 into x");
+        var result = _converter.Convert(lingo);
+        var expected = string.Join('\n', "// test", "x = 1;");
+        Assert.Equal(expected.Trim(), result.Trim());
+    }
+
+    [Fact]
+    public void ElseIfStatementIsConverted()
+    {
+        var lingo = string.Join('\n',
+            "if a = 1 then",
+            "  x = 1",
+            "else if a = 2 then",
+            "  x = 2",
+            "end if");
+        var result = _converter.Convert(lingo);
+        var expected = string.Join('\n',
+            "if (a == 1)",
+            "{",
+            "    x = 1;",
+            "}",
+            "else if (a == 2)",
+            "{",
+            "    x = 2;",
+            "}");
+        Assert.Equal(expected.Trim(), result.Trim());
+    }
+
+    [Fact]
     public void MeVoidAssignmentIsIgnored()
     {
         var lingo = string.Join('\n',
@@ -429,28 +460,28 @@ end";
     {
         var global = new LingoGlobalDeclStmtNode();
         global.Names.AddRange(["g1", "g2"]);
-        Assert.Equal("var g1, g2;", CSharpWriter.Write(global).Trim());
+        Assert.Equal(string.Empty, CSharpWriter.Write(global).Trim());
 
         var prop = new LingoPropertyDeclStmtNode();
         prop.Names.AddRange(["p1", "p2"]);
-        Assert.Equal("var p1, p2;", CSharpWriter.Write(prop).Trim());
+        Assert.Equal(string.Empty, CSharpWriter.Write(prop).Trim());
 
         var inst = new LingoInstanceDeclStmtNode();
         inst.Names.AddRange(["i1"]);
-        Assert.Equal("var i1;", CSharpWriter.Write(inst).Trim());
+        Assert.Equal(string.Empty, CSharpWriter.Write(inst).Trim());
     }
 
     [Fact]
     public void DeclarationStatementsAreParsedAndConverted()
     {
         var result = _converter.Convert("global g1, g2");
-        Assert.Equal("var g1, g2;", result.Trim());
+        Assert.Equal(string.Empty, result.Trim());
 
         result = _converter.Convert("property p1, p2");
-        Assert.Equal("var p1, p2;", result.Trim());
+        Assert.Equal(string.Empty, result.Trim());
 
         result = _converter.Convert("instance i1");
-        Assert.Equal("var i1;", result.Trim());
+        Assert.Equal(string.Empty, result.Trim());
     }
 
     [Fact]

--- a/src/LingoEngine.Lingo.Core/CSharpWriter.cs
+++ b/src/LingoEngine.Lingo.Core/CSharpWriter.cs
@@ -168,12 +168,20 @@ public class CSharpWriter : ILingoAstVisitor
         AppendLine("}");
         if (node.HasElse)
         {
-            AppendLine("else");
-            AppendLine("{");
-            Indent();
-            node.ElseBlock!.Accept(this);
-            Unindent();
-            AppendLine("}");
+            if (node.ElseBlock is LingoBlockNode block && block.Children.Count == 1 && block.Children[0] is LingoIfStmtNode nested)
+            {
+                Append("else ");
+                nested.Accept(this);
+            }
+            else
+            {
+                AppendLine("else");
+                AppendLine("{");
+                Indent();
+                node.ElseBlock!.Accept(this);
+                Unindent();
+                AppendLine("}");
+            }
         }
     }
 
@@ -549,26 +557,11 @@ public class CSharpWriter : ILingoAstVisitor
         AppendLine(");");
     }
 
-    public void Visit(LingoGlobalDeclStmtNode node)
-    {
-        Append("var ");
-        Append(string.Join(", ", node.Names));
-        AppendLine(";");
-    }
+    public void Visit(LingoGlobalDeclStmtNode node) { }
 
-    public void Visit(LingoPropertyDeclStmtNode node)
-    {
-        Append("var ");
-        Append(string.Join(", ", node.Names));
-        AppendLine(";");
-    }
+    public void Visit(LingoPropertyDeclStmtNode node) { }
 
-    public void Visit(LingoInstanceDeclStmtNode node)
-    {
-        Append("var ");
-        Append(string.Join(", ", node.Names));
-        AppendLine(";");
-    }
+    public void Visit(LingoInstanceDeclStmtNode node) { }
 
     public void Visit(LingoRepeatWhileStmtNode node)
     {

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoTokenizer.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoTokenizer.cs
@@ -14,6 +14,7 @@ namespace LingoEngine.Lingo.Core.Tokenizer
         String,
         Identifier,
         Symbol,
+        Comment,
         LeftParen,
         RightParen,
         LeftBracket,
@@ -185,7 +186,7 @@ namespace LingoEngine.Lingo.Core.Tokenizer
                 ';' => MakeToken(LingoTokenType.Semicolon),
                 '+' => MakeToken(LingoTokenType.Plus),
                 '&' => MakeToken(LingoTokenType.Ampersand),
-                '-' => MakeToken(LingoTokenType.Minus),
+                '-' => Peek() == '-' ? Comment() : MakeToken(LingoTokenType.Minus),
                 '*' => MakeToken(LingoTokenType.Asterisk),
                 '/' => MakeToken(LingoTokenType.Slash),
                 '=' => MakeToken(LingoTokenType.Equals),
@@ -197,6 +198,15 @@ namespace LingoEngine.Lingo.Core.Tokenizer
                 '#' => new LingoToken(LingoTokenType.Symbol, ReadIdentifier(), _line),
                 _ => MakeToken(LingoTokenType.Symbol)
             };
+        }
+
+        private LingoToken Comment()
+        {
+            Advance(); // consume second '-'
+            while (Peek() != '\n' && !IsAtEnd())
+                Advance();
+            var text = _source[(_start + 2).._position];
+            return new LingoToken(LingoTokenType.Comment, text.Trim(), _line);
         }
         private void SkipWhitespace()
         {
@@ -213,9 +223,6 @@ namespace LingoEngine.Lingo.Core.Tokenizer
                     case '\n':
                         _line++;
                         Advance();
-                        break;
-                    case '-' when PeekNext() == '-':
-                        while (Peek() != '\n' && !IsAtEnd()) Advance();
                         break;
                     default:
                         return;


### PR DESCRIPTION
## Summary
- Infer property field types by scanning assignments for literals, booleans, and `member().text`
- Test that assignments to properties produce appropriately typed fields

## Testing
- `dotnet format whitespace src/LingoEngine.Lingo.Core/LingoEngine.Lingo.Core.csproj --verbosity diagnostic`
- `dotnet format whitespace Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj --verbosity diagnostic`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a341fddb008332bf9b90ff2af84f7c