### PR TITLE
Refactor converter to use reusable code highlighter

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Tools/DirCodeHighlichter.cs
+++ b/src/Director/LingoEngine.Director.Core/Tools/DirCodeHighlichter.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AbstUI.Components;
+using LingoEngine.FrameworkCommunication;
+
+namespace LingoEngine.Director.Core.Tools;
+
+public class DirCodeHighlichter : IDisposable
+{
+    public enum Language
+    {
+        Lingo,
+        CSharp
+    }
+
+    private readonly AbstInputText _text;
+    private readonly Language _language;
+    private readonly Action _onChanged;
+
+    public DirCodeHighlichter(ILingoFrameworkFactory factory, Language language)
+    {
+        _language = language;
+        _text = factory.CreateInputText("CodeText", 0, null);
+        _text.IsMultiLine = true;
+        _onChanged = () => TextChanged?.Invoke();
+        _text.ValueChanged += _onChanged;
+    }
+
+    public Language CodeLanguage => _language;
+    public AbstInputText TextComponent => _text;
+
+    public event Action? TextChanged;
+
+    public float Width
+    {
+        get => _text.Width;
+        set => _text.Width = value;
+    }
+
+    public float Height
+    {
+        get => _text.Height;
+        set => _text.Height = value;
+    }
+
+    public void SetText(string text) => _text.Text = text;
+    public string Text => _text.Text;
+
+    public void Dispose()
+    {
+        _text.ValueChanged -= _onChanged;
+        _text.Dispose();
+        TextChanged = null;
+    }
+
+    public List<string> WordsLingoCodeKeywords = [.. _lingoKeyWordsDefault];
+    private static readonly string[] _lingoKeyWordsDefault = [
+        "Property", "On", "If", "Then", "Else", "Me", "Or", "And", "True", "False", "Repeat", "With", "End", "To", "Return", "While", "The", "New", "Global"];
+
+    public List<string> WordsLingoCodeBuiltIn = [.. _lingoWordsDefault];
+    private static readonly string[] _lingoWordsDefault = [
+            "Point","Loc","Void","Char","Rgb","In","Line","Word",
+            "Default","Format","Color","Comment","Integer","Boolean","String","Text","String","Symbol",
+            "GetPropertyDescriptionList","GetBehaviorTooltip","IsOKToAttach","GetBehaviorDescription",
+            "_Movie","ActorList","Cursor","Alert",
+            "MemberNum","Member","Preload","Sound",
+            "Sprite","SpriteNum","LocH","LocV","LocZ","Blend","Ink","MouseH","MouseV","Puppet",
+            "DeleteOne","Append","GetPos","AddProp","SendSprite","VoidP","Frame","Length","Count",
+            "Go","Exit",
+            "Value",
+            "Script","Handler",
+            "StepFrame","BeginSprite","EndSprite",
+            "StartMovie","StopMovie",
+            "_Mouse","MouseUp","MouseDown","MouseEnter","MouseLeave",
+            "NetError","NetTextResult","GetNetText",
+            "_Key","KeyPressed","ControlDown","ShiftDown",
+            "_Player",
+            "_Sound",
+            "_System",
+            "Channel","Number",
+            "CastLib",
+            "Put",
+        ];
+
+    public List<string> WordsCCharpCodeBuiltIn = [.. _csharpWordsDefault];
+    private static readonly string[] _csharpWordsDefault = [
+             "abstract","as","base","break","case","catch","checked","class","const","continue",
+            "default","delegate","do","else","enum","event","explicit","extern","finally","fixed",
+            "for","foreach","goto","if","implicit","in","interface","internal","is","lock",
+            "namespace","new","operator","out","override","params","private","protected","public",
+            "readonly","record","ref","return","sealed","sizeof","stackalloc","static","struct",
+            "switch","this","throw","try","typeof","unsafe","using","virtual","volatile","while",
+            "async","await","var","null","true","false","void",
+        ];
+
+    public List<string> WordsCCharpCodeTypes = [.. _csharpWordsCodeTypesDefault];
+    private static readonly string[] _csharpWordsCodeTypesDefault = [
+            "bool","byte","sbyte","char","decimal","double","float","int","uint","nint","nuint",
+            "long","ulong","object","short","ushort","string","void",
+        // NET
+        "List","Add","Remove","IndexOf",
+        // lingo
+         "APoint","ARect","AColor","Loc","Char","FromHex","Line","Word",
+            "format","AColor","Comment","Text","Symbol",
+            "GetPropertyDescriptionList","GetBehaviorTooltip","IsOKToAttach","GetBehaviorDescription","BehaviorPropertyDescriptionList",
+            "_Movie","Actorlist","Cursor","Alert",
+            "MemberNum","Member","Preload","Sound",
+            "Sprite","SpriteNum","LocH","LocV","LocZ","Blend","Ink","MouseH","MouseV","Puppet","ILingoSprite",
+            "DeleteOne","Append","GetPos","Deleteone","Addprop","Sendsprite","Frame","Length","Count",
+            "Go","GoTo",
+            "Script","Handler",
+            "StepFrame","BeginSprite","EndSprite",
+            "StartMovie","StopMovie",
+            "_Mouse","MouseUp","MouseDown","MouseEnter","MouseLeave","LingoMouseEvent",
+            "NetError","NetTextResult","GetNetText",
+            "_Key","KeyPressed","ControlDown","ShiftDown","LingoKeyEvent",
+            "_Player",
+            "_Sound",
+            "_System",
+            "Channel","Number",
+            "CastLib","LingoCast","LingoInkType","ILingoMember"
+        ];
+
+    public static IEnumerable<string> CaseInsensitiveWords(IEnumerable<string> words)
+        => words.SelectMany(w => new[] { w, w.ToLowerInvariant() }).Distinct();
+}

