### PR TITLE
feat(ui): expose selectable collection styles

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using AbstUI.Primitives;
 using AbstUI.Components.Inputs;
+using AbstUI.Styles;
+using AbstUI.Blazor.Primitives;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
 public partial class AbstBlazorInputCombobox : IAbstFrameworkInputCombobox
 {
-
     private readonly List<KeyValuePair<string, string>> _items = new();
     public IReadOnlyList<KeyValuePair<string, string>> Items => _items;
 
@@ -30,6 +31,29 @@ public partial class AbstBlazorInputCombobox : IAbstFrameworkInputCombobox
         SelectedKey = null;
         SelectedValue = null;
         RequestRender();
+    }
+
+    public string? ItemFont { get; set; }
+    public int ItemFontSize { get; set; } = 11;
+    public AColor ItemTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+    public AColor ItemSelectedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+    public AColor ItemSelectedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+    public AColor ItemSelectedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+    public AColor ItemHoverTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+    public AColor ItemHoverBackgroundColor { get; set; } = AbstDefaultColors.ListHoverColor;
+    public AColor ItemHoverBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+    public AColor ItemPressedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+    public AColor ItemPressedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+    public AColor ItemPressedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+
+    private string GetItemStyle(int index)
+    {
+        var style = $"color:{ItemTextColor.ToCss()};";
+        if (index == SelectedIndex)
+        {
+            style += $"background:{ItemSelectedBackgroundColor.ToCss()};";
+        }
+        return style;
     }
 
     private void HandleChange(ChangeEventArgs e)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.razor
@@ -3,6 +3,6 @@
     @for (int i = 0; i < _items.Count; i++)
     {
         var item = _items[i];
-        <option value="@i">@item.Value</option>
+        <option value="@i" style="@GetItemStyle(i)">@item.Value</option>
     }
 </select>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorItemList.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using AbstUI.Components.Inputs;
+using AbstUI.Primitives;
+using AbstUI.Styles;
+using AbstUI.Blazor.Primitives;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
@@ -28,6 +31,29 @@ public partial class AbstBlazorItemList : IAbstFrameworkItemList
         SelectedKey = null;
         SelectedValue = null;
         RequestRender();
+    }
+
+    public string? ItemFont { get; set; }
+    public int ItemFontSize { get; set; } = 11;
+    public AColor ItemTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+    public AColor ItemSelectedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+    public AColor ItemSelectedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+    public AColor ItemSelectedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+    public AColor ItemHoverTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+    public AColor ItemHoverBackgroundColor { get; set; } = AbstDefaultColors.ListHoverColor;
+    public AColor ItemHoverBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+    public AColor ItemPressedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+    public AColor ItemPressedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+    public AColor ItemPressedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+
+    private string GetItemStyle(int index)
+    {
+        var style = $"color:{ItemTextColor.ToCss()};";
+        if (index == SelectedIndex)
+        {
+            style += $"background:{ItemSelectedBackgroundColor.ToCss()};";
+        }
+        return style;
     }
 
     private void HandleChange(ChangeEventArgs e)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorItemList.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorItemList.razor
@@ -3,6 +3,6 @@
     @for (int i = 0; i < _items.Count; i++)
     {
         var item = _items[i];
-        <option value="@i">@item.Value</option>
+        <option value="@i" style="@GetItemStyle(i)">@item.Value</option>
     }
 </select>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputCombobox.cs
@@ -4,6 +4,9 @@ using System.Numerics;
 using ImGuiNET;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.Components.Inputs;
+using AbstUI.Styles;
+using AbstUI.ImGui;
 
 namespace AbstUI.ImGui.Components
 {
@@ -36,6 +39,19 @@ namespace AbstUI.ImGui.Components
             SelectedValue = null;
         }
 
