### PR TITLE
Add global Godot mouse service

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Inputs/IGlobalLingoMouse.cs
+++ b/src/Director/LingoEngine.Director.Core/Inputs/IGlobalLingoMouse.cs
@@ -1,0 +1,8 @@
+using LingoEngine.Inputs;
+
+namespace LingoEngine.Director.Core.Inputs
+{
+    public interface IGlobalLingoMouse : ILingoMouse
+    {
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Inputs/LingoMouseEventExtensions.cs
+++ b/src/Director/LingoEngine.Director.Core/Inputs/LingoMouseEventExtensions.cs
@@ -1,0 +1,52 @@
+using AbstUI.Inputs;
+using LingoEngine.Events;
+using LingoEngine.Inputs;
+
+namespace LingoEngine.Director.Core.Inputs
+{
+    public static class LingoMouseEventExtensions
+    {
+        public static LingoMouseEvent Translate(this LingoMouseEvent mouseEvent, LingoMouse targetMouse)
+        {
+            var offset = ((IAbstMouseInternal)targetMouse).GetMouseOffset();
+            var src = mouseEvent.Mouse;
+
+            var prevH = targetMouse.MouseH;
+            var prevV = targetMouse.MouseV;
+            var prevDown = targetMouse.MouseDown;
+            var prevUp = targetMouse.MouseUp;
+            var prevLeftDown = targetMouse.LeftMouseDown;
+            var prevRightDown = targetMouse.RightMouseDown;
+            var prevRightUp = targetMouse.RightMouseUp;
+            var prevMiddleDown = targetMouse.MiddleMouseDown;
+            var prevDouble = targetMouse.DoubleClick;
+            var prevWheel = targetMouse.WheelDelta;
+
+            targetMouse.MouseH = mouseEvent.MouseH - offset.Left;
+            targetMouse.MouseV = mouseEvent.MouseV - offset.Top;
+            targetMouse.MouseDown = src.MouseDown;
+            targetMouse.MouseUp = src.MouseUp;
+            targetMouse.LeftMouseDown = src.LeftMouseDown;
+            targetMouse.RightMouseDown = src.RightMouseDown;
+            targetMouse.RightMouseUp = src.RightMouseUp;
+            targetMouse.MiddleMouseDown = src.MiddleMouseDown;
+            targetMouse.DoubleClick = src.DoubleClick;
+            targetMouse.WheelDelta = src.WheelDelta;
+
+            var translated = new LingoMouseEvent(targetMouse, mouseEvent.Type);
+
+            targetMouse.MouseH = prevH;
+            targetMouse.MouseV = prevV;
+            targetMouse.MouseDown = prevDown;
+            targetMouse.MouseUp = prevUp;
+            targetMouse.LeftMouseDown = prevLeftDown;
+            targetMouse.RightMouseDown = prevRightDown;
+            targetMouse.RightMouseUp = prevRightUp;
+            targetMouse.MiddleMouseDown = prevMiddleDown;
+            targetMouse.DoubleClick = prevDouble;
+            targetMouse.WheelDelta = prevWheel;
+
+            return translated;
+        }
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
@@ -32,6 +32,8 @@ using LingoEngine.Director.LGodot.Projects;
 using LingoEngine.Projects;
 using AbstUI.LGodot.Styles;
 using LingoEngine.Director.LGodot.Tools;
+using LingoEngine.Director.Core.Inputs;
+using LingoEngine.Director.LGodot.Inputs;
 
 namespace LingoEngine.Director.LGodot
 {
@@ -45,6 +47,7 @@ namespace LingoEngine.Director.LGodot
                 .WithDirectorEngine(directorSettingsConfig)
                 .ServicesMain(s =>
                 {
+                    s.AddSingleton<IGlobalLingoMouse, GlobalLingoMouse>();
                     s.AddSingleton<DirectorGodotStyle>();
                     s.AddSingleton<DirGodotProjectSettingsWindow>();
                     s.AddSingleton<DirGodotToolsWindow>();

--- a/src/Director/LingoEngine.Director.LGodot/Inputs/GlobalLingoMouse.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Inputs/GlobalLingoMouse.cs
@@ -1,0 +1,61 @@
+using Godot;
+using LingoEngine.Director.Core.Inputs;
+using LingoEngine.Inputs;
+using LingoEngine.Bitmaps;
+using LingoEngine.LGodot;
+using LingoEngine.LGodot.Inputs;
+using AbstUI.Primitives;
+using AbstUI.Inputs;
+
+namespace LingoEngine.Director.LGodot.Inputs
+{
+    public class GlobalLingoMouse : LingoMouse, IGlobalLingoMouse
+    {
+        public GlobalLingoMouse(LingoGodotRootNode rootNode)
+            : base(CreateFrameworkMouse(rootNode, out var framework))
+        {
+            framework.ReplaceMouseObj(this);
+        }
+
+        private static ILingoFrameworkMouse CreateFrameworkMouse(LingoGodotRootNode rootNode, out LingoGodotGlobalMouse framework)
+        {
+            framework = new LingoGodotGlobalMouse(rootNode);
+            return framework;
+        }
+    }
+
+    public partial class LingoGodotGlobalMouse : Node, IAbstFrameworkMouse, ILingoFrameworkMouse
+    {
+        private readonly LingoGodotMouse _handler;
+        private LingoMouse? _mouse;
+
+        public LingoGodotGlobalMouse(LingoGodotRootNode rootNode)
+        {
+            _handler = new LingoGodotMouse(new Lazy<LingoMouse>(() => _mouse!));
+            rootNode.RootNode.AddChild(this);
+        }
+
+        public override void _Input(InputEvent inputEvent)
+        {
+            var pos = GetViewport().GetMousePosition();
+            if (inputEvent is InputEventMouseButton mouseButton)
+            {
+                _handler.HandleMouseButtonEvent(mouseButton, true, pos.X, pos.Y);
+            }
+            else if (inputEvent is InputEventMouseMotion mouseMotion)
+            {
+                _handler.HandleMouseMoveEvent(mouseMotion, true, pos.X, pos.Y);
+            }
+        }
+
+        public void ReplaceMouseObj(IAbstMouse lingoMouse)
+        {
+            _mouse = (LingoMouse)lingoMouse;
+            _handler.ReplaceMouseObj(lingoMouse);
+        }
+        public void Release() => GetParent()?.RemoveChild(this);
+        public void HideMouse(bool state) => _handler.HideMouse(state);
+        public void SetCursor(LingoMemberBitmap? image) => _handler.SetCursor(image);
+        public void SetCursor(AMouseCursor value) => _handler.SetCursor(value);
+    }
+}

--- a/src/LingoEngine.LGodot/LingoGodotSetup.cs
+++ b/src/LingoEngine.LGodot/LingoGodotSetup.cs
@@ -21,10 +21,10 @@ namespace LingoEngine.LGodot
                         .AddGodotLogging()
                         .AddSingleton<LingoGodotStyle>()
                         .AddSingleton<ILingoFrameworkFactory, GodotFactory>()
-                        
+
                         .AddSingleton<ILingoFrameworkStageContainer, LingoGodotStageContainer>()
                         .AddSingleton(p => new LingoGodotRootNode(rootNode, withStageInWindow))
-                        .AddSingleton< IAbstGodotRootNode>(p => p.GetRequiredService<LingoGodotRootNode>())
+                        .AddSingleton<IAbstGodotRootNode>(p => p.GetRequiredService<LingoGodotRootNode>())
                         .WithAbstUIGodot()
                         )
                 .WithFrameworkFactory(setup)

--- a/src/LingoEngine/Inputs/LingoMouse.cs
+++ b/src/LingoEngine/Inputs/LingoMouse.cs
@@ -50,7 +50,7 @@ namespace LingoEngine.Inputs
         IAbstMouseSubscription OnMouseWheel(Action<LingoMouseEvent> handler);
         IAbstMouseSubscription OnMouseEvent(Action<LingoMouseEvent> handler);
     }
-   
+
     public class LingoStageMouse : LingoMouse, ILingoStageMouse
     {
         private readonly LingoStage _lingoStage;
@@ -113,12 +113,12 @@ namespace LingoEngine.Inputs
 
 
         public LingoMouse(ILingoFrameworkMouse frameworkMouse)
-            :base((p,type) => new LingoMouseEvent((LingoMouse)p, type), frameworkMouse)
+            : base((p, type) => new LingoMouseEvent((LingoMouse)p, type), frameworkMouse)
         {
             _lingoFrameworkObj = frameworkMouse;
             _cursor = new LingoCursor(frameworkMouse);
         }
-        
+
 
         public void SetCursor(AMouseCursor cursorType)
         {
@@ -143,8 +143,8 @@ namespace LingoEngine.Inputs
         //}
 
 
-       
-        
+
+
 
 
 
@@ -155,6 +155,6 @@ namespace LingoEngine.Inputs
         //public virtual IAbstUIMouseSubscription OnMouseEvent(Action<LingoMouseEvent> handler)
         //    => base.OnMouseEvent(e => handler(e));
 
-       
+
     }
 }


### PR DESCRIPTION
## Summary
- move `IGlobalLingoMouse` interface into the Director core and supply a Godot implementation
- forward global mouse releases through a dedicated handler for cross-window drags
- expose mouse offset through `IAbstMouseInternal` so proxy mice can translate global events
- extract global-to-local translation into `LingoMouseEvent.Translate` extension

## Testing
- `dotnet format src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj --verbosity normal --include src/Director/LingoEngine.Director.Core/Scores/DirectorScoreWindow.cs src/Director/LingoEngine.Director.Core/Inputs/LingoMouseEventExtensions.cs`
- `dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a362420a048332acdd807475c7fea0