--- a/src/Director/LingoEngine.Director.Core/Tools/IDirFrameworkCodeHighlighter.cs
+++ b/src/Director/LingoEngine.Director.Core/Tools/IDirFrameworkCodeHighlighter.cs
@@ -1,0 +1,8 @@
+using LingoEngine.FrameworkCommunication;
+
+namespace LingoEngine.Director.Core.Tools;
+
+public interface IDirFrameworkCodeHighlighter : IFrameworkFor<DirCodeHighlichter>
+{
+    void Init(DirCodeHighlichter highlighter);
+}

--- a/src/Director/LingoEngine.Director.Core/Tools/LingoCSharpConverterPopup.cs
+++ b/src/Director/LingoEngine.Director.Core/Tools/LingoCSharpConverterPopup.cs
@@ -6,24 +6,18 @@ using LingoEngine.Director.Core.UI;
 using LingoEngine.Director.Core.Windowing;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Lingo.Core;
-using LingoEngine.Texts;
 using TextCopy;
 using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace LingoEngine.Director.Core.Tools;
 
-public interface ILingoFrameworkCSharpConverterPopup : IDirFrameworkDialog
-{
-    public void UpdateLingoColors(AbstInputText inputText);
-    public void UpdateCSharpColors(AbstInputText inputText);
-}
 public class LingoCSharpConverterPopup : ICommandHandler<OpenLingoCSharpConverterCommand>, ILingoDialog
 {
     protected readonly IDirectorWindowManager _windowManager;
     protected readonly ILingoFrameworkFactory _factory;
-    private ILingoFrameworkCSharpConverterPopup? _frameworkObj;
-    private AbstInputText _csharpInput;
-    private AbstInputText _lingoInput;
+    private DirCodeHighlichter _csharpHighlighter = null!;
+    private DirCodeHighlichter _lingoHighlighter = null!;
 
     protected sealed class ViewModel
     {
@@ -48,10 +42,7 @@ public class LingoCSharpConverterPopup : ICommandHandler<OpenLingoCSharpConverte
         return true;
     }
 
-    public void Init(IDirFrameworkDialog framework)
-    {
-        _frameworkObj = (ILingoFrameworkCSharpConverterPopup)framework;
-    }
+    public void Init(IDirFrameworkDialog framework) { }
 
     protected AbstPanel BuildPanel(ViewModel vm)
     {
@@ -80,12 +71,12 @@ public class LingoCSharpConverterPopup : ICommandHandler<OpenLingoCSharpConverte
             .AddLabel("LingoLabel", "Lingo")
             .AddButton("CopyLingo", "Copy", () => ClipboardService.SetText(vm.Lingo));
 
-        _lingoInput = _factory.CreateInputText("LingoText", 0, text => vm.Lingo = text);
-        _lingoInput.Width = 380;
-        _lingoInput.Height = 420;
-        _lingoInput.IsMultiLine = true;
-        _lingoInput.ValueChanged += LingoInput_ValueChanged;
-        left.AddItem(_lingoInput);
+        _lingoHighlighter = new DirCodeHighlichter(_factory, DirCodeHighlichter.Language.Lingo);
+        _lingoHighlighter.Width = 380;
+        _lingoHighlighter.Height = 420;
+        _lingoHighlighter.TextChanged += () => vm.Lingo = _lingoHighlighter.Text;
+        left.AddItem(_lingoHighlighter.TextComponent);
+        LinkHighlighter(_lingoHighlighter);
 
         var rightHeader = _factory.CreateWrapPanel(AOrientation.Horizontal, "CSharpHeader");
         right.AddItem(rightHeader);
@@ -93,13 +84,12 @@ public class LingoCSharpConverterPopup : ICommandHandler<OpenLingoCSharpConverte
             .AddLabel("CSharpLabel", "C#")
             .AddButton("CopyCSharp", "Copy", () => ClipboardService.SetText(vm.CSharp));
 
-        _csharpInput = _factory.CreateInputText("CSharpText", 0, null);
-        _csharpInput.Width = 380;
-        _csharpInput.Height = 420;
-        //csharpInput.Enabled = false;
-        _csharpInput.IsMultiLine = true;
-        _csharpInput.ValueChanged += CsharpInput_ValueChanged;
-        right.AddItem(_csharpInput);
+        _csharpHighlighter = new DirCodeHighlichter(_factory, DirCodeHighlichter.Language.CSharp);
+        _csharpHighlighter.Width = 380;
+        _csharpHighlighter.Height = 420;
+        _csharpHighlighter.TextChanged += () => vm.CSharp = _csharpHighlighter.Text;
+        right.AddItem(_csharpHighlighter.TextComponent);
+        LinkHighlighter(_csharpHighlighter);
 
         var errorInput = _factory.CreateInputText("ErrorsText", 0, null);
         errorInput.Width = 800;
@@ -109,7 +99,6 @@ public class LingoCSharpConverterPopup : ICommandHandler<OpenLingoCSharpConverte
         errorInput.Margin = new AMargin(0, 500, 0, 0);
         //prop?.SetValue(framework, DirectorColors.Notification_Error_Border);
         root.AddItem(errorInput, 0, 450);
-        var framework = errorInput.FrameworkObj;
 
         var menuBar = _factory.CreateWrapPanel(AOrientation.Horizontal, "BottomBar");
         menuBar.Width = 800;
@@ -122,100 +111,28 @@ public class LingoCSharpConverterPopup : ICommandHandler<OpenLingoCSharpConverte
             {
                 var converter = new LingoToCSharpConverter();
                 vm.CSharp = converter.Convert(vm.Lingo);
-                _csharpInput.Text = vm.CSharp; //.Replace("\r", "\n");
+                _csharpHighlighter.SetText(vm.CSharp);
                 vm.Errors = string.Join("\n", converter.Errors.Select(e =>
                     string.IsNullOrEmpty(e.File)
                         ? $"Line {e.LineNumber}: {e.LineText} - {e.Error}"
                         : $"{e.File}:{e.LineNumber}: {e.LineText} - {e.Error}"));
                 errorInput.Text = vm.Errors;
-                _frameworkObj?.UpdateCSharpColors(_csharpInput);
             });
 
         return root;
     }
 
