### PR TITLE
Add basic SDL stage overlays and selection

### DIFF
--- a/src/Director/LingoEngine.Director.SDL2/DirSdlSetup.cs
+++ b/src/Director/LingoEngine.Director.SDL2/DirSdlSetup.cs
@@ -4,12 +4,14 @@ using LingoEngine.Director.Core;
 using LingoEngine.Director.Core.Icons;
 using LingoEngine.Director.Core.Casts;
 using LingoEngine.Director.Core.Projects;
+using LingoEngine.Director.Core.Stages;
 using AbstUI.SDL2;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using LingoEngine.Director.SDL2.Casts;
 using LingoEngine.Director.SDL2.Icons;
 using LingoEngine.Director.SDL2.UI;
+using LingoEngine.Director.SDL2.Stages;
 using LingoEngine.Projects;
 using LingoEngine.Setup;
 
@@ -26,6 +28,8 @@ namespace LingoEngine.Director.SDL2
                {
                    s.AddSingleton<DirSdlCastWindow>();
                    s.AddTransient<IDirFrameworkCastWindow>(p => p.GetRequiredService<DirSdlCastWindow>());
+                   s.AddSingleton<DirSdlStageWindow>();
+                   s.AddTransient<IDirFrameworkStageWindow>(p => p.GetRequiredService<DirSdlStageWindow>());
                    s.AddSingleton<IDirectorIconManager>(p =>
                    {
                        var mgr = new DirSdlIconManager(p.GetRequiredService<ILogger<DirSdlIconManager>>(), p.GetRequiredService<SdlRootContext>());

--- a/src/Director/LingoEngine.Director.SDL2/Stages/DirSdlStageWindow.cs
+++ b/src/Director/LingoEngine.Director.SDL2/Stages/DirSdlStageWindow.cs
@@ -1,0 +1,212 @@
+using AbstUI.Primitives;
+using AbstUI.Components;
+using AbstUI.SDL2.Components;
+using AbstUI.SDL2.Components.Containers;
+using AbstUI.SDL2.Components.Graphics;
+using LingoEngine.Core;
+using LingoEngine.Director.Core.Stages;
+using LingoEngine.Director.Core.Tools;
+using LingoEngine.Inputs;
+using LingoEngine.Movies;
+using LingoEngine.Sprites;
+using LingoEngine.Events;
+using AbstUI.Inputs;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LingoEngine.Director.SDL2.Stages;
+
+internal class DirSdlStageWindow : AbstSdlWindow, IDirFrameworkStageWindow, IDisposable
+{
+    private readonly DirectorStageWindow _directorStageWindow;
+    private readonly IDirectorEventSubscription _stageChangedSub;
+    private readonly AbstSdlPanel _stagePanel;
+    private readonly AbstSdlPanel _iconBarPanel;
+    private readonly DirStageManager _stageManager;
+    private readonly StageBoundingBoxesOverlay _boundingBoxes;
+    private readonly StageMotionPathOverlay _motionPath;
+    private readonly AbstSdlGfxCanvas _boundingBoxesCanvas;
+    private readonly AbstSdlGfxCanvas _motionPathCanvas;
+    private readonly AbstSdlGfxCanvas _selectionCanvas;
+    private readonly LingoStageMouse _stageMouse;
+    private readonly LingoKey _key;
+    private readonly IAbstMouseSubscription _pointerClickSub;
+    private readonly ILingoPlayer _player;
+    private const int TitleBarHeight = 24;
+
+    public DirSdlStageWindow(IDirectorEventMediator mediator,
+        IServiceProvider services,
+        ILingoPlayer player,
+        DirectorStageWindow directorStageWindow,
+        DirStageManager stageManager)
+        : base((AbstSdlComponentFactory)services.GetRequiredService<IAbstComponentFactory>())
+    {
+        _directorStageWindow = directorStageWindow;
+        _stageManager = stageManager;
+        _player = player;
+        Init(_directorStageWindow);
+
+        var factory = (AbstSdlComponentFactory)services.GetRequiredService<IAbstComponentFactory>();
+        _stagePanel = factory.CreatePanel("StagePanel").Framework<AbstSdlPanel>();
+        _stagePanel.X = 0;
+        _stagePanel.Y = TitleBarHeight;
+        _stagePanel.Width = _player.Stage.Width;
+        _stagePanel.Height = _player.Stage.Height;
+        _stagePanel.BackgroundColor = _player.Stage.BackgroundColor;
+        AddItem(_stagePanel);
+
+        _iconBarPanel = _directorStageWindow.IconBar.Panel.Framework<AbstSdlPanel>();
+        _iconBarPanel.X = 0;
+        _iconBarPanel.Y = TitleBarHeight + _stagePanel.Height;
+        _iconBarPanel.Width = _stagePanel.Width;
+        AddItem(_iconBarPanel);
+
+        var lp = (LingoPlayer)_player;
+        _stageMouse = (LingoStageMouse)lp.Mouse;
+        _key = lp.Key;
+
+        _boundingBoxes = new StageBoundingBoxesOverlay(lp.Factory, mediator);
+        _boundingBoxes.SetInput(_stageMouse, _key);
+        _boundingBoxesCanvas = _boundingBoxes.Canvas.Framework<AbstSdlGfxCanvas>();
+        _boundingBoxesCanvas.Width = _stagePanel.Width;
+        _boundingBoxesCanvas.Height = _stagePanel.Height;
+        _boundingBoxesCanvas.X = 0;
+        _boundingBoxesCanvas.Y = 0;
+        _stagePanel.AddItem(_boundingBoxesCanvas);
+
+        _motionPath = new StageMotionPathOverlay(lp.Factory);
+        _motionPathCanvas = _motionPath.Canvas.Framework<AbstSdlGfxCanvas>();
+        _motionPathCanvas.Width = _stagePanel.Width;
+        _motionPathCanvas.Height = _stagePanel.Height;
+        _motionPathCanvas.X = 0;
+        _motionPathCanvas.Y = 0;
+        _stagePanel.AddItem(_motionPathCanvas);
+
+        var selCanvas = lp.Factory.CreateGfxCanvas("SelectionCanvas", _player.Stage.Width, _player.Stage.Height);
+        _selectionCanvas = selCanvas.Framework<AbstSdlGfxCanvas>();
+        _selectionCanvas.Visibility = false;
+        _selectionCanvas.X = 0;
+        _selectionCanvas.Y = 0;
+        _stagePanel.AddItem(_selectionCanvas);
+
+        Width = _stagePanel.Width;
+        Height = TitleBarHeight + _stagePanel.Height + _iconBarPanel.Height;
+        _directorStageWindow.ResizeFromFW(true, (int)Width, (int)Height - TitleBarHeight - (int)_iconBarPanel.Height);
+
+        _stageChangedSub = mediator.Subscribe(DirectorEventType.StagePropertiesChanged, () =>
+        {
+            _stagePanel.Width = _player.Stage.Width;
+            _stagePanel.Height = _player.Stage.Height;
+            _stagePanel.BackgroundColor = _player.Stage.BackgroundColor;
+            _iconBarPanel.Y = TitleBarHeight + _stagePanel.Height;
+            _iconBarPanel.Width = _stagePanel.Width;
+            _boundingBoxesCanvas.Width = _stagePanel.Width;
+            _boundingBoxesCanvas.Height = _stagePanel.Height;
+            _motionPathCanvas.Width = _stagePanel.Width;
+            _motionPathCanvas.Height = _stagePanel.Height;
+            _selectionCanvas.Width = _stagePanel.Width;
+            _selectionCanvas.Height = _stagePanel.Height;
+            Width = _stagePanel.Width;
+            Height = TitleBarHeight + _stagePanel.Height + _iconBarPanel.Height;
+            _directorStageWindow.ResizeFromFW(false, (int)Width, (int)Height - TitleBarHeight - (int)_iconBarPanel.Height);
+            return true;
+        });
+
+        _pointerClickSub = _stageMouse.OnMouseDown(OnStageMouseDown);
+        _stageManager.SelectionChanged += OnStageSelectionChanged;
+        _stageManager.SpritesTransformed += OnStageSpritesTransformed;
+
+        UpdateSelectionBox();
+        UpdateBoundingBoxes();
+        UpdateMotionPath();
+    }
+
+    private void OnStageSelectionChanged()
+    {
+        UpdateSelectionBox();
+        UpdateBoundingBoxes();
+        UpdateMotionPath();
+    }
+
+    private void OnStageSpritesTransformed()
+    {
+        UpdateSelectionBox();
+        UpdateBoundingBoxes();
+        UpdateMotionPath();
+    }
+
+    private void OnStageMouseDown(LingoMouseEvent e)
+    {
+        if (_directorStageWindow.SelectedTool != StageTool.Pointer)
+            return;
+        if (_player.ActiveMovie is not LingoMovie movie)
+            return;
+        var sprite = movie.GetSpriteAtPoint(e.MouseH, e.MouseV, skipLockedSprites: true) as LingoSprite2D;
+        if (sprite != null)
+        {
+            _stageManager.HandlePointerClick(sprite, _key.ControlDown);
+        }
+        else if (!_key.ControlDown)
+        {
+            _stageManager.ClearSelection();
+        }
+        UpdateSelectionBox();
+        UpdateBoundingBoxes();
+        UpdateMotionPath();
+    }
+
+    public void UpdateBoundingBoxes()
+    {
+        if (_player.ActiveMovie is not LingoMovie movie || movie.IsPlaying)
+        {
+            _boundingBoxes.Visible = false;
+            return;
+        }
+
+        if (_stageManager.SelectedSprites.Count > 0)
+        {
+            _boundingBoxes.SetSprites(_stageManager.SelectedSprites);
+            _boundingBoxes.Visible = true;
+        }
+        else
+        {
+            _boundingBoxes.Visible = false;
+        }
+    }
+
+    public void UpdateSelectionBox()
+    {
+        if (_stageManager.SelectedSprites.Count == 0)
+        {
+            _selectionCanvas.Visibility = false;
+            return;
+        }
+        var rect = _stageManager.ComputeSelectionRect();
+        _selectionCanvas.Clear(AColors.Transparent);
+        _selectionCanvas.DrawRect(rect, AColors.Yellow, false, 1);
+        _selectionCanvas.Visibility = true;
+    }
+
+    private void UpdateMotionPath()
+    {
+        if (_player.ActiveMovie is not LingoMovie movie || movie.IsPlaying)
+        {
+            _motionPath.Draw(null);
+            return;
+        }
+        var sprite = _stageManager.PrimarySelectedSprite;
+        var path = sprite != null ? _stageManager.GetMotionPath(sprite) : null;
+        _motionPath.Draw(path);
+    }
+
+    public new void Dispose()
+    {
+        _stageChangedSub.Release();
+        _pointerClickSub.Release();
+        _stageManager.SelectionChanged -= OnStageSelectionChanged;
+        _stageManager.SpritesTransformed -= OnStageSpritesTransformed;
+        _boundingBoxes.Dispose();
+        _motionPath.Dispose();
+        base.Dispose();
+    }
+}
+

--- a/src/Director/LingoEngine.Director.SDL2/UI/LingoSdlDirectorRoot.cs
+++ b/src/Director/LingoEngine.Director.SDL2/UI/LingoSdlDirectorRoot.cs
@@ -1,5 +1,6 @@
 using LingoEngine.Core;
 using LingoEngine.Director.SDL2.Casts;
+using LingoEngine.Director.SDL2.Stages;
 using LingoEngine.Projects;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,16 +9,20 @@ namespace LingoEngine.Director.SDL2.UI
     public class LingoSdlDirectorRoot : IDisposable
     {
         private readonly DirSdlCastWindow _castWindow;
+        private readonly DirSdlStageWindow _stageWindow;
 
         public LingoSdlDirectorRoot(LingoPlayer player, IServiceProvider services, LingoProjectSettings settings)
         {
             _castWindow = services.GetRequiredService<DirSdlCastWindow>();
+            _stageWindow = services.GetRequiredService<DirSdlStageWindow>();
             _castWindow.Popup();
+            _stageWindow.Popup();
         }
 
         public void Dispose()
         {
             _castWindow.Dispose();
+            _stageWindow.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Summary
- render bounding box, motion path, and selection overlays in SDL stage window
- allow sprite selection via pointer clicks

## Testing
- `dotnet format src/Director/LingoEngine.Director.SDL2/LingoEngine.Director.SDL2.csproj`
- `dotnet build src/Director/LingoEngine.Director.SDL2/LingoEngine.Director.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a62b3bb7f88332bec2e20d3eca422c