### PR TITLE
feat(abstui): introduce component style hierarchy

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/AbstColorPicker.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/AbstColorPicker.cs
@@ -1,4 +1,5 @@
 using AbstUI.Primitives;
+using AbstUI.Styles;
 
 namespace AbstUI.Components
 {
@@ -8,5 +9,19 @@ namespace AbstUI.Components
     public class AbstColorPicker : AbstInputBase<IAbstFrameworkColorPicker>
     {
         public AColor Color { get => _framework.Color; set => _framework.Color = value; }
+
+        protected override void OnSetStyle(AbstComponentStyle componentStyle)
+        {
+            base.OnSetStyle(componentStyle);
+            if (componentStyle is AbstColorPickerStyle style && style.DefaultColor.HasValue)
+                Color = style.DefaultColor.Value;
+        }
+
+        protected override void OnGetStyle(AbstComponentStyle componentStyle)
+        {
+            base.OnGetStyle(componentStyle);
+            if (componentStyle is AbstColorPickerStyle style)
+                style.DefaultColor = Color;
+        }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/AbstInputBase.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/AbstInputBase.cs
@@ -1,3 +1,6 @@
+using System;
+using AbstUI.Styles;
+
 namespace AbstUI.Components
 {
     /// <summary>
@@ -14,6 +17,44 @@ namespace AbstUI.Components
         {
             add { _framework.ValueChanged += value; }
             remove { _framework.ValueChanged -= value; }
+        }
+
+        protected override void OnSetStyle(AbstComponentStyle componentStyle)
+        {
+            base.OnSetStyle(componentStyle);
+            if (componentStyle is AbstInputStyle style)
+            {
+                if (style.FontSize.HasValue)
+                {
+                    if (_framework is IAbstFrameworkInputText text)
+                        text.FontSize = style.FontSize.Value;
+                    if (_framework is IAbstFrameworkInputNumber number)
+                        number.FontSize = style.FontSize.Value;
+                }
+
+                if (style.Font is not null && _framework is IAbstFrameworkInputText textWithFont)
+                    textWithFont.Font = style.Font;
+
+                if (style.TextColor.HasValue && _framework is IAbstFrameworkInputText textWithColor)
+                    textWithColor.TextColor = style.TextColor.Value;
+            }
+        }
+
+        protected override void OnGetStyle(AbstComponentStyle componentStyle)
+        {
+            base.OnGetStyle(componentStyle);
+            if (componentStyle is AbstInputStyle style)
+            {
+                if (_framework is IAbstFrameworkInputText text)
+                {
+                    style.FontSize = text.FontSize;
+                    style.Font = text.Font;
+                    style.TextColor = text.TextColor;
+                }
+
+                if (_framework is IAbstFrameworkInputNumber number)
+                    style.FontSize = number.FontSize;
+            }
         }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/AbstLabel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/AbstLabel.cs
@@ -1,6 +1,6 @@
-using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.Texts;
+using AbstUI.Styles;
 
 namespace AbstUI.Components
 {
@@ -16,5 +16,27 @@ namespace AbstUI.Components
         public int LineHeight { get => _framework.LineHeight; set => _framework.LineHeight = value; }
         public ATextWrapMode WrapMode { get => _framework.WrapMode; set => _framework.WrapMode = value; }
         public AbstTextAlignment TextAlignment { get => _framework.TextAlignment; set => _framework.TextAlignment = value; }
+
+        protected override void OnSetStyle(AbstComponentStyle componentStyle)
+        {
+            base.OnSetStyle(componentStyle);
+            if (componentStyle is AbstLabelStyle style)
+            {
+                if (style.Font != null) Font = style.Font;
+                if (style.FontSize.HasValue) FontSize = style.FontSize.Value;
+                if (style.FontColor.HasValue) FontColor = style.FontColor.Value;
+            }
+        }
+
+        protected override void OnGetStyle(AbstComponentStyle componentStyle)
+        {
+            base.OnGetStyle(componentStyle);
+            if (componentStyle is AbstLabelStyle style)
+            {
+                style.Font = Font;
+                style.FontSize = FontSize;
+                style.FontColor = FontColor;
+            }
+        }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/AbstNodeBase.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/AbstNodeBase.cs
@@ -1,5 +1,6 @@
 using System;
 using AbstUI.Primitives;
+using AbstUI.Styles;
 
 namespace AbstUI.Components
 {
@@ -20,6 +21,55 @@ namespace AbstUI.Components
         public virtual float Width { get => _framework.Width; set => _framework.Width = value; }
         public virtual float Height { get => _framework.Height; set => _framework.Height = value; }
 
+        #region Styling
+        /// <summary>
+        /// Apply a style to this component.
+        /// </summary>
+        public void SetStyle(AbstComponentStyle componentStyle)
+        {
+            if (componentStyle.Visibility.HasValue)
+                Visibility = componentStyle.Visibility.Value;
+            if (componentStyle.Margin.HasValue)
+                Margin = componentStyle.Margin.Value;
+            if (componentStyle.Width.HasValue)
+                Width = componentStyle.Width.Value;
+            if (componentStyle.Height.HasValue)
+                Height = componentStyle.Height.Value;
+
+            OnSetStyle(componentStyle);
+        }
+
+        /// <summary>
+        /// Retrieve the current style applied to this component.
+        /// </summary>
+        /// <typeparam name="TStyle">Specific style type to return.</typeparam>
+        /// <returns>Populated style instance.</returns>
+        public TStyle GetStyle<TStyle>() where TStyle : AbstComponentStyle, new()
+        {
+            var style = new TStyle
+            {
+                Visibility = Visibility,
+                Margin = Margin,
+                Width = Width,
+                Height = Height,
+            };
+
+            OnGetStyle(style);
+            return style;
+        }
+
+        /// <summary>
+        /// Allows derived components to handle style-specific properties when applying styles.
+        /// </summary>
+        /// <param name="componentStyle">Style being applied.</param>
+        protected virtual void OnSetStyle(AbstComponentStyle componentStyle) { }
+
+        /// <summary>
+        /// Allows derived components to handle style-specific properties when retrieving styles.
+        /// </summary>
+        /// <param name="componentStyle">Style being populated.</param>
+        protected virtual void OnGetStyle(AbstComponentStyle componentStyle) { }
+        #endregion
 
         public virtual T Framework<T>() where T : IAbstFrameworkNode => (T)(object)_framework;
         public virtual IAbstFrameworkNode FrameworkObj => _framework;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstButtonStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstButtonStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstButton"/>.
+/// </summary>
+public class AbstButtonStyle : AbstInputStyle
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstColorPickerStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstColorPickerStyle.cs
@@ -1,0 +1,14 @@
+using AbstUI.Primitives;
+
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstColorPicker"/>.
+/// </summary>
+public class AbstColorPickerStyle : AbstInputStyle
+{
+    /// <summary>
+    /// Default color shown when no value is set.
+    /// </summary>
+    public AColor? DefaultColor { get; set; }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstComponentStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstComponentStyle.cs
@@ -1,0 +1,14 @@
+using AbstUI.Primitives;
+
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Base style applicable to all components.
+/// </summary>
+public class AbstComponentStyle
+{
+    public bool? Visibility { get; set; }
+    public AMargin? Margin { get; set; }
+    public float? Width { get; set; }
+    public float? Height { get; set; }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstContainerStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstContainerStyle.cs
@@ -1,0 +1,13 @@
+using AbstUI.Primitives;
+
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Base style for container components.
+/// </summary>
+public class AbstContainerStyle : AbstComponentStyle
+{
+    public AColor? BackgroundColor { get; set; }
+    public AColor? BorderColor { get; set; }
+    public float? BorderWidth { get; set; }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstGfxCanvasStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstGfxCanvasStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstGfxCanvas"/>.
+/// </summary>
+public class AbstGfxCanvasStyle : AbstComponentStyle
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstHorizontalLineSeparatorStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstHorizontalLineSeparatorStyle.cs
@@ -1,0 +1,12 @@
+using AbstUI.Primitives;
+
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstHorizontalLineSeparator"/>.
+/// </summary>
+public class AbstHorizontalLineSeparatorStyle : AbstComponentStyle
+{
+    public AColor? Color { get; set; }
+    public float? Thickness { get; set; }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputCheckboxStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputCheckboxStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstInputCheckbox"/>.
+/// </summary>
+public class AbstInputCheckboxStyle : AbstInputStyle
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputComboboxStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputComboboxStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstInputCombobox"/>.
+/// </summary>
+public class AbstInputComboboxStyle : AbstInputStyle
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputNumberStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputNumberStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstInputNumber"/>.
+/// </summary>
+public class AbstInputNumberStyle : AbstInputStyle
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputSliderStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputSliderStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstInputSlider"/>.
+/// </summary>
+public class AbstInputSliderStyle : AbstInputStyle
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputSpinBoxStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputSpinBoxStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstInputSpinBox"/>.
+/// </summary>
+public class AbstInputSpinBoxStyle : AbstInputStyle
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputStyle.cs
@@ -1,0 +1,13 @@
+using AbstUI.Primitives;
+
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Base style for input components.
+/// </summary>
+public class AbstInputStyle : AbstComponentStyle
+{
+    public string? Font { get; set; }
+    public int? FontSize { get; set; }
+    public AColor? TextColor { get; set; }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputTextStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputTextStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstInputText"/>.
+/// </summary>
+public class AbstInputTextStyle : AbstInputStyle
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstItemListStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstItemListStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstItemList"/>.
+/// </summary>
+public class AbstItemListStyle : AbstContainerStyle
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstLabelStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstLabelStyle.cs
@@ -1,0 +1,13 @@
+using AbstUI.Primitives;
+
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstLabel"/>.
+/// </summary>
+public class AbstLabelStyle : AbstComponentStyle
+{
+    public string? Font { get; set; }
+    public int? FontSize { get; set; }
+    public AColor? FontColor { get; set; }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstMenuItemStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstMenuItemStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstMenuItem"/>.
+/// </summary>
+public class AbstMenuItemStyle : AbstInputStyle
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstMenuStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstMenuStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstMenu"/>.
+/// </summary>
+public class AbstMenuStyle : AbstContainerStyle
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstPanelStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstPanelStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstPanel"/>.
+/// </summary>
+public class AbstPanelStyle : AbstContainerStyle
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstScrollContainerStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstScrollContainerStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstScrollContainer"/>.
+/// </summary>
+public class AbstScrollContainerStyle : AbstContainerStyle
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstStateButtonStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstStateButtonStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstStateButton"/>.
+/// </summary>
+public class AbstStateButtonStyle : AbstInputStyle
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstTabContainerStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstTabContainerStyle.cs
@@ -1,0 +1,9 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstTabContainer"/>.
+/// </summary>
+public class AbstTabContainerStyle : AbstContainerStyle
+{
+    public float? HeaderHeight { get; set; }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstTabItemStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstTabItemStyle.cs
@@ -1,0 +1,9 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstTabItem"/>.
+/// </summary>
+public class AbstTabItemStyle : AbstContainerStyle
+{
+    public float? TopHeight { get; set; }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstVerticalLineSeparatorStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstVerticalLineSeparatorStyle.cs
@@ -1,0 +1,12 @@
+using AbstUI.Primitives;
+
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstVerticalLineSeparator"/>.
+/// </summary>
+public class AbstVerticalLineSeparatorStyle : AbstComponentStyle
+{
+    public AColor? Color { get; set; }
+    public float? Thickness { get; set; }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstWindowStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstWindowStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstWindow"/>.
+/// </summary>
+public class AbstWindowStyle : AbstContainerStyle
+{
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstWrapPanelStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstWrapPanelStyle.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Style for <see cref="AbstUI.Components.AbstWrapPanel"/>.
+/// </summary>
+public class AbstWrapPanelStyle : AbstContainerStyle
+{
+}


### PR DESCRIPTION
## Summary
- add base `SetStyle`/`GetStyle` hooks for components
- expose style values for inputs, labels, and color pickers

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj -v diag`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest/AbstUI.GfxVisualTest.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a3f338c6788332b3ed9878f559c5c3