### PR TITLE
feat: add text background border colors

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.cs
@@ -7,7 +7,7 @@ using AbstUI.Styles;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
-public partial class AbstBlazorInputCombobox : IAbstFrameworkInputCombobox
+public partial class AbstBlazorInputCombobox : IAbstFrameworkInputCombobox, IHasTextBackgroundBorderColor
 {
 
     private readonly List<KeyValuePair<string, string>> _items = new();
@@ -29,6 +29,9 @@ public partial class AbstBlazorInputCombobox : IAbstFrameworkInputCombobox
     public AColor ItemPressedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
     public AColor ItemPressedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
     public AColor ItemPressedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+    public AColor TextColor { get; set; } = AColors.Black;
+    public AColor BackgroundColor { get; set; } = AbstDefaultColors.Input_Bg;
+    public AColor BorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
 
 
     public void AddItem(string key, string value)
@@ -72,7 +75,9 @@ public partial class AbstBlazorInputCombobox : IAbstFrameworkInputCombobox
             style += $"font-family:{ItemFont};";
         if (ItemFontSize > 0)
             style += $"font-size:{ItemFontSize}px;";
-        style += $"color:{ItemTextColor.ToHex()};";
+        style += $"color:{TextColor.ToHex()};";
+        style += $"background-color:{BackgroundColor.ToHex()};";
+        style += $"border-color:{BorderColor.ToHex()};";
         return style;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputNumber.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputNumber.cs
@@ -1,11 +1,12 @@
 using Microsoft.AspNetCore.Components;
 using AbstUI.Primitives;
+using AbstUI.Styles;
 using System.Numerics;
 using AbstUI.Components.Inputs;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
-public partial class AbstBlazorInputNumber<TValue> : IAbstFrameworkInputNumber<TValue>
+public partial class AbstBlazorInputNumber<TValue> : IAbstFrameworkInputNumber<TValue>, IHasTextBackgroundBorderColor
     where TValue : INumber<TValue>
 {
     [Parameter] public TValue Value { get; set; } = TValue.Zero;
@@ -13,6 +14,9 @@ public partial class AbstBlazorInputNumber<TValue> : IAbstFrameworkInputNumber<T
     [Parameter] public TValue Max { get; set; } = TValue.Zero;
     [Parameter] public ANumberType NumberType { get; set; } = ANumberType.Float;
     [Parameter] public int FontSize { get; set; } = 14;
+    [Parameter] public AColor TextColor { get; set; } = AbstDefaultColors.InputTextColor;
+    [Parameter] public AColor BackgroundColor { get; set; } = AbstDefaultColors.Input_Bg;
+    [Parameter] public AColor BorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
 
     private void HandleInput(ChangeEventArgs e)
     {
@@ -21,5 +25,14 @@ public partial class AbstBlazorInputNumber<TValue> : IAbstFrameworkInputNumber<T
             Value = result;
             ValueChangedInvoke();
         }
+    }
+
+    protected override string BuildStyle()
+    {
+        var style = base.BuildStyle();
+        style += $"color:{TextColor.ToHex()};";
+        style += $"background-color:{BackgroundColor.ToHex()};";
+        style += $"border-color:{BorderColor.ToHex()};";
+        return style;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputText.razor.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputText.razor.cs
@@ -40,6 +40,8 @@ public partial class AbstBlazorInputText
     {
         var style = base.BuildStyle();
         style += $"color:{_component.TextColor.ToHex()};";
+        style += $"background-color:{_component.BackgroundColor.ToHex()};";
+        style += $"border-color:{_component.BorderColor.ToHex()};";
         return style;
     }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputTextComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputTextComponent.cs
@@ -1,10 +1,11 @@
 using System;
 using AbstUI.Components.Inputs;
 using AbstUI.Primitives;
+using AbstUI.Styles;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
-public class AbstBlazorInputTextComponent : AbstBlazorComponentModelBase, IAbstFrameworkInputText
+public class AbstBlazorInputTextComponent : AbstBlazorComponentModelBase, IAbstFrameworkInputText, IHasTextBackgroundBorderColor
 {
     private string _text = string.Empty;
     public string Text
@@ -39,6 +40,20 @@ public class AbstBlazorInputTextComponent : AbstBlazorComponentModelBase, IAbstF
     {
         get => _textColor;
         set { if (!_textColor.Equals(value)) { _textColor = value; RaiseChanged(); } }
+    }
+
+    private AColor _backgroundColor = AbstDefaultColors.Input_Bg;
+    public AColor BackgroundColor
+    {
+        get => _backgroundColor;
+        set { if (!_backgroundColor.Equals(value)) { _backgroundColor = value; RaiseChanged(); } }
+    }
+
+    private AColor _borderColor = AbstDefaultColors.InputBorderColor;
+    public AColor BorderColor
+    {
+        get => _borderColor;
+        set { if (!_borderColor.Equals(value)) { _borderColor = value; RaiseChanged(); } }
     }
 
     private bool _isMultiLine;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorSpinBox.cs
@@ -1,13 +1,18 @@
 using Microsoft.AspNetCore.Components;
 using AbstUI.Components.Inputs;
+using AbstUI.Primitives;
+using AbstUI.Styles;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
-public partial class AbstBlazorSpinBox : IAbstFrameworkSpinBox
+public partial class AbstBlazorSpinBox : IAbstFrameworkSpinBox, IHasTextBackgroundBorderColor
 {
     [Parameter] public float Value { get; set; }
     [Parameter] public float Min { get; set; }
     [Parameter] public float Max { get; set; }
+    [Parameter] public AColor TextColor { get; set; } = AbstDefaultColors.InputTextColor;
+    [Parameter] public AColor BackgroundColor { get; set; } = AbstDefaultColors.Input_Bg;
+    [Parameter] public AColor BorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
 
 
     private void HandleInput(ChangeEventArgs e)
@@ -17,5 +22,14 @@ public partial class AbstBlazorSpinBox : IAbstFrameworkSpinBox
             Value = v;
             ValueChangedInvoke();
         }
+    }
+
+    protected override string BuildStyle()
+    {
+        var style = base.BuildStyle();
+        style += $"color:{TextColor.ToHex()};";
+        style += $"background-color:{BackgroundColor.ToHex()};";
+        style += $"border-color:{BorderColor.ToHex()};";
+        return style;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputCombobox.cs
@@ -9,7 +9,7 @@ using AbstUI.Styles;
 
 namespace AbstUI.ImGui.Components
 {
-    internal class AbstImGuiInputCombobox : AbstImGuiComponent, IAbstFrameworkInputCombobox, IDisposable
+    internal class AbstImGuiInputCombobox : AbstImGuiComponent, IAbstFrameworkInputCombobox, IHasTextBackgroundBorderColor, IDisposable
     {
         public AbstImGuiInputCombobox(AbstImGuiComponentFactory factory) : base(factory)
         {
@@ -38,6 +38,9 @@ namespace AbstUI.ImGui.Components
 
         public event Action? ValueChanged;
         public object FrameworkNode => this;
+        public AColor TextColor { get; set; } = AColors.Black;
+        public AColor BackgroundColor { get; set; } = AbstDefaultColors.Input_Bg;
+        public AColor BorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
         public void AddItem(string key, string value)
         {
             _items.Add(new KeyValuePair<string, string>(key, value));
@@ -56,6 +59,9 @@ namespace AbstUI.ImGui.Components
             if (!Visibility) return nint.Zero;
             global::ImGuiNET.ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
             global::ImGuiNET.ImGui.PushID(Name);
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.Text, TextColor.ToImGuiColor());
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.FrameBg, BackgroundColor.ToImGuiColor());
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.Border, BorderColor.ToImGuiColor());
             if (!Enabled)
                 global::ImGuiNET.ImGui.BeginDisabled();
 
@@ -81,6 +87,7 @@ namespace AbstUI.ImGui.Components
 
             if (!Enabled)
                 global::ImGuiNET.ImGui.EndDisabled();
+            global::ImGuiNET.ImGui.PopStyleColor(3);
             global::ImGuiNET.ImGui.PopID();
             return AbstImGuiRenderResult.RequireRender();
         }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputNumber.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputNumber.cs
@@ -3,10 +3,11 @@ using System.Numerics;
 using ImGuiNET;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.Styles;
 
 namespace AbstUI.ImGui.Components
 {
-    internal class AbstImGuiInputNumber : AbstImGuiComponent, IAbstFrameworkInputNumber<float>, IDisposable
+    internal class AbstImGuiInputNumber : AbstImGuiComponent, IAbstFrameworkInputNumber<float>, IHasTextBackgroundBorderColor, IDisposable
     {
         public AbstImGuiInputNumber(AbstImGuiComponentFactory factory) : base(factory)
         {
@@ -33,13 +34,18 @@ namespace AbstUI.ImGui.Components
         public object FrameworkNode => this;
 
         public int FontSize { get; set; } = 12;
-
+        public AColor TextColor { get; set; } = AColors.Black;
+        public AColor BackgroundColor { get; set; } = AbstDefaultColors.Input_Bg;
+        public AColor BorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
         public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
         {
             if (!Visibility) return nint.Zero;
 
             global::ImGuiNET.ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
             global::ImGuiNET.ImGui.PushID(Name);
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.Text, TextColor.ToImGuiColor());
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.FrameBg, BackgroundColor.ToImGuiColor());
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.Border, BorderColor.ToImGuiColor());
             if (!Enabled)
                 global::ImGuiNET.ImGui.BeginDisabled();
 
@@ -64,6 +70,7 @@ namespace AbstUI.ImGui.Components
 
             if (!Enabled)
                 global::ImGuiNET.ImGui.EndDisabled();
+            global::ImGuiNET.ImGui.PopStyleColor(3);
             global::ImGuiNET.ImGui.PopID();
             return AbstImGuiRenderResult.RequireRender();
         }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputText.cs
@@ -3,10 +3,11 @@ using System.Numerics;
 using ImGuiNET;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.Styles;
 
 namespace AbstUI.ImGui.Components
 {
-    internal class AbstImGuiInputText : AbstImGuiComponent, IAbstFrameworkInputText, IDisposable
+    internal class AbstImGuiInputText : AbstImGuiComponent, IAbstFrameworkInputText, IHasTextBackgroundBorderColor, IDisposable
     {
         public AbstImGuiInputText(AbstImGuiComponentFactory factory, bool multiLine) : base(factory)
         {
@@ -31,6 +32,8 @@ namespace AbstUI.ImGui.Components
         public AMargin Margin { get; set; } = AMargin.Zero;
         public object FrameworkNode => this;
         public AColor TextColor { get; set; } = AColors.Black;
+        public AColor BackgroundColor { get; set; } = AbstDefaultColors.Input_Bg;
+        public AColor BorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
 
         public bool IsMultiLine { get; set; }
 
@@ -47,6 +50,8 @@ namespace AbstUI.ImGui.Components
 
             global::ImGuiNET.ImGui.PushID(Name);
             global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.Text, TextColor.ToImGuiColor());
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.FrameBg, BackgroundColor.ToImGuiColor());
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.Border, BorderColor.ToImGuiColor());
             if (!Enabled) global::ImGuiNET.ImGui.BeginDisabled();
 
             uint cap = MaxLength > 0 ? (uint)MaxLength : 1024u;
@@ -54,7 +59,7 @@ namespace AbstUI.ImGui.Components
                 ValueChanged?.Invoke();
 
             if (!Enabled) global::ImGuiNET.ImGui.EndDisabled();
-            global::ImGuiNET.ImGui.PopStyleColor();
+            global::ImGuiNET.ImGui.PopStyleColor(3);
             global::ImGuiNET.ImGui.PopID();
             return AbstImGuiRenderResult.RequireRender();
         }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiSpinBox.cs
@@ -3,10 +3,11 @@ using System.Numerics;
 using ImGuiNET;
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.Styles;
 
 namespace AbstUI.ImGui.Components
 {
-    internal class AbstImGuiSpinBox : AbstImGuiComponent, IAbstFrameworkSpinBox, IDisposable
+    internal class AbstImGuiSpinBox : AbstImGuiComponent, IAbstFrameworkSpinBox, IHasTextBackgroundBorderColor, IDisposable
     {
         public AbstImGuiSpinBox(AbstImGuiComponentFactory factory) : base(factory)
         {
@@ -31,12 +32,18 @@ namespace AbstUI.ImGui.Components
         public object FrameworkNode => this;
 
         public event Action? ValueChanged;
+        public AColor TextColor { get; set; } = AColors.Black;
+        public AColor BackgroundColor { get; set; } = AbstDefaultColors.Input_Bg;
+        public AColor BorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
 
         public override AbstImGuiRenderResult Render(AbstImGuiRenderContext context)
         {
             if (!Visibility) return nint.Zero;
             global::ImGuiNET.ImGui.SetCursorScreenPos(context.Origin + new Vector2(X, Y));
             global::ImGuiNET.ImGui.PushID(Name);
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.Text, TextColor.ToImGuiColor());
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.FrameBg, BackgroundColor.ToImGuiColor());
+            global::ImGuiNET.ImGui.PushStyleColor(ImGuiCol.Border, BorderColor.ToImGuiColor());
             if (!Enabled)
                 global::ImGuiNET.ImGui.BeginDisabled();
             float val = _value;
@@ -47,6 +54,7 @@ namespace AbstUI.ImGui.Components
             }
             if (!Enabled)
                 global::ImGuiNET.ImGui.EndDisabled();
+            global::ImGuiNET.ImGui.PopStyleColor(3);
             global::ImGuiNET.ImGui.PopID();
             return AbstImGuiRenderResult.RequireRender();
         }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputCombobox.cs
@@ -9,11 +9,14 @@ namespace AbstUI.LGodot.Components
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkInputCombobox"/>.
     /// </summary>
-    public partial class AbstGodotInputCombobox : OptionButton, IAbstFrameworkInputCombobox, IDisposable
+    public partial class AbstGodotInputCombobox : OptionButton, IAbstFrameworkInputCombobox, IHasTextBackgroundBorderColor, IDisposable
     {
         private readonly List<KeyValuePair<string, string>> _items = new();
         private AMargin _margin = AMargin.Zero;
         private Action<string?>? _onChange;
+        private AColor _textColor = AbstDefaultColors.InputTextColor;
+        private AColor _backgroundColor = AbstDefaultColors.Input_Bg;
+        private AColor _borderColor = AbstDefaultColors.InputBorderColor;
 
         private event Action? _onValueChanged;
 
@@ -44,6 +47,35 @@ namespace AbstUI.LGodot.Components
                 AddThemeConstantOverride("margin_right", (int)_margin.Right);
                 AddThemeConstantOverride("margin_top", (int)_margin.Top);
                 AddThemeConstantOverride("margin_bottom", (int)_margin.Bottom);
+            }
+        }
+        public AColor TextColor
+        {
+            get => _textColor;
+            set
+            {
+                _textColor = value;
+                AddThemeColorOverride("font_color", _textColor.ToGodotColor());
+            }
+        }
+
+        public AColor BackgroundColor
+        {
+            get => _backgroundColor;
+            set
+            {
+                _backgroundColor = value;
+                AddThemeColorOverride("background_color", _backgroundColor.ToGodotColor());
+            }
+        }
+
+        public AColor BorderColor
+        {
+            get => _borderColor;
+            set
+            {
+                _borderColor = value;
+                AddThemeColorOverride("border_color", _borderColor.ToGodotColor());
             }
         }
         public object FrameworkNode => this;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputNumber.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputNumber.cs
@@ -9,13 +9,16 @@ namespace AbstUI.LGodot.Components
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkInputNumber"/>.
     /// </summary>
-    public partial class AbstGodotInputNumber<TValue> : LineEdit, IAbstFrameworkInputNumber<TValue>, IDisposable
+    public partial class AbstGodotInputNumber<TValue> : LineEdit, IAbstFrameworkInputNumber<TValue>, IHasTextBackgroundBorderColor, IDisposable
         where TValue : System.Numerics.INumber<TValue>
     {
         private AMargin _margin = AMargin.Zero;
         private ANumberType _numberType = ANumberType.Float;
         private Action<TValue>? _onChange;
         private readonly IAbstFontManager _fontManager;
+        private AColor _textColor = AbstDefaultColors.InputTextColor;
+        private AColor _backgroundColor = AbstDefaultColors.Input_Bg;
+        private AColor _borderColor = AbstDefaultColors.InputBorderColor;
 
         private event Action _onValueChanged;
 
@@ -188,6 +191,36 @@ namespace AbstUI.LGodot.Components
                 AddThemeConstantOverride("margin_right", (int)_margin.Right);
                 AddThemeConstantOverride("margin_top", (int)_margin.Top);
                 AddThemeConstantOverride("margin_bottom", (int)_margin.Bottom);
+            }
+        }
+
+        public AColor TextColor
+        {
+            get => _textColor;
+            set
+            {
+                _textColor = value;
+                AddThemeColorOverride("font_color", _textColor.ToGodotColor());
+            }
+        }
+
+        public AColor BackgroundColor
+        {
+            get => _backgroundColor;
+            set
+            {
+                _backgroundColor = value;
+                AddThemeColorOverride("background_color", _backgroundColor.ToGodotColor());
+            }
+        }
+
+        public AColor BorderColor
+        {
+            get => _borderColor;
+            set
+            {
+                _borderColor = value;
+                AddThemeColorOverride("border_color", _borderColor.ToGodotColor());
             }
         }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputSpinBox.cs
