### PR TITLE
Register SDL2 root context in DI

### DIFF
--- a/src/LingoEngine.SDL2/SdlSetup.cs
+++ b/src/LingoEngine.SDL2/SdlSetup.cs
@@ -58,9 +58,10 @@ public static class SdlSetup
         reg
             .ServicesMain(s => s
                     .WithAbstUISdl()
-                    .AddSingleton(provider => new SdlRootContext(sdlWindow, sdlRenderer, provider.GetRequiredService<SdlFocusManager>()))
+                    .AddSingleton<SdlRootContext>(provider =>
+                        new SdlRootContext(sdlWindow, sdlRenderer, provider.GetRequiredService<SdlFocusManager>()))
+                    .AddSingleton<ISdlRootComponentContext>(p => p.GetRequiredService<SdlRootContext>())
                     .AddSingleton<ILingoFrameworkFactory, LingoSdlFactory>()
-                    
                 )
             .WithFrameworkFactory(setup)
             .AddBuildAction(b =>


### PR DESCRIPTION
## Summary
- Register SdlRootContext as ISdlRootComponentContext during SDL2 engine setup

## Testing
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a55805fe2c8332a3c4f933a750174d