### PR TITLE
Fix event propagation property typo

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Inputs/AbstKeyEvent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Inputs/AbstKeyEvent.cs
@@ -10,7 +10,7 @@ namespace AbstUI.Inputs
     {
         public IAbstKey AbstUIKey { get; }
         public AbstKeyEventType Type { get; }
-        public bool ContinuePropation { get; set; } = true;
+        public bool ContinuePropagation { get; set; } = true;
 
         public bool CommandDown => AbstUIKey.CommandDown;
         public bool ControlDown => AbstUIKey.ControlDown;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Inputs/AbstMouse.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Inputs/AbstMouse.cs
@@ -87,12 +87,12 @@ namespace AbstUI.Inputs
             foreach (var subscription in subscriptions)
             {
                 subscription.Do(eventMouse);
-                if (!eventMouse.ContinuePropation) return;
+                if (!eventMouse.ContinuePropagation) return;
             }
             foreach (var subscription in _mouseEvents)
             {
                 subscription.Do(eventMouse);
-                if (!eventMouse.ContinuePropation) return;
+                if (!eventMouse.ContinuePropagation) return;
             }
             OnDoOnAll(eventMouse, action);
         }
@@ -151,7 +151,7 @@ namespace AbstUI.Inputs
             internal ProxyMouse(Func<IAbstMouse, AbstMouseEventType, TAbstUIMouseEvent> ctorNewEvent, AbstMouse<TAbstUIMouseEvent> parent, IAbstMouseRectProvider provider)
                 : base(ctorNewEvent, parent.Framework<IAbstFrameworkMouse>())
             {
-                Name ="ProxyMouse";
+                Name = "ProxyMouse";
                 _parent = parent;
                 _provider = provider;
                 _downSub = parent.OnMouseDown(HandleDown);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Inputs/AbstMouseEventSubscription.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Inputs/AbstMouseEventSubscription.cs
@@ -12,7 +12,7 @@ namespace AbstUI.Inputs
     {
         public IAbstMouse Mouse { get; protected set; }
         public AbstMouseEventType Type { get; protected set; }
-        public bool ContinuePropation { get; set; } = true;
+        public bool ContinuePropagation { get; set; } = true;
         public float MouseH => Mouse.MouseH;
         public float MouseV => Mouse.MouseV;
         public float WheelDelta => Mouse.WheelDelta;
@@ -24,7 +24,7 @@ namespace AbstUI.Inputs
         }
     }
 
-    public interface IAbstMouseEventHandler<TAbstUIMouseEvent> 
+    public interface IAbstMouseEventHandler<TAbstUIMouseEvent>
         where TAbstUIMouseEvent : AbstMouseEvent
     {
         void RaiseMouseDown(TAbstUIMouseEvent mouse);

--- a/src/LingoEngine/Events/LingoMouseEventSubscription.cs
+++ b/src/LingoEngine/Events/LingoMouseEventSubscription.cs
@@ -3,22 +3,22 @@ using LingoEngine.Inputs;
 
 namespace LingoEngine.Events
 {
-   
+
     public class LingoMouseEvent : AbstMouseEvent
     {
         public new LingoMouse Mouse { get; }
 
         public LingoMouseEvent(LingoMouse lingoMouse, AbstMouseEventType type)
-            :base(lingoMouse, type)
+            : base(lingoMouse, type)
         {
             Mouse = lingoMouse;
         }
         public LingoMouseEvent(AbstMouseEvent mouseEvent, LingoMouse mouse)
-            :base(mouse, mouseEvent.Type)
+            : base(mouse, mouseEvent.Type)
         {
             Mouse = mouse;
-            Type = mouseEvent.Type ;
-            ContinuePropation = mouseEvent.ContinuePropation ;
+            Type = mouseEvent.Type;
+            ContinuePropagation = mouseEvent.ContinuePropagation;
         }
     }
 

--- a/src/LingoEngine/Inputs/LingoJoystickKeyboard.cs
+++ b/src/LingoEngine/Inputs/LingoJoystickKeyboard.cs
@@ -136,7 +136,7 @@ namespace LingoEngine.Inputs
         }
         public void Dispose()
         {
-            
+
             _mouseDownSub.Release();
             _mouseMoveSub.Release();
             _key.Unsubscribe(this);
@@ -152,7 +152,7 @@ namespace LingoEngine.Inputs
             var height = _layout.Length * (CellSize + CellSpacing);
             _canvas.Width = width;
             _canvas.Height = height;
-           
+
             if (_window.Dialog != null)
             {
                 _window.Dialog.BackgroundColor = BackgroundColor;
@@ -365,7 +365,7 @@ namespace LingoEngine.Inputs
             }
         }
 
-       
+
 
 
         private void OnMouseMove(AbstMouseEvent e)
@@ -389,7 +389,7 @@ namespace LingoEngine.Inputs
             if (!_enableMouse) return;
             OnMouseMove(e);
             ExecuteSelectedKey();
-            e.ContinuePropation = false;
+            e.ContinuePropagation = false;
         }
 
         /// <summary>Opens the keyboard popup window at the given position or centered if none.</summary>

--- a/src/LingoEngine/Inputs/LingoMouse.cs
+++ b/src/LingoEngine/Inputs/LingoMouse.cs
@@ -74,7 +74,7 @@ namespace LingoEngine.Inputs
             foreach (var subscription in _subscriptions)
             {
                 action(subscription, eventMouse);
-                if (!eventMouse.ContinuePropation) return;
+                if (!eventMouse.ContinuePropagation) return;
             }
         }
         /// <summary>
@@ -100,7 +100,7 @@ namespace LingoEngine.Inputs
         // <summary>
         /// Creates a proxy mouse that forwards events within the bounds supplied by <paramref name="provider"/>.
         /// </summary>
-       
+
         public new virtual LingoStageMouse CreateNewInstance(IAbstMouseRectProvider provider)
             => new ProxyLingoMouse(this, provider);
         public virtual LingoStageMouse DisplaceMouse(IAbstMouseRectProvider provider)
@@ -200,7 +200,7 @@ namespace LingoEngine.Inputs
 
 
 
-  
+
 
 
     public class LingoMouse : AbstMouse<LingoMouseEvent>, ILingoMouse, IAbstMouseInternal
@@ -215,7 +215,7 @@ namespace LingoEngine.Inputs
         public LingoMouse(ILingoFrameworkMouse frameworkMouse)
             : base((p, type) => new LingoMouseEvent((LingoMouse)p, type), frameworkMouse)
         {
-            Name= "LingoMouse";
+            Name = "LingoMouse";
             _lingoFrameworkObj = frameworkMouse;
             _cursor = new LingoCursor(frameworkMouse);
         }


### PR DESCRIPTION
## Summary
- rename `ContinuePropation` property to `ContinuePropagation`
- update engine and input classes to use `ContinuePropagation`

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI/Inputs/AbstMouse.cs WillMoveToOwnRepo/AbstUI/src/AbstUI/Inputs/AbstKeyEvent.cs WillMoveToOwnRepo/AbstUI/src/AbstUI/Inputs/AbstMouseEventSubscription.cs`
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/Inputs/LingoMouse.cs src/LingoEngine/Inputs/LingoJoystickKeyboard.cs src/LingoEngine/Events/LingoMouseEventSubscription.cs`
- `dotnet test Test/LingoEngine.Tests/LingoEngine.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a6ba31b23483329a3f552631ebd4c5