### PR TITLE
Guard RollOver against missing sprites and add test

### DIFF
--- a/Test/LingoEngine.Lingo.Tests/LingoSprite2DManagerTests.cs
+++ b/Test/LingoEngine.Lingo.Tests/LingoSprite2DManagerTests.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using LingoEngine.Sprites;
+using Xunit;
+
+public class LingoSprite2DManagerTests
+{
+    [Fact]
+    public void RollOver_InactiveSprite_ReturnsFalse()
+    {
+        var manager = (LingoSprite2DManager)FormatterServices.GetUninitializedObject(typeof(LingoSprite2DManager));
+
+        var field = typeof(LingoSpriteManager<LingoSprite2D>).GetField("_activeSprites", BindingFlags.Instance | BindingFlags.NonPublic);
+        field!.SetValue(manager, new Dictionary<int, LingoSprite2D>());
+
+        var result = manager.RollOver(42);
+
+        Assert.False(result);
+    }
+}

--- a/src/LingoEngine/Sprites/LingoSprite2DManager.cs
+++ b/src/LingoEngine/Sprites/LingoSprite2DManager.cs
@@ -176,7 +176,8 @@ namespace LingoEngine.Sprites
 
         internal bool RollOver(int spriteNumber)
         {
-            var sprite = _activeSprites[spriteNumber];
+            if (!_activeSprites.TryGetValue(spriteNumber, out var sprite))
+                return false;
             return sprite.IsMouseInsideBoundingBox(_lingoMouse);
         }
 


### PR DESCRIPTION
## Summary
- Avoid throwing when RollOver is called for a missing sprite by using TryGetValue
- Add unit test verifying inactive sprites return false on RollOver

## Testing
- `dotnet format --include src/LingoEngine/Sprites/LingoSprite2DManager.cs Test/LingoEngine.Lingo.Tests/LingoSprite2DManagerTests.cs` *(fails: Restore operation failed)*
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj --no-build`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj --no-build` *(fails: Unable to load shared library 'SDL2')*
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj --no-build --filter "RollOver_InactiveSprite_ReturnsFalse"`

------
https://chatgpt.com/codex/tasks/task_e_68a6ba38e27083329388d391c50ffe66