### PR TITLE
feat: support selectable collection styling

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using AbstUI.Primitives;
 using AbstUI.Components.Inputs;
+using AbstUI.Styles;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
@@ -15,6 +16,19 @@ public partial class AbstBlazorInputCombobox : IAbstFrameworkInputCombobox
     public int SelectedIndex { get; set; } = -1;
     public string? SelectedKey { get; set; }
     public string? SelectedValue { get; set; }
+
+    public string? ItemFont { get; set; }
+    public int ItemFontSize { get; set; } = 11;
+    public AColor ItemTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+    public AColor ItemSelectedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+    public AColor ItemSelectedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+    public AColor ItemSelectedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+    public AColor ItemHoverTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+    public AColor ItemHoverBackgroundColor { get; set; } = AbstDefaultColors.ListHoverColor;
+    public AColor ItemHoverBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+    public AColor ItemPressedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+    public AColor ItemPressedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+    public AColor ItemPressedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
 
 
     public void AddItem(string key, string value)
@@ -49,5 +63,16 @@ public partial class AbstBlazorInputCombobox : IAbstFrameworkInputCombobox
             }
             ValueChangedInvoke();
         }
+    }
+
+    protected override string BuildStyle()
+    {
+        var style = base.BuildStyle();
+        if (!string.IsNullOrEmpty(ItemFont))
+            style += $"font-family:{ItemFont};";
+        if (ItemFontSize > 0)
+            style += $"font-size:{ItemFontSize}px;";
+        style += $"color:{ItemTextColor.ToHex()};";
+        return style;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorItemList.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using AbstUI.Components.Inputs;
+using AbstUI.Primitives;
+using AbstUI.Styles;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
@@ -13,6 +15,19 @@ public partial class AbstBlazorItemList : IAbstFrameworkItemList
     public int SelectedIndex { get; set; } = -1;
     public string? SelectedKey { get; set; }
     public string? SelectedValue { get; set; }
+
+    public string? ItemFont { get; set; }
+    public int ItemFontSize { get; set; } = 11;
+    public AColor ItemTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+    public AColor ItemSelectedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+    public AColor ItemSelectedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+    public AColor ItemSelectedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+    public AColor ItemHoverTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+    public AColor ItemHoverBackgroundColor { get; set; } = AbstDefaultColors.ListHoverColor;
+    public AColor ItemHoverBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+    public AColor ItemPressedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+    public AColor ItemPressedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+    public AColor ItemPressedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
 
 
     public void AddItem(string key, string value)
@@ -47,5 +62,16 @@ public partial class AbstBlazorItemList : IAbstFrameworkItemList
             }
             ValueChangedInvoke();
         }
