### PR TITLE
Move window positions to window classes

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Bitmaps/DirectorBitmapEditWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Bitmaps/DirectorBitmapEditWindow.cs
@@ -9,10 +9,14 @@ namespace LingoEngine.Director.Core.Bitmaps
             IAbstCommandHandler<PainterDrawPixelCommand>,
             IAbstCommandHandler<PainterFillCommand>
     {
-        public DirectorBitmapEditWindow(IServiceProvider serviceProvider) : base(serviceProvider, DirectorMenuCodes.PictureEditWindow) 
+        public DirectorBitmapEditWindow(IServiceProvider serviceProvider) : base(serviceProvider, DirectorMenuCodes.PictureEditWindow)
         {
             Width = 800;
             Height = 500;
+            MinimumWidth = 200;
+            MinimumHeight = 150;
+            X = 20;
+            Y = 120;
         }
         public bool CanExecute(PainterToolSelectCommand command) => true;
 

--- a/src/Director/LingoEngine.Director.Core/Importer/DirectorBinaryViewerWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Importer/DirectorBinaryViewerWindow.cs
@@ -8,9 +8,14 @@ namespace LingoEngine.Director.Core.Importer
 {
     public class DirectorBinaryViewerWindow : DirectorWindow<IDirFrameworkBinaryViewerWindow>
     {
-        public DirectorBinaryViewerWindow(IServiceProvider serviceProvider) : base(serviceProvider, DirectorMenuCodes.BinaryViewerWindow) {
+        public DirectorBinaryViewerWindow(IServiceProvider serviceProvider) : base(serviceProvider, DirectorMenuCodes.BinaryViewerWindow)
+        {
             Width = 1400;
             Height = 600;
+            MinimumWidth = 200;
+            MinimumHeight = 150;
+            X = 20;
+            Y = 120;
         }
     }
 }

--- a/src/Director/LingoEngine.Director.Core/Importer/DirectorBinaryViewerWindowV2.cs
+++ b/src/Director/LingoEngine.Director.Core/Importer/DirectorBinaryViewerWindowV2.cs
@@ -16,7 +16,7 @@ namespace LingoEngine.Director.Core.Importer;
 /// Experimental binary viewer window that parses test data and exposes stream annotations.
 /// </summary>
 public class DirectorBinaryViewerWindowV2 : DirectorWindow<IDirFrameworkBinaryViewerWindowV2>
-{ 
+{
     private readonly ILogger<DirectorBinaryViewerWindowV2> _logger;
 
     /// <summary>Annotations gathered from the parsed score chunk.</summary>
@@ -29,7 +29,11 @@ public class DirectorBinaryViewerWindowV2 : DirectorWindow<IDirFrameworkBinaryVi
     {
         _logger = logger;
         Width = 1400;
-        Height =  600;
+        Height = 600;
+        MinimumWidth = 200;
+        MinimumHeight = 150;
+        X = 20;
+        Y = 280;
         //LoadTestData();
     }
 
@@ -38,7 +42,7 @@ public class DirectorBinaryViewerWindowV2 : DirectorWindow<IDirFrameworkBinaryVi
         try
         {
             string path = Path.Combine(
-                "..", "..", "Libraries", "LingoEngine", "WillMoveToOwnRepo", "ProjectorRays","Test", "TestData", 
+                "..", "..", "Libraries", "LingoEngine", "WillMoveToOwnRepo", "ProjectorRays", "Test", "TestData",
                 "KeyFramesTest.dir"
                 );
             Data = File.ReadAllBytes(path);

--- a/src/Director/LingoEngine.Director.Core/Importer/DirectorImportExportWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Importer/DirectorImportExportWindow.cs
@@ -7,10 +7,14 @@ namespace LingoEngine.Director.Core.Importer
 {
     public class DirectorImportExportWindow : DirectorWindow<IDirFrameworkImportExportWindow>
     {
-        public DirectorImportExportWindow(IServiceProvider serviceProvider) : base(serviceProvider, DirectorMenuCodes.ImportExportWindow) 
+        public DirectorImportExportWindow(IServiceProvider serviceProvider) : base(serviceProvider, DirectorMenuCodes.ImportExportWindow)
         {
             Width = 400;
-            Height =  300;
+            Height = 300;
+            MinimumWidth = 200;
+            MinimumHeight = 150;
+            X = 120;
+            Y = 120;
         }
     }
 }

--- a/src/Director/LingoEngine.Director.Core/Projects/DirectorProjectSettingsWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Projects/DirectorProjectSettingsWindow.cs
@@ -109,6 +109,10 @@ public class DirectorProjectSettingsWindow : DirectorWindow<IDirFrameworkProject
     {
         Width = 500;
         Height = 200;
+        MinimumWidth = 200;
+        MinimumHeight = 150;
+        X = 100;
+        Y = 100;
         _state = state;
         _resolver = resolver;
         _folderPicker = folderPicker;

--- a/src/Director/LingoEngine.Director.Core/Scores/DirectorScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Scores/DirectorScoreWindow.cs
@@ -79,6 +79,8 @@ namespace LingoEngine.Director.Core.Scores
             Height = 360;
             MinimumHeight = 200;
             MinimumWidth = 300;
+            X = 20;
+            Y = 560;
 
             // Fix top panel
             _panelFix = factory.CreatePanel("ScoreWindowPanelFix");
@@ -240,7 +242,7 @@ namespace LingoEngine.Director.Core.Scores
                     spriteNumWithChannel = Math.Clamp(MathL.RoundToInt((yPosition + 4 + ScollY) / gfxValues.ChannelHeight), 1, 999) + 6;
                 }
             }
-           // Console.WriteLine($"Mouse Event: Frame {mouseFrame}, Channel {spriteNumWithChannel}, isInsideLeft={isInsideLeft}");
+            // Console.WriteLine($"Mouse Event: Frame {mouseFrame}, Channel {spriteNumWithChannel}, isInsideLeft={isInsideLeft}");
             if (spriteNumWithChannel <= 0)
                 return;
             if (isInsideLeft)
@@ -289,7 +291,7 @@ namespace LingoEngine.Director.Core.Scores
 
         protected override void OnResizing(bool firstLoad, int width, int height)
         {
-            base.OnResizing(firstLoad,width, height);
+            base.OnResizing(firstLoad, width, height);
             _labelsBar.OnResize(width, height);
         }
 

--- a/src/Director/LingoEngine.Director.Core/Stages/DirectorStageWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Stages/DirectorStageWindow.cs
@@ -10,8 +10,8 @@ using Microsoft.Extensions.DependencyInjection;
 namespace LingoEngine.Director.Core.Stages
 {
     public class DirectorStageWindow : DirectorWindow<IDirFrameworkStageWindow>,
-        IAbstCommandHandler<StageToolSelectCommand>, 
-        IAbstCommandHandler<MoveSpritesCommand>, 
+        IAbstCommandHandler<StageToolSelectCommand>,
+        IAbstCommandHandler<MoveSpritesCommand>,
         IAbstCommandHandler<RotateSpritesCommand>
     {
         private readonly IHistoryManager _historyManager;
@@ -24,6 +24,12 @@ namespace LingoEngine.Director.Core.Stages
         {
             _historyManager = historyManager;
             IconBar = new StageIconBar(factory, commandManager, player, mediator, stageManager);
+            MinimumWidth = 200;
+            MinimumHeight = 150;
+            Width = 650;
+            Height = 520;
+            X = 70;
+            Y = 22;
         }
 
         private void UpdateSelectionBox() => Framework.UpdateSelectionBox();

--- a/src/Director/LingoEngine.Director.Core/Texts/DirectorTextEditWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Texts/DirectorTextEditWindow.cs
@@ -11,6 +11,12 @@ namespace LingoEngine.Director.Core.Texts
         public DirectorTextEditWindow(ILingoFrameworkFactory factory, IServiceProvider serviceProvider) : base(serviceProvider, DirectorMenuCodes.TextEditWindow)
         {
             IconBar = new TextEditIconBar(factory);
+            Width = 450;
+            Height = 200;
+            MinimumWidth = 200;
+            MinimumHeight = 150;
+            X = 1200;
+            Y = 700;
         }
     }
 }

--- a/src/Director/LingoEngine.Director.Core/UI/DirectorToolsWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/UI/DirectorToolsWindow.cs
@@ -2,12 +2,14 @@ namespace LingoEngine.Director.Core.UI
 {
     public class DirectorToolsWindow : DirectorWindow<IDirFrameworkToolsWindow>
     {
-        public DirectorToolsWindow(IServiceProvider serviceProvider) : base(serviceProvider, DirectorMenuCodes.ToolsWindow) 
+        public DirectorToolsWindow(IServiceProvider serviceProvider) : base(serviceProvider, DirectorMenuCodes.ToolsWindow)
         {
             Width = 60;
-            Height= 300;
+            Height = 300;
             MinimumWidth = 60;
             MinimumHeight = 200;
+            X = 2;
+            Y = 22;
         }
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/UI/LingoGodotDirectorRoot.cs
+++ b/src/Director/LingoEngine.Director.LGodot/UI/LingoGodotDirectorRoot.cs
@@ -38,7 +38,7 @@ namespace LingoEngine.Director.LGodot.UI
 
         public LingoGodotDirectorRoot(LingoPlayer player, IServiceProvider serviceProvider, LingoProjectSettings startupProjectSettings)
         {
-            
+
             _directorParent.Name = "DirectorRoot";
             // set up root
             var parent = (Node2D)serviceProvider.GetRequiredService<LingoGodotRootNode>().RootNode;
@@ -79,8 +79,8 @@ namespace LingoEngine.Director.LGodot.UI
                 _directorParent.AddChild(item);
 
 
-            // Set all positions
-            SetDefaultPositions();
+            foreach (var item in _windows)
+                item.EnsureInBounds();
 
             // close some windows
             _projectSettingsWindow.CloseWindow();
@@ -94,32 +94,15 @@ namespace LingoEngine.Director.LGodot.UI
             {
                 var stageWidth = Math.Min(startupProjectSettings.StageWidth, 800);// scrollbars
                 var stageHeight = Math.Min(startupProjectSettings.StageHeight, 600); // bottombar
-                //var size = new Vector2(stageWidth, stageHeight);
-               // _stageWindow.Size = size;
-                //_stageWindow.CustomMinimumSize = size;
+                                                                                     //var size = new Vector2(stageWidth, stageHeight);
+                                                                                     // _stageWindow.Size = size;
+                                                                                     //_stageWindow.CustomMinimumSize = size;
                 _scoreWindow.SetThePosition(new Vector2(_scoreWindow.Position.X, 640 - 560 + stageHeight));
                 serviceProvider.GetRequiredService<IAbstWindowManager>()
                     .SetWindowSize(DirectorMenuCodes.StageWindow, stageWidth, stageHeight);
                 foreach (var item in _windows)
                     item.EnsureInBounds();
             }
-        }
-
-        private void SetDefaultPositions()
-        {
-            _stageWindow.Position = new Vector2(70, 22);
-            //_castViewer.Position = new Vector2(830, 22);
-            _scoreWindow.Position = new Vector2(20, 560);
-            //_propertyInspector.Position = new Vector2(1530, 22);
-            _toolsWindow.Position = new Vector2(2, 22);
-            _binaryViewer.Position = new Vector2(20, 120);
-            _binaryViewerV2.Position = new Vector2(20, 280);
-            _importExportWindow.Position = new Vector2(120, 120);
-            _projectSettingsWindow.Position = new Vector2(100, 100);
-            _textWindow.Position = new Vector2(1200, 700);
-            _picture.Position = new Vector2(20, 120);
-            foreach (var item in _windows)
-                item.EnsureInBounds();
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary
- define default positions and minimum sizes in individual Director window classes
- drop root-level window positioning and keep bounds check

## Testing
- `dotnet format src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj --include src/Director/LingoEngine.Director.Core/Stages/DirectorStageWindow.cs src/Director/LingoEngine.Director.Core/Scores/DirectorScoreWindow.cs src/Director/LingoEngine.Director.Core/UI/DirectorToolsWindow.cs src/Director/LingoEngine.Director.Core/Importer/DirectorBinaryViewerWindow.cs src/Director/LingoEngine.Director.Core/Importer/DirectorBinaryViewerWindowV2.cs src/Director/LingoEngine.Director.Core/Importer/DirectorImportExportWindow.cs src/Director/LingoEngine.Director.Core/Texts/DirectorTextEditWindow.cs src/Director/LingoEngine.Director.Core/Bitmaps/DirectorBitmapEditWindow.cs src/Director/LingoEngine.Director.Core/Projects/DirectorProjectSettingsWindow.cs --verbosity diagnostic`
- `dotnet format src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj --include src/Director/LingoEngine.Director.Core/Texts/DirectorTextEditWindow.cs src/Director/LingoEngine.Director.Core/Bitmaps/DirectorBitmapEditWindow.cs src/Director/LingoEngine.Director.Core/Projects/DirectorProjectSettingsWindow.cs --verbosity diagnostic`
- `dotnet format src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj --include src/Director/LingoEngine.Director.LGodot/UI/LingoGodotDirectorRoot.cs --verbosity diagnostic`
- `dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj`
- `dotnet build src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a6a760d478833297cafbc3814f1b90