### PR TITLE
Support castlib parameter in member expressions

### DIFF
--- a/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
@@ -82,6 +82,13 @@ public class LingoToCSharpConverterTests
     }
 
     [Fact]
+    public void MemberWithCastNumberIsConverted()
+    {
+        var result = _converter.Convert("member(\"boem1\",3)");
+        Assert.Equal("Member(\"boem1\", 3)", result.Trim());
+    }
+
+    [Fact]
     public void MemberLineConcatenationUsesTypedGetMember()
     {
         var lingo = @"property i,p,dirI,num

--- a/src/LingoEngine.Lingo.Core/CSharpWriter.cs
+++ b/src/LingoEngine.Lingo.Core/CSharpWriter.cs
@@ -566,6 +566,11 @@ public class CSharpWriter : ILingoAstVisitor
     {
         Append("Member(");
         node.Expr.Accept(this);
+        if (node.CastLib != null)
+        {
+            Append(", ");
+            node.CastLib.Accept(this);
+        }
         Append(")");
     }
 
@@ -582,6 +587,11 @@ public class CSharpWriter : ILingoAstVisitor
             {
                 Append("GetMember<ILingoMemberTextBase>(");
                 member.Expr.Accept(this);
+                if (member.CastLib != null)
+                {
+                    Append(", ");
+                    member.CastLib.Accept(this);
+                }
                 Append(").");
                 Append(char.ToUpperInvariant(propName[0]) + propName[1..]);
                 return;

--- a/src/LingoEngine.Lingo.Core/LingoCodeWriterVisitor.cs
+++ b/src/LingoEngine.Lingo.Core/LingoCodeWriterVisitor.cs
@@ -423,8 +423,14 @@ namespace LingoEngine.Lingo.Core
 
         public void Visit(LingoMemberExprNode node)
         {
-            Write("member ");
+            Write("member(");
             node.Expr.Accept(this);
+            if (node.CastLib != null)
+            {
+                Write(", ");
+                node.CastLib.Accept(this);
+            }
+            Write(")");
         }
 
         public void Visit(LingoObjPropExprNode node)

--- a/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
+++ b/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
@@ -670,7 +670,7 @@ public class LingoToCSharpConverter
         public void Visit(LingoChunkExprNode n) { n.Expr.Accept(this); }
         public void Visit(LingoInverseOpNode n) { n.Expr.Accept(this); }
         public void Visit(LingoObjCallV4Node n) { n.Object.Accept(this); if (n.Name.Value != null) Methods.Add(n.Name.Value.AsString()); n.ArgList.Accept(this); }
-        public void Visit(LingoMemberExprNode n) { n.Expr.Accept(this); }
+        public void Visit(LingoMemberExprNode n) { n.Expr.Accept(this); n.CastLib?.Accept(this); }
         public void Visit(LingoObjPropExprNode n) { n.Object.Accept(this); n.Property.Accept(this); }
         public void Visit(LingoPlayCmdStmtNode n) { n.Command.Accept(this); }
         public void Visit(LingoThePropExprNode n) { n.Property.Accept(this); }
@@ -749,7 +749,7 @@ public class LingoToCSharpConverter
         public void Visit(LingoChunkExprNode n) { n.Expr.Accept(this); }
         public void Visit(LingoInverseOpNode n) { n.Expr.Accept(this); }
         public void Visit(LingoObjCallV4Node n) { n.Object.Accept(this); n.ArgList.Accept(this); }
-        public void Visit(LingoMemberExprNode n) { n.Expr.Accept(this); }
+        public void Visit(LingoMemberExprNode n) { n.Expr.Accept(this); n.CastLib?.Accept(this); }
         public void Visit(LingoObjPropExprNode n) { n.Object.Accept(this); n.Property.Accept(this); }
         public void Visit(LingoPlayCmdStmtNode n) { n.Command.Accept(this); }
         public void Visit(LingoThePropExprNode n) { n.Property.Accept(this); }

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
@@ -683,8 +683,13 @@ namespace LingoEngine.Lingo.Core.Tokenizer
                     else if (name.Equals("member", StringComparison.OrdinalIgnoreCase) && Match(LingoTokenType.LeftParen))
                     {
                         var inner = ParseExpression();
+                        LingoNode? castExpr = null;
+                        if (Match(LingoTokenType.Comma))
+                        {
+                            castExpr = ParseExpression();
+                        }
                         Expect(LingoTokenType.RightParen);
-                        expr = new LingoMemberExprNode { Expr = inner };
+                        expr = new LingoMemberExprNode { Expr = inner, CastLib = castExpr };
                         while (Match(LingoTokenType.Dot))
                         {
                             var pTok = Expect(LingoTokenType.Identifier);

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoNodes.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoNodes.cs
@@ -274,6 +274,7 @@ namespace LingoEngine.Lingo.Core.Tokenizer
     public class LingoMemberExprNode : LingoNode
     {
         public LingoNode Expr { get; set; } = null!;
+        public LingoNode? CastLib { get; set; }
         public override void Accept(ILingoAstVisitor visitor) => visitor.Visit(this);
     }
 


### PR DESCRIPTION
## Summary
- allow `member()` calls with an optional cast library argument
- handle cast library parameter when generating C# code
- cover `member(name, cast)` with a regression test

## Testing
- `dotnet format src/LingoEngine.Lingo.Core/LingoEngine.Lingo.Core.csproj --verbosity diagnostic`
- `dotnet format Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj --verbosity diagnostic`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a5e854765c833282412cbc360e5f77