### PR TITLE
Handle sendSprite arguments in converter

### DIFF
--- a/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
@@ -154,6 +154,33 @@ public class LingoToCSharpConverterTests
     }
 
     [Fact]
+    public void SendSpriteWithArgumentIsConverted()
+    {
+        var scripts = new[]
+        {
+            new LingoScriptFile
+            {
+                Name = "B1",
+                Source = "on beginSprite\r\n sendSprite 2, #doIt, 42\r\nend\r\n",
+                Type = LingoScriptType.Behavior
+            },
+            new LingoScriptFile
+            {
+                Name = "B2",
+                Source = "on doIt me, value\r\n end\r\n",
+                Type = LingoScriptType.Behavior
+            }
+        };
+        var batch = _converter.Convert(scripts);
+        var expected = string.Join('\n',
+            "public void BeginSprite()",
+            "{",
+            "    SendSprite<B2>(2, b2 => b2.doIt(42));",
+            "}");
+        Assert.Equal(expected.Trim(), batch.ConvertedScripts["B1"].Trim());
+    }
+
+    [Fact]
     public void SendSpriteUnknownMethodGeneratesBehavior()
     {
         var scripts = new[]

--- a/src/LingoEngine.Lingo.Core/CSharpWriter.cs
+++ b/src/LingoEngine.Lingo.Core/CSharpWriter.cs
@@ -636,7 +636,9 @@ public class CSharpWriter : ILingoAstVisitor
             Append(dn.Datum.AsSymbol());
         else
             node.Message.Accept(this);
-        Append("());");
+        Append("(");
+        node.Arguments?.Accept(this);
+        Append("));");
         AppendLine();
     }
 

--- a/src/LingoEngine.Lingo.Core/LingoCodeWriterVisitor.cs
+++ b/src/LingoEngine.Lingo.Core/LingoCodeWriterVisitor.cs
@@ -493,6 +493,12 @@ namespace LingoEngine.Lingo.Core
             node.Sprite.Accept(this);
             Write(", ");
             node.Message.Accept(this);
+            if (node.Arguments != null)
+            {
+                Write(", ");
+                node.Arguments.Accept(this);
+            }
+            WriteLine();
         }
 
         public void Visit(LingoExitRepeatStmtNode node)

--- a/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
+++ b/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
@@ -484,7 +484,7 @@ public class LingoToCSharpConverter
         public void Visit(LingoCursorStmtNode n) { n.Value.Accept(this); }
         public void Visit(LingoGoToStmtNode n) { n.Target.Accept(this); }
         public void Visit(LingoAssignmentStmtNode n) { n.Target.Accept(this); n.Value.Accept(this); }
-        public void Visit(LingoSendSpriteStmtNode n) { n.Sprite.Accept(this); n.Message.Accept(this); }
+        public void Visit(LingoSendSpriteStmtNode n) { n.Sprite.Accept(this); n.Message.Accept(this); n.Arguments?.Accept(this); }
         public void Visit(LingoObjBracketExprNode n) { n.Object.Accept(this); n.Index.Accept(this); }
         public void Visit(LingoSpritePropExprNode n) { n.Sprite.Accept(this); n.Property.Accept(this); }
         public void Visit(LingoChunkDeleteStmtNode n) { n.Chunk.Accept(this); }
@@ -584,6 +584,7 @@ public class LingoToCSharpConverter
             }
             n.Sprite.Accept(this);
             n.Message.Accept(this);
+            n.Arguments?.Accept(this);
         }
         public void Visit(LingoObjBracketExprNode n) { n.Object.Accept(this); n.Index.Accept(this); }
         public void Visit(LingoSpritePropExprNode n) { n.Sprite.Accept(this); n.Property.Accept(this); }

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
@@ -125,12 +125,21 @@ namespace LingoEngine.Lingo.Core.Tokenizer
                 _currentToken.Lexeme.Equals("sendSprite", StringComparison.OrdinalIgnoreCase))
             {
                 AdvanceToken();
+                var hasParen = Match(LingoTokenType.LeftParen);
                 var sprite = ParseExpression();
-                if (Match(LingoTokenType.Comma))
+                Expect(LingoTokenType.Comma);
+                var message = ParseExpression();
+                var args = new List<LingoNode>();
+                while (Match(LingoTokenType.Comma))
                 {
-                    var message = ParseExpression();
-                    return new LingoSendSpriteStmtNode { Sprite = sprite, Message = message };
+                    args.Add(ParseExpression());
                 }
+                if (hasParen)
+                    Expect(LingoTokenType.RightParen);
+                LingoNode? argList = null;
+                if (args.Count > 0)
+                    argList = new LingoDatumNode(new LingoDatum(args, LingoDatum.DatumType.ArgList));
+                return new LingoSendSpriteStmtNode { Sprite = sprite, Message = message, Arguments = argList };
             }
             var expr = ParseExpression(false);
             if (_currentToken.Type == LingoTokenType.The && expr is LingoVarNode methodVar)

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoNodes.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoNodes.cs
@@ -341,6 +341,7 @@ namespace LingoEngine.Lingo.Core.Tokenizer
     {
         public LingoNode Sprite { get; set; } = null!;
         public LingoNode Message { get; set; } = null!;
+        public LingoNode? Arguments { get; set; }
         public string? TargetType { get; set; }
         public override void Accept(ILingoAstVisitor visitor) => visitor.Visit(this);
     }


### PR DESCRIPTION
## Summary
- allow `sendSprite` to parse calls with parentheses and extra arguments
- propagate parsed arguments into the AST and C# writer
- add coverage for `sendSprite` calls that include a parameter

## Testing
- `dotnet format src/LingoEngine.Lingo.Core/LingoEngine.Lingo.Core.csproj` (no output)
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a37e9827e4833289a796e564538cac