### PR TITLE
Use DI for Blazor component registry

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
@@ -23,11 +23,13 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
 
     private readonly IAbstFontManager _fontManager;
     private readonly AbstBlazorComponentMapper _mapper;
+    private readonly AbstBlazorComponentContainer _registry;
 
-    public AbstBlazorComponentFactory(IServiceProvider serviceProvider, AbstBlazorComponentMapper mapper) : base(serviceProvider)
+    public AbstBlazorComponentFactory(IServiceProvider serviceProvider, AbstBlazorComponentMapper mapper, AbstBlazorComponentContainer registry) : base(serviceProvider)
     {
         _fontManager = FontManager;
         _mapper = mapper;
+        _registry = registry;
         _mapper.Map<AbstBlazorWrapPanelComponent, AbstBlazorWrapPanel>();
         _mapper.Map<AbstBlazorPanelComponent, AbstBlazorPanel>();
         _mapper.Map<AbstBlazorTabContainerComponent, AbstBlazorTabContainer>();
@@ -56,7 +58,7 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
     public AbstWrapPanel CreateWrapPanel(AOrientation orientation, string name)
     {
         var panel = new AbstWrapPanel(this);
-        var impl = new AbstBlazorWrapPanelComponent();
+        var impl = new AbstBlazorWrapPanelComponent(_registry, _mapper);
         panel.Init(impl);
         InitComponent(panel);
         panel.Name = name;
@@ -67,7 +69,7 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
     public AbstPanel CreatePanel(string name)
     {
         var panel = new AbstPanel(this);
-        var impl = new AbstBlazorPanelComponent();
+        var impl = new AbstBlazorPanelComponent(_registry, _mapper);
         panel.Init(impl);
         InitComponent(panel);
         panel.Name = name;
@@ -90,7 +92,7 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
     public AbstTabContainer CreateTabContainer(string name)
     {
         var tab = new AbstTabContainer();
-        var impl = new AbstBlazorTabContainerComponent();
+        var impl = new AbstBlazorTabContainerComponent(_registry, _mapper);
         tab.Init(impl);
         InitComponent(tab);
         tab.Name = name;
@@ -111,7 +113,7 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
     public AbstScrollContainer CreateScrollContainer(string name)
     {
         var scroll = new AbstScrollContainer();
-        var impl = new AbstBlazorScrollContainerComponent();
+        var impl = new AbstBlazorScrollContainerComponent(_registry, _mapper);
         scroll.Init(impl);
         InitComponent(scroll);
         scroll.Name = name;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorPanelComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorPanelComponent.cs
@@ -8,14 +8,28 @@ namespace AbstUI.Blazor.Components.Containers;
 
 public class AbstBlazorPanelComponent : AbstBlazorComponentModelBase, IAbstFrameworkPanel, IAbstBlazorRegistryAware
 {
-    private AbstBlazorComponentContainer _registry = default!;
-    private AbstBlazorComponentContainer _children = default!;
+    private AbstBlazorComponentContainer _registry;
+    private readonly AbstBlazorComponentContainer _children;
     private readonly List<IAbstFrameworkLayoutNode> _items = new();
+
+    public AbstBlazorPanelComponent(AbstBlazorComponentContainer registry, AbstBlazorComponentMapper mapper)
+    {
+        _registry = registry;
+        _children = new AbstBlazorComponentContainer(mapper);
+    }
 
     public void AttachRegistry(AbstBlazorComponentContainer registry)
     {
-        _registry = registry;
-        _children = new AbstBlazorComponentContainer(registry.Mapper);
+        if (!ReferenceEquals(_registry, registry))
+        {
+            _registry = registry;
+            foreach (var item in _items)
+            {
+                if (item is IAbstBlazorRegistryAware aware)
+                    aware.AttachRegistry(_registry);
+                _registry.Register(item);
+            }
+        }
     }
 
     public AbstBlazorComponentContainer ChildContainer => _children;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorScrollContainerComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorScrollContainerComponent.cs
@@ -7,14 +7,28 @@ namespace AbstUI.Blazor.Components.Containers;
 
 public class AbstBlazorScrollContainerComponent : AbstBlazorComponentModelBase, IAbstFrameworkScrollContainer, IAbstBlazorRegistryAware
 {
-    private AbstBlazorComponentContainer _registry = default!;
-    private AbstBlazorComponentContainer _children = default!;
+    private AbstBlazorComponentContainer _registry;
+    private readonly AbstBlazorComponentContainer _children;
     private readonly List<IAbstFrameworkLayoutNode> _items = new();
+
+    public AbstBlazorScrollContainerComponent(AbstBlazorComponentContainer registry, AbstBlazorComponentMapper mapper)
+    {
+        _registry = registry;
+        _children = new AbstBlazorComponentContainer(mapper);
+    }
 
     public void AttachRegistry(AbstBlazorComponentContainer registry)
     {
-        _registry = registry;
-        _children = new AbstBlazorComponentContainer(registry.Mapper);
+        if (!ReferenceEquals(_registry, registry))
+        {
+            _registry = registry;
+            foreach (var item in _items)
+            {
+                if (item is IAbstBlazorRegistryAware aware)
+                    aware.AttachRegistry(_registry);
+                _registry.Register(item);
+            }
+        }
     }
 
     public AbstBlazorComponentContainer ChildContainer => _children;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorTabContainerComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorTabContainerComponent.cs
@@ -5,15 +5,32 @@ namespace AbstUI.Blazor.Components.Containers;
 
 public class AbstBlazorTabContainerComponent : AbstBlazorComponentModelBase, IAbstFrameworkTabContainer, IAbstBlazorRegistryAware
 {
-    private AbstBlazorComponentContainer _registry = default!;
-    private AbstBlazorComponentContainer _children = default!;
+    private AbstBlazorComponentContainer _registry;
+    private readonly AbstBlazorComponentContainer _children;
     private readonly List<AbstBlazorTabItemComponent> _tabs = new();
     private int _selectedIndex = -1;
 
-    public void AttachRegistry(AbstBlazorComponentContainer registry)
+    public AbstBlazorTabContainerComponent(AbstBlazorComponentContainer registry, AbstBlazorComponentMapper mapper)
     {
         _registry = registry;
-        _children = new AbstBlazorComponentContainer(registry.Mapper);
+        _children = new AbstBlazorComponentContainer(mapper);
+    }
+
+    public void AttachRegistry(AbstBlazorComponentContainer registry)
+    {
+        if (!ReferenceEquals(_registry, registry))
+        {
+            _registry = registry;
+            foreach (var tab in _tabs)
+            {
+                if (tab.ContentFrameworkNode is { } node)
+                {
+                    if (node is IAbstBlazorRegistryAware aware)
+                        aware.AttachRegistry(_registry);
+                    _registry.Register(node);
+                }
+            }
+        }
     }
 
     public AbstBlazorComponentContainer ChildContainer => _children;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorWrapPanelComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorWrapPanelComponent.cs
@@ -8,14 +8,28 @@ namespace AbstUI.Blazor.Components.Containers;
 
 public class AbstBlazorWrapPanelComponent : AbstBlazorComponentModelBase, IAbstFrameworkWrapPanel, IAbstBlazorRegistryAware
 {
-    private AbstBlazorComponentContainer _registry = default!;
-    private AbstBlazorComponentContainer _children = default!;
+    private AbstBlazorComponentContainer _registry;
+    private readonly AbstBlazorComponentContainer _children;
     private readonly List<IAbstFrameworkNode> _items = new();
+
+    public AbstBlazorWrapPanelComponent(AbstBlazorComponentContainer registry, AbstBlazorComponentMapper mapper)
+    {
+        _registry = registry;
+        _children = new AbstBlazorComponentContainer(mapper);
+    }
 
     public void AttachRegistry(AbstBlazorComponentContainer registry)
     {
-        _registry = registry;
-        _children = new AbstBlazorComponentContainer(registry.Mapper);
+        if (!ReferenceEquals(_registry, registry))
+        {
+            _registry = registry;
+            foreach (var item in _items)
+            {
+                if (item is IAbstBlazorRegistryAware aware)
+                    aware.AttachRegistry(_registry);
+                _registry.Register(item);
+            }
+        }
     }
 
     public AbstBlazorComponentContainer ChildContainer => _children;


### PR DESCRIPTION
## Summary
- ensure `AbstBlazorComponentMapper` and `AbstBlazorComponentContainer` are registered as singletons
- pass mapper and registry into factory and component constructors so components always have a valid registry
- update registry attachment logic to re-register children only when necessary

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/AbstUI.GfxVisualTest.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a6dc30d5848332b2a0bd1b257fd47b