### PR TITLE
Add styling options to SDL input widgets

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputCheckbox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputCheckbox.cs
@@ -12,7 +12,7 @@ namespace AbstUI.SDL2.Components.Inputs
 {
     internal class AbstSdlInputCheckbox : AbstSdlComponent, IAbstFrameworkInputCheckbox, IHandleSdlEvent, ISdlFocusable, IDisposable
     {
-      
+
         public bool Enabled { get; set; } = true;
         private bool _checked;
         private bool _focused;
@@ -20,6 +20,9 @@ namespace AbstUI.SDL2.Components.Inputs
         private int _texW;
         private int _texH;
         private bool _prevChecked;
+        private AColor _renderedBorderColor;
+        private AColor _renderedBackgroundColor;
+        private AColor _renderedCheckColor;
         public bool Checked
         {
             get => _checked;
@@ -33,6 +36,9 @@ namespace AbstUI.SDL2.Components.Inputs
             }
         }
         public AMargin Margin { get; set; } = AMargin.Zero;
+        public AColor BorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        public AColor BackgroundColor { get; set; } = AbstDefaultColors.Input_Bg;
+        public AColor CheckColor { get; set; } = AbstDefaultColors.InputAccentColor;
         public event Action? ValueChanged;
         public object FrameworkNode => this;
         public AbstSdlInputCheckbox(AbstSdlComponentFactory factory) : base(factory)
@@ -66,7 +72,9 @@ namespace AbstUI.SDL2.Components.Inputs
             int h = (int)Height;
 
             // create texture if needed
-            if (_texture == nint.Zero || w != _texW || h != _texH || _prevChecked != _checked)
+            if (_texture == nint.Zero || w != _texW || h != _texH || _prevChecked != _checked ||
+                !_renderedBorderColor.Equals(BorderColor) || !_renderedBackgroundColor.Equals(BackgroundColor) ||
+                !_renderedCheckColor.Equals(CheckColor))
             {
                 if (_texture != nint.Zero)
                     SDL.SDL_DestroyTexture(_texture);
@@ -77,6 +85,9 @@ namespace AbstUI.SDL2.Components.Inputs
                 _texW = w;
                 _texH = h;
                 _prevChecked = _checked;
+                _renderedBorderColor = BorderColor;
+                _renderedBackgroundColor = BackgroundColor;
+                _renderedCheckColor = CheckColor;
 
                 var prev = SDL.SDL_GetRenderTarget(context.Renderer);
                 SDL.SDL_SetRenderTarget(context.Renderer, _texture);
@@ -87,16 +98,16 @@ namespace AbstUI.SDL2.Components.Inputs
 
                 SDL.SDL_Rect rect = new SDL.SDL_Rect { x = 0, y = 0, w = w, h = h };
 
+                SDL.SDL_SetRenderDrawColor(context.Renderer, BackgroundColor.R, BackgroundColor.G, BackgroundColor.B, BackgroundColor.A);
+                SDL.SDL_RenderFillRect(context.Renderer, ref rect);
+
                 if (_checked)
                 {
-                    var accent = AbstDefaultColors.InputAccentColor;
-                    SDL.SDL_SetRenderDrawColor(context.Renderer, accent.R, accent.G, accent.B, accent.A);
+                    SDL.SDL_SetRenderDrawColor(context.Renderer, CheckColor.R, CheckColor.G, CheckColor.B, CheckColor.A);
                     SDL.SDL_RenderFillRect(context.Renderer, ref rect);
                 }
 
-                // draw border
-                var border = AbstDefaultColors.InputBorderColor;
-                SDL.SDL_SetRenderDrawColor(context.Renderer, border.R, border.G, border.B, border.A);
+                SDL.SDL_SetRenderDrawColor(context.Renderer, BorderColor.R, BorderColor.G, BorderColor.B, BorderColor.A);
                 SDL.SDL_RenderDrawRect(context.Renderer, ref rect);
 
                 SDL.SDL_SetRenderTarget(context.Renderer, prev);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputNumber.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputNumber.cs
@@ -6,10 +6,11 @@ using AbstUI.SDL2.Components.Base;
 using AbstUI.SDL2.Core;
 using AbstUI.SDL2.Events;
 using AbstUI.SDL2.SDLL;
+using AbstUI.Styles;
 
 namespace AbstUI.SDL2.Components.Inputs;
 
-internal class AbstSdlInputNumber<TValue> : AbstSdlComponent, IAbstFrameworkInputNumber<TValue>, IHandleSdlEvent, ISdlFocusable, IDisposable
+internal class AbstSdlInputNumber<TValue> : AbstSdlComponent, IAbstFrameworkInputNumber<TValue>, IHandleSdlEvent, ISdlFocusable, IDisposable, IHasTextBackgroundBorderColor
 #if NET48
     where TValue : struct
 #else
@@ -18,7 +19,7 @@ internal class AbstSdlInputNumber<TValue> : AbstSdlComponent, IAbstFrameworkInpu
 {
     private readonly AbstSdlInputText _textInput;
 
-    
+
 
     public bool Enabled { get; set; } = true;
 
@@ -58,6 +59,24 @@ internal class AbstSdlInputNumber<TValue> : AbstSdlComponent, IAbstFrameworkInpu
     {
         get => _textInput.Font;
         set => _textInput.Font = value;
+    }
+
+    public AColor TextColor
+    {
+        get => _textInput.TextColor;
+        set => _textInput.TextColor = value;
+    }
+
+    public AColor BackgroundColor
+    {
+        get => _textInput.BackgroundColor;
+        set => _textInput.BackgroundColor = value;
+    }
+
+    public AColor BorderColor
+    {
+        get => _textInput.BorderColor;
+        set => _textInput.BorderColor = value;
     }
 
     private TValue Clamp(TValue v)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputSlider.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputSlider.cs
@@ -23,6 +23,9 @@ namespace AbstUI.SDL2.Components.Inputs
         private int _texW;
         private int _texH;
         private TValue _renderedValue = default!;
+        private AColor _renderedTrackColor;
+        private AColor _renderedKnobColor;
+        private AColor _renderedKnobBorderColor;
         public TValue Value
         {
             get => _value;
@@ -38,6 +41,9 @@ namespace AbstUI.SDL2.Components.Inputs
         public TValue MinValue { get; set; } = default!;
         public TValue MaxValue { get; set; } = default!;
         public TValue Step { get; set; } = default!;
+        public AColor TrackColor { get; set; } = AbstDefaultColors.InputBorderColor.Lighten(0.5f);
+        public AColor KnobColor { get; set; } = AbstDefaultColors.InputAccentColor;
+        public AColor KnobBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
         public event Action? ValueChanged;
         public object FrameworkNode => this;
 
@@ -65,7 +71,9 @@ namespace AbstUI.SDL2.Components.Inputs
             int w = (int)Width;
             int h = (int)Height;
 
-            if (_texture == nint.Zero || w != _texW || h != _texH || !Equals(_renderedValue, _value))
+            if (_texture == nint.Zero || w != _texW || h != _texH || !Equals(_renderedValue, _value) ||
+                !_renderedTrackColor.Equals(TrackColor) || !_renderedKnobColor.Equals(KnobColor) ||
+                !_renderedKnobBorderColor.Equals(KnobBorderColor))
             {
                 if (_texture != nint.Zero)
                     SDL.SDL_DestroyTexture(_texture);
@@ -76,6 +84,9 @@ namespace AbstUI.SDL2.Components.Inputs
                 _texW = w;
                 _texH = h;
                 _renderedValue = _value;
+                _renderedTrackColor = TrackColor;
+                _renderedKnobColor = KnobColor;
+                _renderedKnobBorderColor = KnobBorderColor;
 
                 var prev = SDL.SDL_GetRenderTarget(context.Renderer);
                 SDL.SDL_SetRenderTarget(context.Renderer, _texture);
@@ -84,8 +95,7 @@ namespace AbstUI.SDL2.Components.Inputs
                 SDL.SDL_RenderClear(context.Renderer);
 
                 // draw track
-                var trackColor = AbstDefaultColors.InputBorderColor.Lighten(0.5f);
-                SDL.SDL_SetRenderDrawColor(context.Renderer, trackColor.R, trackColor.G, trackColor.B, trackColor.A);
+                SDL.SDL_SetRenderDrawColor(context.Renderer, TrackColor.R, TrackColor.G, TrackColor.B, TrackColor.A);
                 SDL.SDL_Rect track = new SDL.SDL_Rect { x = 0, y = h / 2 - 2, w = w, h = 4 };
                 SDL.SDL_RenderFillRect(context.Renderer, ref track);
 
@@ -99,11 +109,9 @@ namespace AbstUI.SDL2.Components.Inputs
                 int knobW = Math.Min(10, w);
                 int knobX = (int)((w - knobW) * t);
                 SDL.SDL_Rect knob = new SDL.SDL_Rect { x = knobX, y = 0, w = knobW, h = h };
-                var accent = AbstDefaultColors.InputAccentColor;
-                SDL.SDL_SetRenderDrawColor(context.Renderer, accent.R, accent.G, accent.B, accent.A);
+                SDL.SDL_SetRenderDrawColor(context.Renderer, KnobColor.R, KnobColor.G, KnobColor.B, KnobColor.A);
                 SDL.SDL_RenderFillRect(context.Renderer, ref knob);
-                var border = AbstDefaultColors.InputBorderColor;
-                SDL.SDL_SetRenderDrawColor(context.Renderer, border.R, border.G, border.B, border.A);
+                SDL.SDL_SetRenderDrawColor(context.Renderer, KnobBorderColor.R, KnobBorderColor.G, KnobBorderColor.B, KnobBorderColor.A);
                 SDL.SDL_RenderDrawRect(context.Renderer, ref knob);
 
                 SDL.SDL_SetRenderTarget(context.Renderer, prev);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputText.cs
@@ -14,7 +14,7 @@ using AbstUI.SDL2.Core;
 
 namespace AbstUI.SDL2.Components.Inputs
 {
-    internal class AbstSdlInputText : AbstSdlComponent, IAbstFrameworkInputText, IHandleSdlEvent, ISdlFocusable, IDisposable
+    internal class AbstSdlInputText : AbstSdlComponent, IAbstFrameworkInputText, IHandleSdlEvent, ISdlFocusable, IDisposable, IHasTextBackgroundBorderColor
     {
         private readonly bool _multiLine;
         private readonly List<int> _codepoints = new();
@@ -24,7 +24,7 @@ namespace AbstUI.SDL2.Components.Inputs
         private ISdlFontLoadedByUser? _font;
         private SdlGlyphAtlas? _atlas;
 
-      
+
         public bool Enabled { get; set; } = true;
         private string _text = string.Empty;
         public string Text
@@ -45,6 +45,8 @@ namespace AbstUI.SDL2.Components.Inputs
         public AMargin Margin { get; set; } = AMargin.Zero;
         public object FrameworkNode => this;
         public AColor TextColor { get; set; } = AbstDefaultColors.InputTextColor;
+        public AColor BackgroundColor { get; set; } = AbstDefaultColors.Input_Bg;
+        public AColor BorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
 
         public bool IsMultiLine { get; set; }
 
@@ -156,10 +158,9 @@ namespace AbstUI.SDL2.Components.Inputs
                 w = (int)Width,
                 h = (int)Height
             };
-            SDL.SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+            SDL.SDL_SetRenderDrawColor(renderer, BackgroundColor.R, BackgroundColor.G, BackgroundColor.B, BackgroundColor.A);
             SDL.SDL_RenderFillRect(renderer, ref rect);
-            var border = AbstDefaultColors.InputBorderColor;
-            SDL.SDL_SetRenderDrawColor(renderer, border.R, border.G, border.B, border.A);
+            SDL.SDL_SetRenderDrawColor(renderer, BorderColor.R, BorderColor.G, BorderColor.B, BorderColor.A);
             SDL.SDL_RenderDrawRect(renderer, ref rect);
 
             if (_atlas == null || _font == null) return default;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlSeletectableCollection.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlSeletectableCollection.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Primitives;
+using AbstUI.Components.Inputs;
+using AbstUI.SDL2.Components.Base;
+using AbstUI.SDL2.Core;
+using AbstUI.SDL2.Events;
+using AbstUI.SDL2.Components.Containers;
+using AbstUI.Styles;
+
+namespace AbstUI.SDL2.Components.Inputs
+{
+    internal abstract class AbstSdlSeletectableCollection : AbstSdlScrollViewer, IAbstSdlHasSeletectableCollectionStyle
+    {
+        protected AbstSdlSeletectableCollection(AbstSdlComponentFactory factory) : base(factory)
+        {
+        }
+
+        public bool Enabled { get; set; } = true;
+
+        public string? ItemFont { get; set; }
+        public int ItemFontSize { get; set; } = 11;
+        public AColor ItemTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+        public AColor ItemSelectedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+        public AColor ItemSelectedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+        public AColor ItemSelectedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        public AColor ItemHoverTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+        public AColor ItemHoverBackgroundColor { get; set; } = AbstDefaultColors.ListHoverColor;
+        public AColor ItemHoverBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        public AColor ItemPressedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+        public AColor ItemPressedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+        public AColor ItemPressedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+
+        protected readonly List<KeyValuePair<string, string>> ItemsInternal = new();
+        public IReadOnlyList<KeyValuePair<string, string>> Items => ItemsInternal;
+
+        private int _selectedIndex = -1;
+        public virtual int SelectedIndex
+        {
+            get => _selectedIndex;
+            set
+            {
+                if (_selectedIndex == value) return;
+                _selectedIndex = value;
+                if (value >= 0 && value < ItemsInternal.Count)
+                {
+                    SelectedKey = ItemsInternal[value].Key;
+                    SelectedValue = ItemsInternal[value].Value;
+                }
+                else
+                {
+                    SelectedKey = null;
+                    SelectedValue = null;
+                }
+                ComponentContext.QueueRedraw(this);
+                ValueChanged?.Invoke();
+            }
+        }
+
+        public string? SelectedKey { get; set; }
+        public string? SelectedValue { get; set; }
+
+        public event Action? ValueChanged;
+        public object FrameworkNode => this;
+
+        public virtual void AddItem(string key, string value)
+        {
+            ItemsInternal.Add(new KeyValuePair<string, string>(key, value));
+            ComponentContext.QueueRedraw(this);
+        }
+
+        public virtual bool RemoveItem(string key)
+        {
+            int idx = ItemsInternal.FindIndex(it => it.Key == key);
+            if (idx < 0) return false;
+            ItemsInternal.RemoveAt(idx);
+            if (_selectedIndex == idx)
+            {
+                _selectedIndex = -1;
+                SelectedKey = null;
+                SelectedValue = null;
+            }
+            else if (_selectedIndex > idx)
+            {
+                _selectedIndex--;
+            }
+            ComponentContext.QueueRedraw(this);
+            return true;
+        }
+
+        public virtual void ClearItems()
+        {
+            ItemsInternal.Clear();
+            _selectedIndex = -1;
+            SelectedKey = null;
+            SelectedValue = null;
+            ComponentContext.QueueRedraw(this);
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlSpinBox.cs
@@ -9,7 +9,7 @@ using AbstUI.Styles;
 
 namespace AbstUI.SDL2.Components.Inputs;
 
-internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IHandleSdlEvent, ISdlFocusable, IDisposable
+internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IHandleSdlEvent, ISdlFocusable, IDisposable, IHasTextBackgroundBorderColor
 {
     private readonly AbstSdlInputNumber<float> _number;
     private const int ButtonWidth = 16;
@@ -18,6 +18,8 @@ internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IHandle
     public object FrameworkNode => this;
     public event Action? ValueChanged;
     public bool Enabled { get; set; } = true;
+    public AColor ButtonColor { get; set; } = AbstDefaultColors.InputAccentColor;
+    public AColor ButtonBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
 
     public float Value
     {
@@ -43,13 +45,31 @@ internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IHandle
         set => _number.Step = value;
     }
 
-  
+
     public AbstSdlSpinBox(AbstSdlComponentFactory factory) : base(factory)
     {
         _number = new AbstSdlInputNumber<float>(factory);
         _number.ValueChanged += () => ValueChanged?.Invoke();
         Width = 50;
         Height = 20;
+    }
+
+    public AColor TextColor
+    {
+        get => _number.TextColor;
+        set => _number.TextColor = value;
+    }
+
+    public AColor BackgroundColor
+    {
+        get => _number.BackgroundColor;
+        set => _number.BackgroundColor = value;
+    }
+
+    public AColor BorderColor
+    {
+        get => _number.BorderColor;
+        set => _number.BorderColor = value;
     }
 
     public void HandleEvent(AbstSDLEvent e)
@@ -113,12 +133,10 @@ internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IHandle
         var renderer = context.Renderer;
         var up = GetUpRect();
         var down = GetDownRect();
-        var accent = AbstDefaultColors.InputAccentColor;
-        SDL.SDL_SetRenderDrawColor(renderer, accent.R, accent.G, accent.B, accent.A);
+        SDL.SDL_SetRenderDrawColor(renderer, ButtonColor.R, ButtonColor.G, ButtonColor.B, ButtonColor.A);
         SDL.SDL_RenderFillRect(renderer, ref up);
         SDL.SDL_RenderFillRect(renderer, ref down);
-        var border = AbstDefaultColors.InputBorderColor;
-        SDL.SDL_SetRenderDrawColor(renderer, border.R, border.G, border.B, border.A);
+        SDL.SDL_SetRenderDrawColor(renderer, ButtonBorderColor.R, ButtonBorderColor.G, ButtonBorderColor.B, ButtonBorderColor.A);
         SDL.SDL_RenderDrawRect(renderer, ref up);
         SDL.SDL_RenderDrawRect(renderer, ref down);
         // simple triangles

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstSdlHasSeletectableCollectionStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstSdlHasSeletectableCollectionStyle.cs
@@ -1,0 +1,19 @@
+using AbstUI.Primitives;
+
+namespace AbstUI.Components.Inputs;
+
+public interface IAbstSdlHasSeletectableCollectionStyle
+{
+    string? ItemFont { get; set; }
+    int ItemFontSize { get; set; }
+    AColor ItemTextColor { get; set; }
+    AColor ItemSelectedTextColor { get; set; }
+    AColor ItemSelectedBackgroundColor { get; set; }
+    AColor ItemSelectedBorderColor { get; set; }
+    AColor ItemHoverTextColor { get; set; }
+    AColor ItemHoverBackgroundColor { get; set; }
+    AColor ItemHoverBorderColor { get; set; }
+    AColor ItemPressedTextColor { get; set; }
+    AColor ItemPressedBackgroundColor { get; set; }
+    AColor ItemPressedBorderColor { get; set; }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IHasTextBackgroundBorderColor.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IHasTextBackgroundBorderColor.cs
@@ -1,0 +1,10 @@
+using AbstUI.Primitives;
+
+namespace AbstUI.Components.Inputs;
+
+public interface IHasTextBackgroundBorderColor
+{
+    AColor TextColor { get; set; }
+    AColor BackgroundColor { get; set; }
+    AColor BorderColor { get; set; }
+}


### PR DESCRIPTION
## Summary
- expose `IAbstSdlHasSeletectableCollectionStyle` and `IHasTextBackgroundBorderColor` in `AbstUI.Components.Inputs` for reuse
- update SDL selectable collection to reference shared styling interfaces

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IHasTextBackgroundBorderColor.cs WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstSdlHasSeletectableCollectionStyle.cs`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlSeletectableCollection.cs`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a63807c34083328da7af9a01f260dc