### PR TITLE
Use typed text members in Lingo converter

### DIFF
--- a/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
@@ -71,7 +71,28 @@ public class LingoToCSharpConverterTests
     public void PutIntoFieldConvertsToMemberTextAssignment()
     {
         var result = _converter.Convert("put woord into field \"credits\"");
-        Assert.Equal("Member(\"credits\").Text = woord;", result.Trim());
+        Assert.Equal("GetMember<ILingoMemberTextBase>(\"credits\").Text = woord;", result.Trim());
+    }
+
+    [Fact]
+    public void MemberLineAccessUsesTypedGetMember()
+    {
+        var result = _converter.Convert("member(\"MyTextMember\").line[1]");
+        Assert.Equal("GetMember<ILingoMemberTextBase>(\"MyTextMember\").Line[1]", result.Trim());
+    }
+
+    [Fact]
+    public void MemberLineConcatenationUsesTypedGetMember()
+    {
+        var lingo = @"property i,p,dirI,num
+on beginsprite me
+  num=me.spritenum
+  woord=member(""MyTextMember"").line[1] &return& member(""MyTextMember"").line[2] &return& member(""MyTextMember"").line[3]
+  
+end";
+        var file = new LingoScriptFile { Name = "MyScript", Source = lingo, Type = LingoScriptType.Behavior };
+        var result = _converter.Convert(file);
+        Assert.Contains("woord = (((GetMember<ILingoMemberTextBase>(\"MyTextMember\").Line[1] + \"\\n\") + GetMember<ILingoMemberTextBase>(\"MyTextMember\").Line[2]) + \"\\n\") + GetMember<ILingoMemberTextBase>(\"MyTextMember\").Line[3];", result.Replace("\r", ""));
     }
 
     [Fact]
@@ -316,7 +337,7 @@ public class LingoToCSharpConverterTests
     public void MemberTextAccessIsConverted()
     {
         var result = _converter.Convert("member(\"T_Text\").text");
-        Assert.Equal("Member<LingoMemberText>(\"T_Text\").Text", result.Trim());
+        Assert.Equal("GetMember<ILingoMemberTextBase>(\"T_Text\").Text", result.Trim());
     }
 
     [Fact]

--- a/src/LingoEngine.Lingo.Core/CSharpWriter.cs
+++ b/src/LingoEngine.Lingo.Core/CSharpWriter.cs
@@ -571,6 +571,23 @@ public class CSharpWriter : ILingoAstVisitor
 
     public void Visit(LingoObjPropExprNode node)
     {
+        if (node.Object is LingoMemberExprNode member &&
+            node.Property is LingoVarNode propVarText)
+        {
+            var propName = propVarText.VarName;
+            if (propName.Equals("text", StringComparison.OrdinalIgnoreCase) ||
+                propName.Equals("line", StringComparison.OrdinalIgnoreCase) ||
+                propName.Equals("word", StringComparison.OrdinalIgnoreCase) ||
+                propName.Equals("char", StringComparison.OrdinalIgnoreCase))
+            {
+                Append("GetMember<ILingoMemberTextBase>(");
+                member.Expr.Accept(this);
+                Append(").");
+                Append(char.ToUpperInvariant(propName[0]) + propName[1..]);
+                return;
+            }
+        }
+
         if (node.Object is LingoVarNode objVar &&
             objVar.VarName.Equals("me", StringComparison.OrdinalIgnoreCase) &&
             node.Property is LingoVarNode propVar)

--- a/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
+++ b/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
@@ -22,11 +22,13 @@ public class LingoToCSharpConverter
 
         var match = System.Text.RegularExpressions.Regex.Match(
             trimmed,
-            @"^member\s*\(\s*""(?<name>[^""]+)""\s*\)\.text$",
+            @"^member\s*\(\s*""(?<name>[^""]+)""\s*\)\.(?<prop>text|line|word|char)$",
             System.Text.RegularExpressions.RegexOptions.IgnoreCase);
         if (match.Success)
         {
-            return $"Member<LingoMemberText>(\"{match.Groups["name"].Value}\").Text";
+            var prop = match.Groups["prop"].Value;
+            var pascal = char.ToUpperInvariant(prop[0]) + prop[1..];
+            return $"GetMember<ILingoMemberTextBase>(\"{match.Groups["name"].Value}\").{pascal}";
         }
 
         if (TryConvertNewMember(trimmed, out var converted))


### PR DESCRIPTION
## Summary
- ensure Lingo to C# converter uses `GetMember<ILingoMemberTextBase>` for `.text`, `.line`, `.word`, and `.char` access
- parse operands with postfix expressions so concatenated member line accesses handle `& return &`
- add regression test covering multiline member concatenation using `MyTextMember`

## Testing
- `dotnet format src/LingoEngine.Lingo.Core/LingoEngine.Lingo.Core.csproj -v diag`
- `dotnet format Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj -v diag`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a5d871855883329947148e6e194e3f