### PR TITLE
Handle numeric sprite indices in Lingo parser

### DIFF
--- a/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
@@ -756,6 +756,21 @@ end";
     }
 
     [Fact]
+    public void NumericSpriteIndexIsConverted()
+    {
+        var lingo = @"on test
+  sprite(263).visibility = true
+end";
+        var result = _converter.Convert(lingo);
+        var expected = string.Join('\n',
+            "public void Test()",
+            "{",
+            "    Sprite(263).Visibility = true;",
+            "}");
+        Assert.Equal(expected.Trim(), result.Trim());
+    }
+
+    [Fact]
     public void AccessModifierIsAppliedToHandlers()
     {
         var lingo = @"on test

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
@@ -727,33 +727,17 @@ namespace LingoEngine.Lingo.Core.Tokenizer
 
         private LingoNode ParseSpriteIndex()
         {
-            LingoNode expr;
-            if (_currentToken.Type == LingoTokenType.Me)
-            {
-                expr = new LingoVarNode { VarName = "me" };
-                AdvanceToken();
-            }
-            else if (_currentToken.Type == LingoTokenType.Identifier)
-            {
-                expr = new LingoVarNode { VarName = _currentToken.Lexeme };
-                AdvanceToken();
-            }
-            else
-            {
-                expr = new LingoErrorNode();
-            }
+            // A sprite index can be any valid expression (numbers, variables,
+            // property chains, etc.). The previous implementation only allowed
+            // identifiers or `me`, leaving the current token untouched when a
+            // number was encountered. This resulted in a parser error such as
+            // "Expected token RightParen, but got Number" for expressions like
+            // `sprite(263).property`.
 
-            while (Match(LingoTokenType.Dot))
-            {
-                var pTok = Expect(LingoTokenType.Identifier);
-                expr = new LingoObjPropExprNode
-                {
-                    Object = expr,
-                    Property = new LingoVarNode { VarName = pTok.Lexeme }
-                };
-            }
-
-            return expr;
+            // Reuse the general expression parser here so that any valid Lingo
+            // expression can serve as the sprite index and the token stream is
+            // advanced correctly.
+            return ParseExpression();
         }
 
         private LingoNode ParsePutStatement()


### PR DESCRIPTION
## Summary
- parse sprite indices using general expression to allow numeric values
- add regression test covering numeric sprite index conversion

## Testing
- `dotnet format src/LingoEngine.Lingo.Core/LingoEngine.Lingo.Core.csproj --verbosity diagnostic`
- `dotnet format Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj --verbosity diagnostic`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a61da82adc833299a905c1d7a3ed5d