### PR TITLE
Add main window abstraction across frameworks

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIBlazorSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIBlazorSetup.cs
@@ -1,6 +1,8 @@
 using AbstUI.Blazor.Styles;
 using AbstUI.Components;
 using AbstUI.Styles;
+using AbstUI.Windowing;
+using AbstUI.Blazor.Windowing;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AbstUI.Blazor;
@@ -16,7 +18,9 @@ public static class AbstUIBlazorSetup
             .AddSingleton<AbstUIScriptResolver>()
             .AddSingleton<AbstBlazorComponentMapper>()
             .AddSingleton<AbstBlazorComponentContainer>()
-            .AddSingleton<IAbstComponentFactory, AbstBlazorComponentFactory>();
+            .AddSingleton<IAbstComponentFactory, AbstBlazorComponentFactory>()
+            .AddSingleton<IAbstFrameworkMainWindow, AbstBlazorMainWindow>()
+            .WithAbstUI();
         return services;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Windowing/AbstBlazorMainWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Windowing/AbstBlazorMainWindow.cs
@@ -1,0 +1,26 @@
+using AbstUI.Primitives;
+using AbstUI.Windowing;
+
+namespace AbstUI.Blazor.Windowing;
+
+public class AbstBlazorMainWindow : IAbstFrameworkMainWindow
+{
+    private AbstMainWindow _window = null!;
+    private APoint _size;
+
+    public string Title { get; set; } = string.Empty;
+
+    public void Init(AbstMainWindow instance)
+    {
+        _window = instance;
+        _window.SetTheSizeFromFW(_size);
+    }
+
+    public APoint GetTheSize() => _size;
+
+    public void SetTheSize(APoint size)
+    {
+        _size = size;
+    }
+}
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUIGodotSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUIGodotSetup.cs
@@ -23,6 +23,7 @@ namespace AbstUI.LGodot
                 .AddSingleton<IAbstGlobalMouse, GlobalGodotAbstMouse>()
                 .AddSingleton<IAbstGlobalKey, GlobalAbstKey>()
                 .AddSingleton<IAbstGodotWindowManager, AbstGodotWindowManager>()
+                .AddSingleton<IAbstFrameworkMainWindow, AbstGodotMainWindow>()
 
 
                 .AddSingleton<IAbstFontManager, AbstGodotFontManager>()

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Windowing/AbstGodotMainWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Windowing/AbstGodotMainWindow.cs
@@ -1,0 +1,55 @@
+using Godot;
+using AbstUI.Primitives;
+using AbstUI.Windowing;
+
+namespace AbstUI.LGodot.Windowing;
+
+public class AbstGodotMainWindow : IAbstFrameworkMainWindow
+{
+    private readonly IAbstGodotRootNode _root;
+    private AbstMainWindow _window = null!;
+
+    public AbstGodotMainWindow(IAbstGodotRootNode root)
+    {
+        _root = root;
+        var viewport = root.RootNode.GetViewport();
+        if (viewport != null)
+        {
+            viewport.SizeChanged += OnViewportSizeChanged;
+        }
+    }
+
+    private string _title = string.Empty;
+    public string Title
+    {
+        get => _title;
+        set
+        {
+            _title = value;
+            DisplayServer.WindowSetTitle(value);
+        }
+    }
+
+    public void Init(AbstMainWindow instance)
+    {
+        _window = instance;
+        _window.SetTheSizeFromFW(GetTheSize());
+    }
+
+    private void OnViewportSizeChanged()
+    {
+        _window.SetTheSizeFromFW(GetTheSize());
+    }
+
+    public APoint GetTheSize()
+    {
+        var size = _root.RootNode.GetViewport().GetVisibleRect().Size;
+        return new APoint(size.X, size.Y);
+    }
+
+    public void SetTheSize(APoint size)
+    {
+        DisplayServer.WindowSetSize(new Vector2I((int)size.X, (int)size.Y));
+    }
+}
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUIUnitySetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUIUnitySetup.cs
@@ -1,7 +1,9 @@
 ﻿using AbstUI.Components;
 using AbstUI.LUnity.Components;
 using AbstUI.LUnity.Styles;
+using AbstUI.LUnity.Windowing;
 using AbstUI.Styles;
+using AbstUI.Windowing;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AbstUI.LUnity
@@ -14,6 +16,7 @@ namespace AbstUI.LUnity
                 .AddSingleton<IAbstFontManager, UnityFontManager>()
                 .AddSingleton<IAbstStyleManager, AbstStyleManager>()
                 .AddSingleton<IAbstComponentFactory, AbstUnityComponentFactory>()
+                .AddSingleton<IAbstFrameworkMainWindow, AbstUnityMainWindow>()
                 .WithAbstUI();
 
             return services;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Windowing/AbstUnityMainWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Windowing/AbstUnityMainWindow.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+using AbstUI.Primitives;
