### PR TITLE
docs: arrange README images with titles

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+**Note:** The TetriGrounds demo and its assets are distributed under a separate license. Refer to `Demo/TetriGrounds/LICENSE.assets.txt` for details on those assets.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # LingoEngine
 
+### Director.NET
+
 **LingoEngine** is a modern, cross-platform C# runtime designed to emulate Macromedia Director's **Lingo** scripting language. It enables playback of original Lingo code and behaviors on top of modern rendering backends like **Godot**, **SDL2**, **Unity**, and **Blazor**, allowing legacy projects to be revived or reimagined with full flexibility.
 
 ![Director full screenshot](Images/Direcor-FullScreenshot.jpg)
 
-<img src="Images/PropertyInspector.png" alt="Property Inspector" width="50%" />
-<img src="Images/TempoChange.jpg" alt="Tempo Change" width="50%" />
-<img src="Images/Director_CodeConverter1.jpg" alt="Tempo Change" width="50%" />
+#### Property inspector
+
+<img src="Images/PropertyInspector.png" alt="Property Inspector" width="49%" /><img src="Images/TempoChange.jpg" alt="Tempo Change" width="49%" />
+
+#### Easy Lingo to C# conversion
+
+<img src="Images/Director_CodeConverter1.jpg" alt="Easy Lingo to C# conversion" width="100%" />
 
 > ⚠️ **Can you help us make this dream project come true?**  
 > This project is still under heavy development, and we can use some help. Reach out if you want to contribute.
@@ -152,6 +158,8 @@ Please also read our [Code of Conduct](CODE_OF_CONDUCT.md).
 ## 📄 License
 
 Licensed under the [MIT License](LICENSE).
+
+> **Note:** The TetriGrounds demo's assets are not covered by the MIT License. See [Demo/TetriGrounds/LICENSE.assets.txt](Demo/TetriGrounds/LICENSE.assets.txt) for details.
 
 ---
 


### PR DESCRIPTION
## Summary
- display property inspector screenshots side-by-side with a heading
- add "Easy Lingo to C# conversion" heading and widen corresponding screenshot
- add Director.NET subtitle and mention TetriGrounds assets' separate license

## Testing
- `dotnet --version`


------
https://chatgpt.com/codex/tasks/task_e_68a6a82a9f088332aa1edc3e24134084