+    }
+
+    protected override string BuildStyle()
+    {
+        var style = base.BuildStyle();
+        if (!string.IsNullOrEmpty(ItemFont))
+            style += $"font-family:{ItemFont};";
+        if (ItemFontSize > 0)
+            style += $"font-size:{ItemFontSize}px;";
+        style += $"color:{ItemTextColor.ToHex()};";
+        return style;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputCombobox.cs
@@ -4,6 +4,8 @@ using System.Numerics;
 using ImGuiNET;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.Components.Inputs;
+using AbstUI.Styles;
 
 namespace AbstUI.ImGui.Components
 {
@@ -20,6 +22,19 @@ namespace AbstUI.ImGui.Components
         public int SelectedIndex { get; set; } = -1;
         public string? SelectedKey { get; set; }
         public string? SelectedValue { get; set; }
+
+        public string? ItemFont { get; set; }
+        public int ItemFontSize { get; set; } = 11;
+        public AColor ItemTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+        public AColor ItemSelectedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+        public AColor ItemSelectedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+        public AColor ItemSelectedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        public AColor ItemHoverTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+        public AColor ItemHoverBackgroundColor { get; set; } = AbstDefaultColors.ListHoverColor;
+        public AColor ItemHoverBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        public AColor ItemPressedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+        public AColor ItemPressedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+        public AColor ItemPressedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
 
         public event Action? ValueChanged;
         public object FrameworkNode => this;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputItemList.cs
@@ -4,6 +4,8 @@ using System.Numerics;
 using ImGuiNET;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.Components.Inputs;
+using AbstUI.Styles;
 
 namespace AbstUI.ImGui.Components
 {
@@ -20,6 +22,19 @@ namespace AbstUI.ImGui.Components
         public int SelectedIndex { get; set; } = -1;
         public string? SelectedKey { get; set; }
         public string? SelectedValue { get; set; }
+
+        public string? ItemFont { get; set; }
+        public int ItemFontSize { get; set; } = 11;
+        public AColor ItemTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+        public AColor ItemSelectedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+        public AColor ItemSelectedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+        public AColor ItemSelectedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        public AColor ItemHoverTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+        public AColor ItemHoverBackgroundColor { get; set; } = AbstDefaultColors.ListHoverColor;
+        public AColor ItemHoverBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        public AColor ItemPressedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+        public AColor ItemPressedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+        public AColor ItemPressedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
 
         public event Action? ValueChanged;
         public object FrameworkNode => this;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputCombobox.cs
@@ -11,7 +11,7 @@ namespace AbstUI.LGodot.Components
     /// </summary>
     public partial class AbstGodotInputCombobox : OptionButton, IAbstFrameworkInputCombobox, IDisposable
     {
-        private readonly List<KeyValuePair<string,string>> _items = new();
+        private readonly List<KeyValuePair<string, string>> _items = new();
         private AMargin _margin = AMargin.Zero;
         private Action<string?>? _onChange;
 
@@ -47,10 +47,10 @@ namespace AbstUI.LGodot.Components
             }
         }
         public object FrameworkNode => this;
-        public IReadOnlyList<KeyValuePair<string,string>> Items => _items;
+        public IReadOnlyList<KeyValuePair<string, string>> Items => _items;
         public void AddItem(string key, string value)
         {
-            _items.Add(new KeyValuePair<string,string>(key,value));
+            _items.Add(new KeyValuePair<string, string>(key, value));
             int idx = ItemCount;
             base.AddItem(value);
             SetItemMetadata(idx, key);
@@ -92,6 +92,19 @@ namespace AbstUI.LGodot.Components
                 }
             }
         }
+
+        public string? ItemFont { get; set; }
+        public int ItemFontSize { get; set; } = 11;
+        public AColor ItemTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+        public AColor ItemSelectedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+        public AColor ItemSelectedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+        public AColor ItemSelectedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        public AColor ItemHoverTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+        public AColor ItemHoverBackgroundColor { get; set; } = AbstDefaultColors.ListHoverColor;
+        public AColor ItemHoverBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        public AColor ItemPressedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+        public AColor ItemPressedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+        public AColor ItemPressedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
 
         event Action? IAbstFrameworkNodeInput.ValueChanged
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotItemList.cs
@@ -2,6 +2,7 @@ using Godot;
 using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.Components.Inputs;
+using AbstUI.Styles;
 
 namespace AbstUI.LGodot.Components
 {
@@ -10,7 +11,7 @@ namespace AbstUI.LGodot.Components
     /// </summary>
     public partial class AbstGodotItemList : ItemList, IAbstFrameworkItemList, IDisposable
     {
-        private readonly List<KeyValuePair<string,string>> _items = new();
+        private readonly List<KeyValuePair<string, string>> _items = new();
         private AMargin _margin = AMargin.Zero;
         private Action<string?>? _onChange;
         private event Action? _onValueChanged;
@@ -47,7 +48,7 @@ namespace AbstUI.LGodot.Components
             _onItemSelected = idx =>
             {
                 _onValueChanged?.Invoke();
-                if (idx>=0 && idx < _items.Count)
+                if (idx >= 0 && idx < _items.Count)
                     _onChange?.Invoke(_items[(int)idx].Key);
             };
             ItemSelected += _onItemSelected;
@@ -59,7 +60,7 @@ namespace AbstUI.LGodot.Components
 
         public void AddItem(string key, string value)
         {
-            _items.Add(new KeyValuePair<string,string>(key, value));
+            _items.Add(new KeyValuePair<string, string>(key, value));
             int idx = ItemCount;
             base.AddItem(value);
             SetItemMetadata(idx, key);
@@ -117,6 +118,19 @@ namespace AbstUI.LGodot.Components
                 }
             }
         }
