### PR TITLE
Handle return constant and field assignment

### DIFF
--- a/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
@@ -39,6 +39,38 @@ public class LingoToCSharpConverterTests
     }
 
     [Fact]
+    public void ReturnConstantIsConvertedToNewLine()
+    {
+        var result = _converter.Convert("x = \"a\" & return & \"b\"");
+        Assert.Equal("x = (\"a\" + \"\\n\") + \"b\";", result.Trim());
+    }
+
+    [Fact]
+    public void PutIntoFieldConvertsToMemberTextAssignment()
+    {
+        var result = _converter.Convert("put woord into field \"credits\"");
+        Assert.Equal("Member(\"credits\").Text = woord;", result.Trim());
+    }
+
+    [Fact]
+    public void ReturnStatementWithValueIsConverted()
+    {
+        var result = _converter.Convert("return 5");
+        Assert.Equal("return 5;", result.Trim());
+    }
+
+    [Fact]
+    public void ReturnStatementWithoutValueIsOnItsOwnLine()
+    {
+        var lingo = "return\nput 1 into x";
+        var result = _converter.Convert(lingo);
+        var expected = string.Join('\n',
+            "return;",
+            "x = 1;");
+        Assert.Equal(expected, result.Trim());
+    }
+
+    [Fact]
     public void IfStatementIsConverted()
     {
         var lingo = "if 1 then\nput 2 into x\nend if";

--- a/src/LingoEngine.Lingo.Core/CSharpWriter.cs
+++ b/src/LingoEngine.Lingo.Core/CSharpWriter.cs
@@ -91,7 +91,7 @@ public class CSharpWriter : ILingoAstVisitor
         return datum.Type switch
         {
             LingoDatum.DatumType.Integer or LingoDatum.DatumType.Float => datum.AsString(),
-            LingoDatum.DatumType.String => $"\"{datum.AsString()}\"",
+            LingoDatum.DatumType.String => $"\"{EscapeString(datum.AsString())}\"",
             LingoDatum.DatumType.Symbol => $"Symbol(\"{datum.AsString()}\")",
             LingoDatum.DatumType.VarRef => datum.AsString(),
             LingoDatum.DatumType.List => datum.Value is List<LingoNode> list

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
@@ -250,8 +250,12 @@ namespace LingoEngine.Lingo.Core.Tokenizer
 
                 case LingoTokenType.Return:
                     LingoNode? retValue = null;
-                    if (_currentToken.Type != LingoTokenType.End && _currentToken.Type != LingoTokenType.Eof)
+                    if (_currentToken.Type != LingoTokenType.End &&
+                        _currentToken.Type != LingoTokenType.Eof &&
+                        _currentToken.Line == keywordToken.Line)
+                    {
                         retValue = ParseExpression();
+                    }
                     return new LingoReturnStmtNode(retValue);
 
                 default:
@@ -627,6 +631,11 @@ namespace LingoEngine.Lingo.Core.Tokenizer
                     AdvanceToken();
                     break;
 
+                case LingoTokenType.Return:
+                    expr = new LingoDatumNode(new LingoDatum("\n"));
+                    AdvanceToken();
+                    break;
+
                 case LingoTokenType.The:
                     AdvanceToken();
                     var propTok = Expect(LingoTokenType.Identifier);
@@ -672,6 +681,15 @@ namespace LingoEngine.Lingo.Core.Tokenizer
                                 Property = new LingoVarNode { VarName = pTok.Lexeme }
                             };
                         }
+                    }
+                    else if (name.Equals("field", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var arg = ParseExpression();
+                        expr = new LingoObjPropExprNode
+                        {
+                            Object = new LingoMemberExprNode { Expr = arg },
+                            Property = new LingoVarNode { VarName = "Text" }
+                        };
                     }
                     else
                     {


### PR DESCRIPTION
## Summary
- treat `return` used inside expressions as a newline constant
- map `put … into field "name"` to `Member("name").Text = …`
- escape newline characters when emitting string literals
- only parse `return` statement arguments when they appear on the same line to disambiguate from the newline constant

## Testing
- `dotnet format src/LingoEngine.Lingo.Core/LingoEngine.Lingo.Core.csproj --include src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs --verbosity normal`
- `dotnet format Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj --include Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs --verbosity normal`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj --filter "ReturnConstantIsConvertedToNewLine|PutIntoFieldConvertsToMemberTextAssignment|ReturnStatementWithValueIsConverted|ReturnStatementWithoutValueIsOnItsOwnLine"`


------
https://chatgpt.com/codex/tasks/task_e_68a5ac4bfe90833280bbae822197bb13