### PR TITLE
Fix Blazor AbstUI project and align namespaces

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
@@ -1,7 +1,12 @@
 using System;
 using AbstUI.Components;
 using AbstUI.Primitives;
-using AbstUI.Blazor.Components;
+using AbstUI.Blazor.Components.Containers;
+using AbstUI.Blazor.Components.Inputs;
+using AbstUI.Blazor.Components.Menus;
+using AbstUI.Blazor.Components.Buttons;
+using AbstUI.Blazor.Components.Texts;
+using AbstUI.Blazor.Components.Graphics;
 using AbstUI.Styles;
 using AbstUI.Windowing;
 using AbstUI.Components.Graphics;
@@ -17,21 +22,21 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
 {
 
     private readonly IAbstFontManager _fontManager;
-      private readonly AbstBlazorComponentMapper _mapper;
+    private readonly AbstBlazorComponentMapper _mapper;
 
     public AbstBlazorComponentFactory(IServiceProvider serviceProvider, AbstBlazorComponentMapper mapper) : base(serviceProvider)
     {
         _fontManager = FontManager;
-         _mapper = mapper;
-        _mapper.Map<AbstBlazorWrapPanelComponent>(typeof(Components.AbstBlazorWrapPanel));
-        _mapper.Map<AbstBlazorPanelComponent>(typeof(Components.AbstBlazorPanel));
-        _mapper.Map<AbstBlazorTabContainerComponent>(typeof(Components.AbstBlazorTabContainer));
-        _mapper.Map<AbstBlazorScrollContainerComponent>(typeof(Components.AbstBlazorScrollContainer));
-        _mapper.Map<AbstBlazorInputCheckboxComponent>(typeof(Components.AbstBlazorInputCheckbox));
-        _mapper.Map<AbstBlazorButtonComponent>(typeof(Components.AbstBlazorButton));
-        _mapper.Map<AbstBlazorLabelComponent>(typeof(Components.AbstBlazorLabel));
-        _mapper.Map<AbstBlazorInputTextComponent>(typeof(Components.AbstBlazorInputText));
-        _mapper.Map<AbstBlazorLayoutWrapper>(typeof(Components.AbstBlazorLayoutWrapper));
+        _mapper = mapper;
+        _mapper.Map<AbstBlazorWrapPanelComponent>(typeof(AbstBlazorWrapPanel));
+        _mapper.Map<AbstBlazorPanelComponent>(typeof(AbstBlazorPanel));
+        _mapper.Map<AbstBlazorTabContainerComponent>(typeof(AbstBlazorTabContainer));
+        _mapper.Map<AbstBlazorScrollContainerComponent>(typeof(AbstBlazorScrollContainer));
+        _mapper.Map<AbstBlazorInputCheckboxComponent>(typeof(AbstBlazorInputCheckbox));
+        _mapper.Map<AbstBlazorButtonComponent>(typeof(AbstBlazorButton));
+        _mapper.Map<AbstBlazorLabelComponent>(typeof(AbstBlazorLabel));
+        _mapper.Map<AbstBlazorInputTextComponent>(typeof(AbstBlazorInputText));
+        _mapper.Map<AbstBlazorLayoutWrapper>(typeof(AbstBlazorLayoutWrapper));
     }
 
     public AbstGfxCanvas CreateGfxCanvas(string name, int width, int height)
@@ -173,7 +178,7 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
         var spin = new AbstInputSpinBox();
         var impl = new AbstBlazorSpinBox();
         spin.Init(impl);
-            InitComponent(spin);
+        InitComponent(spin);
         spin.Name = name;
         if (min.HasValue) spin.Min = min.Value;
         if (max.HasValue) spin.Max = max.Value;
@@ -188,7 +193,7 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
         var impl = new AbstBlazorInputCheckboxComponent();
         impl.Name = name;
         input.Init(impl);
-            InitComponent(input);
+        InitComponent(input);
         input.Name = name;
         if (onChange != null)
             input.ValueChanged += () => onChange(input.Checked);
@@ -200,7 +205,7 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
         var input = new AbstInputCombobox();
         var impl = new AbstBlazorInputCombobox();
         input.Init(impl);
-            InitComponent(input);
+        InitComponent(input);
         input.Name = name;
         if (onChange != null)
             input.ValueChanged += () => onChange(input.SelectedKey);
@@ -212,7 +217,7 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
         var list = new AbstItemList();
         var impl = new AbstBlazorItemList();
         list.Init(impl);
-            InitComponent(list);
+        InitComponent(list);
         list.Name = name;
         if (onChange != null)
             list.ValueChanged += () => onChange(list.SelectedKey);
@@ -224,7 +229,7 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
         var picker = new AbstColorPicker();
         var impl = new AbstBlazorColorPicker();
         picker.Init(impl);
-            InitComponent(picker);
+        InitComponent(picker);
         picker.Name = name;
         if (onChange != null)
             picker.ValueChanged += () => onChange(picker.Color);
@@ -236,7 +241,7 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
         var button = new AbstStateButton();
         var impl = new AbstBlazorStateButton();
         button.Init(impl);
-            InitComponent(button);
+        InitComponent(button);
         button.Name = name;
         button.Text = text;
         if (texture != null) button.TextureOn = texture;
@@ -249,7 +254,7 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
         var menu = new AbstMenu();
         var impl = new AbstBlazorMenu(this, name);
         menu.Init(impl);
-            InitComponent(menu);
+        InitComponent(menu);
         menu.Name = name;
         return menu;
     }
