### PR TITLE
Fix SDL glyph atlas blending

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Texts/SdlGlyphAtlas.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Texts/SdlGlyphAtlas.cs
@@ -50,6 +50,13 @@ internal sealed class SdlGlyphAtlas : IDisposable
         if (glyphSurface == nint.Zero)
             return;
 
+        // Ensure the glyph surface uses the same pixel format as the atlas texture
+        // so that channel ordering and alpha data are preserved when copying.
+        nint converted = SDL.SDL_ConvertSurfaceFormat(glyphSurface, SDL.SDL_PIXELFORMAT_RGBA8888, 0);
+        SDL.SDL_FreeSurface(glyphSurface);
+        glyphSurface = converted;
+        SDL.SDL_SetSurfaceBlendMode(glyphSurface, SDL.SDL_BlendMode.SDL_BLENDMODE_NONE);
+
         SDL.SDL_Surface surf = Marshal.PtrToStructure<SDL.SDL_Surface>(glyphSurface);
         int w = surf.w;
         int h = surf.h;


### PR DESCRIPTION
## Summary
- ensure glyph surfaces are converted to RGBA format before copying to the atlas texture
- disable source surface blending to preserve glyph alpha

## Testing
- `dotnet format --verify-no-changes WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/AbstUI.GfxVisualTest.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a6ec0a2a9883329f6a76c995f85976