-    private void CsharpInput_ValueChanged() => _frameworkObj?.UpdateCSharpColors(_csharpInput);
-
-    private void LingoInput_ValueChanged() => _frameworkObj?.UpdateLingoColors(_lingoInput);
+    private void LinkHighlighter(DirCodeHighlichter highlighter)
+    {
+        if (_factory is LingoBaseFrameworkFactory fw)
+            fw.ServiceProvider.GetRequiredService<IDirFrameworkCodeHighlighter>().Init(highlighter);
+    }
 
     public void Dispose()
     {
-        _lingoInput.ValueChanged -= LingoInput_ValueChanged;
-        _csharpInput.ValueChanged -= CsharpInput_ValueChanged;
-        _lingoInput.Dispose();
-        _csharpInput.Dispose();
+        _lingoHighlighter.Dispose();
+        _csharpHighlighter.Dispose();
     }
-
-    public List<string> WordsLingoCodeKeywords = [.. _lingoKeyWordsDefault];
-    private static readonly string[] _lingoKeyWordsDefault = [
-        "Property", "On", "If", "Then", "Else", "Me", "Or", "And", "True", "False", "Repeat", "With", "End", "To", "Return", "While", "The", "New", "Global"];
-
-    public List<string> WordsLingoCodeBuiltIn = [.. _lingoWordsDefault];
-    private static readonly string[] _lingoWordsDefault = [
-            "Point","Loc","Void","Char","Rgb","In","Line","Word",
-            "Default","Format","Color","Comment","Integer","Boolean","String","Text","String","Symbol",
-            "GetPropertyDescriptionList","GetBehaviorTooltip","IsOKToAttach","GetBehaviorDescription",
-            "_Movie","ActorList","Cursor","Alert",
-            "MemberNum","Member","Preload","Sound",
-            "Sprite","SpriteNum","LocH","LocV","LocZ","Blend","Ink","MouseH","MouseV","Puppet",
-            "DeleteOne","Append","GetPos","AddProp","SendSprite","VoidP","Frame","Length","Count",
-            "Go","Exit",
-            "Value",
-            "Script","Handler",
-            "StepFrame","BeginSprite","EndSprite",
-            "StartMovie","StopMovie",
-            "_Mouse","MouseUp","MouseDown","MouseEnter","MouseLeave",
-            "NetError","NetTextResult","GetNetText",
-            "_Key","KeyPressed","ControlDown","ShiftDown",
-            "_Player",
-            "_Sound",
-            "_System",
-            "Channel","Number",
-            "CastLib",
-            "Put",
-        ];
-    public static IEnumerable<string> CaseInsensitiveWords(IEnumerable<string> words)
-        => words.SelectMany(w => new[] { w, w.ToLowerInvariant() }).Distinct();
-    public List<string> WordsCCharpCodeBuiltIn = [.. _csharpWordsDefault];
-    private static readonly string[] _csharpWordsDefault = [
-             "abstract","as","base","break","case","catch","checked","class","const","continue",
-            "default","delegate","do","else","enum","event","explicit","extern","finally","fixed",
-            "for","foreach","goto","if","implicit","in","interface","internal","is","lock",
-            "namespace","new","operator","out","override","params","private","protected","public",
-            "readonly","record","ref","return","sealed","sizeof","stackalloc","static","struct",
-            "switch","this","throw","try","typeof","unsafe","using","virtual","volatile","while",
-            "async","await","var","null","true","false","void",
-
-
-        ];
-    public List<string> WordsCCharpCodeTypes = [.. _csharpWordsCodeTypesDefault];
-    private static readonly string[] _csharpWordsCodeTypesDefault = [
-
-            "bool","byte","sbyte","char","decimal","double","float","int","uint","nint","nuint",
-            "long","ulong","object","short","ushort","string","void",
-
-        // NET
-        "List","Add","Remove","IndexOf",
-
-        // lingo 
-         "APoint","ARect","AColor","Loc","Char","FromHex","Line","Word",
-            "format","AColor","Comment","Text","Symbol",
-            "GetPropertyDescriptionList","GetBehaviorTooltip","IsOKToAttach","GetBehaviorDescription","BehaviorPropertyDescriptionList",
-            "_Movie","Actorlist","Cursor","Alert",
-            "MemberNum","Member","Preload","Sound",
-            "Sprite","SpriteNum","LocH","LocV","LocZ","Blend","Ink","MouseH","MouseV","Puppet","ILingoSprite",
-            "DeleteOne","Append","GetPos","Deleteone","Addprop","Sendsprite","Frame","Length","Count",
-            "Go","GoTo",
-            "Script","Handler",
-            "StepFrame","BeginSprite","EndSprite",
-            "StartMovie","StopMovie",
-            "_Mouse","MouseUp","MouseDown","MouseEnter","MouseLeave","LingoMouseEvent",
-            "NetError","NetTextResult","GetNetText",
-            "_Key","KeyPressed","ControlDown","ShiftDown","LingoKeyEvent",
-            "_Player",
-            "_Sound",
-            "_System",
-            "Channel","Number",
-            "CastLib","LingoCast","LingoInkType","ILingoMember"
-        ];
+    public DirCodeHighlichter LingoHighlighter => _lingoHighlighter;
+    public DirCodeHighlichter CSharpHighlighter => _csharpHighlighter;
 }

