### PR TITLE
feat: add sprite state management

### DIFF
--- a/src/LingoEngine/Sounds/LingoSpriteSound.cs
+++ b/src/LingoEngine/Sounds/LingoSpriteSound.cs
@@ -49,11 +49,11 @@ public class LingoSpriteSound : LingoSprite, ILingoSpriteWithMember
         base.EndSprite();
     }
 
-        public override void OnRemoveMe()
-        {
-            Sound?.ReleaseFromRefUser(this);
-            _onRemoveMe(this);
-        }
+    public override void OnRemoveMe()
+    {
+        Sound?.ReleaseFromRefUser(this);
+        _onRemoveMe(this);
+    }
 
     public override Action<LingoSprite> GetCloneAction()
     {
@@ -69,6 +69,23 @@ public class LingoSpriteSound : LingoSprite, ILingoSpriteWithMember
         };
 
         return action;
+    }
+
+    protected override LingoSpriteState CreateState() => new LingoSpriteSoundState();
+
+    protected override void OnLoadState(LingoSpriteState state)
+    {
+        if (state is not LingoSpriteSoundState s) return;
+        Channel = s.Channel;
+        Sound = s.Sound;
+        Sound?.UsedBy(this);
+    }
+
+    protected override void OnGetState(LingoSpriteState state)
+    {
+        if (state is not LingoSpriteSoundState s) return;
+        s.Channel = Channel;
+        s.Sound = Sound;
     }
 
     public ILingoMember? GetMember() => Sound;

--- a/src/LingoEngine/Sprites/LingoSprite.cs
+++ b/src/LingoEngine/Sprites/LingoSprite.cs
@@ -17,7 +17,7 @@ namespace LingoEngine.Sprites
 
         public int BeginFrame
         {
-            get => _beginFrame; 
+            get => _beginFrame;
             set
             {
                 _beginFrame = value;
@@ -26,7 +26,7 @@ namespace LingoEngine.Sprites
         }
         public int EndFrame
         {
-            get => _endFrame; 
+            get => _endFrame;
             set
             {
                 _endFrame = value;
@@ -41,7 +41,7 @@ namespace LingoEngine.Sprites
                 _name = value;
                 NotifyAnimationChanged();
             }
-        }        
+        }
         /// <summary>
         /// This represents the puppetsprite controlled by script.
         /// </summary>
@@ -58,7 +58,7 @@ namespace LingoEngine.Sprites
         public bool IsSingleFrame { get; protected set; }
         public bool Lock
         {
-            get => _lock; 
+            get => _lock;
             set
             {
                 _lock = value;
@@ -67,6 +67,8 @@ namespace LingoEngine.Sprites
         }
 
         public bool IsDeleted { get; private set; }
+
+        public LingoSpriteState? InitialState { get; internal set; }
 
         public event Action? AnimationChanged;
 
@@ -128,14 +130,17 @@ namespace LingoEngine.Sprites
                 _eventMediator.Subscribe(actor, SpriteNum + 6);
                 if (actor is IHasBeginSpriteEvent begin) begin.BeginSprite();
             }
-           
+
+            if (InitialState != null)
+                LoadState(InitialState);
+
             BeginSprite();
         }
         protected virtual void BeginSprite() { }
