### PR TITLE
Add markdown renderer to AbstUI

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/Docs/MarkDownRenderer.md
+++ b/WillMoveToOwnRepo/AbstUI/Docs/MarkDownRenderer.md
@@ -1,0 +1,52 @@
+# AbstMarkdownRenderer
+
+`AbstMarkdownRenderer` draws a subset of Markdown on an `AbstGfxCanvas`. It understands normal Markdown constructs alongside a set of custom tags for font control and styling.
+
+## Supported Markdown
+
+- Headings using `#`, `##` and `###`
+- Paragraph text
+- **Bold** via `**bold**`
+- *Italic* via `*italic*`
+- __Underline__ via `__underline__`
+- Images `![alt](path size=100x50)` or without the `size` parameter for natural dimensions
+
+## Custom Tags
+
+Custom tags are wrapped in double braces to avoid clashing with standard Markdown:
+
+- `{{FONT-SIZE:20}}` – change font size
+- `{{FONT-FAMILY:Arial}}` – switch font family
+- `{{ALIGN:left|center|right|justify}}` – set text alignment
+- `{{COLOR:#RRGGBB}}` – set text color
+- `{{STYLE:name}}` and `{{/STYLE}}` – push and pop a named style supplied by the host application
+
+Example:
+
+```
+{{FONT-FAMILY:Arial}}
+{{FONT-SIZE:18}}
+# Heading
+
+Normal paragraph with **bold**, *italic* and __underline__.
+
+{{COLOR:#00FF00}}Colored text{{COLOR:#000000}}
+
+{{ALIGN:center}}
+![logo](images/logo.png size=128x64)
+{{ALIGN:left}}
+
+{{STYLE:quote}}
+This paragraph uses a predefined style.
+{{/STYLE}}
+```
+
+Styles are provided when creating the renderer:
+
+```csharp
+var styles = new Dictionary<string, AbstTextStyle>
+{
+    ["quote"] = new AbstTextStyle { FontSize = 14, MarginLeft = 20, Italic = true }
+};
+var renderer = new AbstMarkdownRenderer(canvas, fontManager, imageLoader, styles);
+```

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Styles/AbstBlazorFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Styles/AbstBlazorFontManager.cs
@@ -35,4 +35,10 @@ public class AbstBlazorFontManager : IAbstFontManager
         => _defaultFont = font?.ToString() ?? string.Empty;
 
     public IEnumerable<string> GetAllNames() => _loadedFonts.Keys;
+
+    public float MeasureTextWidth(string text, string fontName, int fontSize)
+        => text.Length * fontSize * 0.6f;
+
+    public FontInfo GetFontInfo(string fontName, int fontSize)
+        => new(fontSize, 0);
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Styles/AbstGodotFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Styles/AbstGodotFontManager.cs
@@ -38,5 +38,21 @@ namespace AbstUI.LGodot.Styles
         public void SetDefaultFont<T>(T font) where T : class => _defaultStyle = (font as Font)!;
 
         public IEnumerable<string> GetAllNames() => _loadedFonts.Keys;
+
+        public float MeasureTextWidth(string text, string fontName, int fontSize)
+        {
+            var font = string.IsNullOrEmpty(fontName) ? _defaultStyle :
+                (_loadedFonts.TryGetValue(fontName, out var f) ? f : _defaultStyle);
+            return font.GetStringSize(text, HorizontalAlignment.Left, -1, fontSize).X;
+        }
+
+        public FontInfo GetFontInfo(string fontName, int fontSize)
+        {
+            var font = string.IsNullOrEmpty(fontName) ? _defaultStyle :
+                (_loadedFonts.TryGetValue(fontName, out var f) ? f : _defaultStyle);
+            int height = (int)font.GetHeight(fontSize);
+            int ascent = (int)font.GetAscent(fontSize);
+            return new FontInfo(height, height - ascent);
+        }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Styles/UnityFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Styles/UnityFontManager.cs
@@ -40,4 +40,29 @@ internal class UnityFontManager : IAbstFontManager
     public void SetDefaultFont<T>(T font) where T : class => _defaultFont = (font as Font)!;
 
     public IEnumerable<string> GetAllNames() => _loadedFonts.Keys;