--- a/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
@@ -34,6 +34,7 @@ using AbstUI.LGodot.Styles;
 using LingoEngine.Director.LGodot.Tools;
 using LingoEngine.Director.Core.Inputs;
 using LingoEngine.Director.LGodot.Inputs;
+using LingoEngine.Director.Core.Tools;
 
 namespace LingoEngine.Director.LGodot
 {
@@ -65,6 +66,7 @@ namespace LingoEngine.Director.LGodot
                     s.AddSingleton<IDirFilePicker, GodotFilePicker>();
                     s.AddSingleton<IDirFolderPicker, GodotFolderPicker>();
                     s.AddTransient<GodotLingoCSharpConverterPopup>();
+                    s.AddTransient<IDirFrameworkCodeHighlighter, DirGodotCodeHighlighter>();
                     s.AddTransient<Window>();
                     s.AddSingleton<DirGodotFrameworkFactory>();
                     s.AddSingleton<IDirectorIconManager>(p =>

--- a/src/Director/LingoEngine.Director.LGodot/Tools/DirGodotCodeHighlighter.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Tools/DirGodotCodeHighlighter.cs
@@ -1,0 +1,71 @@
+using AbstUI.LGodot.Components;
+using AbstUI.LGodot.Primitives;
+using Godot;
+using LingoEngine.Director.Core.Styles;
+using LingoEngine.Director.Core.Tools;
+using LingoEngine.FrameworkCommunication;
+using System;
+
+namespace LingoEngine.Director.LGodot.Tools;
+
+public class DirGodotCodeHighlighter : IDirFrameworkCodeHighlighter, IFrameworkFor<DirCodeHighlichter>, IDisposable
+{
+    private DirCodeHighlichter _base = null!;
+    private readonly CodeHighlighter _highlighter = new();
+
+    public DirGodotCodeHighlighter() { }
+
+    public void Init(DirCodeHighlichter highlighter)
+    {
+        _base = highlighter;
+        _base.TextChanged += UpdateColors;
+        Setup();
+        UpdateColors();
+    }
+
+    public void Dispose()
+    {
+        _base.TextChanged -= UpdateColors;
+    }
+
+    private void Setup()
+    {
+        if (_base.CodeLanguage == DirCodeHighlichter.Language.Lingo)
+        {
+            var keywordColor = DirectorColors.LingoCodeKeyword.ToGodotColor();
+            foreach (var word in DirCodeHighlichter.CaseInsensitiveWords(_base.WordsLingoCodeKeywords))
+                _highlighter.AddKeywordColor(word, keywordColor);
+
+            var builtInColor = DirectorColors.LingoCodeBuiltIn.ToGodotColor();
+            foreach (var word in DirCodeHighlichter.CaseInsensitiveWords(_base.WordsLingoCodeBuiltIn))
+                _highlighter.AddKeywordColor(word, builtInColor);
+
+            var literalColor = DirectorColors.LingoCodeLiteral.ToGodotColor();
+            _highlighter.NumberColor = literalColor;
+            _highlighter.AddColorRegion("--", "", DirectorColors.LingoCodeComment.ToGodotColor(), true);
+            _highlighter.AddColorRegion("\"", "\"", literalColor);
+        }
+        else
+        {
+            var keywordColor = DirectorColors.CCharpCodeBuiltIn.ToGodotColor();
+            foreach (var word in _base.WordsCCharpCodeBuiltIn)
+                _highlighter.AddKeywordColor(word, keywordColor);
+
+            var typeColor = DirectorColors.CCharpCodeTypes.ToGodotColor();
+            foreach (var word in _base.WordsCCharpCodeTypes)
+                _highlighter.AddKeywordColor(word, typeColor);
+
+            _highlighter.NumberColor = DirectorColors.CCharpCodeNumber.ToGodotColor();
+            _highlighter.AddColorRegion("//", "", DirectorColors.CCharpCodeComment.ToGodotColor(), true);
+            _highlighter.AddColorRegion("/*", "*/", DirectorColors.CCharpCodeComment.ToGodotColor());
+            _highlighter.AddColorRegion("\"", "\"", DirectorColors.CCharpCodeString.ToGodotColor());
+            _highlighter.AddColorRegion("@\"", "\"", DirectorColors.CCharpCodeString.ToGodotColor());
+        }
+    }
+
+    private void UpdateColors()
+    {
+        var textEdit = (TextEdit)_base.TextComponent.Framework<AbstGodotInputText>().FrameworkNode;
+        textEdit.SyntaxHighlighter = _highlighter;
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/Tools/GodotLingoCSharpConverterPopup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Tools/GodotLingoCSharpConverterPopup.cs
@@ -1,94 +1,13 @@
-using AbstUI.Components;
-using AbstUI.LGodot.Components;
-using AbstUI.LGodot.Primitives;
 using Godot;
-using LingoEngine.Director.Core.Styles;
 using LingoEngine.Director.Core.Tools;
 using LingoEngine.Director.Core.Windowing;
 using LingoEngine.FrameworkCommunication;
-using System.Linq;
 
 namespace LingoEngine.Director.LGodot.Tools;
 
-public partial class GodotLingoCSharpConverterPopup : Window, ILingoFrameworkCSharpConverterPopup, IFrameworkFor<LingoCSharpConverterPopup>
+public partial class GodotLingoCSharpConverterPopup : Window, IDirFrameworkDialog, IFrameworkFor<LingoCSharpConverterPopup>
 {
-    private CodeHighlighter _lingoHighlighter;
-    private CodeHighlighter _csharpHighlighter;
-    private LingoCSharpConverterPopup? _lingoDialog;
-    private List<string> _wordsLingoCodeBuiltIn = new();
-    private List<string> _wordsLingoCodeKeywords = new();
-    private List<string> _wordsCCharpCodeBuiltIn = new();
-    private List<string> _wordsCCharpCodeTypes = new();
+    public GodotLingoCSharpConverterPopup() { }
 
-    public GodotLingoCSharpConverterPopup()
-    {
-
-    }
-
-
-    public void Init(ILingoDialog lingoDialog)
-    {
-        _lingoDialog = (LingoCSharpConverterPopup)lingoDialog;
-        _wordsLingoCodeBuiltIn = LingoCSharpConverterPopup.CaseInsensitiveWords(_lingoDialog.WordsLingoCodeBuiltIn).ToList();
-        _wordsLingoCodeKeywords = LingoCSharpConverterPopup.CaseInsensitiveWords(_lingoDialog.WordsLingoCodeKeywords).ToList();
-        _wordsCCharpCodeBuiltIn = _lingoDialog.WordsCCharpCodeBuiltIn;
-        _wordsCCharpCodeTypes = _lingoDialog.WordsCCharpCodeTypes;
-        _lingoHighlighter = CreateLingoHighlighter();
-        _csharpHighlighter = CreateCSharpHighlighter();
-    }
-    private CodeHighlighter CreateLingoHighlighter()
-    {
-        var highlighter = new CodeHighlighter();
-
-        var keywordColor = DirectorColors.LingoCodeKeyword.ToGodotColor();
-        foreach (var word in _wordsLingoCodeKeywords)
-            highlighter.AddKeywordColor(word, keywordColor);
-
-        var builtInColor = DirectorColors.LingoCodeBuiltIn.ToGodotColor();
-
-        foreach (var word in _wordsLingoCodeBuiltIn)
-            highlighter.AddKeywordColor(word, builtInColor);
-
-        var literalColor = DirectorColors.LingoCodeLiteral.ToGodotColor();
-        highlighter.NumberColor = literalColor;
-
-        highlighter.AddColorRegion("--", "", DirectorColors.LingoCodeComment.ToGodotColor(), true);
-        highlighter.AddColorRegion("\"", "\"", literalColor);
-
-        return highlighter;
-    }
-
-    public void UpdateCSharpColors(AbstInputText inputText)
-    {
-        ((TextEdit)inputText.Framework<AbstGodotInputText>().FrameworkNode).SyntaxHighlighter = _csharpHighlighter;
-    }
-
-    public void UpdateLingoColors(AbstInputText inputText)
-    {
-        ((TextEdit)inputText.Framework<AbstGodotInputText>().FrameworkNode).SyntaxHighlighter = _lingoHighlighter;
-    }
-
-    private CodeHighlighter CreateCSharpHighlighter()
-    {
-        var highlighter = new CodeHighlighter();
-
-        var keywordColor = DirectorColors.CCharpCodeBuiltIn.ToGodotColor();
-        foreach (var word in _wordsCCharpCodeBuiltIn)
-            highlighter.AddKeywordColor(word, keywordColor);
-
-        var typeColor = DirectorColors.CCharpCodeTypes.ToGodotColor();
-        foreach (var word in _wordsCCharpCodeTypes)
-            highlighter.AddKeywordColor(word, typeColor);
-
-
-
-        highlighter.NumberColor = DirectorColors.CCharpCodeNumber.ToGodotColor(); ;
-
-        highlighter.AddColorRegion("//", "", DirectorColors.CCharpCodeComment.ToGodotColor(), true);
-        highlighter.AddColorRegion("/*", "*/", DirectorColors.CCharpCodeComment.ToGodotColor());
-        highlighter.AddColorRegion("\"", "\"", DirectorColors.CCharpCodeString.ToGodotColor());
-        highlighter.AddColorRegion("@\"", "\"", DirectorColors.CCharpCodeString.ToGodotColor());
-
-        return highlighter;
-    }
+    public void Init(ILingoDialog lingoDialog) { }
 }


### PR DESCRIPTION
## Summary
- add DirCodeHighlichter component with shared keyword lists
- wire Godot-specific DirGodotCodeHighlighter linked via factory
- update LingoCSharpConverterPopup to use highlighters for Lingo and C#

## Testing
- `dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj`
- `dotnet build src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a3f573e4f4833292d23665dad3e7e3