### PR TITLE
Fix selectable collection interface naming

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCombobox.razor
@@ -6,3 +6,9 @@
         <option value="@i">@item.Value</option>
     }
 </select>
+<style>
+    #@Name option { color:@ItemTextColor.ToHex(); }
+    #@Name option:hover { color:@ItemHoverTextColor.ToHex(); background-color:@ItemHoverBackgroundColor.ToHex(); }
+    #@Name option:active { color:@ItemPressedTextColor.ToHex(); background-color:@ItemPressedBackgroundColor.ToHex(); }
+    #@Name option:checked, #@Name option:selected { color:@ItemSelectedTextColor.ToHex(); background-color:@ItemSelectedBackgroundColor.ToHex(); }
+</style>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorItemList.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorItemList.razor
@@ -6,3 +6,9 @@
         <option value="@i">@item.Value</option>
     }
 </select>
+<style>
+    #@Name option { color:@ItemTextColor.ToHex(); }
+    #@Name option:hover { color:@ItemHoverTextColor.ToHex(); background-color:@ItemHoverBackgroundColor.ToHex(); }
+    #@Name option:active { color:@ItemPressedTextColor.ToHex(); background-color:@ItemPressedBackgroundColor.ToHex(); }
+    #@Name option:checked, #@Name option:selected { color:@ItemSelectedTextColor.ToHex(); background-color:@ItemSelectedBackgroundColor.ToHex(); }
+</style>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputCombobox.cs
@@ -3,6 +3,7 @@ using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.Styles;
 using AbstUI.Components.Inputs;
+using AbstUI.LGodot.Primitives;
 
 namespace AbstUI.LGodot.Components
 {
@@ -26,6 +27,7 @@ namespace AbstUI.LGodot.Components
             ItemSelected += idx => _onValueChanged?.Invoke();
             _onChange = onChange;
             if (_onChange != null) ItemSelected += _ => _onChange(SelectedKey);
+            UpdatePopupStyle();
         }
 
 
@@ -125,18 +127,65 @@ namespace AbstUI.LGodot.Components
             }
         }
 