-       
+
         internal virtual void DoEndSprite()
         {
-           
+
             foreach (var actor in _spriteActors)
             {
                 if (actor is IHasEndSpriteEvent end) end.EndSprite();
@@ -160,6 +165,36 @@ namespace LingoEngine.Sprites
             AnimationChanged?.Invoke();
         }
 
+        public void LoadState(LingoSpriteState state)
+        {
+            BeginFrame = state.BeginFrame;
+            EndFrame = state.EndFrame;
+            Name = state.Name;
+            Puppet = state.Puppet;
+            SpriteNum = state.SpriteNum;
+            Lock = state.Lock;
+            OnLoadState(state);
+        }
+
+        protected virtual void OnLoadState(LingoSpriteState state) { }
+
+        public LingoSpriteState GetState()
+        {
+            var state = CreateState();
+            state.BeginFrame = BeginFrame;
+            state.EndFrame = EndFrame;
+            state.Name = Name;
+            state.Puppet = Puppet;
+            state.SpriteNum = SpriteNum;
+            state.Lock = Lock;
+            OnGetState(state);
+            return state;
+        }
+
+        protected virtual LingoSpriteState CreateState() => new();
+
+        protected virtual void OnGetState(LingoSpriteState state) { }
+
         public virtual Action<LingoSprite> GetCloneAction()
         {
             Action<LingoSprite> action = s => { };
@@ -168,7 +203,7 @@ namespace LingoEngine.Sprites
             int begin = BeginFrame;
             int end = EndFrame;
             string name = Name;
-            
+
             action = s =>
             {
                 s.Name = name;

--- a/src/LingoEngine/Sprites/LingoSprite2D.cs
+++ b/src/LingoEngine/Sprites/LingoSprite2D.cs
@@ -169,11 +169,16 @@ namespace LingoEngine.Sprites
         public byte[] Thumbnail { get; set; } = new byte[] { };
         public string ModifiedBy { get; set; } = "";
 
-        public float Width { get => _frameworkSprite.Width; 
-            set => _frameworkSprite.DesiredWidth = value; 
+        public float Width
+        {
+            get => _frameworkSprite.Width;
+            set => _frameworkSprite.DesiredWidth = value;
         }
-        public float Height { get => _frameworkSprite.Height; 
-            set => _frameworkSprite.DesiredHeight = value; }
+        public float Height
+        {
+            get => _frameworkSprite.Height;
+            set => _frameworkSprite.DesiredHeight = value;
+        }
 
         public ILingoMember? GetMember() => Member;
 
@@ -237,7 +242,7 @@ namespace LingoEngine.Sprites
             if (configure != null)
                 configure(behavior);
             return behavior;
-        } 
+        }
         private void CallBehaviorForEvents<T>(Action<T> action)
         {
             foreach (var item in _behaviors.OfType<T>())
@@ -346,7 +351,7 @@ When a movie stops, events occur in the following order:
             // Subscribe all behaviors
             _behaviors.ForEach(b =>
             {
-                _eventMediator.Subscribe(b, SpriteNum + 6,true); //  we ignore mouse because it has to be within the boundingbox
+                _eventMediator.Subscribe(b, SpriteNum + 6, true); //  we ignore mouse because it has to be within the boundingbox
                 if (_movie.IsPlaying)
                     if (b is IHasBeginSpriteEvent beginSpriteEvent) beginSpriteEvent.BeginSprite();
 
@@ -364,13 +369,13 @@ When a movie stops, events occur in the following order:
         }
         internal override void DoEndSprite()
         {
-                _behaviors.ForEach(b =>
-                {
-                    // Unsubscribe all behaviors
-                    _eventMediator.Unsubscribe(b, true); //  we ignore mouse because it has to be within the boundingbox
-                    if (_movie.IsPlaying)
-                        if (b is IHasEndSpriteEvent endSpriteEvent) endSpriteEvent.EndSprite();
-                });
+            _behaviors.ForEach(b =>
+            {
+                // Unsubscribe all behaviors
+                _eventMediator.Unsubscribe(b, true); //  we ignore mouse because it has to be within the boundingbox
+                if (_movie.IsPlaying)
+                    if (b is IHasEndSpriteEvent endSpriteEvent) endSpriteEvent.EndSprite();
+            });
             FrameworkObj.Hide();
             _textureSubscription?.Release();
             _textureSubscription = null;
@@ -460,7 +465,7 @@ When a movie stops, events occur in the following order:
             _frameworkSprite.MemberChanged();
 
 
-        } 
+        }
         #endregion
 
 
@@ -547,17 +552,17 @@ When a movie stops, events occur in the following order:
             // Only respond if the sprite is active and the mouse is within the bounding box
             if (IsActive && IsMouseInsideBoundingBox(mouse.Mouse))
             {
-                
-                    CallBehaviorForEvents<IHasMouseMoveEvent>(b => b.MouseMove(mouse));
-                    _eventMediator.RaiseMouseMove(mouse);
 
-                    if (!isMouseInside)
-                    {
-                        MouseEnter(mouse); // Mouse has entered the sprite
-                        CallBehaviorForEvents<IHasMouseEnterEvent>(b => b.MouseEnter(mouse));
-                        _eventMediator.RaiseMouseEnter(mouse);
-                        isMouseInside = true;
-                    }
+                CallBehaviorForEvents<IHasMouseMoveEvent>(b => b.MouseMove(mouse));
+                _eventMediator.RaiseMouseMove(mouse);
+
+                if (!isMouseInside)
+                {
+                    MouseEnter(mouse); // Mouse has entered the sprite
+                    CallBehaviorForEvents<IHasMouseEnterEvent>(b => b.MouseEnter(mouse));
+                    _eventMediator.RaiseMouseEnter(mouse);
+                    isMouseInside = true;
+                }
             }
             else
             {
@@ -672,7 +677,7 @@ When a movie stops, events occur in the following order:
             var rect = Rect; // LingoRect.New(LocH,LocV,Width,Height);
             if (!rect.Contains(mouse.MouseLoc))
                 return false;
-            
+
             if (InkType != LingoInkType.BackgroundTransparent || Member == null)
                 return true;
 
@@ -786,6 +791,72 @@ When a movie stops, events occur in the following order:
             };
 
             return action;
+        }
+
+        protected override LingoSpriteState CreateState() => new LingoSprite2DState();
+
+        protected override void OnLoadState(LingoSpriteState state)
+        {
+            if (state is not LingoSprite2DState s) return;
+            SetMember(s.Member);
+            DisplayMember = s.DisplayMember;
+            SpritePropertiesOffset = s.SpritePropertiesOffset;
+            Ink = s.Ink;
+            Visibility = s.Visibility;
+            Hilite = s.Hilite;
+            Linked = s.Linked;
+            Loaded = s.Loaded;
+            MediaReady = s.MediaReady;
+            Blend = s.Blend;
+            LocH = s.LocH;
+            LocV = s.LocV;
+            LocZ = s.LocZ;
+            Width = s.Width;
+            Height = s.Height;
+            Rotation = s.Rotation;
+            Skew = s.Skew;
+            FlipH = s.FlipH;
+            FlipV = s.FlipV;
+            Cursor = s.Cursor;
+            Constraint = s.Constraint;
+            DirectToStage = s.DirectToStage;
+            RegPoint = s.RegPoint;
+            ForeColor = s.ForeColor;
+            BackColor = s.BackColor;
+            Editable = s.Editable;
+            IsDraggable = s.IsDraggable;
+        }
+
+        protected override void OnGetState(LingoSpriteState state)
+        {
+            if (state is not LingoSprite2DState s) return;
+            s.Member = (LingoMember?)Member;
+            s.DisplayMember = DisplayMember;
+            s.SpritePropertiesOffset = SpritePropertiesOffset;
+            s.Ink = Ink;
+            s.Visibility = Visibility;
+            s.Hilite = Hilite;
+            s.Linked = Linked;
+            s.Loaded = Loaded;
+            s.MediaReady = MediaReady;
+            s.Blend = Blend;
+            s.LocH = LocH;
+            s.LocV = LocV;
+            s.LocZ = LocZ;
+            s.Width = Width;
+            s.Height = Height;
+            s.Rotation = Rotation;
+            s.Skew = Skew;
+            s.FlipH = FlipH;
+            s.FlipV = FlipV;
+            s.Cursor = Cursor;
+            s.Constraint = Constraint;
+            s.DirectToStage = DirectToStage;
+            s.RegPoint = RegPoint;
+            s.ForeColor = ForeColor;
+            s.BackColor = BackColor;
+            s.Editable = Editable;
+            s.IsDraggable = IsDraggable;
         }
 
         public void UpdateTexture(IAbstTexture2D texture)

--- a/src/LingoEngine/Sprites/LingoSprite2DVirtual.cs
+++ b/src/LingoEngine/Sprites/LingoSprite2DVirtual.cs
@@ -394,5 +394,57 @@ namespace LingoEngine.Sprites
             Texture = texture;
             _textureSubscription = texture.AddUser(this);
         }
+
+        protected override LingoSpriteState CreateState() => new LingoSprite2DVirtualState();
+
+        protected override void OnLoadState(LingoSpriteState state)
+        {
+            if (state is not LingoSprite2DVirtualState s) return;
+            SetMember(s.Member);
+            DisplayMember = s.DisplayMember;
+            Ink = s.Ink;
+            Hilite = s.Hilite;
+            Linked = s.Linked;
+            Loaded = s.Loaded;
+            Blend = s.Blend;
+            LocH = s.LocH;
+            LocV = s.LocV;
+            LocZ = s.LocZ;
+            Rotation = s.Rotation;
+            Skew = s.Skew;
+            FlipH = s.FlipH;
+            FlipV = s.FlipV;
+            Constraint = s.Constraint;
+            RegPoint = s.RegPoint;
+            ForeColor = s.ForeColor;
+            BackColor = s.BackColor;
+            Width = s.Width;
+            Height = s.Height;
+        }
+
+        protected override void OnGetState(LingoSpriteState state)
+        {
+            if (state is not LingoSprite2DVirtualState s) return;
+            s.Member = (LingoMember?)Member;
+            s.DisplayMember = DisplayMember;
+            s.Ink = Ink;
+            s.Hilite = Hilite;
+            s.Linked = Linked;
+            s.Loaded = Loaded;
+            s.Blend = Blend;
+            s.LocH = LocH;
+            s.LocV = LocV;
+            s.LocZ = LocZ;
+            s.Rotation = Rotation;
+            s.Skew = Skew;
+            s.FlipH = FlipH;
+            s.FlipV = FlipV;
+            s.Constraint = Constraint;
+            s.RegPoint = RegPoint;
+            s.ForeColor = ForeColor;
+            s.BackColor = BackColor;
+            s.Width = Width;
+            s.Height = Height;
+        }
     }
 }

