### PR TITLE
Add scroll bounds and handle to SDL scroll viewer

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdInputltemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdInputltemList.cs
@@ -85,6 +85,9 @@ namespace AbstUI.SDL2.Components
                 }
                 y += _lineHeight;
             }
+
+            ContentWidth = w;
+            ContentHeight = _lineHeight * _items.Count;
         }
 
         private void DrawItemText(string text, int x, int y, SDL.SDL_Color color, AbstSDLRenderContext ctx)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlScrollContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlScrollContainer.cs
@@ -30,6 +30,7 @@ namespace AbstUI.SDL2.Components
 
         protected override void RenderContent(AbstSDLRenderContext context)
         {
+            float maxX = 0, maxY = 0;
             foreach (var child in _children)
             {
                 if (child.FrameworkNode is AbstSdlComponent comp)
@@ -45,8 +46,14 @@ namespace AbstUI.SDL2.Components
 
                     ctx.OffsetX = oldOffX;
                     ctx.OffsetY = oldOffY;
+
+                    maxX = MathF.Max(maxX, comp.X + comp.Width);
+                    maxY = MathF.Max(maxY, comp.Y + comp.Height);
                 }
             }
+
+            ContentWidth = maxX;
+            ContentHeight = maxY;
         }
 
         public override void Dispose()


### PR DESCRIPTION
## Summary
- clamp SDL scroll viewer to content size and render draggable handles and step arrows
- track content extents for SDL scroll container and item list

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlScrollViewer.cs --verbosity diagnostic`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a391ea06bc83329abe864927ffa97e