### PR TITLE
Ensure SDL2 components redraw on window resize

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUISdlRootContext.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUISdlRootContext.cs
@@ -66,6 +66,12 @@ public abstract class AbstUISdlRootContext<TMouse> : IAbstSDLRootContext, ISdlRo
             {
                 if (e.type == SDL.SDL_EventType.SDL_QUIT)
                     running = false;
+                else if (e.type == SDL.SDL_EventType.SDL_WINDOWEVENT &&
+                         (e.window.windowEvent == SDL.SDL_WindowEventID.SDL_WINDOWEVENT_SIZE_CHANGED ||
+                          e.window.windowEvent == SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESIZED))
+                {
+                    ComponentContainer.QueueRedrawAll();
+                }
                 _frameworkKey?.ProcessEvent(e);
                 _frameworkMouse?.ProcessEvent(e);
                 ComponentContainer.HandleEvent(e);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Base/AbstSdlComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Base/AbstSdlComponent.cs
@@ -48,8 +48,12 @@ public abstract class AbstSdlComponent : IAbstSDLComponent, IDisposable
         get => _width;
         set
         {
-            _width = value;
-            ComponentContext.TargetWidth = (int)value;
+            if (Math.Abs(_width - value) > float.Epsilon)
+            {
+                _width = value;
+                ComponentContext.TargetWidth = (int)value;
+                ComponentContext.QueueRedraw(this);
+            }
         }
     }
 
@@ -59,8 +63,12 @@ public abstract class AbstSdlComponent : IAbstSDLComponent, IDisposable
         get => _height;
         set
         {
-            _height = value;
-            ComponentContext.TargetHeight = (int)value;
+            if (Math.Abs(_height - value) > float.Epsilon)
+            {
+                _height = value;
+                ComponentContext.TargetHeight = (int)value;
+                ComponentContext.QueueRedraw(this);
+            }
         }
     }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Core/AbstSDLComponentContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Core/AbstSDLComponentContainer.cs
@@ -41,6 +41,20 @@ public class AbstSDLComponentContainer
 
     public void Deactivate(AbstSDLComponentContext context) => _activeComponents.Remove(context);
 
+    /// <summary>
+    /// Requests a redraw for every registered component.
+    /// Useful when a global event like a window resize requires
+    /// all cached textures to be regenerated.
+    /// </summary>
+    public void QueueRedrawAll()
+    {
+        foreach (var ctx in _allComponents)
+        {
+            if (ctx.Component != null)
+                ctx.QueueRedraw(ctx.Component);
+        }
+    }
+
     public void Render(AbstSDLRenderContext renderContext)
     {
         foreach (var ctx in _activeComponents)


### PR DESCRIPTION
## Summary
- Add container-wide redraw request and trigger it when the SDL window is resized
- Re-render components when their dimensions change

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Core/AbstSDLComponentContainer.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUISdlRootContext.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Base/AbstSdlComponent.cs -v d`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/AbstUI.GfxVisualTest.SDL2.csproj`
- `dotnet build src/LingoEngine.SDL2/LingoEngine.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a61a441ef88332852cc570721a2202