--- a/src/LingoEngine/Sprites/LingoSpriteManager.cs
+++ b/src/LingoEngine/Sprites/LingoSpriteManager.cs
@@ -20,7 +20,7 @@ namespace LingoEngine.Sprites
         IEnumerable<TSprite> GetAllSprites();
         IEnumerable<TSprite> GetAllSpritesByChannel(int channel);
         IEnumerable<TSprite> GetAllSpritesBySpriteNumAndChannel(int spriteNumAndChannel);
-        
+
         void MoveSprite(TSprite sprite, int newFrame);
     }
 
@@ -53,7 +53,7 @@ namespace LingoEngine.Sprites
         internal abstract void BeginSprites();
         internal virtual LingoSprite? Add(int spriteNumWithChannel, int begin, int end, ILingoMember? member)
         {
-            return OnAdd(spriteNumWithChannel- SpriteNumChannelOffset, begin, end, member);
+            return OnAdd(spriteNumWithChannel - SpriteNumChannelOffset, begin, end, member);
         }
         protected abstract LingoSprite? OnAdd(int spriteNum, int begin, int end, ILingoMember? member);
         internal abstract void EndSprites();
@@ -65,7 +65,7 @@ namespace LingoEngine.Sprites
     public abstract class LingoSpriteManager<TSprite> : LingoSpriteManager
         where TSprite : LingoSprite
     {
-       
+
         protected readonly Dictionary<int, LingoSpriteChannel> _spriteChannels = new();
         protected readonly Dictionary<string, TSprite> _spritesByName = new();
         protected readonly List<TSprite> _allTimeSprites = new();
@@ -76,7 +76,7 @@ namespace LingoEngine.Sprites
         protected readonly List<TSprite> _exitedSprites = new();
 
         internal List<TSprite> AllTimeSprites => _allTimeSprites;
-       
+
 
         public override int MaxSpriteChannelCount
         {
@@ -89,7 +89,7 @@ namespace LingoEngine.Sprites
                     if (_spriteChannels.Count < _maxSpriteChannelCount)
                     {
                         for (int i = _spriteChannels.Count; i < _maxSpriteChannelCount; i++)
-                            _spriteChannels.Add(i, new LingoSpriteChannel(i,_movie));
+                            _spriteChannels.Add(i, new LingoSpriteChannel(i, _movie));
                     }
                 }
             }
