### PR TITLE
Fix SDL2 component coordinate handling inside containers

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputCombobox.cs
@@ -123,8 +123,8 @@ namespace AbstUI.SDL2.Components.Inputs
             _popup.ItemPressedBackgroundColor = ItemPressedBackgroundColor;
             _popup.ItemPressedBorderColor = ItemPressedBorderColor;
 
-            _popup.X = X;
-            _popup.Y = Y + Height;
+            _popup.X = ComponentContext.X;
+            _popup.Y = ComponentContext.Y + Height;
             _popup.Width = Width;
             int desired = Items.Count * _lineHeight + 2;
             _popup.Height = desired > 200 ? 200 : desired;
@@ -153,7 +153,7 @@ namespace AbstUI.SDL2.Components.Inputs
             ComponentContext.QueueRedraw(this);
         }
 
-        private bool HitTest(int x, int y) => x >= X && x <= X + Width && y >= Y && y <= Y + Height;
+        private bool HitTest(int x, int y) => x >= ComponentContext.X && x <= ComponentContext.X + Width && y >= ComponentContext.Y && y <= ComponentContext.Y + Height;
 
       
         public void SetFocus(bool focus)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputItemList.cs
@@ -109,11 +109,11 @@ namespace AbstUI.SDL2.Components.Inputs
             ref var ev = ref e.Event;
             if (ev.type == SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN && ev.button.button == SDL.SDL_BUTTON_LEFT)
             {
-                if (ev.button.x >= X && ev.button.x <= X + Width &&
-                    ev.button.y >= Y && ev.button.y <= Y + Height)
+                if (ev.button.x >= ComponentContext.X && ev.button.x <= ComponentContext.X + Width &&
+                    ev.button.y >= ComponentContext.Y && ev.button.y <= ComponentContext.Y + Height)
                 {
                     Factory.FocusManager.SetFocus(this);
-                    int idx = (int)((ev.button.y - Y + ScrollVertical) / _lineHeight);
+                    int idx = (int)((ev.button.y - ComponentContext.Y + ScrollVertical) / _lineHeight);
                     if (idx >= 0 && idx < Items.Count)
                     {
                         _pressedIndex = idx;
@@ -134,10 +134,10 @@ namespace AbstUI.SDL2.Components.Inputs
             else if (ev.type == SDL.SDL_EventType.SDL_MOUSEMOTION)
             {
                 int newHover = -1;
-                if (ev.motion.x >= X && ev.motion.x <= X + Width &&
-                    ev.motion.y >= Y && ev.motion.y <= Y + Height)
+                if (ev.motion.x >= ComponentContext.X && ev.motion.x <= ComponentContext.X + Width &&
+                    ev.motion.y >= ComponentContext.Y && ev.motion.y <= ComponentContext.Y + Height)
                 {
-                    newHover = (int)((ev.motion.y - Y + ScrollVertical) / _lineHeight);
+                    newHover = (int)((ev.motion.y - ComponentContext.Y + ScrollVertical) / _lineHeight);
                     if (newHover < 0 || newHover >= Items.Count) newHover = -1;
                 }
                 if (newHover != _hoverIndex)


### PR DESCRIPTION
## Summary
- fix tab container to offset content and events using absolute component context
- position combobox popup using component context and adjust hit testing
- use component context coordinates for input item list events to enable scrolling within containers

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/AbstUI.GfxVisualTest.SDL2.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a6ecfcf498833292edca0262b0687e