+        public string? ItemFont { get; set; }
+        public int ItemFontSize { get; set; } = 11;
+        public AColor ItemTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+        public AColor ItemSelectedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+        public AColor ItemSelectedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+        public AColor ItemSelectedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        public AColor ItemHoverTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+        public AColor ItemHoverBackgroundColor { get; set; } = AbstDefaultColors.ListHoverColor;
+        public AColor ItemHoverBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        public AColor ItemPressedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+        public AColor ItemPressedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+        public AColor ItemPressedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+
         public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
         {
             if (!Visibility) return nint.Zero;
@@ -45,6 +61,10 @@ namespace AbstUI.ImGui.Components
                 global::ImGuiNET.ImGui.BeginDisabled();
 
             string preview = SelectedValue ?? string.Empty;
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.Text, ItemTextColor.ToImGuiColor());
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.Header, ItemSelectedBackgroundColor.ToImGuiColor());
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.HeaderHovered, ItemHoverBackgroundColor.ToImGuiColor());
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.HeaderActive, ItemPressedBackgroundColor.ToImGuiColor());
             if (global::ImGuiNET.ImGui.BeginCombo("##combo", preview))
             {
                 for (int i = 0; i < _items.Count; i++)
@@ -63,6 +83,7 @@ namespace AbstUI.ImGui.Components
                 }
                 global::ImGuiNET.ImGui.EndCombo();
             }
+            global::ImGuiNET.ImGui.PopStyleColor(4);
 
             if (!Enabled)
                 global::ImGuiNET.ImGui.EndDisabled();

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputItemList.cs
@@ -4,6 +4,9 @@ using System.Numerics;
 using ImGuiNET;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.Components.Inputs;
+using AbstUI.Styles;
+using AbstUI.ImGui;
 
 namespace AbstUI.ImGui.Components
 {
@@ -34,6 +37,19 @@ namespace AbstUI.ImGui.Components
             SelectedKey = null;
             SelectedValue = null;
         }
+
+        public string? ItemFont { get; set; }
+        public int ItemFontSize { get; set; } = 11;
+        public AColor ItemTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+        public AColor ItemSelectedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+        public AColor ItemSelectedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+        public AColor ItemSelectedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        public AColor ItemHoverTextColor { get; set; } = AbstDefaultColors.InputTextColor;
+        public AColor ItemHoverBackgroundColor { get; set; } = AbstDefaultColors.ListHoverColor;
+        public AColor ItemHoverBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        public AColor ItemPressedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
+        public AColor ItemPressedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
+        public AColor ItemPressedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
         public override void Dispose() => base.Dispose();
 
         public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
@@ -47,6 +63,10 @@ namespace AbstUI.ImGui.Components
             if (!Enabled)
                 global::ImGuiNET.ImGui.BeginDisabled();
 
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.Text, ItemTextColor.ToImGuiColor());
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.Header, ItemSelectedBackgroundColor.ToImGuiColor());
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.HeaderHovered, ItemHoverBackgroundColor.ToImGuiColor());
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.HeaderActive, ItemPressedBackgroundColor.ToImGuiColor());
             if (global::ImGuiNET.ImGui.BeginListBox("##list", new Vector2(Width, Height)))
             {
                 for (int i = 0; i < _items.Count; i++)
@@ -65,6 +85,7 @@ namespace AbstUI.ImGui.Components
                 }
                 global::ImGuiNET.ImGui.EndListBox();
             }
+            global::ImGuiNET.ImGui.PopStyleColor(4);
 
             if (!Enabled)
                 global::ImGuiNET.ImGui.EndDisabled();

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputCombobox.cs
@@ -3,6 +3,7 @@ using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.Styles;
 using AbstUI.Components.Inputs;
+using AbstUI.LGodot.Primitives;
 
 namespace AbstUI.LGodot.Components
 {
@@ -11,7 +12,7 @@ namespace AbstUI.LGodot.Components
     /// </summary>
     public partial class AbstGodotInputCombobox : OptionButton, IAbstFrameworkInputCombobox, IDisposable
     {
-        private readonly List<KeyValuePair<string,string>> _items = new();
+        private readonly List<KeyValuePair<string, string>> _items = new();
         private AMargin _margin = AMargin.Zero;
         private Action<string?>? _onChange;
 
@@ -23,6 +24,7 @@ namespace AbstUI.LGodot.Components
             ItemSelected += idx => _onValueChanged?.Invoke();
             _onChange = onChange;
             if (_onChange != null) ItemSelected += _ => _onChange(SelectedKey);
+            UpdatePopupStyle();
         }
 
 
@@ -47,10 +49,10 @@ namespace AbstUI.LGodot.Components
             }
         }
         public object FrameworkNode => this;
