### PR TITLE
Ensure SDL window component tracks size and position

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlPanel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlPanel.cs
@@ -18,6 +18,7 @@ namespace AbstUI.SDL2.Components.Containers
         public AColor? BackgroundColor { get; set; }
         public AColor? BorderColor { get; set; }
         public float BorderWidth { get; set; }
+        public bool ClipChildren { get; set; }
         public object FrameworkNode => this;
 
         private readonly List<IAbstFrameworkLayoutNode> _children = new();
@@ -80,6 +81,12 @@ namespace AbstUI.SDL2.Components.Containers
                 SDL.SDL_RenderClear(context.Renderer);
             }
 
+            if (ClipChildren)
+            {
+                SDL.SDL_Rect clip = new SDL.SDL_Rect { x = 0, y = 0, w = w, h = h };
+                SDL.SDL_RenderSetClipRect(context.Renderer, ref clip);
+            }
+
             foreach (var child in _children)
             {
                 if (child.FrameworkNode is AbstSdlComponent comp)
@@ -94,6 +101,9 @@ namespace AbstUI.SDL2.Components.Containers
                     ctx.OffsetY = oldOffY;
                 }
             }
+
+            if (ClipChildren)
+                SDL.SDL_RenderSetClipRect(context.Renderer, nint.Zero);
 
             if (BorderWidth > 0 && BorderColor is { } bc)
             {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlWindow.cs
@@ -84,6 +84,7 @@ public class AbstSdlWindow : AbstSdlPanel, IAbstFrameworkWindow, IHandleSdlEvent
     public AbstSdlWindow(AbstSdlComponentFactory factory) : base(factory)
     {
         _factory = factory;
+        ClipChildren = true;
         //var mouse = ((IAbstMouseInternal)factory.RootContext.AbstMouse).CreateNewInstance(window);
         //var key = ((AbstKey)factory.RootContext.AbstKey).CreateNewInstance(window);
         //_abstWindow.Init(this, mouse, key);
@@ -108,6 +109,8 @@ public class AbstSdlWindow : AbstSdlPanel, IAbstFrameworkWindow, IHandleSdlEvent
     {
         Visibility = true;
         _factory.WindowManager.SetActiveWindow(this);
+        _abstWindow.SetPositionFromFW((int)X, (int)Y);
+        _abstWindow.ResizeFromFW(false, (int)Width, (int)Height);
         _abstWindow.RaiseWindowStateChanged(true);
     }
 
@@ -117,6 +120,7 @@ public class AbstSdlWindow : AbstSdlPanel, IAbstFrameworkWindow, IHandleSdlEvent
 
         X = (size.X - Width) / 2f;
         Y = (size.Y - Height) / 2f;
+        _abstWindow.SetPositionFromFW((int)X, (int)Y);
         Popup();
     }
 
@@ -130,26 +134,22 @@ public class AbstSdlWindow : AbstSdlPanel, IAbstFrameworkWindow, IHandleSdlEvent
     internal void BringToFront()
         => _factory.RootContext.ComponentContainer.Activate(ComponentContext);
 
-    public void OpenWindow()
-    {
+    public void OpenWindow() => Popup();
 
-    }
-
-    public void CloseWindow()
-    {
-
-    }
+    public void CloseWindow() => Hide();
 
     public void MoveWindow(int x, int y)
     {
         X = x;
         Y = y;
+        _abstWindow.SetPositionFromFW(x, y);
     }
 
     public void SetPositionAndSize(int x, int y, int width, int height)
     {
         X = x;
         Y = y;
+        _abstWindow.SetPositionFromFW(x, y);
         SetSize(width, height);
     }
 
@@ -162,6 +162,7 @@ public class AbstSdlWindow : AbstSdlPanel, IAbstFrameworkWindow, IHandleSdlEvent
     {
         Width = width;
         Height = height;
+        _abstWindow.ResizeFromFW(false, width, height);
     }
 
     public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
@@ -256,6 +257,7 @@ public class AbstSdlWindow : AbstSdlPanel, IAbstFrameworkWindow, IHandleSdlEvent
                 {
                     X = e.Event.motion.x - _dragOffsetX;
                     Y = e.Event.motion.y - _dragOffsetY;
+                    _abstWindow.SetPositionFromFW((int)X, (int)Y);
                     e.StopPropagation = true;
                 }
                 break;


### PR DESCRIPTION
## Summary
- synchronize SDL window with AbstWindow by reporting position and size on open, move, resize, and drag
- clip window children to the window rectangle to prevent overflow

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlPanel.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlWindow.cs --no-restore -v diag`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --no-restore`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/AbstUI.GfxVisualTest.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a62b9e6e8083328c8a74b27ab5f91d