+
+    public float MeasureTextWidth(string text, string fontName, int fontSize)
+    {
+        var font = string.IsNullOrEmpty(fontName) ? _defaultFont :
+            (_loadedFonts.TryGetValue(fontName, out var f) ? f : _defaultFont);
+        font.RequestCharactersInTexture(text, fontSize, FontStyle.Normal);
+        float width = 0f;
+        foreach (var ch in text)
+        {
+            if (font.GetCharacterInfo(ch, out var info, fontSize))
+                width += info.advance;
+        }
+        return width;
+    }
+
+    public FontInfo GetFontInfo(string fontName, int fontSize)
+    {
+        var font = string.IsNullOrEmpty(fontName) ? _defaultFont :
+            (_loadedFonts.TryGetValue(fontName, out var f) ? f : _defaultFont);
+        font.RequestCharactersInTexture(" ", fontSize, FontStyle.Normal);
+        font.GetCharacterInfo(' ', out var info, fontSize);
+        int height = Mathf.CeilToInt(info.glyphHeight);
+        int top = Mathf.CeilToInt(info.glyphHeight - info.maxY);
+        return new FontInfo(height, top);
+    }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Styles/SdlFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Styles/SdlFontManager.cs
@@ -64,7 +64,24 @@ public class SdlFontManager : IAbstFontManager
 
     public IEnumerable<string> GetAllNames() => _loadedFonts.Keys;
 
+    public float MeasureTextWidth(string text, string fontName, int fontSize)
+    {
+        var user = new object();
+        var font = GetTyped(user, string.IsNullOrEmpty(fontName) ? null : fontName, fontSize);
+        SDL_ttf.TTF_SizeUTF8(font.FontHandle, text, out int w, out _);
+        font.Release();
+        return w;
+    }
 
+    public FontInfo GetFontInfo(string fontName, int fontSize)
+    {
+        var user = new object();
+        var font = GetTyped(user, string.IsNullOrEmpty(fontName) ? null : fontName, fontSize);
+        int height = SDL_ttf.TTF_FontHeight(font.FontHandle);
+        int ascent = SDL_ttf.TTF_FontAscent(font.FontHandle);
+        font.Release();
+        return new FontInfo(height, height - ascent);
+    }
 
     // SDL Fonts
     public void InitFonts()
@@ -101,7 +118,7 @@ public class SdlFontManager : IAbstFontManager
 
     private class LoadedFontWithSize
     {
-      
+
 
         private Dictionary<object, SdlLoadedFontByUser> _fontUsers = new();
         private Action<LoadedFontWithSize> _onRemove;
@@ -167,7 +184,7 @@ public class SdlFontManager : IAbstFontManager
             _onRemove = onRemove;
         }
 
-       
+
 
         public void Release() => _onRemove(this);
     }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/IAbstFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/IAbstFontManager.cs
@@ -8,5 +8,10 @@
         T GetDefaultFont<T>() where T : class;
         void SetDefaultFont<T>(T font) where T : class;
         IEnumerable<string> GetAllNames();
+
+        float MeasureTextWidth(string text, string fontName, int fontSize) => text.Length * fontSize * 0.6f;
+        FontInfo GetFontInfo(string fontName, int fontSize) => new(fontSize, 0);
     }
