### PR TITLE
docs: expand subproject readmes

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/README.md
+++ b/WillMoveToOwnRepo/AbstUI/README.md
@@ -1,10 +1,104 @@
 # AbstUI
 
-AbstUI (Abstraction User Interface) is an abstraction layer that decouples user interface components from specific rendering frameworks. It provides common UI primitives so the same UI code can render consistently across SDL2, Godot, Unity, or other platforms. This allows AbstUI to be reused independently of any particular engine.
+AbstUI (Abstraction User Interface) is an abstraction layer that decouples user interface
+components from specific rendering frameworks. It provides common UI primitives so the same
+UI code can render consistently across SDL2, Godot, Unity, Blazor, and more. This allows
+AbstUI to be reused independently of any particular engine.
 
-The repository currently includes the core abstractions and optional backends:
-- `AbstUI`: core primitives and components.
-- `AbstUI.SDL2`: SDL2 backend.
-- `AbstUI.LGodot`: Godot backend.
-- `AbstUI.LUnity`: Unity backend.
-- `AbstUI.Blazor`: Blazor backend.
+## Project Structure
+
+Source code lives under `src/` with a small project per backend:
+
+- `AbstUI/` – core primitives and layout components.
+- `AbstUI.SDL2/` – SDL2 renderer for the primitives.
+- `AbstUI.LGodot/` – Godot integration layer.
+- `AbstUI.LUnity/` – Unity integration layer.
+- `AbstUI.Blazor/` – Blazor/WebAssembly backend.
+- `AbstUI.ImGui/` – experimental ImGui renderer.
+- `AbstUI.SDL2RmlUi/` – experimental SDL2 backend augmented with [RmlUi.NET](https://www.nuget.org/packages/RmlUi.NET) input widgets.
+
+Visual test harnesses for the backends live in the `Test/` folder.
+
+## Architecture
+
+AbstUI defines a set of rendering‑agnostic controls (buttons, labels, layout containers, etc.).
+Each backend translates these controls into native widgets for its target framework while
+sharing the same high‑level component model. The separation enables the same UI definition to
+run across multiple engines with minimal changes.
+
+### Global Engine Flags
+
+`AbstEngineGlobal` stores runtime flags that are shared across backends. The
+static `RunFramework` value indicates which host (SDL2, Godot, Unity, etc.) is
+currently driving the UI and allows components to branch on framework‑specific
+behaviour. `IsRunningDirector` toggles extra features when the UI is embedded in
+the Director‑style editor.
+
+### Mouse Input
+
+`AbstMouse` abstracts pointer state and exposes events such as `Moved` and
+`ButtonPressed`. Backends implement `IAbstFrameworkMouse` to feed platform
+events into the engine. Components can subscribe to `AbstMouseEventSubscription`
+objects to react to clicks or hover state without depending on a particular
+windowing system.
+
+### Keyboard Input
+
+Keyboard handling follows the same pattern: `AbstKey` represents individual
+keys while `AbstKeyEvent` describes presses and releases. Framework adapters
+implement `IAbstFrameworkKey` so text boxes and shortcut managers receive
+notifications in a uniform way.
+
+### Window Management
+
+The `AbstWindowManager` coordinates top‑level windows and dialogs. A main window
+creates additional `AbstWindow` instances for dialogs or context menus, and
+each backend supplies an `IAbstFrameworkWindow` to handle native windowing
+details. This keeps layout logic independent from the host platform.
+
+### Command Handling
+
+UI actions are decoupled from their effects through a lightweight command system. Components
+create commands that are dispatched to registered handlers at runtime:
+
+```csharp
+public sealed record OpenWindowCommand(string WindowCode) : IAbstCommand;
+
+public sealed class OpenWindowHandler : IAbstCommandHandler<OpenWindowCommand>
+{
+    public bool Handle(OpenWindowCommand cmd)
+    {
+        Console.WriteLine($"Opening {cmd.WindowCode}");
+        return true;
+    }
+}
+
+var manager = new AbstCommandManager(provider)
+    .Register<OpenWindowHandler, OpenWindowCommand>();
+manager.Handle(new OpenWindowCommand("settings"));
+```
+
+### Example: Button Component
+
+Controls such as `AbstButton` expose a framework‑agnostic API while backends
+provide the platform implementation through `IAbstFrameworkButton`:
+
+```csharp
+// Resolve the component factory from dependency injection
+var factory = serviceProvider.GetRequiredService<IAbstComponentFactory>();
+var button = factory.CreateButton("play", "Play");
+button.Pressed += () => Console.WriteLine("Pressed!");
+
+// SDL2 backend implementation
+internal class AbstSdlButton : AbstSdlComponent, IAbstFrameworkButton
+{
+    public event Action? Pressed;
+    // framework-specific rendering omitted
+}
+
+// Interface each backend implements
+public interface IAbstFrameworkButton : IAbstFrameworkNode
+{
+    event Action? Pressed;
+}
+```

--- a/src/LingoEngine/README.md
+++ b/src/LingoEngine/README.md
@@ -1,3 +1,93 @@
 # LingoEngine Core
 
-Contains the language runtime and high level abstractions used across all framework adapters.
+The core engine library hosts the runtime that executes Lingo scripts and exposes high‑level
+abstractions that are shared by every backend. The structure mirrors classic Macromedia
+Director concepts so that movies, casts, and sprites behave the same regardless of the
+rendering platform.
+
+## Folder Layout
+
+- `Core/` – shared utilities and dependency‑injection helpers.
+- `FrameworkCommunication/` – interfaces used by platform adapters to talk to the engine.
+- `Animations/`, `Sprites/`, `Bitmaps/`, `Sounds/`, `Movies/`… – implementations of common
+  Director building blocks.
+- `Projects/` – project definitions and bootstrap logic.
+- `Setup/` and `LingoEngineSetup.cs` – extension methods to wire everything up in a service
+  collection.
+- `Tools/`, `Scripts/`, and other folders provide supporting utilities, assets, or build
+  helpers.
+
+The engine is designed around dependency injection so that host applications can register only
+the services they need. Each subfolder represents a small, focused feature area that can be
+extended without touching the rest of the codebase.
+
+## Animations
+
+`Animations/` contains tweening helpers and sprite animators. Key frames describe how a value
+changes over time:
+
+```csharp
+var tween = new LingoTween<int>();
+tween.AddKeyFrame(1, 0);
+tween.AddKeyFrame(30, 100);
+```
+
+## Sprites
+
+Sprites are the visual actors on stage. Movies create and configure them via `AddSprite`:
+
+```csharp
+var sprite = movie.AddSprite(1, s => s.LocH = 100);
+```
+
+## Bitmaps
+
+Bitmap members wrap image data for sprites to display:
+
+```csharp
+var cast = movie.CastLibsContainer.ActiveCast;
+var bitmap = cast.Add<LingoMemberBitmap>(1, "Logo");
+```
+
+## Sounds
+
+The sound system manages channels and playback:
+
+```csharp
+var channel = movie.Sound.GetSoundChannel(1);
+channel.Play(memberSound);
+```
+
+## Movies
+
+Movies orchestrate sprites, sounds, and scripts. A movie can be created and played through the
+player API:
+
+```csharp
+var movie = lingoPlayer.NewMovie("Intro");
+movie.Play();
+```
+
+## Projects
+
+Projects describe how a game is wired together. Implement `ILingoProjectFactory` to configure
+services, load cast libraries, and start the initial movie:
+
+```csharp
+public class MyProjectFactory : ILingoProjectFactory
+{
+    public void Setup(ILingoEngineRegistration config)
+        => config.WithProjectSettings(s => s.ProjectName = "MyProject");
+}
+```
+
+### Example: TetriGrounds
+
+The TetriGrounds demo wires these pieces together using the SDL2 backend:
+
+```csharp
+services.RegisterLingoEngine(c => c
+    .WithLingoSdlEngine("TetriGrounds", 730, 547)
+    .SetProjectFactory<TetriGroundsProjectFactory>()
+    .BuildAndRunProject());
+```


### PR DESCRIPTION
## Summary
- document global flags, input, and window manager in AbstUI
- show creating bitmap members from the active cast

## Testing
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a6b9eb51f48332b268f7de69937dd7