-        public IReadOnlyList<KeyValuePair<string,string>> Items => _items;
+        public IReadOnlyList<KeyValuePair<string, string>> Items => _items;
         public void AddItem(string key, string value)
         {
-            _items.Add(new KeyValuePair<string,string>(key,value));
+            _items.Add(new KeyValuePair<string, string>(key, value));
             int idx = ItemCount;
             base.AddItem(value);
             SetItemMetadata(idx, key);
@@ -60,6 +62,29 @@ namespace AbstUI.LGodot.Components
             _items.Clear();
             Clear();
         }
+
+        public string? ItemFont { get; set; }
+        public int ItemFontSize { get; set; } = 11;
+        private AColor _itemTextColor = AbstDefaultColors.InputTextColor;
+        public AColor ItemTextColor { get => _itemTextColor; set { _itemTextColor = value; UpdatePopupStyle(); } }
+        private AColor _itemSelectedTextColor = AbstDefaultColors.InputSelectionText;
+        public AColor ItemSelectedTextColor { get => _itemSelectedTextColor; set { _itemSelectedTextColor = value; UpdatePopupStyle(); } }
+        private AColor _itemSelectedBackgroundColor = AbstDefaultColors.InputAccentColor;
+        public AColor ItemSelectedBackgroundColor { get => _itemSelectedBackgroundColor; set { _itemSelectedBackgroundColor = value; UpdatePopupStyle(); } }
+        private AColor _itemSelectedBorderColor = AbstDefaultColors.InputBorderColor;
+        public AColor ItemSelectedBorderColor { get => _itemSelectedBorderColor; set { _itemSelectedBorderColor = value; UpdatePopupStyle(); } }
+        private AColor _itemHoverTextColor = AbstDefaultColors.InputTextColor;
+        public AColor ItemHoverTextColor { get => _itemHoverTextColor; set { _itemHoverTextColor = value; UpdatePopupStyle(); } }
+        private AColor _itemHoverBackgroundColor = AbstDefaultColors.ListHoverColor;
+        public AColor ItemHoverBackgroundColor { get => _itemHoverBackgroundColor; set { _itemHoverBackgroundColor = value; UpdatePopupStyle(); } }
+        private AColor _itemHoverBorderColor = AbstDefaultColors.InputBorderColor;
+        public AColor ItemHoverBorderColor { get => _itemHoverBorderColor; set { _itemHoverBorderColor = value; UpdatePopupStyle(); } }
+        private AColor _itemPressedTextColor = AbstDefaultColors.InputSelectionText;
+        public AColor ItemPressedTextColor { get => _itemPressedTextColor; set { _itemPressedTextColor = value; UpdatePopupStyle(); } }
+        private AColor _itemPressedBackgroundColor = AbstDefaultColors.InputAccentColor;
+        public AColor ItemPressedBackgroundColor { get => _itemPressedBackgroundColor; set { _itemPressedBackgroundColor = value; UpdatePopupStyle(); } }
+        private AColor _itemPressedBorderColor = AbstDefaultColors.InputBorderColor;
+        public AColor ItemPressedBorderColor { get => _itemPressedBorderColor; set { _itemPressedBorderColor = value; UpdatePopupStyle(); } }
         public int SelectedIndex { get => Selected; set => Selected = value; }
         public string? SelectedKey
         {
@@ -91,6 +116,39 @@ namespace AbstUI.LGodot.Components
                     }
                 }
             }
