### PR TITLE
Sync channel visibility with score mute button

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Scores/DirScoreChannelHeader.cs
+++ b/src/Director/LingoEngine.Director.Core/Scores/DirScoreChannelHeader.cs
@@ -10,19 +10,19 @@ namespace LingoEngine.Director.Core.Scores
     {
         private AColor _textColor = AColor.FromHex("#a0a0a0");
         protected readonly DirScoreGfxValues _gfxValues;
-        private readonly Action<DirScoreChannelHeader,bool> _muteStateChanged;
+        private readonly Action<DirScoreChannelHeader, bool> _muteStateChanged;
 
         public virtual string Icon { get; set; }
         public virtual string Label { get; set; }
         private bool _muted;
         public bool IsMuted => _muted;
 
-        public int Width { get; private set; }  
-        public int Height { get; private set; }  
+        public int Width { get; private set; }
+        public int Height { get; private set; }
         public float Y { get; set; }
         public bool Visible { get; internal set; } = true;
 
-        public DirScoreChannelHeader(string icon, string label, DirScoreGfxValues gfxValues, Action<DirScoreChannelHeader,bool> muteStateChanged)
+        public DirScoreChannelHeader(string icon, string label, DirScoreGfxValues gfxValues, Action<DirScoreChannelHeader, bool> muteStateChanged)
         {
             _gfxValues = gfxValues;
             _muteStateChanged = muteStateChanged;
@@ -36,20 +36,20 @@ namespace LingoEngine.Director.Core.Scores
         {
             var xOffset = 1;
             var y = Y;
-            
 
-            canvas.DrawText(new APoint(xOffset+20 + 25, y+ 11), Icon,null, _textColor, 10);
+
+            canvas.DrawText(new APoint(xOffset + 20 + 25, y + 11), Icon, null, _textColor, 10);
             if (!string.IsNullOrEmpty(Label))
-                canvas.DrawText(new APoint(xOffset+20 + 2, y+ 11), Label, null, _textColor, 10,45, AbstUI.Texts.AbstTextAlignment.Right);
+                canvas.DrawText(new APoint(xOffset + 20 + 2, y + 11), Label, null, _textColor, 10, 45, AbstUI.Texts.AbstTextAlignment.Right);
 
             // Visibility rect
             var btnWidth = 8;
             var btnHeight = 8;
-            var btnLeft = xOffset+5;
-            var btnTop = y+ 4;
+            var btnLeft = xOffset + 5;
+            var btnTop = y + 4;
             if (_muted)
             {
-                canvas.DrawRect(new ARect(btnLeft, btnTop, btnLeft+ btnWidth, btnTop+btnHeight), DirectorColors.LineDarker);
+                canvas.DrawRect(new ARect(btnLeft, btnTop, btnLeft + btnWidth, btnTop + btnHeight), DirectorColors.LineDarker);
                 canvas.DrawLine(new APoint(btnLeft, btnTop + btnHeight), new APoint(btnLeft + btnWidth, btnTop + btnHeight), DirectorColors.LineLight);  // bottom line
                 canvas.DrawLine(new APoint(btnLeft + btnWidth, btnTop), new APoint(btnLeft + btnWidth, btnTop + btnHeight), DirectorColors.LineLight); // right line
             }
@@ -76,14 +76,16 @@ namespace LingoEngine.Director.Core.Scores
             // Vertical line at the end
             canvas.DrawLine(new APoint(Width, y), new APoint(Width, y + _gfxValues.ChannelHeight), _gfxValues.ColLineDark);
 
-           
+
         }
-        public void SetMuted(bool state)
+        public void SetMuted(bool state, bool notify = true)
         {
             _muted = state;
-            _muteStateChanged(this, state);
+            if (notify)
+                _muteStateChanged(this, state);
             OnMutedChanged(state);
         }
+        public void SetMutedExternal(bool state) => SetMuted(state, false);
         protected virtual void OnMutedChanged(bool state) { }
         public void ToggleMute() => SetMuted(!_muted);
     }

--- a/src/Director/LingoEngine.Director.Core/Scores/DirScoreLeftChannelsContainer.cs
+++ b/src/Director/LingoEngine.Director.Core/Scores/DirScoreLeftChannelsContainer.cs
@@ -2,15 +2,16 @@
 using LingoEngine.Director.Core.Tools;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Movies;
+using LingoEngine.Sprites;
 
 namespace LingoEngine.Director.Core.Scores
 {
     public class DirScoreLeftChannelsContainer : DirScoreLeftContainer
     {
         protected LingoMovie? _movie;
-   
 
-        public DirScoreLeftChannelsContainer(DirScoreGfxValues gfxValues, ILingoFrameworkFactory factory, APoint position, IDirectorEventMediator mediator) : base(gfxValues, factory, position,10, mediator)
+
+        public DirScoreLeftChannelsContainer(DirScoreGfxValues gfxValues, ILingoFrameworkFactory factory, APoint position, IDirectorEventMediator mediator) : base(gfxValues, factory, position, 10, mediator)
         {
         }
 
@@ -35,8 +36,14 @@ namespace LingoEngine.Director.Core.Scores
             _canvas.Height = _gfxValues.ChannelHeight * _movie.MaxSpriteChannelCount;
             for (int c = 1; c < _movie.MaxSpriteChannelCount; c++)
             {
-                var ch = _movie.Channel(c);
-                var header = new DirScoreChannelHeader("", c.ToString(), _gfxValues, (c, state) => { if (_movie != null) ch.Visibility = state; });
+                var ch = (LingoSpriteChannel)_movie.Channel(c);
+                var header = new DirScoreChannelHeader("", c.ToString(), _gfxValues, (cHeader, state) => { if (_movie != null) ch.Visibility = state; });
+                ch.VisibilityChanged += (_, visible) =>
+                {
+                    header.SetMutedExternal(visible);
+                    Draw();
+                };
+                header.SetMutedExternal(ch.Visibility);
                 channels.Add(header);
             }
             SetChannels(channels.ToArray());

--- a/src/LingoEngine/Sprites/LingoSpriteChannel.cs
+++ b/src/LingoEngine/Sprites/LingoSpriteChannel.cs
@@ -1,4 +1,5 @@
-﻿using AbstUI.Primitives;
+﻿using System;
+using AbstUI.Primitives;
 using LingoEngine.Casts;
 using LingoEngine.Members;
 using LingoEngine.Movies;
@@ -27,7 +28,7 @@ namespace LingoEngine.Sprites
     /// </summary>
     public interface ILingoSpriteChannel : ILingoSprite
     {
-       
+
 
         /// <summary>
         /// Returns the number of a sprite channel. 
@@ -68,6 +69,7 @@ namespace LingoEngine.Sprites
         private readonly LingoMovie _movie;
         private bool _visibility = true;
         private ILingoSprite? _sprite;
+        public event Action<LingoSpriteChannel, bool>? VisibilityChanged;
         /// <inheritdoc/>
         /// <inheritdoc/>
         public int Number { get; private set; }
@@ -75,11 +77,13 @@ namespace LingoEngine.Sprites
         public bool Scripted { get; private set; }
         public bool Visibility
         {
-            get => _visibility; set
+            get => _visibility;
+            set
             {
-                if (_visibility == value) return; // avoid inifinty loop   
+                if (_visibility == value) return; // avoid inifinty loop
                 _visibility = value;
                 if (_sprite != null) _sprite.Visibility = value;
+                VisibilityChanged?.Invoke(this, value);
             }
         }
         #region Properties proxy
@@ -149,7 +153,7 @@ namespace LingoEngine.Sprites
             _movie = movie;
         }
 
-        
+
 
         public bool Puppet
         {
@@ -204,9 +208,9 @@ namespace LingoEngine.Sprites
         }
 
 
-       
 
-        
+
+
 
         public ILingoSprite SetMember(int memberNumber, int? castLibNum = null) => _sprite.SetMember(memberNumber, castLibNum);
         public ILingoSprite SetMember(string memberName, int? castLibNum = null) => _sprite.SetMember(memberName, castLibNum);
@@ -222,6 +226,6 @@ namespace LingoEngine.Sprites
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
 
         public bool HasSprite() => _sprite != null;
-      
+
     }
 }


### PR DESCRIPTION
## Summary
- add visibility changed event on `LingoSpriteChannel`
- allow `DirScoreChannelHeader` to update mute state without notifying
- sync channel headers with channel visibility in `DirScoreLeftChannelsContainer`

## Testing
- `dotnet format --no-restore --include src/LingoEngine/Sprites/LingoSpriteChannel.cs src/Director/LingoEngine.Director.Core/Scores/DirScoreChannelHeader.cs src/Director/LingoEngine.Director.Core/Scores/DirScoreLeftChannelsContainer.cs -v minimal`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`
- `dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a5ecbaa4188332917de9ff3615fab8