### PR TITLE
Fix SDL2 scroll container child offsets and restore render targets

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlButton.cs
@@ -32,14 +32,14 @@ namespace AbstUI.SDL2.Components
 
         public event Action? Pressed;
 
-      
+
         public AbstSdlButton(AbstSdlComponentFactory factory) : base(factory)
         {
             _fontManager = factory.FontManager;
         }
         private void EnsureResources(AbstSDLRenderContext ctx)
         {
-            _font = _fontManager.GetDefaultFont<IAbstSdlFont>().Get(this,12);
+            _font = _fontManager.GetDefaultFont<IAbstSdlFont>().Get(this, 12);
             _atlas ??= new SdlGlyphAtlas(ctx.Renderer, _font!.FontHandle);
         }
 
@@ -58,6 +58,7 @@ namespace AbstUI.SDL2.Components
                     (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, w, h);
                 SDL.SDL_SetTextureBlendMode(_texture, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
 
+                var prevTarget = SDL.SDL_GetRenderTarget(context.Renderer);
                 SDL.SDL_SetRenderTarget(context.Renderer, _texture);
 
                 SDL.SDL_SetRenderDrawColor(context.Renderer, 200, 200, 200, 255);
@@ -80,7 +81,7 @@ namespace AbstUI.SDL2.Components
                     _atlas.DrawRun(span, tx, baseline, new SDL.SDL_Color { r = 0, g = 0, b = 0, a = 255 });
                 }
 
-                SDL.SDL_SetRenderTarget(context.Renderer, nint.Zero);
+                SDL.SDL_SetRenderTarget(context.Renderer, prevTarget);
                 _renderedText = Text;
                 _texW = w;
                 _texH = h;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputCombobox.cs
@@ -195,6 +195,7 @@ namespace AbstUI.SDL2.Components
                     (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, w, h);
                 SDL.SDL_SetTextureBlendMode(_texture, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
 
+                var prevTarget = SDL.SDL_GetRenderTarget(context.Renderer);
                 SDL.SDL_SetRenderTarget(context.Renderer, _texture);
                 SDL.SDL_SetRenderDrawColor(context.Renderer, 255, 255, 255, 255);
                 SDL.SDL_RenderClear(context.Renderer);
@@ -213,7 +214,7 @@ namespace AbstUI.SDL2.Components
                     _atlas!.DrawRun(span, 4, baseline, new SDL.SDL_Color { r = 0, g = 0, b = 0, a = 255 });
                 }
 
-                SDL.SDL_SetRenderTarget(context.Renderer, nint.Zero);
+                SDL.SDL_SetRenderTarget(context.Renderer, prevTarget);
                 _texW = w;
                 _texH = h;
                 _renderedText = text;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlPanel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlPanel.cs
@@ -63,6 +63,7 @@ namespace AbstUI.SDL2.Components
                 _texH = h;
             }
 
+            var prevTarget = SDL.SDL_GetRenderTarget(context.Renderer);
             SDL.SDL_SetRenderTarget(context.Renderer, _texture);
 
             if (BackgroundColor is { } bg)
@@ -102,7 +103,7 @@ namespace AbstUI.SDL2.Components
                 }
             }
 
-            SDL.SDL_SetRenderTarget(context.Renderer, nint.Zero);
+            SDL.SDL_SetRenderTarget(context.Renderer, prevTarget);
             return _texture;
         }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlScrollContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlScrollContainer.cs
@@ -37,9 +37,12 @@ namespace AbstUI.SDL2.Components
                     var ctx = comp.ComponentContext;
                     var oldOffX = ctx.OffsetX;
                     var oldOffY = ctx.OffsetY;
-                    ctx.OffsetX += -ScrollHorizontal;
-                    ctx.OffsetY += -ScrollVertical;
+
+                    // Render child relative to this container's origin and scroll position
+                    ctx.OffsetX += -X - ScrollHorizontal;
+                    ctx.OffsetY += -Y - ScrollVertical;
                     ctx.RenderToTexture(context);
+
                     ctx.OffsetX = oldOffX;
                     ctx.OffsetY = oldOffY;
                 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlScrollViewer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlScrollViewer.cs
@@ -52,6 +52,7 @@ namespace AbstUI.SDL2.Components
                     (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, w, h);
                 SDL.SDL_SetTextureBlendMode(_texture, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
 
+                var prevTarget = SDL.SDL_GetRenderTarget(context.Renderer);
                 SDL.SDL_SetRenderTarget(context.Renderer, _texture);
                 SDL.SDL_SetRenderDrawColor(context.Renderer, 255, 255, 255, 255);
                 SDL.SDL_RenderClear(context.Renderer);
@@ -80,14 +81,14 @@ namespace AbstUI.SDL2.Components
                 SDL.SDL_RenderDrawRect(context.Renderer, ref hbar);
                 SDL.SDL_RenderDrawRect(context.Renderer, ref corner);
 
-                SDL.SDL_SetRenderTarget(context.Renderer, nint.Zero);
+                SDL.SDL_SetRenderTarget(context.Renderer, prevTarget);
 
                 _texW = w;
                 _texH = h;
                 _lastScrollH = ScrollHorizontal;
                 _lastScrollV = ScrollVertical;
             }
-  
+
             return _texture;
         }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlTabContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlTabContainer.cs
@@ -91,6 +91,7 @@ namespace AbstUI.SDL2.Components
                 SDL.SDL_SetTextureBlendMode(_texture, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
             }
 
+            var prevTarget = SDL.SDL_GetRenderTarget(context.Renderer);
             SDL.SDL_SetRenderTarget(context.Renderer, _texture);
             SDL.SDL_SetRenderDrawColor(context.Renderer, 255, 255, 255, 255);
             SDL.SDL_RenderClear(context.Renderer);
@@ -139,7 +140,7 @@ namespace AbstUI.SDL2.Components
                 }
             }
 
-            SDL.SDL_SetRenderTarget(context.Renderer, nint.Zero);
+            SDL.SDL_SetRenderTarget(context.Renderer, prevTarget);
             _texW = w;
             _texH = h;
             return _texture;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlWrapPanel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlWrapPanel.cs
@@ -81,6 +81,7 @@ namespace AbstUI.SDL2.Components
                 _texH = h;
             }
 
+            var prevTarget = SDL.SDL_GetRenderTarget(context.Renderer);
             SDL.SDL_SetRenderTarget(context.Renderer, _texture);
             SDL.SDL_SetRenderDrawColor(context.Renderer, 0, 0, 0, 0);
             SDL.SDL_RenderClear(context.Renderer);
@@ -140,7 +141,7 @@ namespace AbstUI.SDL2.Components
                 comp?.ComponentContext.RenderToTexture(context);
             }
 
-            SDL.SDL_SetRenderTarget(context.Renderer, nint.Zero);
+            SDL.SDL_SetRenderTarget(context.Renderer, prevTarget);
             return _texture;
         }
     }


### PR DESCRIPTION
## Summary
- ensure SDL2 scroll container renders children relative to its origin
- preserve SDL render targets by restoring previous target after component rendering

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --verify-no-changes`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/AbstUI.GfxVisualTest.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a37c44df548332a2a9e9433f9e8bb8