@@ -288,7 +293,7 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
         return sep;
     }
 
-   
+
 
     public AbstButton CreateButton(string name, string text = "")
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
@@ -28,8 +28,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
-	<PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.5" />
-	<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.5" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorBaseInput.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/AbstBlazorBaseInput.cs
@@ -1,36 +1,35 @@
 using Microsoft.AspNetCore.Components;
-using AbstUI.Primitives;
 using AbstUI.Components.Inputs;
 
 namespace AbstUI.Blazor.Components;
 
-public abstract class AbstBlazorBaseInput : IAbstFrameworkNodeInput
+/// <summary>
+/// Base class for all Blazor input components providing common behaviour
+/// such as enabled state management and disposal handling.
+/// </summary>
+public abstract class AbstBlazorBaseInput : AbstBlazorComponentBase, IAbstFrameworkNodeInput
 {
-    private bool _isdisposed;
-   [Parameter]  public bool Enabled {get;set; }
-   [Parameter]  public float X {get;set; }
-   [Parameter]  public float Y {get;set; }
-    [Parameter] public string Name { get; set; } = "";
-   [Parameter]  public bool Visibility {get;set; }
-   [Parameter]  public float Width {get;set; }
-   [Parameter]  public float Height {get;set; }
-    [Parameter] public AMargin Margin {get;set; }
+    private bool _isDisposed;
 
-    public abstract object FrameworkNode { get; }
+    /// <summary>Whether the control is enabled.</summary>
+    [Parameter] public bool Enabled { get; set; } = true;
 
     public event Action? ValueChanged;
 
-
     protected void ValueChangedInvoke()
     {
-        if (_isdisposed) return;
+        if (_isDisposed) return;
         ValueChanged?.Invoke();
     }
-    public void Dispose()
+
+    public override void Dispose()
     {
-        if (_isdisposed) return;
-        _isdisposed = true;
+        if (_isDisposed) return;
+        _isDisposed = true;
         OnDispose();
+        base.Dispose();
     }
-    protected void OnDispose() { }
+
+    /// <summary>Hook for derived classes to dispose additional resources.</summary>
+    protected virtual void OnDispose() { }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Buttons/AbstBlazorButton.razor.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Buttons/AbstBlazorButton.razor.cs
@@ -1,9 +1,9 @@
 using System;
 using Microsoft.AspNetCore.Components;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Buttons;
 
-public partial class AbstBlazorButton : AbstBlazorComponentBase
+public partial class AbstBlazorButton
 {
     private AbstBlazorButtonComponent _component = default!;
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Buttons/AbstBlazorButtonComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Buttons/AbstBlazorButtonComponent.cs
@@ -2,7 +2,7 @@ using System;
 using AbstUI.Components.Buttons;
 using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Buttons;
 
 public class AbstBlazorButtonComponent : IAbstFrameworkButton
 {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Buttons/AbstBlazorStateButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Buttons/AbstBlazorStateButton.cs
@@ -2,16 +2,14 @@ using Microsoft.AspNetCore.Components;
 using AbstUI.Primitives;
 using AbstUI.Components.Buttons;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Buttons;
 
-public partial class AbstBlazorStateButton : AbstBlazorBaseInput, IAbstFrameworkStateButton
+public partial class AbstBlazorStateButton : IAbstFrameworkStateButton
 {
     [Parameter] public string Text { get; set; } = string.Empty;
     [Parameter] public bool IsOn { get; set; }
     public IAbstTexture2D? TextureOn { get; set; }
     public IAbstTexture2D? TextureOff { get; set; }
-
-    public override object FrameworkNode => throw new NotImplementedException();
 
     private void HandleClick()
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Buttons/AbstBlazorStateButton.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Buttons/AbstBlazorStateButton.razor
@@ -1,2 +1,2 @@
-@inherits AbstBlazorComponentBase
+@inherits AbstBlazorBaseInput
 <button @onclick="HandleClick" disabled="@(Enabled ? null : true)" style="@BuildStyle()">@Text</button>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorLayoutWrapper.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorLayoutWrapper.cs
@@ -2,15 +2,12 @@ using Microsoft.AspNetCore.Components;
 using AbstUI.Primitives;
 using AbstUI.Components.Containers;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Containers;
 
-public partial class AbstBlazorLayoutWrapper : AbstBlazorComponentBase, IAbstFrameworkLayoutWrapper
+public partial class AbstBlazorLayoutWrapper : IAbstFrameworkLayoutWrapper
 {
     private readonly RenderFragment? _contentFragment;
     private readonly AbstLayoutWrapper _lingoLayoutWrapper;
-
-    public object FrameworkNode => this;
-
     public AbstBlazorLayoutWrapper(AbstLayoutWrapper layoutWrapper)
     {
         _lingoLayoutWrapper = layoutWrapper;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorPanel.razor.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorPanel.razor.cs
@@ -1,8 +1,8 @@
 using Microsoft.AspNetCore.Components;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Containers;
 
-public partial class AbstBlazorPanel : AbstBlazorComponentBase
+public partial class AbstBlazorPanel
 {
     private AbstBlazorPanelComponent _component = default!;
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorPanelComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorPanelComponent.cs
@@ -4,7 +4,7 @@ using AbstUI.Components;
 using AbstUI.Components.Containers;
 using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Containers;
 
 public class AbstBlazorPanelComponent : AbstBlazorComponentModelBase, IAbstFrameworkPanel, IAbstBlazorRegistryAware
 {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorScrollContainer.razor.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorScrollContainer.razor.cs
@@ -1,8 +1,8 @@
 using Microsoft.AspNetCore.Components;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Containers;
 
-public partial class AbstBlazorScrollContainer : AbstBlazorComponentBase
+public partial class AbstBlazorScrollContainer
 {
     private AbstBlazorScrollContainerComponent _component = default!;
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorScrollContainerComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorScrollContainerComponent.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using AbstUI.Components;
 using AbstUI.Components.Containers;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Containers;
 
 public class AbstBlazorScrollContainerComponent : AbstBlazorComponentModelBase, IAbstFrameworkScrollContainer, IAbstBlazorRegistryAware
 {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorTabContainer.razor.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorTabContainer.razor.cs
@@ -1,8 +1,8 @@
 using Microsoft.AspNetCore.Components;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Containers;
 
-public partial class AbstBlazorTabContainer : AbstBlazorComponentBase
+public partial class AbstBlazorTabContainer
 {
     private AbstBlazorTabContainerComponent _component = default!;
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorTabContainerComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorTabContainerComponent.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using AbstUI.Components.Containers;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Containers;
 
 public class AbstBlazorTabContainerComponent : AbstBlazorComponentModelBase, IAbstFrameworkTabContainer, IAbstBlazorRegistryAware
 {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorTabItemComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorTabItemComponent.cs
@@ -2,7 +2,7 @@ using System;
 using AbstUI.Components;
 using AbstUI.Components.Containers;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Containers;
 
 internal class AbstBlazorTabItemComponent : AbstBlazorComponentModelBase, IAbstFrameworkTabItem
 {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorWindow.cs
@@ -5,7 +5,7 @@ using AbstUI.Windowing;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Containers;
 
 internal class AbstBlazorWindow : AbstBlazorPanel, IDisposable, IAbstFrameworkWindow
 {
@@ -19,7 +19,7 @@ internal class AbstBlazorWindow : AbstBlazorPanel, IDisposable, IAbstFrameworkWi
 
     [Inject] private IJSRuntime JS { get; set; } = default!;
 
-  
+
 
     public string Title
     {
@@ -111,7 +111,7 @@ internal class AbstBlazorWindow : AbstBlazorPanel, IDisposable, IAbstFrameworkWi
         _lingoWindow.RaiseWindowStateChanged(true);
     }
 
-    
+
 
     private void EnsureModule()
     {
@@ -160,5 +160,5 @@ internal class AbstBlazorWindow : AbstBlazorPanel, IDisposable, IAbstFrameworkWi
         Height = height;
     }
 
-  
+
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorWrapPanel.razor.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorWrapPanel.razor.cs
@@ -1,9 +1,9 @@
 using Microsoft.AspNetCore.Components;
 using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Containers;
 
-public partial class AbstBlazorWrapPanel : AbstBlazorComponentBase
+public partial class AbstBlazorWrapPanel
 {
     private AbstBlazorWrapPanelComponent _component = default!;
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorWrapPanelComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorWrapPanelComponent.cs
@@ -4,7 +4,7 @@ using AbstUI.Components;
 using AbstUI.Components.Containers;
 using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Containers;
 
 public class AbstBlazorWrapPanelComponent : AbstBlazorComponentModelBase, IAbstFrameworkWrapPanel, IAbstBlazorRegistryAware
 {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Graphics/AbstBlazorGfxCanvas.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Graphics/AbstBlazorGfxCanvas.cs
@@ -7,9 +7,9 @@ using AbstUI.Primitives;
 using AbstUI.Texts;
 using AbstUI.Components.Graphics;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Graphics;
 
-public partial class AbstBlazorGfxCanvas : AbstBlazorComponentBase, IAbstFrameworkGfxCanvas
+public partial class AbstBlazorGfxCanvas : IAbstFrameworkGfxCanvas
 {
     [Parameter] public bool Pixilated { get; set; }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorColorPicker.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorColorPicker.cs
@@ -2,14 +2,11 @@ using Microsoft.AspNetCore.Components;
 using AbstUI.Primitives;
 using AbstUI.Components.Inputs;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Inputs;
 
-public partial class AbstBlazorColorPicker : AbstBlazorBaseInput, IAbstFrameworkColorPicker
+public partial class AbstBlazorColorPicker : IAbstFrameworkColorPicker
 {
     [Parameter] public AColor Color { get; set; } = AColor.FromRGB(0, 0, 0);
-    [Parameter] public bool Enabled { get; set; } = true;
-
-
     private void HandleInput(ChangeEventArgs e)
     {
         if (e.Value is string hex && hex.StartsWith("#"))

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorColorPicker.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorColorPicker.razor
@@ -1,2 +1,2 @@
-@inherits AbstBlazorComponentBase
+@inherits AbstBlazorBaseInput
 <input type="color" value="@Color.ToHex()" @oninput="HandleInput" disabled="@(Enabled ? null : true)" style="@BuildStyle()" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCheckbox.razor.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCheckbox.razor.cs
@@ -1,8 +1,8 @@
 using Microsoft.AspNetCore.Components;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Inputs;
 
-public partial class AbstBlazorInputCheckbox : AbstBlazorComponentBase
+public partial class AbstBlazorInputCheckbox
 {
     private AbstBlazorInputCheckboxComponent _component = default!;
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCheckboxComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCheckboxComponent.cs
@@ -1,7 +1,7 @@
 using System;
 using AbstUI.Components.Inputs;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Inputs;
 
 public class AbstBlazorInputCheckboxComponent : AbstBlazorComponentModelBase, IAbstFrameworkInputCheckbox
 {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.cs
@@ -4,9 +4,9 @@ using Microsoft.AspNetCore.Components;
 using AbstUI.Primitives;
 using AbstUI.Components.Inputs;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Inputs;
 
-public partial class AbstBlazorInputCombobox : AbstBlazorBaseInput, IAbstFrameworkInputCombobox
+public partial class AbstBlazorInputCombobox : IAbstFrameworkInputCombobox
 {
 
     private readonly List<KeyValuePair<string, string>> _items = new();
@@ -47,7 +47,7 @@ public partial class AbstBlazorInputCombobox : AbstBlazorBaseInput, IAbstFramewo
                 SelectedKey = null;
                 SelectedValue = null;
             }
-            ValueChanged?.Invoke();
+            ValueChangedInvoke();
         }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.razor
@@ -1,4 +1,4 @@
-@inherits AbstBlazorComponentBase
+@inherits AbstBlazorBaseInput
 <select id="@Name" value="@SelectedIndex" @onchange="HandleChange" disabled="@(Enabled ? null : true)" style="@BuildStyle()">
     @for (int i = 0; i < _items.Count; i++)
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputNumber.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputNumber.cs
@@ -3,9 +3,9 @@ using AbstUI.Primitives;
 using System.Numerics;
 using AbstUI.Components.Inputs;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Inputs;
 
-public partial class AbstBlazorInputNumber<TValue> : AbstBlazorBaseInput, IAbstFrameworkInputNumber<TValue>
+public partial class AbstBlazorInputNumber<TValue> : IAbstFrameworkInputNumber<TValue>
     where TValue : INumber<TValue>
 {
     [Parameter] public TValue Value { get; set; } = TValue.Zero;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputNumber.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputNumber.razor
@@ -1,3 +1,3 @@
 @typeparam TValue where TValue : System.Numerics.INumber<TValue>
-@inherits AbstBlazorComponentBase
+@inherits AbstBlazorBaseInput
 <input type="number" value="@Value" min="@Min" max="@Max" @oninput="HandleInput" disabled="@(Enabled ? null : true)" style="@BuildStyle()" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputSlider.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputSlider.cs
@@ -2,9 +2,9 @@ using Microsoft.AspNetCore.Components;
 using System.Numerics;
 using AbstUI.Components.Inputs;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Inputs;
 
-public partial class AbstBlazorInputSlider<TValue> : AbstBlazorBaseInput,IAbstFrameworkInputSlider<TValue>
+public partial class AbstBlazorInputSlider<TValue> : IAbstFrameworkInputSlider<TValue>
     where TValue : INumber<TValue>
 {
     [Parameter] public TValue Value { get; set; } = TValue.Zero;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputSlider.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputSlider.razor
@@ -1,3 +1,3 @@
 @typeparam TValue where TValue : System.Numerics.INumber<TValue>
-@inherits AbstBlazorComponentBase
+@inherits AbstBlazorBaseInput
 <input type="range" value="@Value" min="@MinValue" max="@MaxValue" step="@Step" @oninput="HandleInput" disabled="@(Enabled ? null : true)" style="@BuildStyle()" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputText.razor.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputText.razor.cs
@@ -2,9 +2,9 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Inputs;
 
-public partial class AbstBlazorInputText : AbstBlazorComponentBase
+public partial class AbstBlazorInputText
 {
     private AbstBlazorInputTextComponent _component = default!;
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputTextComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputTextComponent.cs
@@ -2,7 +2,7 @@ using System;
 using AbstUI.Components.Inputs;
 using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Inputs;
 
 public class AbstBlazorInputTextComponent : AbstBlazorComponentModelBase, IAbstFrameworkInputText
 {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorItemList.cs
@@ -3,12 +3,10 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using AbstUI.Components.Inputs;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Inputs;
 
-public partial class AbstBlazorItemList : AbstBlazorBaseInput, IAbstFrameworkItemList
+public partial class AbstBlazorItemList : IAbstFrameworkItemList
 {
-    [Parameter] public bool Enabled { get; set; } = true;
-
     private readonly List<KeyValuePair<string, string>> _items = new();
     public IReadOnlyList<KeyValuePair<string, string>> Items => _items;
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorItemList.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorItemList.razor
@@ -1,4 +1,4 @@
-@inherits AbstBlazorComponentBase
+@inherits AbstBlazorBaseInput
 <select id="@Name" value="@SelectedIndex" @onchange="HandleChange" disabled="@(Enabled ? null : true)" style="@BuildStyle()" size="@_items.Count">
     @for (int i = 0; i < _items.Count; i++)
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorSpinBox.cs
@@ -1,9 +1,9 @@
 using Microsoft.AspNetCore.Components;
 using AbstUI.Components.Inputs;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Inputs;
 
-public partial class AbstBlazorSpinBox : AbstBlazorBaseInput, IAbstFrameworkSpinBox
+public partial class AbstBlazorSpinBox : IAbstFrameworkSpinBox
 {
     [Parameter] public float Value { get; set; }
     [Parameter] public float Min { get; set; }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorSpinBox.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorSpinBox.razor
@@ -1,2 +1,2 @@
-@inherits AbstBlazorComponentBase
+@inherits AbstBlazorBaseInput
 <input type="number" value="@Value" min="@Min" max="@Max" @oninput="HandleInput" disabled="@(Enabled ? null : true)" style="@BuildStyle()" />

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstInputComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstInputComponent.cs
@@ -2,12 +2,12 @@ using Microsoft.AspNetCore.Components;
 using AbstUI.Inputs;
 using AbstUI.Blazor.Inputs;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Inputs;
 
 /// <summary>
 /// Component that routes DOM mouse and keyboard events to the AbstUI input wrappers.
 /// </summary>
-public partial class AbstInputComponent : AbstBlazorComponentBase
+public partial class AbstInputComponent
 {
     [Parameter] public RenderFragment? ChildContent { get; set; }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Menus/AbstBlazorMenu.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Menus/AbstBlazorMenu.cs
@@ -3,7 +3,7 @@ using AbstUI.Components.Buttons;
 using AbstUI.Components.Menus;
 using AbstUI.Primitives;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Menus;
 
 internal class AbstBlazorMenu : IAbstFrameworkMenu, IDisposable
 {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Menus/AbstBlazorMenuItem.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Menus/AbstBlazorMenuItem.cs
@@ -1,7 +1,7 @@
 using System;
 using AbstUI.Components.Menus;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Menus;
 
 internal class AbstBlazorMenuItem : IAbstFrameworkMenuItem, IDisposable
 {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Texts/AbstBlazorLabel.razor.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Texts/AbstBlazorLabel.razor.cs
@@ -1,9 +1,9 @@
 using Microsoft.AspNetCore.Components;
 using AbstUI.Texts;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Texts;
 
-public partial class AbstBlazorLabel : AbstBlazorComponentBase
+public partial class AbstBlazorLabel
 {
     private AbstBlazorLabelComponent _component = default!;
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Texts/AbstBlazorLabelComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Texts/AbstBlazorLabelComponent.cs
@@ -2,7 +2,7 @@ using AbstUI.Components.Texts;
 using AbstUI.Primitives;
 using AbstUI.Texts;
 
-namespace AbstUI.Blazor.Components;
+namespace AbstUI.Blazor.Components.Texts;
 
 public class AbstBlazorLabelComponent : AbstBlazorComponentModelBase, IAbstFrameworkLabel
 {


### PR DESCRIPTION
## Summary
- target .NET 9 for AbstUI.Blazor and use ASP.NET Core 9 packages
- implement shared Blazor input base class and wire up components with proper `@inherits`
- organize components into sub-namespaces and update factory mappings

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a575f656648332accac6cb6c961d57