+using AbstUI.Windowing;
+
+namespace AbstUI.LUnity.Windowing;
+
+public class AbstUnityMainWindow : IAbstFrameworkMainWindow
+{
+    private AbstMainWindow _window = null!;
+
+    public string Title
+    {
+        get => Application.productName;
+        set => Application.productName = value;
+    }
+
+    public void Init(AbstMainWindow instance)
+    {
+        _window = instance;
+        _window.SetTheSizeFromFW(GetTheSize());
+    }
+
+    public APoint GetTheSize() => new(Screen.width, Screen.height);
+
+    public void SetTheSize(APoint size)
+    {
+        Screen.SetResolution((int)size.X, (int)size.Y, Screen.fullScreenMode);
+    }
+}
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUISDLSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUISDLSetup.cs
@@ -21,6 +21,7 @@ namespace AbstUI.SDL2
                 .AddSingleton<AbstSdlComponentFactory>()
                 .AddTransient<IAbstComponentFactory>(p => p.GetRequiredService<AbstSdlComponentFactory>())
                 //.AddTransient<IAbstFrameworkDialog, AbstSDLDialog>()
+                .AddSingleton<IAbstFrameworkMainWindow, AbstSdlMainWindow>()
 
 
                 .AddSingleton<IAbstFontManager, SdlFontManager>()

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Windowing/AbstSdlMainWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Windowing/AbstSdlMainWindow.cs
@@ -1,0 +1,32 @@
+using AbstUI.Primitives;
+using AbstUI.SDL2.Core;
+using AbstUI.Windowing;
+
+namespace AbstUI.SDL2.Windowing;
+
+internal class AbstSdlMainWindow : IAbstFrameworkMainWindow
+{
+    private readonly ISdlRootComponentContext _context;
+    private AbstMainWindow _window = null!;
+
+    public AbstSdlMainWindow(ISdlRootComponentContext context)
+    {
+        _context = context;
+    }
+
+    public string Title { get; set; } = string.Empty;
+
+    public void Init(AbstMainWindow instance)
+    {
+        _window = instance;
+        _window.SetTheSizeFromFW(GetTheSize());
+    }
+
+    public APoint GetTheSize() => _context.GetWindowSize();
+
+    public void SetTheSize(APoint size)
+    {
+        // SDL2 window resizing not implemented
+    }
+}
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUISetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUISetup.cs
@@ -13,6 +13,7 @@ namespace AbstUI
             services
                 .AddTransient<IAbstDialog, AbstDialog>()
                 .AddTransient<AbstDialog>()
+                .AddSingleton<AbstMainWindow>()
                  .AddSingleton<IAbstShortCutManager, AbstShortCutManager>()
                  .AddSingleton<AbstWindowManager>()
                  .AddTransient(p => (IAbstWindowManager)p.GetRequiredService<AbstWindowManager>())

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Windowing/AbstMainWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Windowing/AbstMainWindow.cs
@@ -1,0 +1,40 @@
+using System;
+using AbstUI.Primitives;
+
+namespace AbstUI.Windowing;
+
+public class AbstMainWindow
+{
+    private readonly IAbstFrameworkMainWindow _framework;
+    private APoint _size;
+
+    public AbstMainWindow(IAbstFrameworkMainWindow framework)
+    {
+        _framework = framework;
+        _framework.Init(this);
+        _size = _framework.GetTheSize();
+    }
+
+    public string Title
+    {
+        get => _framework.Title;
+        set => _framework.Title = value;
+    }
+
+    public event Action<APoint>? SizeChanged;
+
+    public APoint GetSize() => _size;
+
+    public void SetTheSizeFromFW(APoint size)
+    {
+        _size = size;
+        SizeChanged?.Invoke(size);
+    }
+
+    public void SetSize(APoint size)
+    {
+        _size = size;
+        _framework.SetTheSize(size);
+    }
+}
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Windowing/IAbstFrameworkMainWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Windowing/IAbstFrameworkMainWindow.cs
@@ -1,0 +1,12 @@
+using AbstUI.FrameworkCommunication;
+using AbstUI.Primitives;
+
+namespace AbstUI.Windowing;
+
+public interface IAbstFrameworkMainWindow : IFrameworkForInitializable<AbstMainWindow>
+{
+    string Title { get; set; }
+    APoint GetTheSize();
+    void SetTheSize(APoint size);
+}
+


### PR DESCRIPTION
## Summary
- add `AbstMainWindow` abstraction and framework interface
- implement Godot, SDL2, Unity, and Blazor main windows
- register main window services in DI for each framework
- size the main window before project initialization and keep new windows within its bounds

## Testing
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/Setup/LingoEngineRegistration.cs --verify-no-changes --verbosity diagnostic`
- `dotnet build src/LingoEngine/LingoEngine.csproj`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a697b2344483329378ed9960158cdb