### PR TITLE
Implement SDL2 rendering for basic UI controls

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstSdlComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstSdlComponentFactory.cs
@@ -2,6 +2,7 @@ using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.SDL2.Components;
 using AbstUI.SDL2.Styles;
+using AbstUI.Styles;
 using AbstUI.Windowing;
 
 namespace AbstUI.SDL2
@@ -22,6 +23,7 @@ namespace AbstUI.SDL2
         {
             _rootContext = rootContext;
             FontManagerTyped = (SdlFontManager)FontManager;
+            AbstDefaultStyles.RegisterInputStyles(StyleManager);
         }
 
         public AbstSDLComponentContext CreateContext(IAbstSDLComponent component, AbstSDLComponentContext? parent = null)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdInputltemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdInputltemList.cs
@@ -6,6 +6,7 @@ using AbstUI.Primitives;
 using AbstUI.SDL2.SDLL;
 using AbstUI.SDL2.Texts;
 using AbstUI.SDL2.Styles;
+using AbstUI.Styles;
 
 namespace AbstUI.SDL2.Components
 {
@@ -47,7 +48,7 @@ namespace AbstUI.SDL2.Components
 
         private void EnsureResources(AbstSDLRenderContext ctx)
         {
-            _font ??= ctx.SdlFontManager.GetTyped(this, null, 12);
+            _font ??= ctx.SdlFontManager.GetTyped(this, null, 11);
             _atlas ??= new SdlGlyphAtlas(ctx.Renderer, _font.FontHandle);
             if (_lineHeight == 0)
             {
@@ -69,7 +70,8 @@ namespace AbstUI.SDL2.Components
                 SDL.SDL_Rect rect = new SDL.SDL_Rect { x = 0, y = y, w = w, h = _lineHeight };
                 if (i == SelectedIndex)
                 {
-                    SDL.SDL_SetRenderDrawColor(context.Renderer, 0, 120, 215, 255);
+                    var accent = AbstDefaultColors.InputAccentColor;
+                    SDL.SDL_SetRenderDrawColor(context.Renderer, accent.R, accent.G, accent.B, accent.A);
                     SDL.SDL_RenderFillRect(context.Renderer, ref rect);
                     SDL.SDL_Color txt = new SDL.SDL_Color { r = 255, g = 255, b = 255, a = 255 };
                     DrawItemText(_items[i].Value, 4, y, txt, context);
@@ -78,9 +80,10 @@ namespace AbstUI.SDL2.Components
                 {
                     SDL.SDL_SetRenderDrawColor(context.Renderer, 255, 255, 255, 255);
                     SDL.SDL_RenderFillRect(context.Renderer, ref rect);
-                    SDL.SDL_SetRenderDrawColor(context.Renderer, 0, 0, 0, 255);
+                    var border = AbstDefaultColors.InputBorderColor;
+                    SDL.SDL_SetRenderDrawColor(context.Renderer, border.R, border.G, border.B, border.A);
                     SDL.SDL_RenderDrawRect(context.Renderer, ref rect);
-                    SDL.SDL_Color txt = new SDL.SDL_Color { r = 0, g = 0, b = 0, a = 255 };
+                    SDL.SDL_Color txt = AbstDefaultColors.InputTextColor.ToSDLColor();
                     DrawItemText(_items[i].Value, 4, y, txt, context);
                 }
                 y += _lineHeight;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputCheckbox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputCheckbox.cs
@@ -4,6 +4,7 @@ using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.SDL2;
 using AbstUI.SDL2.SDLL;
+using AbstUI.Styles;
 
 namespace AbstUI.SDL2.Components
 {
@@ -15,6 +16,10 @@ namespace AbstUI.SDL2.Components
         public bool Enabled { get; set; } = true;
         private bool _checked;
         private bool _focused;
+        private nint _texture;
+        private int _texW;
+        private int _texH;
+        private bool _prevChecked;
         public bool Checked
         {
             get => _checked;
@@ -52,9 +57,58 @@ namespace AbstUI.SDL2.Components
         public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
         {
             if (!Visibility) return default;
-            return default;
+
+            int w = (int)Width;
+            int h = (int)Height;
+
+            // create texture if needed
+            if (_texture == nint.Zero || w != _texW || h != _texH || _prevChecked != _checked)
+            {
+                if (_texture != nint.Zero)
+                    SDL.SDL_DestroyTexture(_texture);
+
+                _texture = SDL.SDL_CreateTexture(context.Renderer, SDL.SDL_PIXELFORMAT_RGBA8888,
+                    (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, w, h);
+                SDL.SDL_SetTextureBlendMode(_texture, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
+                _texW = w;
+                _texH = h;
+                _prevChecked = _checked;
+
+                var prev = SDL.SDL_GetRenderTarget(context.Renderer);
+                SDL.SDL_SetRenderTarget(context.Renderer, _texture);
+
+                // clear with transparent background
+                SDL.SDL_SetRenderDrawColor(context.Renderer, 0, 0, 0, 0);
+                SDL.SDL_RenderClear(context.Renderer);
+
+                SDL.SDL_Rect rect = new SDL.SDL_Rect { x = 0, y = 0, w = w, h = h };
+
+                if (_checked)
+                {
+                    var accent = AbstDefaultColors.InputAccentColor;
+                    SDL.SDL_SetRenderDrawColor(context.Renderer, accent.R, accent.G, accent.B, accent.A);
+                    SDL.SDL_RenderFillRect(context.Renderer, ref rect);
+                }
+
+                // draw border
+                var border = AbstDefaultColors.InputBorderColor;
+                SDL.SDL_SetRenderDrawColor(context.Renderer, border.R, border.G, border.B, border.A);
+                SDL.SDL_RenderDrawRect(context.Renderer, ref rect);
+
+                SDL.SDL_SetRenderTarget(context.Renderer, prev);
+            }
+
+            return _texture;
         }
 
-        public override void Dispose() => base.Dispose();
+        public override void Dispose()
+        {
+            if (_texture != nint.Zero)
+            {
+                SDL.SDL_DestroyTexture(_texture);
+                _texture = nint.Zero;
+            }
+            base.Dispose();
+        }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputCombobox.cs
@@ -8,6 +8,7 @@ using AbstUI.SDL2;
 using AbstUI.SDL2.SDLL;
 using AbstUI.SDL2.Texts;
 using AbstUI.SDL2.Styles;
+using AbstUI.Styles;
 
 namespace AbstUI.SDL2.Components
 {
@@ -19,6 +20,9 @@ namespace AbstUI.SDL2.Components
         public bool Enabled { get; set; } = true;
         public AMargin Margin { get; set; } = AMargin.Zero;
         private bool _focused;
+        public string? Font { get; set; }
+        public int FontSize { get; set; } = 11;
+        public AColor TextColor { get; set; } = AbstDefaultColors.InputTextColor;
 
         private readonly List<KeyValuePair<string, string>> _items = new();
         public IReadOnlyList<KeyValuePair<string, string>> Items => _items;
@@ -62,7 +66,7 @@ namespace AbstUI.SDL2.Components
 
         private void EnsureResources(AbstSDLRenderContext ctx)
         {
-            _font ??= ctx.SdlFontManager.GetTyped(this, null, 12);
+            _font ??= ctx.SdlFontManager.GetTyped(this, Font, FontSize);
             _atlas ??= new SdlGlyphAtlas(ctx.Renderer, _font.FontHandle);
             if (_lineHeight == 0)
             {
@@ -199,7 +203,8 @@ namespace AbstUI.SDL2.Components
                 SDL.SDL_SetRenderTarget(context.Renderer, _texture);
                 SDL.SDL_SetRenderDrawColor(context.Renderer, 255, 255, 255, 255);
                 SDL.SDL_RenderClear(context.Renderer);
-                SDL.SDL_SetRenderDrawColor(context.Renderer, 0, 0, 0, 255);
+                var border = AbstDefaultColors.InputBorderColor;
+                SDL.SDL_SetRenderDrawColor(context.Renderer, border.R, border.G, border.B, border.A);
                 SDL.SDL_Rect rect = new SDL.SDL_Rect { x = 0, y = 0, w = w, h = h };
                 SDL.SDL_RenderDrawRect(context.Renderer, ref rect);
 
@@ -211,7 +216,8 @@ namespace AbstUI.SDL2.Components
                     int ascent = SDL_ttf.TTF_FontAscent(_font!.FontHandle);
                     int descent = SDL_ttf.TTF_FontDescent(_font.FontHandle);
                     int baseline = (h - (ascent - descent)) / 2 + ascent;
-                    _atlas!.DrawRun(span, 4, baseline, new SDL.SDL_Color { r = 0, g = 0, b = 0, a = 255 });
+                    var color = TextColor.ToSDLColor();
+                    _atlas!.DrawRun(span, 4, baseline, color);
                 }
 
                 SDL.SDL_SetRenderTarget(context.Renderer, prevTarget);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlInputText.cs
@@ -8,6 +8,7 @@ using AbstUI.SDL2;
 using AbstUI.SDL2.SDLL;
 using AbstUI.SDL2.Texts;
 using AbstUI.SDL2.Styles;
+using AbstUI.Styles;
 
 namespace AbstUI.SDL2.Components
 {
@@ -42,10 +43,10 @@ namespace AbstUI.SDL2.Components
         }
         public int MaxLength { get; set; }
         public string? Font { get; set; }
-        public int FontSize { get; set; } = 12;
+        public int FontSize { get; set; } = 11;
         public AMargin Margin { get; set; } = AMargin.Zero;
         public object FrameworkNode => this;
-        public AColor TextColor { get; set; } = AColors.Black;
+        public AColor TextColor { get; set; } = AbstDefaultColors.InputTextColor;
 
         public bool IsMultiLine { get; set; }
 
@@ -153,7 +154,8 @@ namespace AbstUI.SDL2.Components
             };
             SDL.SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
             SDL.SDL_RenderFillRect(renderer, ref rect);
-            SDL.SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+            var border = AbstDefaultColors.InputBorderColor;
+            SDL.SDL_SetRenderDrawColor(renderer, border.R, border.G, border.B, border.A);
             SDL.SDL_RenderDrawRect(renderer, ref rect);
 
             if (_atlas == null || _font == null) return default;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlSpinBox.cs
@@ -3,6 +3,7 @@ using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.SDL2;
 using AbstUI.SDL2.SDLL;
+using AbstUI.Styles;
 
 namespace AbstUI.SDL2.Components;
 
@@ -108,10 +109,12 @@ internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IHandle
         var renderer = context.Renderer;
         var up = GetUpRect();
         var down = GetDownRect();
-        SDL.SDL_SetRenderDrawColor(renderer, 200, 200, 200, 255);
+        var accent = AbstDefaultColors.InputAccentColor;
+        SDL.SDL_SetRenderDrawColor(renderer, accent.R, accent.G, accent.B, accent.A);
         SDL.SDL_RenderFillRect(renderer, ref up);
         SDL.SDL_RenderFillRect(renderer, ref down);
-        SDL.SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+        var border = AbstDefaultColors.InputBorderColor;
+        SDL.SDL_SetRenderDrawColor(renderer, border.R, border.G, border.B, border.A);
         SDL.SDL_RenderDrawRect(renderer, ref up);
         SDL.SDL_RenderDrawRect(renderer, ref down);
         // simple triangles

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/AbstDefaultColors.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/AbstDefaultColors.cs
@@ -36,6 +36,11 @@ namespace AbstUI.Styles
         public static AColor Input_Border = new AColor(50, 50, 50);           // Border for text inputs
         public static AColor Input_Bg = new AColor(255, 255, 255);            // Background for text inputs
 
+        // Consolidated defaults for inputs
+        public static AColor InputBorderColor = Input_Border;   // Standard border color
+        public static AColor InputTextColor = InputText;        // Default text color
+        public static AColor InputAccentColor = InputSelection; // Accent/highlight color
+
 
         // Tabs
         public static AColor BG_Tabs = new AColor(157, 172, 191);             // Inactive tabs

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/AbstDefaultStyles.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/AbstDefaultStyles.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using AbstUI.Components;
+using AbstUI.Styles.Components;
+
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Helper to register default styles for AbstUI components.
+/// </summary>
+public static class AbstDefaultStyles
+{
+    /// <summary>
+    /// Registers default styling for common input components.
+    /// </summary>
+    public static void RegisterInputStyles(IAbstStyleManager styleManager)
+    {
+        var checkboxStyle = new AbstInputCheckboxStyle();
+        var stateButtonStyle = new AbstStateButtonStyle();
+        var sliderStyle = new AbstInputSliderStyle();
+        var textStyle = new AbstInputTextStyle();
+        var numberStyle = new AbstInputNumberStyle();
+        var comboboxStyle = new AbstInputComboboxStyle();
+        var spinBoxStyle = new AbstInputSpinBoxStyle();
+
+        var styles = new List<AbstInputStyle>
+        {
+            checkboxStyle,
+            stateButtonStyle,
+            sliderStyle,
+            textStyle,
+            numberStyle,
+            comboboxStyle,
+            spinBoxStyle,
+        };
+
+        foreach (var style in styles)
+        {
+            style.BorderColor = AbstDefaultColors.InputBorderColor;
+            style.TextColor = AbstDefaultColors.InputTextColor;
+            style.AccentColor = AbstDefaultColors.InputAccentColor;
+            style.Font = null;
+            style.FontSize = 11;
+        }
+
+        styleManager.Register<AbstInputCheckbox>(checkboxStyle);
+        styleManager.Register<AbstStateButton>(stateButtonStyle);
+        styleManager.Register<AbstInputSlider<int>>(sliderStyle);
+        styleManager.Register<AbstInputSlider<float>>(sliderStyle);
+        styleManager.Register<AbstInputText>(textStyle);
+        styleManager.Register<AbstInputNumber<int>>(numberStyle);
+        styleManager.Register<AbstInputNumber<float>>(numberStyle);
+        styleManager.Register<AbstInputCombobox>(comboboxStyle);
+        styleManager.Register<AbstInputSpinBox>(spinBoxStyle);
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputStyle.cs
@@ -10,4 +10,6 @@ public class AbstInputStyle : AbstComponentStyle
     public string? Font { get; set; }
     public int? FontSize { get; set; }
     public AColor? TextColor { get; set; }
+    public AColor? BorderColor { get; set; }
+    public AColor? AccentColor { get; set; }
 }


### PR DESCRIPTION
## Summary
- default input styles leave font unspecified while providing shared border, text, and accent colors
- SDL2 text, combobox, spin box, and list components render using common input colors and font size 11
- spin box buttons draw with accent fill and border outline for consistency

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj --verify-no-changes -v diag`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --verify-no-changes -v diag`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a55ab4685483328c6a52d96c421fe0