### PR TITLE
Refactor SDL root context and inject global inputs

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/Program.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/Program.cs
@@ -23,8 +23,9 @@ serviceCollection
 var serviceProvier = serviceCollection.BuildServiceProvider();
 
 var factory = new AbstSdlComponentFactory(rootContext, serviceProvier);
+rootContext.Factory = factory;
 
 var scroll = GfxTestScene.Build(factory);
 rootContext.ComponentContainer.Activate(((dynamic)scroll.FrameworkObj).ComponentContext);
 
-rootContext.Run(factory);
+rootContext.Run();

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/TestSdlRootComponentContext.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/TestSdlRootComponentContext.cs
@@ -1,6 +1,7 @@
 using System;
 using AbstUI.Inputs;
 using AbstUI.Primitives;
+using AbstUI.SDL2;
 using AbstUI.SDL2.Components;
 using AbstUI.SDL2.Core;
 using AbstUI.SDL2.Inputs;
@@ -8,96 +9,57 @@ using AbstUI.SDL2.SDLL;
 
 namespace LingoEngine.SDL2.GfxVisualTest;
 
-/// <summary>
-/// Minimal SDL2 environment for the AbstUI graphics visual test.
-/// Provides the <see cref="ISdlRootComponentContext"/> required by
-/// <see cref="AbstSdlComponentFactory"/> and runs a basic render loop.
-/// </summary>
-public sealed class TestSdlRootComponentContext : ISdlRootComponentContext, IDisposable
+public sealed class TestSdlRootComponentContext : AbstUISdlRootContext<AbstMouse>
 {
     private readonly SdlMouse<AbstMouseEvent> _sdlMouse;
     private readonly SdlKey _sdlKey;
-    private readonly AbstMouse _abstMouse;
-    private readonly AbstKey _abstKey;
-
-    public nint Window { get; }
-    public nint Renderer { get; }
-
-    public AbstSDLComponentContainer ComponentContainer { get; }
-    public IAbstMouse AbstMouse => _abstMouse;
-    public IAbstKey AbstKey => _abstKey;
-    public SdlFocusManager FocusManager { get; }
 
     public TestSdlRootComponentContext()
+        : base(CreateWindowAndRenderer(out var renderer), renderer, new SdlFocusManager())
+    {
+        _sdlMouse = new SdlMouse<AbstMouseEvent>(new Lazy<AbstMouse<AbstMouseEvent>>(() => AbstMouse));
+        AbstMouse = new AbstMouse(_sdlMouse);
+
+        _sdlKey = new SdlKey();
+        AbstKey = new AbstKey(_sdlKey);
+        _sdlKey.SetKeyObj((AbstKey)AbstKey);
+
+        GlobalMouse = new GlobalSDLAbstMouse();
+        GlobalKey = new GlobalSDLAbstKey();
+    }
+
+    private static nint CreateWindowAndRenderer(out nint renderer)
     {
         SDL.SDL_Init(SDL.SDL_INIT_VIDEO);
         SDL_image.IMG_Init(SDL_image.IMG_InitFlags.IMG_INIT_PNG | SDL_image.IMG_InitFlags.IMG_INIT_JPG);
         SDL_ttf.TTF_Init();
-        SDL_mixer.Mix_Init(SDL_mixer.MIX_InitFlags.MIX_INIT_MP3); 
+        SDL_mixer.Mix_Init(SDL_mixer.MIX_InitFlags.MIX_INIT_MP3);
 
-        Window = SDL.SDL_CreateWindow(
+        var window = SDL.SDL_CreateWindow(
             "AbstUI SDL2 Visual Test",
             SDL.SDL_WINDOWPOS_CENTERED,
             SDL.SDL_WINDOWPOS_CENTERED,
             800,
             600,
             SDL.SDL_WindowFlags.SDL_WINDOW_SHOWN);
-        Renderer = SDL.SDL_CreateRenderer(
-            Window,
+        renderer = SDL.SDL_CreateRenderer(
+            window,
             -1,
             SDL.SDL_RendererFlags.SDL_RENDERER_ACCELERATED);
-
-        FocusManager = new SdlFocusManager();
-        ComponentContainer = new AbstSDLComponentContainer(FocusManager);
-
-        _sdlMouse = new SdlMouse<AbstMouseEvent>(new Lazy<AbstMouse<AbstMouseEvent>>(() => _abstMouse));
-        _abstMouse = new AbstMouse(_sdlMouse);
-
-        _sdlKey = new SdlKey();
-        _abstKey = new AbstKey(_sdlKey);
-        _sdlKey.SetKeyObj(_abstKey);
+        return window;
     }
 
-    /// <summary>
-    /// Runs a simple SDL2 loop until a key is pressed or the window is closed.
-    /// </summary>
-    public void Run(AbstSdlComponentFactory factory)
+    protected override void Render()
     {
-        bool running = true;
-        while (running && !Console.KeyAvailable)
-        {
-            while (SDL.SDL_PollEvent(out var e) == 1)
-            {
-                if (e.type == SDL.SDL_EventType.SDL_QUIT)
-                    running = false;
-                _sdlKey.ProcessEvent(e);
-                _sdlMouse.ProcessEvent(e);
-                ComponentContainer.HandleEvent(e);
-            }
-
-            SDL.SDL_SetRenderDrawColor(Renderer, 200, 200, 150, 255);
-            SDL.SDL_RenderClear(Renderer);
-            ComponentContainer.Render(factory.CreateRenderContext());
-            SDL.SDL_RenderPresent(Renderer);
-
-            SDL.SDL_Delay(16);
-        }
+        SDL.SDL_SetRenderDrawColor(Renderer, 200, 200, 150, 255);
+        SDL.SDL_RenderClear(Renderer);
+        base.Render();
     }
 
-    public APoint GetWindowSize()
+    public override void Dispose()
     {
-        SDL.SDL_GetWindowSize(Window, out var w, out var h);
-        return new APoint(w, h);
-    }
-
-    public void Dispose()
-    {
-        SDL.SDL_DestroyRenderer(Renderer);
-        SDL.SDL_DestroyWindow(Window);
         SDL_ttf.TTF_Quit();
-        SDL_image.IMG_Quit();
         SDL_mixer.Mix_Quit();
-        SDL.SDL_Quit();
+        base.Dispose();
     }
 }
-

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/IAbstSDLRootContext.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/IAbstSDLRootContext.cs
@@ -5,5 +5,6 @@ namespace AbstUI.SDL2
     public interface IAbstSDLRootContext
     {
         IAbstGlobalMouse GlobalMouse { get; set; }
+        IAbstGlobalKey GlobalKey { get; set; }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Inputs/GlobalSDLAbstKey.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Inputs/GlobalSDLAbstKey.cs
@@ -2,13 +2,17 @@ using AbstUI.Inputs;
 
 namespace AbstUI.SDL2.Inputs
 {
-    public class GlobalSDLAbstKey : AbstKey , IAbstGlobalKey
+    public class GlobalSDLAbstKey : AbstKey, IAbstGlobalKey
     {
+        private readonly SdlKey _framework;
+
         public GlobalSDLAbstKey()
         {
-            var framework = new SdlKey();
-            Init(framework);
+            _framework = new SdlKey();
+            Init(_framework);
         }
+
+        internal SdlKey Framework => _framework;
     }
-  
+
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Inputs/GlobalSDLAbstMouse.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Inputs/GlobalSDLAbstMouse.cs
@@ -4,53 +4,48 @@ using AbstUI.SDL2.SDLL;
 
 namespace AbstUI.SDL2.Inputs
 {
-    
+
     public class GlobalSDLAbstMouse : AbstMouse, IAbstGlobalMouse
     {
-
-        public GlobalSDLAbstMouse(IAbstSDLRootContext rootNode)
-            : base(CreateFrameworkMouse(rootNode, out var framework))
+        public GlobalSDLAbstMouse()
+            : base(CreateFrameworkMouse(out var framework))
         {
             framework.ReplaceMouseObj(this);
-            rootNode.GlobalMouse = this;
         }
 
-        private static IAbstFrameworkMouse CreateFrameworkMouse(IAbstSDLRootContext rootNode, out AbstGodotGlobalMouse<GlobalSDLAbstMouse, AbstMouseEvent> framework)
+        private static IAbstFrameworkMouse CreateFrameworkMouse(out AbstSdlGlobalMouse<GlobalSDLAbstMouse, AbstMouseEvent> framework)
         {
-            framework = new AbstGodotGlobalMouse<GlobalSDLAbstMouse,AbstMouseEvent>(rootNode);
+            framework = new AbstSdlGlobalMouse<GlobalSDLAbstMouse, AbstMouseEvent>();
             return framework;
         }
     }
 
-    public partial class AbstGodotGlobalMouse<TAbstMouseType, TAbstUIMouseEvent> : IAbstFrameworkMouse
+    public class AbstSdlGlobalMouse<TAbstMouseType, TAbstUIMouseEvent> : IAbstFrameworkMouse
         where TAbstMouseType : AbstMouse<TAbstUIMouseEvent>
         where TAbstUIMouseEvent : AbstMouseEvent
     {
         private readonly SdlMouse<TAbstUIMouseEvent> _handler;
         private AbstMouse<TAbstUIMouseEvent>? _mouse;
 
-        public AbstGodotGlobalMouse(IAbstSDLRootContext rootNode)
+        public AbstSdlGlobalMouse()
         {
-            
             _handler = new SdlMouse<TAbstUIMouseEvent>(new Lazy<AbstMouse<TAbstUIMouseEvent>>(() => (TAbstMouseType)_mouse!));
         }
 
-       
         public void ReplaceMouseObj(IAbstMouse lingoMouse)
         {
             _mouse = (AbstMouse<TAbstUIMouseEvent>)lingoMouse;
             _handler.ReplaceMouseObj(lingoMouse);
         }
+
         public void Release()
         {
-            //GetParent()?.RemoveChild(this);
         }
 
         public void HideMouse(bool state) => _handler.HideMouse(state);
 
         public void SetCursor(AMouseCursor cursor)
         {
-            
         }
 
         public void ProcessEvent(SDL.SDL_Event e)

--- a/src/LingoEngine.SDL2/Core/LingoSdlFactory.cs
+++ b/src/LingoEngine.SDL2/Core/LingoSdlFactory.cs
@@ -58,10 +58,11 @@ public class LingoSdlFactory : ILingoFrameworkFactory, IDisposable
     {
         _serviceProvider = serviceProvider;
         _rootContext = rootContext;
-        _rootContext.Factory = this;
         _fontManager = (SdlFontManager)_serviceProvider.GetRequiredService<IAbstFontManager>();
         _styleManager = _serviceProvider.GetRequiredService<IAbstStyleManager>();
         _gfxFactory = (AbstSdlComponentFactory)serviceProvider.GetRequiredService<IAbstComponentFactory>();
+        _rootContext.Factory = _gfxFactory;
+        _rootContext.LingoFactory = this;
     }
 
     public IAbstComponentFactory GfxFactory => _gfxFactory;

--- a/src/LingoEngine.SDL2/SdlSetup.cs
+++ b/src/LingoEngine.SDL2/SdlSetup.cs
@@ -7,6 +7,7 @@ using AbstUI.SDL2.SDLL;
 using AbstUI.SDL2;
 using LingoEngine.Core;
 using AbstUI.SDL2.Core;
+using AbstUI.Inputs;
 
 namespace LingoEngine.SDL2;
 
@@ -60,7 +61,12 @@ public static class SdlSetup
             .ServicesMain(s => s
                     .WithAbstUISdl()
                     .AddSingleton<SdlRootContext>(provider =>
-                        new SdlRootContext(sdlWindow, sdlRenderer, provider.GetRequiredService<SdlFocusManager>()))
+                        new SdlRootContext(
+                            sdlWindow,
+                            sdlRenderer,
+                            provider.GetRequiredService<SdlFocusManager>(),
+                            provider.GetRequiredService<IAbstGlobalMouse>(),
+                            provider.GetRequiredService<IAbstGlobalKey>()))
                     .AddSingleton<ISdlRootComponentContext>(p => p.GetRequiredService<SdlRootContext>())
                     .AddSingleton<IAbstSDLRootContext>(p => p.GetRequiredService<SdlRootContext>())
                     .AddSingleton<ILingoFrameworkFactory, LingoSdlFactory>()


### PR DESCRIPTION
## Summary
- Move reusable SDL event loop and global input handling into `AbstUISdlRootContext`
- Inject global mouse and key into `SdlRootContext` and wire up `LingoSdlFactory`
- Update SDL2 visual test to run with new shared root context

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet build src/LingoEngine.SDL2/LingoEngine.SDL2.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/AbstUI.GfxVisualTest.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a5e9411f8c83328cccc09dec77671f