### PR TITLE
Translate Lingo void to C# null

### DIFF
--- a/Test/LingoEngine.Lingo.Core.Tests/ClassGenerationTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/ClassGenerationTests.cs
@@ -215,4 +215,43 @@ end",
         Assert.Contains("public string c;", result);
         Assert.Contains("public bool d;", result);
     }
+
+    [Theory]
+    [InlineData("blur", "IHasBlurEvent", null)]
+    [InlineData("focus", "IHasFocusEvent", null)]
+    [InlineData("keyDown", "IHasKeyDownEvent", "LingoKeyEvent key")]
+    [InlineData("keyUp", "IHasKeyUpEvent", "LingoKeyEvent key")]
+    [InlineData("mouseWithin", "IHasMouseWithinEvent", "LingoMouseEvent mouse")]
+    [InlineData("mouseLeave", "IHasMouseLeaveEvent", "LingoMouseEvent mouse")]
+    [InlineData("mouseDown", "IHasMouseDownEvent", "LingoMouseEvent mouse")]
+    [InlineData("mouseUp", "IHasMouseUpEvent", "LingoMouseEvent mouse")]
+    [InlineData("mouseMove", "IHasMouseMoveEvent", "LingoMouseEvent mouse")]
+    [InlineData("mouseWheel", "IHasMouseWheelEvent", "LingoMouseEvent mouse")]
+    [InlineData("mouseEnter", "IHasMouseEnterEvent", "LingoMouseEvent mouse")]
+    [InlineData("mouseExit", "IHasMouseExitEvent", "LingoMouseEvent mouse")]
+    [InlineData("beginSprite", "IHasBeginSpriteEvent", null)]
+    [InlineData("endSprite", "IHasEndSpriteEvent", null)]
+    [InlineData("stepFrame", "IHasStepFrameEvent", null)]
+    [InlineData("prepareFrame", "IHasPrepareFrameEvent", null)]
+    [InlineData("enterFrame", "IHasEnterFrameEvent", null)]
+    [InlineData("exitFrame", "IHasExitFrameEvent", null)]
+
+    public void EventHandlersImplementInterfaces(string handler, string expectedInterface, string? param)
+    {
+        var file = new LingoScriptFile
+        {
+            Name = "MyScript",
+            Source = $"on {handler} me\nend",
+            Type = LingoScriptType.Behavior
+        };
+
+        var result = _converter.Convert(file);
+        var classDecl = $"public class MyScriptBehavior : LingoSpriteBehavior, {expectedInterface}";
+        Assert.Contains(classDecl, result);
+        var methodName = char.ToUpperInvariant(handler[0]) + handler[1..];
+        if (param is null)
+            Assert.Contains($"public void {methodName}()", result);
+        else
+            Assert.Contains($"public void {methodName}({param})", result);
+    }
 }

--- a/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
@@ -123,7 +123,7 @@ public class LingoToCSharpConverterTests
             "end");
         var result = _converter.Convert(lingo);
         var expected = string.Join('\n',
-            "public void Mousedown()",
+            "public void Mousedown(LingoMouseEvent mouse)",
             "{",
             "    if (myLock == false)",
             "    {",
@@ -296,6 +296,22 @@ public class LingoToCSharpConverterTests
             "}",
             "myMembers = [\"A\", \"B\"];",
             "y = myMembers[2];");
+        Assert.Equal(expected.Trim(), result.Trim());
+    }
+
+    [Fact]
+    public void VoidpWithVoidLiteralIsConverted()
+    {
+        var lingo = string.Join('\n',
+            "if voidp(void) then",
+            "  x = 1",
+            "end if");
+        var result = _converter.Convert(lingo);
+        var expected = string.Join('\n',
+            "if (null == null)",
+            "{",
+            "    x = 1;",
+            "}");
         Assert.Equal(expected.Trim(), result.Trim());
     }
 
@@ -588,18 +604,18 @@ on mouseleave me
 end";
         var result = _converter.Convert(lingo);
         var expected = string.Join('\n',
-            "public void MouseUp()",
+            "public void MouseUp(LingoMouseEvent mouse)",
             "{",
             "    Cursor = -1;",
             "    _Movie.GoTo(\"Game\");",
             "}",
             "",
-            "public void MouseWithin()",
+            "public void MouseWithin(LingoMouseEvent mouse)",
             "{",
             "    Cursor = 280;",
             "}",
             "",
-            "public void Mouseleave()",
+            "public void Mouseleave(LingoMouseEvent mouse)",
             "{",
             "    Cursor = -1;",
             "}");
