### PR TITLE
test: expand ink pre-renderer coverage

### DIFF
--- a/Test/LingoEngine.Lingo.Tests/InkPreRendererTests.cs
+++ b/Test/LingoEngine.Lingo.Tests/InkPreRendererTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using AbstUI.Primitives;
 using LingoEngine.Primitives;
 using LingoEngine.Tools;
@@ -5,14 +6,57 @@ using Xunit;
 
 public class InkPreRendererTests
 {
-    [Fact]
-    public void BlendInkProducesOpaquePreMultipliedPixels()
+    private static byte[] Rgba(byte r, byte g, byte b, byte a) => new[] { r, g, b, a };
+
+    private static byte[] Apply(byte[] rgba, LingoInkType ink) =>
+        InkPreRenderer.Apply(rgba, ink, new AColor(0, 0, 0));
+
+    public static IEnumerable<object[]> ApplyCases()
     {
-        var rgba = new byte[] { 100, 150, 200, 128 };
-        var result = InkPreRenderer.Apply(rgba, LingoInkType.Blend, new AColor(0, 0, 0));
-        Assert.Equal(50, result[0]);
-        Assert.Equal(75, result[1]);
-        Assert.Equal(100, result[2]);
-        Assert.Equal(255, result[3]);
+        yield return new object[]
+        {
+            LingoInkType.Copy,
+            Rgba(100, 150, 200, 128),
+            Rgba(100, 150, 200, 128)
+        };
+        yield return new object[]
+        {
+            LingoInkType.Copy,
+            Rgba(100, 150, 200, 0),
+            Rgba(100, 150, 200, 0)
+        };
+        yield return new object[]
+        {
+            LingoInkType.Add,
+            Rgba(100, 150, 200, 128),
+            Rgba(100, 150, 200, 128)
+        };
+        yield return new object[]
+        {
+            LingoInkType.Add,
+            Rgba(100, 150, 200, 0),
+            Rgba(100, 150, 200, 0)
+        };
+        yield return new object[]
+        {
+            LingoInkType.Blend,
+            Rgba(100, 150, 200, 128),
+            Rgba(50, 75, 100, 255)
+        };
+        yield return new object[]
+        {
+            LingoInkType.Blend,
+            Rgba(100, 150, 200, 0),
+            Rgba(0, 0, 0, 255)
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(ApplyCases))]
+    public void ApplyProducesExpectedPixels(LingoInkType ink, byte[] input, byte[] expected)
+    {
+        var result = Apply(input, ink);
+        Assert.Equal(expected, result);
     }
 }
+


### PR DESCRIPTION
## Summary
- add helper methods for rgba creation and ink application
- cover Copy, Add, and Blend inks with theory-driven tests, including transparent inputs

## Testing
- `dotnet format Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj --include Test/LingoEngine.Lingo.Tests/InkPreRendererTests.cs --verbosity diag`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj --filter InkPreRendererTests`


------
https://chatgpt.com/codex/tasks/task_e_68a6c5f78cf48332971d6953f4f604ef