+        }
+
+        private void UpdatePopupStyle()
+        {
+            var popup = GetPopup();
+            popup.AddThemeColorOverride("font_color", _itemTextColor.ToGodotColor());
+            popup.AddThemeColorOverride("font_color_hover", _itemHoverTextColor.ToGodotColor());
+            popup.AddThemeColorOverride("font_color_pressed", _itemPressedTextColor.ToGodotColor());
+            popup.AddThemeColorOverride("font_color_selected", _itemSelectedTextColor.ToGodotColor());
+
+            var hover = new StyleBoxFlat
+            {
+                BgColor = _itemHoverBackgroundColor.ToGodotColor(),
+                BorderColor = _itemHoverBorderColor.ToGodotColor()
+            };
+            hover.SetBorderWidthAll(1);
+            popup.AddThemeStyleboxOverride("hover", hover);
+
+            var pressed = new StyleBoxFlat
+            {
+                BgColor = _itemPressedBackgroundColor.ToGodotColor(),
+                BorderColor = _itemPressedBorderColor.ToGodotColor()
+            };
+            pressed.SetBorderWidthAll(1);
+            popup.AddThemeStyleboxOverride("pressed", pressed);
+
+            var selected = new StyleBoxFlat
+            {
+                BgColor = _itemSelectedBackgroundColor.ToGodotColor(),
+                BorderColor = _itemSelectedBorderColor.ToGodotColor()
+            };
+            selected.SetBorderWidthAll(1);
+            popup.AddThemeStyleboxOverride("focus", selected);
         }
 
         event Action? IAbstFrameworkNodeInput.ValueChanged

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotItemList.cs
@@ -2,6 +2,8 @@ using Godot;
 using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.Components.Inputs;
+using AbstUI.Styles;
+using AbstUI.LGodot.Primitives;
 
 namespace AbstUI.LGodot.Components
 {
@@ -10,7 +12,7 @@ namespace AbstUI.LGodot.Components
     /// </summary>
     public partial class AbstGodotItemList : ItemList, IAbstFrameworkItemList, IDisposable
     {
-        private readonly List<KeyValuePair<string,string>> _items = new();
+        private readonly List<KeyValuePair<string, string>> _items = new();
         private AMargin _margin = AMargin.Zero;
         private Action<string?>? _onChange;
         private event Action? _onValueChanged;
@@ -47,19 +49,20 @@ namespace AbstUI.LGodot.Components
             _onItemSelected = idx =>
             {
                 _onValueChanged?.Invoke();
-                if (idx>=0 && idx < _items.Count)
+                if (idx >= 0 && idx < _items.Count)
                     _onChange?.Invoke(_items[(int)idx].Key);
             };
             ItemSelected += _onItemSelected;
             SizeFlagsHorizontal = SizeFlags.ExpandFill;
             SizeFlagsVertical = SizeFlags.ExpandFill;
             CustomMinimumSize = new Vector2(100, 50);
+            UpdateStyle();
         }
 
 
         public void AddItem(string key, string value)
         {
-            _items.Add(new KeyValuePair<string,string>(key, value));
+            _items.Add(new KeyValuePair<string, string>(key, value));
             int idx = ItemCount;
             base.AddItem(value);
             SetItemMetadata(idx, key);
@@ -69,6 +72,29 @@ namespace AbstUI.LGodot.Components
             _items.Clear();
             Clear();
         }
+
+        public string? ItemFont { get; set; }
+        public int ItemFontSize { get; set; } = 11;
+        private AColor _itemTextColor = AbstDefaultColors.InputTextColor;
+        public AColor ItemTextColor { get => _itemTextColor; set { _itemTextColor = value; UpdateStyle(); } }
+        private AColor _itemSelectedTextColor = AbstDefaultColors.InputSelectionText;
+        public AColor ItemSelectedTextColor { get => _itemSelectedTextColor; set { _itemSelectedTextColor = value; UpdateStyle(); } }
+        private AColor _itemSelectedBackgroundColor = AbstDefaultColors.InputAccentColor;
+        public AColor ItemSelectedBackgroundColor { get => _itemSelectedBackgroundColor; set { _itemSelectedBackgroundColor = value; UpdateStyle(); } }
+        private AColor _itemSelectedBorderColor = AbstDefaultColors.InputBorderColor;
+        public AColor ItemSelectedBorderColor { get => _itemSelectedBorderColor; set { _itemSelectedBorderColor = value; UpdateStyle(); } }
+        private AColor _itemHoverTextColor = AbstDefaultColors.InputTextColor;
+        public AColor ItemHoverTextColor { get => _itemHoverTextColor; set { _itemHoverTextColor = value; UpdateStyle(); } }
+        private AColor _itemHoverBackgroundColor = AbstDefaultColors.ListHoverColor;
+        public AColor ItemHoverBackgroundColor { get => _itemHoverBackgroundColor; set { _itemHoverBackgroundColor = value; UpdateStyle(); } }
+        private AColor _itemHoverBorderColor = AbstDefaultColors.InputBorderColor;
+        public AColor ItemHoverBorderColor { get => _itemHoverBorderColor; set { _itemHoverBorderColor = value; UpdateStyle(); } }
+        private AColor _itemPressedTextColor = AbstDefaultColors.InputSelectionText;
+        public AColor ItemPressedTextColor { get => _itemPressedTextColor; set { _itemPressedTextColor = value; UpdateStyle(); } }
+        private AColor _itemPressedBackgroundColor = AbstDefaultColors.InputAccentColor;
+        public AColor ItemPressedBackgroundColor { get => _itemPressedBackgroundColor; set { _itemPressedBackgroundColor = value; UpdateStyle(); } }
+        private AColor _itemPressedBorderColor = AbstDefaultColors.InputBorderColor;
+        public AColor ItemPressedBorderColor { get => _itemPressedBorderColor; set { _itemPressedBorderColor = value; UpdateStyle(); } }
         public int _selectedIndex;
         public int SelectedIndex
         {
@@ -116,6 +142,37 @@ namespace AbstUI.LGodot.Components
                     }
                 }
             }