@@ -617,7 +633,7 @@ on exitFrame
 end";
         var result = _converter.Convert(lingo);
         var expected = string.Join('\n',
-            "public void MouseDown()",
+            "public void MouseDown(LingoMouseEvent mouse)",
             "{",
             "    Sprite(SpriteNum).LocH = Sprite(SpriteNum).LocH + 5;",
             "}",
@@ -897,7 +913,7 @@ end",
             "    if (myValue == -1)",
             "    {",
             "        myValue = SendSprite<GetCounterStartDataBehavior>(myDataSpriteNum, getcounterstartdatabehavior => getcounterstartdatabehavior.GetCounterStartData(myDataName));",
-            "        if (myValue == void)",
+            "        if (myValue == null)",
             "        {",
             "            myValue = 0;",
             "        }",

--- a/docs/Lingo_vs_CSharp.md
+++ b/docs/Lingo_vs_CSharp.md
@@ -11,6 +11,7 @@ The tables below summarize how LingoEngine converts Lingo syntax into C#.
 | `global gVar` | `GlobalVars` singleton injected via DI |
 | `property myValue` | class field/property |
 | `me` | `this` |
+| `void` | `null` |
 | `sprite(n).locH` | `Sprite(n).LocH` |
 | `sprite(n).member = member("Name")` | `Sprite(n).SetMember("Name");` |
 | `member("Name").text` | `Member<LingoMemberText>("Name").Text` |

--- a/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
+++ b/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
@@ -247,7 +247,41 @@ public class LingoToCSharpConverter
         var propDecls = ExtractPropertyDeclarations(script.Source);
 
         var sb = new System.Text.StringBuilder();
-        sb.AppendLine($"public class {className} : {baseType}{(hasPropDescHandler ? ", ILingoPropertyDescriptionList" : string.Empty)}");
+        var interfaces = new List<string>();
+        if (hasPropDescHandler)
+            interfaces.Add("ILingoPropertyDescriptionList");
+
+        var eventInterfaces = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["blur"] = "IHasBlurEvent",
+            ["focus"] = "IHasFocusEvent",
+            ["keydown"] = "IHasKeyDownEvent",
+            ["keyup"] = "IHasKeyUpEvent",
+            ["mousewithin"] = "IHasMouseWithinEvent",
+            ["mouseleave"] = "IHasMouseLeaveEvent",
+            ["mousedown"] = "IHasMouseDownEvent",
+            ["mouseup"] = "IHasMouseUpEvent",
+            ["mousemove"] = "IHasMouseMoveEvent",
+            ["mousewheel"] = "IHasMouseWheelEvent",
+            ["mouseenter"] = "IHasMouseEnterEvent",
+            ["mouseexit"] = "IHasMouseExitEvent",
+            ["beginsprite"] = "IHasBeginSpriteEvent",
+            ["endsprite"] = "IHasEndSpriteEvent",
+            ["stepframe"] = "IHasStepFrameEvent",
+            ["prepareframe"] = "IHasPrepareFrameEvent",
+            ["enterframe"] = "IHasEnterFrameEvent",
+            ["exitframe"] = "IHasExitFrameEvent"
+        };
+
+        foreach (var kv in eventInterfaces)
+        {
+            if (handlers.Contains(kv.Key))
+                interfaces.Add(kv.Value);
+        }
+
+        var interfaceSuffix = interfaces.Count > 0 ? ", " + string.Join(", ", interfaces) : string.Empty;
+
+        sb.AppendLine($"public class {className} : {baseType}{interfaceSuffix}");
         sb.AppendLine("{");
 
         var fieldMap = new Dictionary<string, (string Type, string? Default)>(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
## Summary
- Ensure C# writer outputs `null` for Lingo `void` literals and identifiers
- Handle `voidp` calls by generating null comparisons
- Test `voidp(void)` to confirm conversion to `null == null`
- Document mapping from Lingo’s `void` to C# `null`
- Detect input event handlers and add matching `IHas*` interfaces
- Generate typed event handler signatures ignoring `me`
- Cover all input event interfaces with new converter tests
- Map sprite and frame events to their `IHas*` interfaces and verify with tests

## Testing
- `dotnet format src/LingoEngine.Lingo.Core/LingoEngine.Lingo.Core.csproj --verbosity diagnostic` *(fails: /usr/bin/dotnet not found)*
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj` *(fails: /usr/bin/dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e4000590833292afd616749a9921