### PR TITLE
Add SDL2 property inspector window

### DIFF
--- a/src/Director/LingoEngine.Director.SDL2/DirSdlSetup.cs
+++ b/src/Director/LingoEngine.Director.SDL2/DirSdlSetup.cs
@@ -3,6 +3,7 @@ using LingoEngine.Core;
 using LingoEngine.Director.Core;
 using LingoEngine.Director.Core.Icons;
 using LingoEngine.Director.Core.Casts;
+using LingoEngine.Director.Core.Inspector;
 using LingoEngine.Director.Core.Projects;
 using LingoEngine.Director.Core.Stages;
 using AbstUI.SDL2;
@@ -10,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using LingoEngine.Director.SDL2.Casts;
 using LingoEngine.Director.SDL2.Icons;
+using LingoEngine.Director.SDL2.Inspector;
 using LingoEngine.Director.SDL2.UI;
 using LingoEngine.Director.SDL2.Stages;
 using LingoEngine.Projects;
@@ -30,6 +32,8 @@ namespace LingoEngine.Director.SDL2
                    s.AddTransient<IDirFrameworkCastWindow>(p => p.GetRequiredService<DirSdlCastWindow>());
                    s.AddSingleton<DirSdlStageWindow>();
                    s.AddTransient<IDirFrameworkStageWindow>(p => p.GetRequiredService<DirSdlStageWindow>());
+                   s.AddSingleton<DirSdlPropertyInspectorWindow>();
+                   s.AddTransient<IDirFrameworkPropertyInspectorWindow>(p => p.GetRequiredService<DirSdlPropertyInspectorWindow>());
                    s.AddSingleton<IDirectorIconManager>(p =>
                    {
                        var mgr = new DirSdlIconManager(p.GetRequiredService<ILogger<DirSdlIconManager>>(), p.GetRequiredService<SdlRootContext>());

--- a/src/Director/LingoEngine.Director.SDL2/Inspector/DirSdlPropertyInspectorWindow.cs
+++ b/src/Director/LingoEngine.Director.SDL2/Inspector/DirSdlPropertyInspectorWindow.cs
@@ -1,0 +1,39 @@
+using AbstUI.Components;
+using AbstUI.SDL2.Components;
+using AbstUI.SDL2.Components.Containers;
+using LingoEngine.Director.Core.Inspector;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LingoEngine.Director.SDL2.Inspector;
+
+internal class DirSdlPropertyInspectorWindow : AbstSdlWindow, IDirFrameworkPropertyInspectorWindow
+{
+    private readonly DirectorPropertyInspectorWindow _directorInspectorWindow;
+    private readonly AbstSdlPanel _headerPanel;
+    private readonly AbstSdlTabContainer _tabs;
+    private const int TitleBarHeight = 24;
+
+    public DirSdlPropertyInspectorWindow(DirectorPropertyInspectorWindow directorInspectorWindow, IServiceProvider services)
+        : base((AbstSdlComponentFactory)services.GetRequiredService<IAbstComponentFactory>())
+    {
+        _directorInspectorWindow = directorInspectorWindow;
+        Init(_directorInspectorWindow);
+        _directorInspectorWindow.Init(TitleBarHeight);
+
+        _headerPanel = _directorInspectorWindow.HeaderPanel.Framework<AbstSdlPanel>();
+        _tabs = _directorInspectorWindow.Tabs.Framework<AbstSdlTabContainer>();
+
+        _headerPanel.Y = TitleBarHeight;
+        _headerPanel.Width = Width;
+
+        _tabs.Y = TitleBarHeight + _headerPanel.Height;
+        _tabs.Width = Width;
+        _tabs.Height = Height - TitleBarHeight - _headerPanel.Height;
+
+        AddItem(_headerPanel);
+        AddItem(_tabs);
+
+        _directorInspectorWindow.ResizeFromFW(true, (int)Width, (int)Height - TitleBarHeight - (int)_headerPanel.Height);
+    }
+}
+

--- a/src/Director/LingoEngine.Director.SDL2/UI/LingoSdlDirectorRoot.cs
+++ b/src/Director/LingoEngine.Director.SDL2/UI/LingoSdlDirectorRoot.cs
@@ -1,5 +1,6 @@
 using LingoEngine.Core;
 using LingoEngine.Director.SDL2.Casts;
+using LingoEngine.Director.SDL2.Inspector;
 using LingoEngine.Director.SDL2.Stages;
 using LingoEngine.Projects;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,19 +11,23 @@ namespace LingoEngine.Director.SDL2.UI
     {
         private readonly DirSdlCastWindow _castWindow;
         private readonly DirSdlStageWindow _stageWindow;
+        private readonly DirSdlPropertyInspectorWindow _inspectorWindow;
 
         public LingoSdlDirectorRoot(LingoPlayer player, IServiceProvider services, LingoProjectSettings settings)
         {
             _castWindow = services.GetRequiredService<DirSdlCastWindow>();
             _stageWindow = services.GetRequiredService<DirSdlStageWindow>();
+            _inspectorWindow = services.GetRequiredService<DirSdlPropertyInspectorWindow>();
             _castWindow.Popup();
             _stageWindow.Popup();
+            _inspectorWindow.Popup();
         }
 
         public void Dispose()
         {
             _castWindow.Dispose();
             _stageWindow.Dispose();
+            _inspectorWindow.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add SDL2 window wrapper for director property inspector
- register property inspector window in SDL2 setup and startup

## Testing
- `dotnet format src/Director/LingoEngine.Director.SDL2/LingoEngine.Director.SDL2.csproj -v diag`
- `dotnet build src/Director/LingoEngine.Director.SDL2/LingoEngine.Director.SDL2.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a633eaf6c48332bd50223e544c481d