-        public string? ItemFont { get; set; }
-        public int ItemFontSize { get; set; } = 11;
-        public AColor ItemTextColor { get; set; } = AbstDefaultColors.InputTextColor;
-        public AColor ItemSelectedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
-        public AColor ItemSelectedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
-        public AColor ItemSelectedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
-        public AColor ItemHoverTextColor { get; set; } = AbstDefaultColors.InputTextColor;
-        public AColor ItemHoverBackgroundColor { get; set; } = AbstDefaultColors.ListHoverColor;
-        public AColor ItemHoverBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
-        public AColor ItemPressedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
-        public AColor ItemPressedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
-        public AColor ItemPressedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        private string? _itemFont;
+        private int _itemFontSize = 11;
+        private AColor _itemTextColor = AbstDefaultColors.InputTextColor;
+        private AColor _itemSelectedTextColor = AbstDefaultColors.InputSelectionText;
+        private AColor _itemSelectedBackgroundColor = AbstDefaultColors.InputAccentColor;
+        private AColor _itemSelectedBorderColor = AbstDefaultColors.InputBorderColor;
+        private AColor _itemHoverTextColor = AbstDefaultColors.InputTextColor;
+        private AColor _itemHoverBackgroundColor = AbstDefaultColors.ListHoverColor;
+        private AColor _itemHoverBorderColor = AbstDefaultColors.InputBorderColor;
+        private AColor _itemPressedTextColor = AbstDefaultColors.InputSelectionText;
+        private AColor _itemPressedBackgroundColor = AbstDefaultColors.InputAccentColor;
+        private AColor _itemPressedBorderColor = AbstDefaultColors.InputBorderColor;
+
+        public string? ItemFont { get => _itemFont; set { _itemFont = value; UpdatePopupStyle(); } }
+        public int ItemFontSize { get => _itemFontSize; set { _itemFontSize = value; UpdatePopupStyle(); } }
+        public AColor ItemTextColor { get => _itemTextColor; set { _itemTextColor = value; UpdatePopupStyle(); } }
+        public AColor ItemSelectedTextColor { get => _itemSelectedTextColor; set { _itemSelectedTextColor = value; UpdatePopupStyle(); } }
+        public AColor ItemSelectedBackgroundColor { get => _itemSelectedBackgroundColor; set { _itemSelectedBackgroundColor = value; UpdatePopupStyle(); } }
+        public AColor ItemSelectedBorderColor { get => _itemSelectedBorderColor; set { _itemSelectedBorderColor = value; UpdatePopupStyle(); } }
+        public AColor ItemHoverTextColor { get => _itemHoverTextColor; set { _itemHoverTextColor = value; UpdatePopupStyle(); } }
+        public AColor ItemHoverBackgroundColor { get => _itemHoverBackgroundColor; set { _itemHoverBackgroundColor = value; UpdatePopupStyle(); } }
+        public AColor ItemHoverBorderColor { get => _itemHoverBorderColor; set { _itemHoverBorderColor = value; UpdatePopupStyle(); } }
+        public AColor ItemPressedTextColor { get => _itemPressedTextColor; set { _itemPressedTextColor = value; UpdatePopupStyle(); } }
+        public AColor ItemPressedBackgroundColor { get => _itemPressedBackgroundColor; set { _itemPressedBackgroundColor = value; UpdatePopupStyle(); } }
+        public AColor ItemPressedBorderColor { get => _itemPressedBorderColor; set { _itemPressedBorderColor = value; UpdatePopupStyle(); } }
+
+        private void UpdatePopupStyle()
+        {
+            var popup = GetPopup();
+            popup.AddThemeFontSizeOverride("font_size", _itemFontSize);
+            popup.AddThemeColorOverride("font_color", _itemTextColor.ToGodotColor());
+            popup.AddThemeColorOverride("font_color_hover", _itemHoverTextColor.ToGodotColor());
+            popup.AddThemeColorOverride("font_color_selected", _itemSelectedTextColor.ToGodotColor());
+            popup.AddThemeColorOverride("font_color_pressed", _itemPressedTextColor.ToGodotColor());
+
+            var selected = new StyleBoxFlat
+            {
+                BgColor = _itemSelectedBackgroundColor.ToGodotColor(),
+                BorderColor = _itemSelectedBorderColor.ToGodotColor()
+            };
+            selected.SetBorderWidthAll(1);
+            popup.AddThemeStyleboxOverride("selected", selected);
+
+            var hover = new StyleBoxFlat
+            {
+                BgColor = _itemHoverBackgroundColor.ToGodotColor(),
+                BorderColor = _itemHoverBorderColor.ToGodotColor()
+            };
+            hover.SetBorderWidthAll(1);
+            popup.AddThemeStyleboxOverride("hover", hover);
+
+            var pressed = new StyleBoxFlat
+            {
+                BgColor = _itemPressedBackgroundColor.ToGodotColor(),
+                BorderColor = _itemPressedBorderColor.ToGodotColor()
+            };
+            pressed.SetBorderWidthAll(1);
+            popup.AddThemeStyleboxOverride("pressed", pressed);
+        }
 
         event Action? IAbstFrameworkNodeInput.ValueChanged
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputNumber.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputNumber.cs
@@ -3,6 +3,7 @@ using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.Styles;
 using AbstUI.Components.Inputs;
+using AbstUI.LGodot.Primitives;
 
 namespace AbstUI.LGodot.Components
 {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputSpinBox.cs
@@ -3,6 +3,7 @@ using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.Styles;
 using AbstUI.Components.Inputs;
+using AbstUI.LGodot.Primitives;
 
 namespace AbstUI.LGodot.Components
 {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotItemList.cs
@@ -3,6 +3,7 @@ using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.Components.Inputs;
 using AbstUI.Styles;
+using AbstUI.LGodot.Primitives;
 
 namespace AbstUI.LGodot.Components
 {
@@ -55,6 +56,7 @@ namespace AbstUI.LGodot.Components
             SizeFlagsHorizontal = SizeFlags.ExpandFill;
             SizeFlagsVertical = SizeFlags.ExpandFill;
             CustomMinimumSize = new Vector2(100, 50);
+            UpdateItemStyle();
         }
 
 
@@ -119,18 +121,64 @@ namespace AbstUI.LGodot.Components
             }
         }
 