+
+        public string? ItemFont { get; set; }
+        public int ItemFontSize { get; set; } = 11;
+        public AColor ItemTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+        public AColor ItemSelectedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+        public AColor ItemSelectedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+        public AColor ItemSelectedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        public AColor ItemHoverTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+        public AColor ItemHoverBackgroundColor { get; set; } = AbstDefaultColors.ListHoverColor;
+        public AColor ItemHoverBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        public AColor ItemPressedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+        public AColor ItemPressedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+        public AColor ItemPressedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
 
         event Action? IAbstFrameworkNodeInput.ValueChanged
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputCombobox.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using AbstUI.Components.Inputs;
 using AbstUI.LUnity.Components.Base;
+using AbstUI.Primitives;
+using AbstUI.Styles;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -104,6 +106,19 @@ internal class AbstUnityInputCombobox : AbstUnityComponent, IAbstFrameworkInputC
                 SelectedIndex = index;
         }
     }
+
+    public string? ItemFont { get; set; }
+    public int ItemFontSize { get; set; } = 11;
+    public AColor ItemTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+    public AColor ItemSelectedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+    public AColor ItemSelectedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+    public AColor ItemSelectedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+    public AColor ItemHoverTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+    public AColor ItemHoverBackgroundColor { get; set; } = AbstDefaultColors.ListHoverColor;
+    public AColor ItemHoverBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+    public AColor ItemPressedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+    public AColor ItemPressedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+    public AColor ItemPressedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
 
     public event Action? ValueChanged;
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputCombobox.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
+using AbstUI.Primitives;
 
 namespace AbstUI.Components.Inputs
 {
     /// <summary>
     /// Engine level wrapper for a combobox input.
     /// </summary>
-    public class AbstInputCombobox : AbstInputBase<IAbstFrameworkInputCombobox>
+    public class AbstInputCombobox : AbstInputBase<IAbstFrameworkInputCombobox>, IAbstSdlHasSeletectableCollectionStyle
     {
         public IReadOnlyList<KeyValuePair<string, string>> Items => _framework.Items;
         public void AddItem(string key, string value) => _framework.AddItem(key, value);
@@ -13,5 +14,18 @@ namespace AbstUI.Components.Inputs
         public int SelectedIndex { get => _framework.SelectedIndex; set => _framework.SelectedIndex = value; }
         public string? SelectedKey { get => _framework.SelectedKey; set => _framework.SelectedKey = value; }
         public string? SelectedValue { get => _framework.SelectedValue; set => _framework.SelectedValue = value; }
+
+        public string? ItemFont { get => _framework.ItemFont; set => _framework.ItemFont = value; }
+        public int ItemFontSize { get => _framework.ItemFontSize; set => _framework.ItemFontSize = value; }
+        public AColor ItemTextColor { get => _framework.ItemTextColor; set => _framework.ItemTextColor = value; }
+        public AColor ItemSelectedTextColor { get => _framework.ItemSelectedTextColor; set => _framework.ItemSelectedTextColor = value; }
+        public AColor ItemSelectedBackgroundColor { get => _framework.ItemSelectedBackgroundColor; set => _framework.ItemSelectedBackgroundColor = value; }
+        public AColor ItemSelectedBorderColor { get => _framework.ItemSelectedBorderColor; set => _framework.ItemSelectedBorderColor = value; }
+        public AColor ItemHoverTextColor { get => _framework.ItemHoverTextColor; set => _framework.ItemHoverTextColor = value; }
+        public AColor ItemHoverBackgroundColor { get => _framework.ItemHoverBackgroundColor; set => _framework.ItemHoverBackgroundColor = value; }
+        public AColor ItemHoverBorderColor { get => _framework.ItemHoverBorderColor; set => _framework.ItemHoverBorderColor = value; }
+        public AColor ItemPressedTextColor { get => _framework.ItemPressedTextColor; set => _framework.ItemPressedTextColor = value; }
+        public AColor ItemPressedBackgroundColor { get => _framework.ItemPressedBackgroundColor; set => _framework.ItemPressedBackgroundColor = value; }
+        public AColor ItemPressedBorderColor { get => _framework.ItemPressedBorderColor; set => _framework.ItemPressedBorderColor = value; }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstItemList.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
+using AbstUI.Primitives;
 
 namespace AbstUI.Components.Inputs
 {
     /// <summary>
     /// Engine level wrapper around a framework item list widget.
     /// </summary>
-    public class AbstItemList : AbstInputBase<IAbstFrameworkItemList>
+    public class AbstItemList : AbstInputBase<IAbstFrameworkItemList>, IAbstSdlHasSeletectableCollectionStyle
     {
         public IReadOnlyList<KeyValuePair<string, string>> Items => _framework.Items;
         public void AddItem(string key, string value) => _framework.AddItem(key, value);
@@ -13,5 +14,18 @@ namespace AbstUI.Components.Inputs
         public int SelectedIndex { get => _framework.SelectedIndex; set => _framework.SelectedIndex = value; }
         public string? SelectedKey { get => _framework.SelectedKey; set => _framework.SelectedKey = value; }
         public string? SelectedValue { get => _framework.SelectedValue; set => _framework.SelectedValue = value; }
+
+        public string? ItemFont { get => _framework.ItemFont; set => _framework.ItemFont = value; }
+        public int ItemFontSize { get => _framework.ItemFontSize; set => _framework.ItemFontSize = value; }
+        public AColor ItemTextColor { get => _framework.ItemTextColor; set => _framework.ItemTextColor = value; }
+        public AColor ItemSelectedTextColor { get => _framework.ItemSelectedTextColor; set => _framework.ItemSelectedTextColor = value; }
+        public AColor ItemSelectedBackgroundColor { get => _framework.ItemSelectedBackgroundColor; set => _framework.ItemSelectedBackgroundColor = value; }
+        public AColor ItemSelectedBorderColor { get => _framework.ItemSelectedBorderColor; set => _framework.ItemSelectedBorderColor = value; }
+        public AColor ItemHoverTextColor { get => _framework.ItemHoverTextColor; set => _framework.ItemHoverTextColor = value; }
+        public AColor ItemHoverBackgroundColor { get => _framework.ItemHoverBackgroundColor; set => _framework.ItemHoverBackgroundColor = value; }
+        public AColor ItemHoverBorderColor { get => _framework.ItemHoverBorderColor; set => _framework.ItemHoverBorderColor = value; }
+        public AColor ItemPressedTextColor { get => _framework.ItemPressedTextColor; set => _framework.ItemPressedTextColor = value; }
+        public AColor ItemPressedBackgroundColor { get => _framework.ItemPressedBackgroundColor; set => _framework.ItemPressedBackgroundColor = value; }
+        public AColor ItemPressedBorderColor { get => _framework.ItemPressedBorderColor; set => _framework.ItemPressedBorderColor = value; }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstFrameworkInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstFrameworkInputCombobox.cs
@@ -5,7 +5,7 @@ namespace AbstUI.Components.Inputs
     /// <summary>
     /// Framework specific combo box input.
     /// </summary>
-    public interface IAbstFrameworkInputCombobox : IAbstFrameworkNodeInput
+    public interface IAbstFrameworkInputCombobox : IAbstFrameworkNodeInput, IAbstSdlHasSeletectableCollectionStyle
     {
         IReadOnlyList<KeyValuePair<string, string>> Items { get; }
         void AddItem(string key, string value);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstFrameworkItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstFrameworkItemList.cs
@@ -5,7 +5,7 @@ namespace AbstUI.Components.Inputs
     /// <summary>
     /// Framework specific list widget allowing selection of items.
     /// </summary>
-    public interface IAbstFrameworkItemList : IAbstFrameworkNodeInput
+    public interface IAbstFrameworkItemList : IAbstFrameworkNodeInput, IAbstSdlHasSeletectableCollectionStyle
     {
         /// <summary>Current items in the list.</summary>
         IReadOnlyList<KeyValuePair<string, string>> Items { get; }


### PR DESCRIPTION
## Summary
- enforce selectable collection style on combobox and item list interfaces
- forward item font and color properties through input wrappers
- implement selectable collection style fields for ImGui, Blazor, Unity and Godot backends

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputCombobox.cs WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstItemList.cs WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstFrameworkInputCombobox.cs WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstFrameworkItemList.cs --verbosity diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputCombobox.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputItemList.cs --verbosity diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputCombobox.cs --verbosity diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorItemList.cs --verbosity diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputCombobox.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotItemList.cs --verbosity diagnostic`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj -f net8.0`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj -f net8.0` *(fails: missing framework types)*
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj -f net8.0`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj -f net8.0` *(fails: unimplemented interface members)*
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj -f net9.0`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj -f net8.0` *(fails: missing assets for net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a6660df4833293d4cadd5e18387d