+        }
+
+        private void UpdateStyle()
+        {
+            AddThemeColorOverride("font_color", _itemTextColor.ToGodotColor());
+            AddThemeColorOverride("font_color_hovered", _itemHoverTextColor.ToGodotColor());
+            AddThemeColorOverride("font_color_selected", _itemSelectedTextColor.ToGodotColor());
+
+            var hover = new StyleBoxFlat
+            {
+                BgColor = _itemHoverBackgroundColor.ToGodotColor(),
+                BorderColor = _itemHoverBorderColor.ToGodotColor()
+            };
+            hover.SetBorderWidthAll(1);
+            AddThemeStyleboxOverride("hover", hover);
+
+            var pressed = new StyleBoxFlat
+            {
+                BgColor = _itemPressedBackgroundColor.ToGodotColor(),
+                BorderColor = _itemPressedBorderColor.ToGodotColor()
+            };
+            pressed.SetBorderWidthAll(1);
+            AddThemeStyleboxOverride("pressed", pressed);
+
+            var selected = new StyleBoxFlat
+            {
+                BgColor = _itemSelectedBackgroundColor.ToGodotColor(),
+                BorderColor = _itemSelectedBorderColor.ToGodotColor()
+            };
+            selected.SetBorderWidthAll(1);
+            AddThemeStyleboxOverride("selected", selected);
         }
 
         event Action? IAbstFrameworkNodeInput.ValueChanged

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputCombobox.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using AbstUI.Components.Inputs;
 using AbstUI.LUnity.Components.Base;
+using AbstUI.Primitives;
+using AbstUI.Styles;
+using AbstUI.LUnity.Primitives;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -20,6 +23,7 @@ internal class AbstUnityInputCombobox : AbstUnityComponent, IAbstFrameworkInputC
     {
         _dropdown = dropdown;
         _dropdown.onValueChanged.AddListener(OnSelectionChanged);
+        UpdateColors();
     }
 
     private static GameObject CreateGameObject(out Dropdown dropdown)
@@ -118,5 +122,39 @@ internal class AbstUnityInputCombobox : AbstUnityComponent, IAbstFrameworkInputC
         _items.Clear();
         _dropdown.options.Clear();
         SelectedIndex = -1;