-        public string? ItemFont { get; set; }
-        public int ItemFontSize { get; set; } = 11;
-        public AColor ItemTextColor { get; set; } = AbstDefaultColors.InputTextColor;
-        public AColor ItemSelectedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
-        public AColor ItemSelectedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
-        public AColor ItemSelectedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
-        public AColor ItemHoverTextColor { get; set; } = AbstDefaultColors.InputTextColor;
-        public AColor ItemHoverBackgroundColor { get; set; } = AbstDefaultColors.ListHoverColor;
-        public AColor ItemHoverBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
-        public AColor ItemPressedTextColor { get; set; } = AbstDefaultColors.InputSelectionText;
-        public AColor ItemPressedBackgroundColor { get; set; } = AbstDefaultColors.InputAccentColor;
-        public AColor ItemPressedBorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
+        private string? _itemFont;
+        private int _itemFontSize = 11;
+        private AColor _itemTextColor = AbstDefaultColors.InputTextColor;
+        private AColor _itemSelectedTextColor = AbstDefaultColors.InputSelectionText;
+        private AColor _itemSelectedBackgroundColor = AbstDefaultColors.InputAccentColor;
+        private AColor _itemSelectedBorderColor = AbstDefaultColors.InputBorderColor;
+        private AColor _itemHoverTextColor = AbstDefaultColors.InputTextColor;
+        private AColor _itemHoverBackgroundColor = AbstDefaultColors.ListHoverColor;
+        private AColor _itemHoverBorderColor = AbstDefaultColors.InputBorderColor;
+        private AColor _itemPressedTextColor = AbstDefaultColors.InputSelectionText;
+        private AColor _itemPressedBackgroundColor = AbstDefaultColors.InputAccentColor;
+        private AColor _itemPressedBorderColor = AbstDefaultColors.InputBorderColor;
+
+        public string? ItemFont { get => _itemFont; set { _itemFont = value; UpdateItemStyle(); } }
+        public int ItemFontSize { get => _itemFontSize; set { _itemFontSize = value; UpdateItemStyle(); } }
+        public AColor ItemTextColor { get => _itemTextColor; set { _itemTextColor = value; UpdateItemStyle(); } }
+        public AColor ItemSelectedTextColor { get => _itemSelectedTextColor; set { _itemSelectedTextColor = value; UpdateItemStyle(); } }
+        public AColor ItemSelectedBackgroundColor { get => _itemSelectedBackgroundColor; set { _itemSelectedBackgroundColor = value; UpdateItemStyle(); } }
+        public AColor ItemSelectedBorderColor { get => _itemSelectedBorderColor; set { _itemSelectedBorderColor = value; UpdateItemStyle(); } }
+        public AColor ItemHoverTextColor { get => _itemHoverTextColor; set { _itemHoverTextColor = value; UpdateItemStyle(); } }
+        public AColor ItemHoverBackgroundColor { get => _itemHoverBackgroundColor; set { _itemHoverBackgroundColor = value; UpdateItemStyle(); } }
+        public AColor ItemHoverBorderColor { get => _itemHoverBorderColor; set { _itemHoverBorderColor = value; UpdateItemStyle(); } }
+        public AColor ItemPressedTextColor { get => _itemPressedTextColor; set { _itemPressedTextColor = value; UpdateItemStyle(); } }
+        public AColor ItemPressedBackgroundColor { get => _itemPressedBackgroundColor; set { _itemPressedBackgroundColor = value; UpdateItemStyle(); } }
+        public AColor ItemPressedBorderColor { get => _itemPressedBorderColor; set { _itemPressedBorderColor = value; UpdateItemStyle(); } }
+
+        private void UpdateItemStyle()
+        {
+            AddThemeFontSizeOverride("font_size", _itemFontSize);
+            AddThemeColorOverride("font_color", _itemTextColor.ToGodotColor());
+            AddThemeColorOverride("font_color_hover", _itemHoverTextColor.ToGodotColor());
+            AddThemeColorOverride("font_color_selected", _itemSelectedTextColor.ToGodotColor());
+            AddThemeColorOverride("font_color_pressed", _itemPressedTextColor.ToGodotColor());
+
+            var selected = new StyleBoxFlat
+            {
+                BgColor = _itemSelectedBackgroundColor.ToGodotColor(),
+                BorderColor = _itemSelectedBorderColor.ToGodotColor()
+            };
+            selected.SetBorderWidthAll(1);
+            AddThemeStyleboxOverride("selected", selected);
+
+            var hover = new StyleBoxFlat
+            {
+                BgColor = _itemHoverBackgroundColor.ToGodotColor(),
+                BorderColor = _itemHoverBorderColor.ToGodotColor()
+            };
+            hover.SetBorderWidthAll(1);
+            AddThemeStyleboxOverride("hover", hover);
+
+            var pressed = new StyleBoxFlat
+            {
+                BgColor = _itemPressedBackgroundColor.ToGodotColor(),
+                BorderColor = _itemPressedBorderColor.ToGodotColor()
+            };
+            pressed.SetBorderWidthAll(1);
+            AddThemeStyleboxOverride("pressed", pressed);
+        }
 
         event Action? IAbstFrameworkNodeInput.ValueChanged
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlComponentFactory.cs
@@ -38,7 +38,7 @@ namespace AbstUI.SDL2.Components
             : base(serviceProvider)
         {
             _rootContext = rootContext;
-            _windowManager = (IAbstSdlWindowManager)serviceProvider.GetRequiredService< IAbstFrameworkWindowManager>();
+            _windowManager = (IAbstSdlWindowManager)serviceProvider.GetRequiredService<IAbstFrameworkWindowManager>();
             FontManagerTyped = (SdlFontManager)FontManager;
             AbstDefaultStyles.RegisterInputStyles(StyleManager);
         }