@@ -98,7 +98,7 @@ namespace LingoEngine.Sprites
         public override int SpriteTotalCount => _activeSprites.Count;
         public override int SpriteMaxNumber => _activeSprites.Keys.DefaultIfEmpty(0).Max();
 
-        
+
 
         public event Action<int>? SpriteListChanged;
         protected void RaiseSpriteListChanged(int spritenumChannel) => SpriteListChanged?.Invoke(spritenumChannel);
@@ -144,6 +144,9 @@ namespace LingoEngine.Sprites
             SpriteJustCreated(sprite);
 
             configure?.Invoke(sprite);
+
+            sprite.InitialState = sprite.GetState();
+
             RaiseSpriteListChanged(sprite.SpriteNumWithChannel);
             return sprite;
         }
@@ -178,7 +181,7 @@ namespace LingoEngine.Sprites
                 return false;
             sprite.RemoveMe();
             return true;
-        } 
+        }
         internal bool RemoveSprite(LingoSprite2D sprite)
         {
             sprite.RemoveMe();
@@ -288,9 +291,9 @@ namespace LingoEngine.Sprites
 
 
 
-        public override void MuteChannel(int channel,bool state)
+        public override void MuteChannel(int channel, bool state)
         {
-            if(state)
+            if (state)
             {
                 if (!_mutedSprites.Contains(channel))
                     _mutedSprites.Add(channel);

--- a/src/LingoEngine/Sprites/LingoSpriteState.cs
+++ b/src/LingoEngine/Sprites/LingoSpriteState.cs
@@ -1,0 +1,75 @@
+using LingoEngine.Members;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.Sprites;
+
+public class LingoSpriteState
+{
+    public int BeginFrame { get; set; }
+    public int EndFrame { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public bool Puppet { get; set; }
+    public int SpriteNum { get; set; }
+    public bool Lock { get; set; }
+}
+
+public class LingoSprite2DState : LingoSpriteState
+{
+    public LingoMember? Member { get; set; }
+    public int DisplayMember { get; set; }
+    public int SpritePropertiesOffset { get; set; }
+    public int Ink { get; set; }
+    public bool Visibility { get; set; }
+    public bool Hilite { get; set; }
+    public bool Linked { get; set; }
+    public bool Loaded { get; set; }
+    public bool MediaReady { get; set; }
+    public float Blend { get; set; }
+    public float LocH { get; set; }
+    public float LocV { get; set; }
+    public int LocZ { get; set; }
+    public float Width { get; set; }
+    public float Height { get; set; }
+    public float Rotation { get; set; }
+    public float Skew { get; set; }
+    public bool FlipH { get; set; }
+    public bool FlipV { get; set; }
+    public int Cursor { get; set; }
+    public int Constraint { get; set; }
+    public bool DirectToStage { get; set; }
+    public APoint RegPoint { get; set; }
+    public AColor ForeColor { get; set; }
+    public AColor BackColor { get; set; }
+    public bool Editable { get; set; }
+    public bool IsDraggable { get; set; }
+}
+
+public class LingoSprite2DVirtualState : LingoSpriteState
+{
+    public LingoMember? Member { get; set; }
+    public int DisplayMember { get; set; }
+    public int Ink { get; set; }
+    public bool Hilite { get; set; }
+    public bool Linked { get; set; }
+    public bool Loaded { get; set; }
+    public float Blend { get; set; }
+    public float LocH { get; set; }
+    public float LocV { get; set; }
+    public int LocZ { get; set; }
+    public float Rotation { get; set; }
+    public float Skew { get; set; }
+    public bool FlipH { get; set; }
+    public bool FlipV { get; set; }
+    public int Constraint { get; set; }
+    public APoint RegPoint { get; set; }
+    public AColor ForeColor { get; set; }
+    public AColor BackColor { get; set; }
+    public float Width { get; set; }
+    public float Height { get; set; }
+}
+
+public class LingoSpriteSoundState : LingoSpriteState
+{
+    public int Channel { get; set; }
+    public LingoMemberSound? Sound { get; set; }
+}


### PR DESCRIPTION
## Summary
- add `LingoSpriteState` hierarchy for common and sprite-specific state data
- capture initial sprite state and expose `LoadState`/`GetState` hooks
- implement state handling for 2D, virtual, and sound sprites
- restore initial properties on `BeginSprite` and drop immutable `IsSingleFrame` from state

## Testing
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/Sprites/LingoSprite.cs src/LingoEngine/Sprites/LingoSpriteState.cs src/LingoEngine/Sprites/LingoSpriteManager.cs --verbosity diagnostic`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a436b286e883328f93cb98baf03186