@@ -6,10 +6,13 @@ using AbstUI.Components.Inputs;
 
 namespace AbstUI.LGodot.Components
 {
-    public partial class AbstGodotSpinBox : SpinBox, IAbstFrameworkSpinBox, IDisposable
+    public partial class AbstGodotSpinBox : SpinBox, IAbstFrameworkSpinBox, IHasTextBackgroundBorderColor, IDisposable
     {
         private AMargin _margin = AMargin.Zero;
         private Action<float>? _onChange;
+        private AColor _textColor = AbstDefaultColors.InputTextColor;
+        private AColor _backgroundColor = AbstDefaultColors.Input_Bg;
+        private AColor _borderColor = AbstDefaultColors.InputBorderColor;
 
         public AbstGodotSpinBox(AbstInputSpinBox spin, IAbstFontManager lingoFontManager, Action<float>? onChange)
         {
@@ -52,6 +55,36 @@ namespace AbstUI.LGodot.Components
         {
             add => _onValueChanged += value;
             remove => _onValueChanged -= value;
+        }
+
+        public AColor TextColor
+        {
+            get => _textColor;
+            set
+            {
+                _textColor = value;
+                AddThemeColorOverride("font_color", _textColor.ToGodotColor());
+            }
+        }
+
+        public AColor BackgroundColor
+        {
+            get => _backgroundColor;
+            set
+            {
+                _backgroundColor = value;
+                AddThemeColorOverride("background_color", _backgroundColor.ToGodotColor());
+            }
+        }
+
+        public AColor BorderColor
+        {
+            get => _borderColor;
+            set
+            {
+                _borderColor = value;
+                AddThemeColorOverride("border_color", _borderColor.ToGodotColor());
+            }
         }
 
         public new void Dispose()

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputText.cs
@@ -11,7 +11,7 @@ namespace AbstUI.LGodot.Components.Inputs
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkInputText"/> using composition.
     /// </summary>
-    public class AbstGodotInputText : IAbstFrameworkInputText, IDisposable
+    public class AbstGodotInputText : IAbstFrameworkInputText, IHasTextBackgroundBorderColor, IDisposable
     {
         private readonly Action<string>? _onChange;
         private readonly IAbstFontManager _fontManager;
@@ -26,6 +26,8 @@ namespace AbstUI.LGodot.Components.Inputs
         private float _wantedWidth = 10;
         private float _wantedHeight = 10;
         private AColor _textColor = AColors.Black;
+        private AColor _backgroundColor = AbstDefaultColors.Input_Bg;
+        private AColor _borderColor = AbstDefaultColors.InputBorderColor;
         private bool _isMultiLine;
         public object FrameworkNode => _control;
 
@@ -229,6 +231,26 @@ namespace AbstUI.LGodot.Components.Inputs
             {
                 _textColor = value;
                 _control.AddThemeColorOverride("font_color", _textColor.ToGodotColor());
+            }
+        }
+
+        public AColor BackgroundColor
+        {
+            get => _backgroundColor;
+            set
+            {
+                _backgroundColor = value;
+                _control.AddThemeColorOverride("background_color", _backgroundColor.ToGodotColor());
+            }
+        }
+
+        public AColor BorderColor
+        {
+            get => _borderColor;
+            set
+            {
+                _borderColor = value;
+                _control.AddThemeColorOverride("border_color", _borderColor.ToGodotColor());
             }
         }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputCombobox.cs
@@ -12,22 +12,28 @@ namespace AbstUI.LUnity.Components.Inputs;
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkInputCombobox"/>.
 /// </summary>
-internal class AbstUnityInputCombobox : AbstUnityComponent, IAbstFrameworkInputCombobox
+internal class AbstUnityInputCombobox : AbstUnityComponent, IAbstFrameworkInputCombobox, IHasTextBackgroundBorderColor
 {
     private readonly Dropdown _dropdown;
     private readonly List<KeyValuePair<string, string>> _items = new();
+    private readonly Image _image;
     private int _selectedIndex = -1;
+    private AColor _textColor = AbstDefaultColors.InputTextColor;
+    private AColor _backgroundColor = AbstDefaultColors.Input_Bg;
+    private AColor _borderColor = AbstDefaultColors.InputBorderColor;
 
-    public AbstUnityInputCombobox() : base(CreateGameObject(out var dropdown))
+    public AbstUnityInputCombobox() : base(CreateGameObject(out var dropdown, out var image))
     {
         _dropdown = dropdown;
+        _image = image;
         _dropdown.onValueChanged.AddListener(OnSelectionChanged);
+        _image.color = _backgroundColor.ToUnityColor();
     }
 
-    private static GameObject CreateGameObject(out Dropdown dropdown)
+    private static GameObject CreateGameObject(out Dropdown dropdown, out Image image)
     {
         var go = new GameObject("Dropdown");
-        go.AddComponent<Image>();
+        image = go.AddComponent<Image>();
         dropdown = go.AddComponent<Dropdown>();
         return go;
     }
@@ -133,5 +139,32 @@ internal class AbstUnityInputCombobox : AbstUnityComponent, IAbstFrameworkInputC
         _items.Clear();
         _dropdown.options.Clear();
         SelectedIndex = -1;
+    }
+
+    public AColor TextColor
+    {
+        get => _textColor;
+        set
+        {
+            _textColor = value;
+            if (_dropdown.captionText != null)
+                _dropdown.captionText.color = value.ToUnityColor();
+        }
+    }
+
+    public AColor BackgroundColor
+    {
+        get => _backgroundColor;
+        set
+        {
+            _backgroundColor = value;
+            _image.color = value.ToUnityColor();
+        }
+    }
+
+    public AColor BorderColor
+    {
+        get => _borderColor;
+        set => _borderColor = value;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputNumber.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputNumber.cs
@@ -7,31 +7,38 @@ using AbstUI.LUnity.Components.Base;
 using AbstUI.Primitives;
 using UnityEngine;
 using UnityEngine.UI;
+using AbstUI.Styles;
 
 namespace AbstUI.LUnity.Components.Inputs;
 
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkInputNumber{TValue}"/>.
 /// </summary>
-internal class AbstUnityInputNumber<TValue> : AbstUnityComponent, IAbstFrameworkInputNumber<TValue>
+internal class AbstUnityInputNumber<TValue> : AbstUnityComponent, IAbstFrameworkInputNumber<TValue>, IHasTextBackgroundBorderColor
     where TValue : struct, INumber<TValue>
 {
     private readonly InputField _inputField;
     private readonly Text _textComponent;
+    private readonly Image _image;
     private TValue _value = TValue.Zero;
     private string _currentText = string.Empty;
+    private AColor _textColor = new(0, 0, 0);
+    private AColor _backgroundColor = AbstDefaultColors.Input_Bg;
+    private AColor _borderColor = AbstDefaultColors.InputBorderColor;
 
-    public AbstUnityInputNumber() : base(CreateGameObject(out var input, out var text))
+    public AbstUnityInputNumber() : base(CreateGameObject(out var input, out var text, out var image))
     {
         _inputField = input;
         _textComponent = text;
+        _image = image;
         _inputField.onValueChanged.AddListener(OnValueChanged);
+        _image.color = _backgroundColor.ToUnityColor();
     }
 
-    private static GameObject CreateGameObject(out InputField input, out Text text)
+    private static GameObject CreateGameObject(out InputField input, out Text text, out Image image)
     {
         var go = new GameObject("InputNumber");
-        go.AddComponent<Image>();
+        image = go.AddComponent<Image>();
         input = go.AddComponent<InputField>();
         var textGo = new GameObject("Text");
         textGo.transform.parent = go.transform;
@@ -106,6 +113,32 @@ internal class AbstUnityInputNumber<TValue> : AbstUnityComponent, IAbstFramework
     {
         get => _textComponent.fontSize;
         set => _textComponent.fontSize = value;
+    }
+
+    public AColor TextColor
+    {
+        get => _textColor;
+        set
+        {
+            _textColor = value;
+            _textComponent.color = value.ToUnityColor();
+        }
+    }
+
+    public AColor BackgroundColor
+    {
+        get => _backgroundColor;
+        set
+        {
+            _backgroundColor = value;
+            _image.color = value.ToUnityColor();
+        }
+    }
+
+    public AColor BorderColor
+    {
+        get => _borderColor;
+        set => _borderColor = value;
     }
 
     public event Action? ValueChanged;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputText.cs
@@ -5,30 +5,36 @@ using AbstUI.LUnity.Primitives;
 using AbstUI.Primitives;
 using UnityEngine;
 using UnityEngine.UI;
+using AbstUI.Styles;
 
 namespace AbstUI.LUnity.Components.Inputs;
 
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkInputText"/>.
 /// </summary>
-internal class AbstUnityInputText : AbstUnityComponent, IAbstFrameworkInputText
+internal class AbstUnityInputText : AbstUnityComponent, IAbstFrameworkInputText, IHasTextBackgroundBorderColor
 {
     private readonly InputField _inputField;
     private readonly Text _textComponent;
+    private readonly Image _image;
     private string _text = string.Empty;
     private AColor _textColor = new(0, 0, 0);
+    private AColor _backgroundColor = AbstDefaultColors.Input_Bg;
+    private AColor _borderColor = AbstDefaultColors.InputBorderColor;
 
-    public AbstUnityInputText() : base(CreateGameObject(out var input, out var text))
+    public AbstUnityInputText() : base(CreateGameObject(out var input, out var text, out var image))
     {
         _inputField = input;
         _textComponent = text;
+        _image = image;
         _inputField.onValueChanged.AddListener(OnValueChanged);
+        _image.color = _backgroundColor.ToUnityColor();
     }
 
-    private static GameObject CreateGameObject(out InputField input, out Text text)
+    private static GameObject CreateGameObject(out InputField input, out Text text, out Image image)
     {
         var go = new GameObject("InputField");
-        go.AddComponent<Image>();
+        image = go.AddComponent<Image>();
         input = go.AddComponent<InputField>();
         var textGo = new GameObject("Text");
         textGo.transform.parent = go.transform;
@@ -82,6 +88,22 @@ internal class AbstUnityInputText : AbstUnityComponent, IAbstFrameworkInputText
             _textColor = value;
             _textComponent.color = value.ToUnityColor();
         }
+    }
+
+    public AColor BackgroundColor
+    {
+        get => _backgroundColor;
+        set
+        {
+            _backgroundColor = value;
+            _image.color = value.ToUnityColor();
+        }
+    }
+
+    public AColor BorderColor
+    {
+        get => _borderColor;
+        set => _borderColor = value;
     }
 
     public bool IsMultiLine

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Components/Inputs/RmlUiInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Components/Inputs/RmlUiInputText.cs
@@ -1,5 +1,6 @@
 using AbstUI.Components;
 using AbstUI.Primitives;
+using AbstUI.Styles;
 using RmlUiNet;
 
 namespace AbstUI.SDL2RmlUi.Components;
@@ -7,7 +8,7 @@ namespace AbstUI.SDL2RmlUi.Components;
 /// <summary>
 /// Single-line or multi-line text input implemented with RmlUi elements.
 /// </summary>
-public class RmlUiInputText : IAbstFrameworkInputText, IDisposable
+public class RmlUiInputText : IAbstFrameworkInputText, IHasTextBackgroundBorderColor, IDisposable
 {
     private readonly ElementDocument _document;
     private Element _element;
@@ -26,6 +27,8 @@ public class RmlUiInputText : IAbstFrameworkInputText, IDisposable
     private string? _font;
     private int _fontSize;
     private AColor _textColor = AColors.Black;
+    private AColor _backgroundColor = AbstDefaultColors.Input_Bg;
+    private AColor _borderColor = AbstDefaultColors.InputBorderColor;
     private bool _isMultiLine;
     private event Action? _valueChanged;
 
@@ -73,6 +76,8 @@ public class RmlUiInputText : IAbstFrameworkInputText, IDisposable
         if (!string.IsNullOrEmpty(_font)) _element.SetProperty("font-family", _font);
         if (_fontSize != 0) _element.SetProperty("font-size", $"{_fontSize}px");
         _element.SetProperty("color", _textColor.ToHex());
+        _element.SetProperty("background-color", _backgroundColor.ToHex());
+        _element.SetProperty("border-color", _borderColor.ToHex());
 
         if (_input != null) _input.SetValue(_text);
         else _textarea?.SetInnerRml(_text);
@@ -214,6 +219,26 @@ public class RmlUiInputText : IAbstFrameworkInputText, IDisposable
         {
             _textColor = value;
             _element.SetProperty("color", value.ToHex());
+        }
+    }
+
+    public AColor BackgroundColor
+    {
+        get => _backgroundColor;
+        set
+        {
+            _backgroundColor = value;
+            _element.SetProperty("background-color", value.ToHex());
+        }
+    }
+
+    public AColor BorderColor
+    {
+        get => _borderColor;
+        set
+        {
+            _borderColor = value;
+            _element.SetProperty("border-color", value.ToHex());
         }
     }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputCombobox.cs
@@ -6,7 +6,7 @@ namespace AbstUI.Components.Inputs
     /// <summary>
     /// Engine level wrapper for a combobox input.
     /// </summary>
-    public class AbstInputCombobox : AbstInputBase<IAbstFrameworkInputCombobox>, IAbstSdlHasSeletectableCollectionStyle
+    public class AbstInputCombobox : AbstInputBase<IAbstFrameworkInputCombobox>, IAbstSdlHasSeletectableCollectionStyle, IHasTextBackgroundBorderColor
     {
         public IReadOnlyList<KeyValuePair<string, string>> Items => _framework.Items;
         public void AddItem(string key, string value) => _framework.AddItem(key, value);
@@ -27,5 +27,9 @@ namespace AbstUI.Components.Inputs
         public AColor ItemPressedTextColor { get => _framework.ItemPressedTextColor; set => _framework.ItemPressedTextColor = value; }
         public AColor ItemPressedBackgroundColor { get => _framework.ItemPressedBackgroundColor; set => _framework.ItemPressedBackgroundColor = value; }
         public AColor ItemPressedBorderColor { get => _framework.ItemPressedBorderColor; set => _framework.ItemPressedBorderColor = value; }
+
+        public AColor TextColor { get => ((IHasTextBackgroundBorderColor)_framework).TextColor; set => ((IHasTextBackgroundBorderColor)_framework).TextColor = value; }
+        public AColor BackgroundColor { get => ((IHasTextBackgroundBorderColor)_framework).BackgroundColor; set => ((IHasTextBackgroundBorderColor)_framework).BackgroundColor = value; }
+        public AColor BorderColor { get => ((IHasTextBackgroundBorderColor)_framework).BorderColor; set => ((IHasTextBackgroundBorderColor)_framework).BorderColor = value; }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputNumber.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputNumber.cs
@@ -40,7 +40,7 @@ namespace AbstUI.Components.Inputs
     /// <summary>
     /// Engine level wrapper for a numeric input field.
     /// </summary>
-    public class AbstInputNumber<TValue> : AbstInputBase<IAbstFrameworkInputNumber<TValue>>
+    public class AbstInputNumber<TValue> : AbstInputBase<IAbstFrameworkInputNumber<TValue>>, IHasTextBackgroundBorderColor
 #if NET48
         where TValue : struct
 #else
@@ -53,5 +53,8 @@ namespace AbstUI.Components.Inputs
 
         public ANumberType NumberType { get => _framework.NumberType; set => _framework.NumberType = value; }
         public int FontSize { get => _framework.FontSize; set => _framework.FontSize = value; }
+        public AColor TextColor { get => ((IHasTextBackgroundBorderColor)_framework).TextColor; set => ((IHasTextBackgroundBorderColor)_framework).TextColor = value; }
+        public AColor BackgroundColor { get => ((IHasTextBackgroundBorderColor)_framework).BackgroundColor; set => ((IHasTextBackgroundBorderColor)_framework).BackgroundColor = value; }
+        public AColor BorderColor { get => ((IHasTextBackgroundBorderColor)_framework).BorderColor; set => ((IHasTextBackgroundBorderColor)_framework).BorderColor = value; }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputSpinBox.cs
@@ -1,12 +1,17 @@
+using AbstUI.Primitives;
+
 namespace AbstUI.Components.Inputs
 {
     /// <summary>
     /// Engine level wrapper for a spinbox input.
     /// </summary>
-    public class AbstInputSpinBox : AbstInputBase<IAbstFrameworkSpinBox>
+    public class AbstInputSpinBox : AbstInputBase<IAbstFrameworkSpinBox>, IHasTextBackgroundBorderColor
     {
         public float Value { get => _framework.Value; set => _framework.Value = value; }
         public float Min { get => _framework.Min; set => _framework.Min = value; }
         public float Max { get => _framework.Max; set => _framework.Max = value; }
+        public AColor TextColor { get => ((IHasTextBackgroundBorderColor)_framework).TextColor; set => ((IHasTextBackgroundBorderColor)_framework).TextColor = value; }
+        public AColor BackgroundColor { get => ((IHasTextBackgroundBorderColor)_framework).BackgroundColor; set => ((IHasTextBackgroundBorderColor)_framework).BackgroundColor = value; }
+        public AColor BorderColor { get => ((IHasTextBackgroundBorderColor)_framework).BorderColor; set => ((IHasTextBackgroundBorderColor)_framework).BorderColor = value; }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputText.cs
@@ -5,14 +5,15 @@ namespace AbstUI.Components.Inputs
     /// <summary>
     /// Engine level wrapper for a single line text input.
     /// </summary>
-    public class AbstInputText : AbstInputBase<IAbstFrameworkInputText>
+    public class AbstInputText : AbstInputBase<IAbstFrameworkInputText>, IHasTextBackgroundBorderColor
     {
-
         public string Text { get => _framework.Text; set => _framework.Text = value; }
         public int MaxLength { get => _framework.MaxLength; set => _framework.MaxLength = value; }
         public string? Font { get => _framework.Font; set => _framework.Font = value; }
         public int FontSize { get => _framework.FontSize; set => _framework.FontSize = value; }
-        public AColor TextColor { get => _framework.TextColor; set => _framework.TextColor = value; }
+        public AColor TextColor { get => ((IHasTextBackgroundBorderColor)_framework).TextColor; set => ((IHasTextBackgroundBorderColor)_framework).TextColor = value; }
+        public AColor BackgroundColor { get => ((IHasTextBackgroundBorderColor)_framework).BackgroundColor; set => ((IHasTextBackgroundBorderColor)_framework).BackgroundColor = value; }
+        public AColor BorderColor { get => ((IHasTextBackgroundBorderColor)_framework).BorderColor; set => ((IHasTextBackgroundBorderColor)_framework).BorderColor = value; }
         public bool IsMultiLine { get => _framework.IsMultiLine; set => _framework.IsMultiLine = value; }
     }
 }


### PR DESCRIPTION
## Summary
- forward TextColor, BackgroundColor and BorderColor via IHasTextBackgroundBorderColor in common inputs
- expose color settings for Unity, Godot, ImGui, Blazor, and RmlUi input widgets

## Testing
- `dotnet-format WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputText.cs WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputNumber.cs WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputCombobox.cs WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputSpinBox.cs`
- `dotnet-format WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputText.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputNumber.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputCombobox.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputSpinBox.cs`
- `dotnet-format WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputText.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputNumber.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputCombobox.cs`
- `dotnet-format WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputText.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputNumber.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiInputCombobox.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiSpinBox.cs`
- `dotnet-format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputTextComponent.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputText.razor.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputNumber.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorSpinBox.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.cs`
- `dotnet-format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/AbstUI.SDL2RmlUi.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Components/Inputs/RmlUiInputText.cs`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj -f net8.0`
- ⚠️ `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj -f net8.0` (missing assets)
- ⚠️ `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj -f net8.0` (missing dependencies)
- ⚠️ `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj -f net8.0` (missing dependencies)
- ⚠️ `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj -f net8.0` (missing assets)
- ⚠️ `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/AbstUI.SDL2RmlUi.csproj -f net8.0` (missing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68a6ad8764708332bd8d4bd66cb69ba3