@@ -234,7 +234,7 @@ namespace AbstUI.SDL2.Components
         public AbstItemList CreateItemList(string name, Action<string?>? onChange = null)
         {
             var list = new AbstItemList();
-            var impl = new AbstSdInputltemList(this);
+            var impl = new AbstSdlInputItemList(this);
             list.Init(impl);
             InitComponent(list);
             list.Name = name;
@@ -285,7 +285,7 @@ namespace AbstUI.SDL2.Components
             InitComponent(button);
             if (onChange != null)
                 button.ValueChanged += () => onChange(button.IsOn);
-            
+
             button.Name = name;
             button.Text = text;
             if (texture != null)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputCombobox.cs
@@ -13,7 +13,7 @@ using AbstUI.SDL2.Core;
 
 namespace AbstUI.SDL2.Components.Inputs
 {
-    internal class AbstSdlInputCombobox : AbstSdlSeletectableCollection, IAbstFrameworkInputCombobox, IHandleSdlEvent, ISdlFocusable, IDisposable, IHasTextBackgroundBorderColor
+    internal class AbstSdlInputCombobox : AbstSdlSelectableCollection, IAbstFrameworkInputCombobox, IHandleSdlEvent, ISdlFocusable, IDisposable, IHasTextBackgroundBorderColor
     {
         public AbstSdlInputCombobox(AbstSdlComponentFactory factory) : base(factory)
         {
@@ -26,7 +26,7 @@ namespace AbstUI.SDL2.Components.Inputs
         public AColor BorderColor { get; set; } = AbstDefaultColors.InputBorderColor;
         public new AColor BackgroundColor { get; set; } = AbstDefaultColors.Input_Bg;
 
-        private AbstSdInputltemList? _popup;
+        private AbstSdlInputItemList? _popup;
         private bool _open;
         private ISdlFontLoadedByUser? _font;
         private SdlGlyphAtlas? _atlas;
@@ -106,7 +106,7 @@ namespace AbstUI.SDL2.Components.Inputs
         {
             if (_popup == null)
             {
-                _popup = new AbstSdInputltemList(Factory);
+                _popup = new AbstSdlInputItemList(Factory);
                 foreach (var it in Items)
                     _popup.AddItem(it.Key, it.Value);
                 _popup.ValueChanged += PopupOnValueChanged;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputItemList.cs
@@ -9,7 +9,7 @@ using AbstUI.SDL2.Core;
 
 namespace AbstUI.SDL2.Components.Inputs
 {
-    internal class AbstSdInputltemList : AbstSdlSeletectableCollection, IAbstFrameworkItemList, ISdlFocusable, IDisposable
+    internal class AbstSdlInputItemList : AbstSdlSelectableCollection, IAbstFrameworkItemList, ISdlFocusable, IDisposable
     {
         private bool _focused;
         public bool HasFocus => _focused;
@@ -20,7 +20,7 @@ namespace AbstUI.SDL2.Components.Inputs
         private int _hoverIndex = -1;
         private int _pressedIndex = -1;
 
-        public AbstSdInputltemList(AbstSdlComponentFactory factory) : base(factory)
+        public AbstSdlInputItemList(AbstSdlComponentFactory factory) : base(factory)
         {
         }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlSelectableCollection.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlSelectableCollection.cs
@@ -10,9 +10,9 @@ using AbstUI.Styles;
 
 namespace AbstUI.SDL2.Components.Inputs
 {
-    internal abstract class AbstSdlSeletectableCollection : AbstSdlScrollViewer, IAbstSdlHasSeletectableCollectionStyle
+    internal abstract class AbstSdlSelectableCollection : AbstSdlScrollViewer, IAbstSdlHasSelectableCollectionStyle
     {
-        protected AbstSdlSeletectableCollection(AbstSdlComponentFactory factory) : base(factory)
+        protected AbstSdlSelectableCollection(AbstSdlComponentFactory factory) : base(factory)
         {
         }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstInputCombobox.cs
@@ -6,7 +6,7 @@ namespace AbstUI.Components.Inputs
     /// <summary>
     /// Engine level wrapper for a combobox input.
     /// </summary>
-    public class AbstInputCombobox : AbstInputBase<IAbstFrameworkInputCombobox>, IAbstSdlHasSeletectableCollectionStyle, IHasTextBackgroundBorderColor
+    public class AbstInputCombobox : AbstInputBase<IAbstFrameworkInputCombobox>, IAbstSdlHasSelectableCollectionStyle, IHasTextBackgroundBorderColor
     {
         public IReadOnlyList<KeyValuePair<string, string>> Items => _framework.Items;
         public void AddItem(string key, string value) => _framework.AddItem(key, value);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/AbstItemList.cs
@@ -6,7 +6,7 @@ namespace AbstUI.Components.Inputs
     /// <summary>
     /// Engine level wrapper around a framework item list widget.
     /// </summary>
-    public class AbstItemList : AbstInputBase<IAbstFrameworkItemList>, IAbstSdlHasSeletectableCollectionStyle
+    public class AbstItemList : AbstInputBase<IAbstFrameworkItemList>, IAbstSdlHasSelectableCollectionStyle
     {
         public IReadOnlyList<KeyValuePair<string, string>> Items => _framework.Items;
         public void AddItem(string key, string value) => _framework.AddItem(key, value);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstFrameworkInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstFrameworkInputCombobox.cs
@@ -5,7 +5,7 @@ namespace AbstUI.Components.Inputs
     /// <summary>
     /// Framework specific combo box input.
     /// </summary>
-    public interface IAbstFrameworkInputCombobox : IAbstFrameworkNodeInput, IAbstSdlHasSeletectableCollectionStyle
+    public interface IAbstFrameworkInputCombobox : IAbstFrameworkNodeInput, IAbstSdlHasSelectableCollectionStyle
     {
         IReadOnlyList<KeyValuePair<string, string>> Items { get; }
         void AddItem(string key, string value);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstFrameworkItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstFrameworkItemList.cs
@@ -5,7 +5,7 @@ namespace AbstUI.Components.Inputs
     /// <summary>
     /// Framework specific list widget allowing selection of items.
     /// </summary>
-    public interface IAbstFrameworkItemList : IAbstFrameworkNodeInput, IAbstSdlHasSeletectableCollectionStyle
+    public interface IAbstFrameworkItemList : IAbstFrameworkNodeInput, IAbstSdlHasSelectableCollectionStyle
     {
         /// <summary>Current items in the list.</summary>
         IReadOnlyList<KeyValuePair<string, string>> Items { get; }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstSdlHasSelectableCollectionStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Inputs/IAbstSdlHasSelectableCollectionStyle.cs
@@ -2,7 +2,7 @@ using AbstUI.Primitives;
 
 namespace AbstUI.Components.Inputs;
 
-public interface IAbstSdlHasSeletectableCollectionStyle
+public interface IAbstSdlHasSelectableCollectionStyle
 {
     string? ItemFont { get; set; }
     int ItemFontSize { get; set; }


### PR DESCRIPTION
## Summary
- rename `IAbstSdlHasSeletectableCollectionStyle` to `IAbstSdlHasSelectableCollectionStyle`
- update SDL collection classes to `AbstSdlSelectableCollection` and `AbstSdlInputItemList`
- adjust SDL component factory and wrappers to use the new names
- apply selectable item styling in Godot and Blazor implementations

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj --include "Components/Inputs/AbstGodotInputCombobox.cs" "Components/Inputs/AbstGodotItemList.cs" "Components/Inputs/AbstGodotInputSpinBox.cs" "Components/Inputs/AbstGodotInputNumber.cs" -v diag`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --include "Components/Inputs/AbstBlazorItemList.razor" "Components/Inputs/AbstBlazorInputCombobox.razor" -v diag`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a6c6bc55a48332b8bc486a528639fc