+    }
+    public string? ItemFont { get; set; }
+    public int ItemFontSize { get; set; } = 11;
+    private AColor _itemTextColor = AbstDefaultColors.InputTextColor;
+    public AColor ItemTextColor { get => _itemTextColor; set { _itemTextColor = value; UpdateColors(); } }
+    private AColor _itemSelectedTextColor = AbstDefaultColors.InputSelectionText;
+    public AColor ItemSelectedTextColor { get => _itemSelectedTextColor; set { _itemSelectedTextColor = value; UpdateColors(); } }
+    private AColor _itemSelectedBackgroundColor = AbstDefaultColors.InputAccentColor;
+    public AColor ItemSelectedBackgroundColor { get => _itemSelectedBackgroundColor; set { _itemSelectedBackgroundColor = value; UpdateColors(); } }
+    private AColor _itemSelectedBorderColor = AbstDefaultColors.InputBorderColor;
+    public AColor ItemSelectedBorderColor { get => _itemSelectedBorderColor; set { _itemSelectedBorderColor = value; UpdateColors(); } }
+    private AColor _itemHoverTextColor = AbstDefaultColors.InputTextColor;
+    public AColor ItemHoverTextColor { get => _itemHoverTextColor; set { _itemHoverTextColor = value; UpdateColors(); } }
+    private AColor _itemHoverBackgroundColor = AbstDefaultColors.ListHoverColor;
+    public AColor ItemHoverBackgroundColor { get => _itemHoverBackgroundColor; set { _itemHoverBackgroundColor = value; UpdateColors(); } }
+    private AColor _itemHoverBorderColor = AbstDefaultColors.InputBorderColor;
+    public AColor ItemHoverBorderColor { get => _itemHoverBorderColor; set { _itemHoverBorderColor = value; UpdateColors(); } }
+    private AColor _itemPressedTextColor = AbstDefaultColors.InputSelectionText;
+    public AColor ItemPressedTextColor { get => _itemPressedTextColor; set { _itemPressedTextColor = value; UpdateColors(); } }
+    private AColor _itemPressedBackgroundColor = AbstDefaultColors.InputAccentColor;
+    public AColor ItemPressedBackgroundColor { get => _itemPressedBackgroundColor; set { _itemPressedBackgroundColor = value; UpdateColors(); } }
+    private AColor _itemPressedBorderColor = AbstDefaultColors.InputBorderColor;
+    public AColor ItemPressedBorderColor { get => _itemPressedBorderColor; set { _itemPressedBorderColor = value; UpdateColors(); } }
+
+    private void UpdateColors()
+    {
+        if (_dropdown.captionText != null)
+            _dropdown.captionText.color = _itemTextColor.ToUnityColor();
+        var colors = _dropdown.colors;
+        colors.normalColor = _itemTextColor.ToUnityColor();
+        colors.highlightedColor = _itemHoverBackgroundColor.ToUnityColor();
+        colors.pressedColor = _itemPressedBackgroundColor.ToUnityColor();
+        colors.selectedColor = _itemSelectedBackgroundColor.ToUnityColor();
+        _dropdown.colors = colors;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputCombobox.cs
@@ -5,7 +5,7 @@ namespace AbstUI.Components.Inputs
     /// <summary>
     /// Engine level wrapper for a combobox input.
     /// </summary>
-    public class AbstInputCombobox : AbstInputBase<IAbstFrameworkInputCombobox>
+    public class AbstInputCombobox : AbstSelectableCollection<IAbstFrameworkInputCombobox>
     {
         public IReadOnlyList<KeyValuePair<string, string>> Items => _framework.Items;
         public void AddItem(string key, string value) => _framework.AddItem(key, value);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstItemList.cs
@@ -5,7 +5,7 @@ namespace AbstUI.Components.Inputs
     /// <summary>
     /// Engine level wrapper around a framework item list widget.
     /// </summary>
-    public class AbstItemList : AbstInputBase<IAbstFrameworkItemList>
+    public class AbstItemList : AbstSelectableCollection<IAbstFrameworkItemList>
     {
         public IReadOnlyList<KeyValuePair<string, string>> Items => _framework.Items;
         public void AddItem(string key, string value) => _framework.AddItem(key, value);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstSelectableCollection.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstSelectableCollection.cs
@@ -1,0 +1,25 @@
+using AbstUI.Primitives;
+
+namespace AbstUI.Components.Inputs;
+
+/// <summary>
+/// Base class for inputs that expose a selectable collection of items.
+/// </summary>
+public abstract class AbstSelectableCollection<TFramework> : AbstInputBase<TFramework>, IAbstSdlHasSeletectableCollectionStyle
+    where TFramework : IAbstFrameworkNodeInput, IAbstSdlHasSeletectableCollectionStyle
+{
+    public string? ItemFont { get => _framework.ItemFont; set => _framework.ItemFont = value; }
+    public int ItemFontSize { get => _framework.ItemFontSize; set => _framework.ItemFontSize = value; }
+    public AColor ItemTextColor { get => _framework.ItemTextColor; set => _framework.ItemTextColor = value; }
+    public AColor ItemSelectedTextColor { get => _framework.ItemSelectedTextColor; set => _framework.ItemSelectedTextColor = value; }
+    public AColor ItemSelectedBackgroundColor { get => _framework.ItemSelectedBackgroundColor; set => _framework.ItemSelectedBackgroundColor = value; }
+    public AColor ItemSelectedBorderColor { get => _framework.ItemSelectedBorderColor; set => _framework.ItemSelectedBorderColor = value; }
+    public AColor ItemHoverTextColor { get => _framework.ItemHoverTextColor; set => _framework.ItemHoverTextColor = value; }
+    public AColor ItemHoverBackgroundColor { get => _framework.ItemHoverBackgroundColor; set => _framework.ItemHoverBackgroundColor = value; }
+    public AColor ItemHoverBorderColor { get => _framework.ItemHoverBorderColor; set => _framework.ItemHoverBorderColor = value; }
+    public AColor ItemPressedTextColor { get => _framework.ItemPressedTextColor; set => _framework.ItemPressedTextColor = value; }
+    public AColor ItemPressedBackgroundColor { get => _framework.ItemPressedBackgroundColor; set => _framework.ItemPressedBackgroundColor = value; }
+    public AColor ItemPressedBorderColor { get => _framework.ItemPressedBorderColor; set => _framework.ItemPressedBorderColor = value; }
+
+}
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstFrameworkInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstFrameworkInputCombobox.cs
@@ -5,7 +5,7 @@ namespace AbstUI.Components.Inputs
     /// <summary>
     /// Framework specific combo box input.
     /// </summary>
-    public interface IAbstFrameworkInputCombobox : IAbstFrameworkNodeInput
+    public interface IAbstFrameworkInputCombobox : IAbstFrameworkNodeInput, IAbstSdlHasSeletectableCollectionStyle
     {
         IReadOnlyList<KeyValuePair<string, string>> Items { get; }
         void AddItem(string key, string value);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstFrameworkItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstFrameworkItemList.cs
@@ -5,7 +5,7 @@ namespace AbstUI.Components.Inputs
     /// <summary>
     /// Framework specific list widget allowing selection of items.
     /// </summary>
-    public interface IAbstFrameworkItemList : IAbstFrameworkNodeInput
+    public interface IAbstFrameworkItemList : IAbstFrameworkNodeInput, IAbstSdlHasSeletectableCollectionStyle
     {
         /// <summary>Current items in the list.</summary>
         IReadOnlyList<KeyValuePair<string, string>> Items { get; }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputComboboxStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstInputComboboxStyle.cs
@@ -1,3 +1,5 @@
+using AbstUI.Components.Inputs;
+
 namespace AbstUI.Styles.Components;
 
 /// <summary>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstItemListStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/Components/AbstItemListStyle.cs
@@ -1,8 +1,10 @@
+using AbstUI.Components.Inputs;
+
 namespace AbstUI.Styles.Components;
 
 /// <summary>
 /// Style for <see cref="AbstUI.Components.Inputs.AbstItemList"/>.
 /// </summary>
-public class AbstItemListStyle : AbstContainerStyle
+public class AbstItemListStyle : AbstInputStyle
 {
 }


### PR DESCRIPTION
## Summary
- apply selectable item colors directly to components instead of a shared style
- implement selectable color properties across Blazor, ImGui, Godot, and Unity frameworks
- drop unused `AbstSelectableCollectionStyle` base

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj -f net8.0`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj -f net9.0`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj -f net8.0`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj -f net8.0` *(fails: component factory return types)*
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj -f net8`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj -f net8.0` *(fails: missing interface members)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a65e131c8332a97fa05a692bf226