### PR TITLE
Improve Lingo to C# conversion with two-pass analysis

### DIFF
--- a/src/LingoEngine.Lingo.Core/ScriptBundle.cs
+++ b/src/LingoEngine.Lingo.Core/ScriptBundle.cs
@@ -29,4 +29,21 @@ public class LingoBatchResult
 {
     public Dictionary<string, string> ConvertedScripts { get; } = new();
     public HashSet<string> CustomMethods { get; } = new();
+    public Dictionary<string, List<MethodSignature>> Methods { get; } = new();
+    public Dictionary<string, List<PropertyInfo>> Properties { get; } = new();
 }
+
+/// <summary>
+/// Represents a converted method signature.
+/// </summary>
+public record MethodSignature(string Name, List<ParameterInfo> Parameters);
+
+/// <summary>
+/// Represents a parameter detected during conversion.
+/// </summary>
+public record ParameterInfo(string Name, string Type);
+
+/// <summary>
+/// Represents a property detected during conversion.
+/// </summary>
+public record PropertyInfo(string Name, string Type);


### PR DESCRIPTION
## Summary
- capture method signatures and property info during batch conversion
- infer property and parameter types, emitting class wrappers in second pass
- expand tests for sendSprite, metadata collection, and parameter type inference

## Testing
- `dotnet format src/LingoEngine.Lingo.Core/LingoEngine.Lingo.Core.csproj`
- `dotnet format Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a4051a481483328ee7e138ef62857f