+
+    public readonly record struct FontInfo(int FontHeight, int TopIndentation);
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
@@ -1,0 +1,356 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using AbstUI.Components.Graphics;
+using AbstUI.Primitives;
+using AbstUI.Styles;
+
+namespace AbstUI.Texts
+{
+    /// <summary>
+    /// Simple markdown renderer that draws on an <see cref="AbstGfxCanvas"/>.
+    /// Supports headers (#), bold (**), italic (*), underline (__), images
+    /// (optionally sized via <c>![alt](path size=100x50)</c>) and custom font/color
+    /// tags wrapped in <c>{{...</c>}} such as <c>{{FONT-SIZE:20}}</c>,
+    /// <c>{{FONT-FAMILY:Arial}}</c>, <c>{{COLOR:#FF0000}}</c>, alignment tags
+    /// like <c>{{ALIGN:center}}</c> and paragraph style references
+    /// <c>{{STYLE:MyStyle}}</c> that apply properties including line height
+    /// and margins from predefined <see cref="AbstTextStyle"/> entries.
+    /// </summary>
+    public class AbstMarkdownRenderer
+    {
+        private readonly AbstGfxCanvas _canvas;
+        private readonly IAbstFontManager _fontManager;
+        private readonly Func<string, (byte[] data, int width, int height, APixelFormat format)>? _imageLoader;
+
+        private string _fontFamily = "Arial";
+        private int _fontSize = 12;
+        private AbstTextAlignment _alignment = AbstTextAlignment.Left;
+        private AColor _color = AColors.Black;
+        private int _lineHeight;
+        private int _marginLeft;
+        private int _marginRight;
+        private bool _styleBold;
+        private bool _styleItalic;
+        private bool _styleUnderline;
+        private readonly Stack<AbstTextStyle> _styleStack = new();
+
+        private Dictionary<string, AbstTextStyle> _styles = new();
+
+        /// <summary>Optional set of named styles that can be referenced with {{STYLE:name}} tags.</summary>
+        public IEnumerable<AbstTextStyle> Styles
+        {
+            get => _styles.Values;
+            set => _styles = value?.ToDictionary(s => s.Name) ?? new();
+        }
+
+        public AbstMarkdownRenderer(
+            AbstGfxCanvas canvas,
+            IAbstFontManager fontManager,
+            Func<string, (byte[] data, int width, int height, APixelFormat format)>? imageLoader = null)
+        {
+            _canvas = canvas;
+            _fontManager = fontManager;
+            _imageLoader = imageLoader;
+        }
+
+        /// <summary>Renders markdown text on the canvas starting from the given position.</summary>
+        public void Render(string markdown, APoint start)
+        {
+            var lines = markdown.Split('\n');
+            var pos = start;
+            var firstLine = true;
+
+            foreach (var rawLine in lines)
+            {
+                var line = rawLine.TrimEnd('\r');
+                ApplyLeadingStyle(ref line);
+                ProcessTags(ref line);
+
+                // determine header level
+                int headerLevel = 0;
+                while (headerLevel < line.Length && line[headerLevel] == '#')
+                    headerLevel++;
+                var content = headerLevel > 0 ? line.Substring(headerLevel).TrimStart() : line;
+
+                int usedFontSize = headerLevel > 0 ? 32 - (headerLevel - 1) * 4 : _fontSize;
+                bool headerBold = headerLevel > 0;
+
+                if (content.StartsWith("!["))
+                {
+                    var match = Regex.Match(content, @"!\[[^\]]*\]\(([^)\s]+)(?:\s+size=(\d+)x(\d+))?\)");
+                    if (match.Success)
+                    {
+                        string path = match.Groups[1].Value;
+                        int? w = match.Groups[2].Success ? int.Parse(match.Groups[2].Value) : null;
+                        int? h = match.Groups[3].Success ? int.Parse(match.Groups[3].Value) : null;
+                        int renderedHeight = RenderImage(path, pos, w, h);
+                        pos.Offset(0, renderedHeight + 4);
+                        continue;
+                    }
+                }
+
+                var plain = StripFormatting(content);
+                float lineWidth = EstimateWidth(plain, usedFontSize);
+                float lineX = pos.X;
+                if (_alignment == AbstTextAlignment.Center)
+                    lineX -= lineWidth / 2f;
+                else if (_alignment == AbstTextAlignment.Right)
+                    lineX -= lineWidth;
+                lineX += _marginLeft;
+                if (_alignment == AbstTextAlignment.Right)
+                    lineX -= _marginRight;
+                else if (_alignment == AbstTextAlignment.Center)
+                    lineX -= _marginRight / 2f;
+
+                bool bold = headerBold || _styleBold;
+                bool italic = _styleItalic;
+                bool underline = _styleUnderline;
+
+                var fontInfo = _fontManager.GetFontInfo(_fontFamily, usedFontSize);
+                RenderInlineText(content, new APoint(lineX, pos.Y - (firstLine ? fontInfo.TopIndentation : 0)), usedFontSize, bold, italic, underline);
+                int advance = _lineHeight > 0 ? _lineHeight : fontInfo.FontHeight + 4;
+                pos.Offset(0, advance);
+                firstLine = false;
+            }
+        }
+
+        private void ApplyStyle(AbstTextStyle style)
+        {
+            _fontSize = style.FontSize;
+            _fontFamily = style.Font;
+            _color = style.Color;
+            _alignment = style.Alignment;
+            _styleBold = style.Bold;
+            _styleItalic = style.Italic;
+            _styleUnderline = style.Underline;
+            _lineHeight = style.LineHeight;
+            _marginLeft = style.MarginLeft;
+            _marginRight = style.MarginRight;
+        }
+
+        private void ApplyLeadingStyle(ref string line)
+        {
+            while (true)
+            {
+                var trimmed = line.TrimStart();
+                if (trimmed.StartsWith("{{STYLE:", StringComparison.Ordinal))
+                {
+                    int start = line.IndexOf("{{STYLE:", StringComparison.Ordinal);
+                    int end = line.IndexOf("}}", start + 8, StringComparison.Ordinal);
+                    if (end == -1)
+                        break;
+                    var name = line.Substring(start + 8, end - (start + 8)).Trim();
+                    _styleStack.Push(new AbstTextStyle
+                    {
+                        FontSize = _fontSize,
+                        Font = _fontFamily,
+                        Color = _color,
+                        Alignment = _alignment,
+                        Bold = _styleBold,
+                        Italic = _styleItalic,
+                        Underline = _styleUnderline,
+                        LineHeight = _lineHeight,
+                        MarginLeft = _marginLeft,
+                        MarginRight = _marginRight
+                    });
+                    if (_styles.TryGetValue(name, out var style))
+                        ApplyStyle(style);
+                    line = line.Remove(start, end - start + 2);
+                }
+                else if (trimmed.StartsWith("{{STYLE}}", StringComparison.Ordinal) || trimmed.StartsWith("{{/STYLE}}", StringComparison.Ordinal))
+                {
+                    int start = line.IndexOf("{{", StringComparison.Ordinal);
+                    int end = line.IndexOf("}}", start + 2, StringComparison.Ordinal);
+                    if (end == -1)
+                        break;
+                    if (_styleStack.Count > 0)
+                        ApplyStyle(_styleStack.Pop());
+                    line = line.Remove(start, end - start + 2);
+                }
+                else
+                    break;
+            }
+        }
+
+        private void ProcessTags(ref string line)
+        {
+            int index = 0;
+            while (true)
+            {
+                int start = line.IndexOf("{{", index, StringComparison.Ordinal);
+                if (start == -1)
+                    break;
+                int end = line.IndexOf("}}", start + 2, StringComparison.Ordinal);
+                if (end == -1)
+                    break;
+
+                string tag = line.Substring(start + 2, end - start - 2);
+                if (tag.StartsWith("STYLE", StringComparison.OrdinalIgnoreCase))
+                {
+                    index = end + 2;
+                    continue;
+                }
+                ApplyTag(tag);
+                line = line.Remove(start, end - start + 2);
+            }
+        }
+
+        private void ApplyTag(string tag)
+        {
+            if (tag.StartsWith("FONT-SIZE:", StringComparison.OrdinalIgnoreCase))
+            {
+                if (int.TryParse(tag.Substring(10), out var size))
+                    _fontSize = size;
+            }
+            else if (tag.StartsWith("FONT-FAMILY:", StringComparison.OrdinalIgnoreCase))
+            {
+                _fontFamily = tag.Substring(12);
+            }
+            else if (tag.StartsWith("ALIGN:", StringComparison.OrdinalIgnoreCase))
+            {
+                var val = tag.Substring(6).Trim().ToLowerInvariant();
+                _alignment = val switch
+                {
+                    "center" => AbstTextAlignment.Center,
+                    "right" => AbstTextAlignment.Right,
+                    "justify" or "justified" => AbstTextAlignment.Justified,
+                    _ => AbstTextAlignment.Left,
+                };
+            }
+            else if (tag.StartsWith("COLOR:", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    _color = AColor.FromHex(tag.Substring(6).Trim());
+                }
+                catch
+                {
+                    // ignore invalid color
+                }
+            }
+        }
+
+        private void RenderInlineText(string content, APoint pos, int fontSize, bool initialBold, bool initialItalic, bool initialUnderline)
+        {
+            int i = 0;
+            bool bold = initialBold;
+            bool italic = initialItalic;
+            bool underline = initialUnderline;
+            var sb = new StringBuilder();
+            float currentX = pos.X;
+
+            void Flush()
+            {
+                if (sb.Length == 0)
+                    return;
+                string font = _fontFamily;
+                if (bold && italic)
+                    font += " BoldItalic";
+                else if (bold)
+                    font += " Bold";
+                else if (italic)
+                    font += " Italic";
+
+                string text = sb.ToString();
+                float width = EstimateWidth(text, fontSize);
+                _canvas.DrawText(new APoint(currentX, pos.Y), text, font, _color, fontSize, -1, AbstTextAlignment.Left);
+                if (underline)
+                    _canvas.DrawLine(new APoint(currentX, pos.Y + fontSize), new APoint(currentX + width, pos.Y + fontSize), _color, 1);
+                currentX += width;
+                sb.Clear();
+            }
+
+            while (i < content.Length)
+            {
+                if (content.IndexOf("{{STYLE:", i, StringComparison.Ordinal) == i)
+                {
+                    int end = content.IndexOf("}}", i + 8, StringComparison.Ordinal);
+                    if (end != -1)
+                    {
+                        Flush();
+                        var name = content.Substring(i + 8, end - (i + 8)).Trim();
+                        _styleStack.Push(new AbstTextStyle
+                        {
+                            FontSize = _fontSize,
+                            Font = _fontFamily,
+                            Color = _color,
+                            Alignment = _alignment,
+                            Bold = bold,
+                            Italic = italic,
+                            Underline = underline,
+                            LineHeight = _lineHeight,
+                            MarginLeft = _marginLeft,
+                            MarginRight = _marginRight
+                        });
+                        if (_styles.TryGetValue(name, out var style))
+                            ApplyStyle(style);
+                        bold = _styleBold;
+                        italic = _styleItalic;
+                        underline = _styleUnderline;
+                        i = end + 2;
+                        continue;
+                    }
+                }
+                if (content.IndexOf("{{STYLE}}", i, StringComparison.Ordinal) == i || content.IndexOf("{{/STYLE}}", i, StringComparison.Ordinal) == i)
+                {
+                    Flush();
+                    if (_styleStack.Count > 0)
+                        ApplyStyle(_styleStack.Pop());
+                    bold = _styleBold;
+                    italic = _styleItalic;
+                    underline = _styleUnderline;
+                    i += content.IndexOf("{{STYLE}}", i, StringComparison.Ordinal) == i ? 9 : 10;
+                    continue;
+                }
+                if (content.IndexOf("**", i, StringComparison.Ordinal) == i)
+                {
+                    Flush();
+                    bold = !bold;
+                    i += 2;
+                    continue;
+                }
+                if (content.IndexOf("__", i, StringComparison.Ordinal) == i)
+                {
+                    Flush();
+                    underline = !underline;
+                    i += 2;
+                    continue;
+                }
+                if (content[i] == '*')
+                {
+                    Flush();
+                    italic = !italic;
+                    i++;
+                    continue;
+                }
+                sb.Append(content[i]);
+                i++;
+            }
+            Flush();
+        }
+
+        private float EstimateWidth(string text, int fontSize)
+            => _fontManager.MeasureTextWidth(text, _fontFamily, fontSize);
+
+        private static string StripFormatting(string text)
+        {
+            text = Regex.Replace(text, @"!\[[^\]]*\]\([^)]+\)", string.Empty);
+            text = text.Replace("**", string.Empty).Replace("*", string.Empty).Replace("__", string.Empty);
+            return text;
+        }
+
+        private int RenderImage(string path, APoint position, int? widthOverride, int? heightOverride)
+        {
+            if (_imageLoader == null)
+                return 0;
+            var (data, width, height, format) = _imageLoader(path);
+            int drawWidth = widthOverride ?? width;
+            int drawHeight = heightOverride ?? height;
+            _canvas.DrawPicture(data, drawWidth, drawHeight, position, format);
+            return drawHeight;
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstTextStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstTextStyle.cs
@@ -1,0 +1,21 @@
+using AbstUI.Primitives;
+
+namespace AbstUI.Texts;
+
+/// <summary>
+/// Represents a collection of style properties that can be applied to text.
+/// </summary>
+public class AbstTextStyle
+{
+    public string Name { get; set; } = string.Empty;
+    public int FontSize { get; set; }
+    public string Font { get; set; } = string.Empty;
+    public AColor Color { get; set; } = AColors.Black;
+    public AbstTextAlignment Alignment { get; set; } = AbstTextAlignment.Left;
+    public bool Bold { get; set; }
+    public bool Italic { get; set; }
+    public bool Underline { get; set; }
+    public int LineHeight { get; set; }
+    public int MarginLeft { get; set; }
+    public int MarginRight { get; set; }
+}

--- a/src/Director/LingoEngine.Director.Core/Texts/TextEditIconBar.cs
+++ b/src/Director/LingoEngine.Director.Core/Texts/TextEditIconBar.cs
@@ -31,10 +31,13 @@ public class TextEditIconBar
     private readonly AbstPanel _colorDisplay;
     private readonly AbstColorPicker _colorPicker;
     private readonly AbstInputSpinBox _fontSize;
+    private readonly AbstInputSpinBox _lineHeight;
+    private readonly AbstInputSpinBox _marginLeft;
+    private readonly AbstInputSpinBox _marginRight;
     private readonly AbstInputCombobox _fontsCombo;
 
-    private readonly Dictionary<string, TextStyle> _styles = new();
-    private TextStyle _currentStyle;
+    private readonly Dictionary<string, AbstTextStyle> _styles = new();
+    private AbstTextStyle _currentStyle;
 
     private const string DefaultStyleName = "Default";
 
@@ -55,6 +58,12 @@ public class TextEditIconBar
     public event Action<string>? FontChanged;
     /// <summary>Raised when color changes.</summary>
     public event Action<AColor>? ColorChanged;
+    /// <summary>Raised when line height changes.</summary>
+    public event Action<int>? LineHeightChanged;
+    /// <summary>Raised when left margin changes.</summary>
+    public event Action<int>? MarginLeftChanged;
+    /// <summary>Raised when right margin changes.</summary>
+    public event Action<int>? MarginRightChanged;
 
     /// <summary>Returns whether bold is currently selected.</summary>
     public bool IsBold => _boldButton.IsOn;
@@ -65,25 +74,12 @@ public class TextEditIconBar
     /// <summary>Currently selected font name.</summary>
     public string SelectedFont => _fontsCombo.SelectedValue ?? string.Empty;
 
-    /// <summary>Represents a collection of style properties.</summary>
-    public class TextStyle
-    {
-        public string Name { get; set; } = string.Empty;
-        public int FontSize { get; set; }
-        public string Font { get; set; } = string.Empty;
-        public AColor Color { get; set; }
-        public AbstTextAlignment Alignment { get; set; }
-        public bool Bold { get; set; }
-        public bool Italic { get; set; }
-        public bool Underline { get; set; }
-    }
-
     public TextEditIconBar(ILingoFrameworkFactory factory)
     {
         const int actionBarHeight = 22;
 
         // Ensure default style exists
-        var defaultStyle = new TextStyle
+        var defaultStyle = new AbstTextStyle
         {
             Name = DefaultStyleName,
             FontSize = 12,
@@ -92,7 +88,10 @@ public class TextEditIconBar
             Alignment = AbstTextAlignment.Left,
             Bold = false,
             Italic = false,
-            Underline = false
+            Underline = false,
+            LineHeight = 0,
+            MarginLeft = 0,
+            MarginRight = 0
         };
         _styles.Add(defaultStyle.Name, defaultStyle);
         _currentStyle = defaultStyle;
@@ -172,6 +171,30 @@ public class TextEditIconBar
         _fontSize.Width = 50;
         container.AddItem(_fontSize);
 
+        _lineHeight = factory.CreateSpinBox("LineHeight", 0, 500, v =>
+        {
+            _currentStyle.LineHeight = (int)v;
+            LineHeightChanged?.Invoke((int)v);
+        });
+        _lineHeight.Width = 50;
+        container.AddItem(_lineHeight);
+
+        _marginLeft = factory.CreateSpinBox("MarginLeft", 0, 500, v =>
+        {
+            _currentStyle.MarginLeft = (int)v;
+            MarginLeftChanged?.Invoke((int)v);
+        });
+        _marginLeft.Width = 50;
+        container.AddItem(_marginLeft);
+
+        _marginRight = factory.CreateSpinBox("MarginRight", 0, 500, v =>
+        {
+            _currentStyle.MarginRight = (int)v;
+            MarginRightChanged?.Invoke((int)v);
+        });
+        _marginRight.Width = 50;
+        container.AddItem(_marginRight);
+
         _fontsCombo = factory.CreateInputCombobox("FontsCombo", s =>
         {
             if (s != null)
@@ -224,6 +247,27 @@ public class TextEditIconBar
         _currentStyle.FontSize = size;
     }
 
+    /// <summary>Set the current line height.</summary>
+    public void SetLineHeight(int value)
+    {
+        _lineHeight.Value = value;
+        _currentStyle.LineHeight = value;
+    }
+
+    /// <summary>Set the left margin.</summary>
+    public void SetMarginLeft(int value)
+    {
+        _marginLeft.Value = value;
+        _currentStyle.MarginLeft = value;
+    }
+
+    /// <summary>Set the right margin.</summary>
+    public void SetMarginRight(int value)
+    {
+        _marginRight.Value = value;
+        _currentStyle.MarginRight = value;
+    }
+
     /// <summary>Set the alignment state.</summary>
     public void SetAlignment(AbstTextAlignment alignment)
     {
@@ -272,6 +316,9 @@ public class TextEditIconBar
         SetBold(member.Bold);
         SetItalic(member.Italic);
         SetUnderline(member.Underline);
+        SetLineHeight(0);
+        SetMarginLeft(0);
+        SetMarginRight(0);
 
         // Update default style from member
         var style = _styles[DefaultStyleName];
@@ -282,6 +329,9 @@ public class TextEditIconBar
         style.Bold = member.Bold;
         style.Italic = member.Italic;
         style.Underline = member.Underline;
+        style.LineHeight = 0;
+        style.MarginLeft = 0;
+        style.MarginRight = 0;
 
         ApplyStyle(DefaultStyleName);
         _stylesCombo.SelectedKey = DefaultStyleName;
@@ -304,13 +354,16 @@ public class TextEditIconBar
             SetBold(style.Bold);
             SetItalic(style.Italic);
             SetUnderline(style.Underline);
+            SetLineHeight(style.LineHeight);
+            SetMarginLeft(style.MarginLeft);
+            SetMarginRight(style.MarginRight);
         }
     }
 
     private void AddStyle()
     {
         string newName = GenerateStyleName();
-        var style = new TextStyle
+        var style = new AbstTextStyle
         {
             Name = newName,
             FontSize = _currentStyle.FontSize,
@@ -319,7 +372,10 @@ public class TextEditIconBar
             Alignment = _currentStyle.Alignment,
             Bold = _currentStyle.Bold,
             Italic = _currentStyle.Italic,
-            Underline = _currentStyle.Underline
+            Underline = _currentStyle.Underline,
+            LineHeight = _currentStyle.LineHeight,
+            MarginLeft = _currentStyle.MarginLeft,
+            MarginRight = _currentStyle.MarginRight
         };
         _styles.Add(newName, style);
         RefreshStylesCombo();


### PR DESCRIPTION
## Summary
- extract shared `TextStyle` with font, alignment, line-height and margin properties
- allow `AbstMarkdownRenderer` to apply named styles via `{{STYLE:name}}`
- extend `TextEditIconBar` with line-height and margin controls using the shared style class
- return `FontInfo` with height and top indentation for accurate first-line layout
- implement font metrics for SDL2, Unity, Godot and Blazor font managers
- document renderer usage and custom tags in `Docs/MarkDownRenderer.md`

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Styles/SdlFontManager.cs --no-restore --verbosity normal`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Styles/UnityFontManager.cs --no-restore --verbosity normal`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Styles/AbstGodotFontManager.cs --no-restore --verbosity normal`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Styles/AbstBlazorFontManager.cs --no-restore --verbosity normal`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj -f net8.0`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj -f net8.0` *(fails: 'AbstUnityButton' does not implement interface member)*
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj -f net8.0` *(fails: assets file missing target net8.0)*
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj -f net8.0` *(fails: assets file missing target net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b663d5fc83329bff6cb64ed6615d