### PR TITLE
Add content property synchronization for windows

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorWindow.cs
@@ -68,6 +68,21 @@ internal class AbstBlazorWindow : AbstBlazorPanel, IDisposable, IAbstFrameworkWi
 
     public IAbstKey AbstKey => _abstWindow.Key;
 
+    private IAbstFrameworkNode? _content;
+    public IAbstFrameworkNode? Content
+    {
+        get => _content;
+        set
+        {
+            if (_content == value) return;
+            Component.RemoveAll();
+            _content = value;
+            if (value is IAbstFrameworkLayoutNode layout)
+                Component.AddItem(layout);
+            _lingoWindow.SetContentFromFW(value);
+        }
+    }
+
     public AbstBlazorWindow(IAbstWindow window, AbstBlazorComponentFactory factory)
     {
         _lingoWindow = (IAbstWindowInternal)window;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiWindow.cs
@@ -67,6 +67,21 @@ internal class AbstImGuiWindow : AbstImGuiPanel, IAbstFrameworkWindow, IDisposab
         set => base.BackgroundColor = value;
     }
 
+    private IAbstFrameworkNode? _content;
+    public IAbstFrameworkNode? Content
+    {
+        get => _content;
+        set
+        {
+            if (_content == value) return;
+            RemoveAll();
+            _content = value;
+            if (value is IAbstFrameworkLayoutNode layout)
+                AddItem(layout);
+            _lingoWindow.SetContentFromFW(value);
+        }
+    }
+
 
     public void OnResize(int width, int height)
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Windowing/BaseGodotWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Windowing/BaseGodotWindow.cs
@@ -66,6 +66,22 @@ namespace AbstEngine.Director.LGodot
         public IAbstMouse<AbstMouseEvent> MouseT => (IAbstMouse < AbstMouseEvent > )_window.Mouse;
         public IAbstKey AbstKey => _window.Key;
 
+        private IAbstFrameworkNode? _content;
+        public IAbstFrameworkNode? Content
+        {
+            get => _content;
+            set
+            {
+                if (_content == value) return;
+                if (_content?.FrameworkNode is Node oldNode)
+                    RemoveChild(oldNode);
+                _content = value;
+                if (_content?.FrameworkNode is Node newNode)
+                    AddChild(newNode);
+                _window.SetContentFromFW(value);
+            }
+        }
+
         string IAbstFrameworkNode.Name { get => Name; set => Name = value; }
         public bool Visibility { get => Visible; set => Visible = value; }
         public float Width

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlWindow.cs
@@ -7,6 +7,7 @@ using AbstUI.SDL2.Styles;
 using AbstUI.SDL2.SDLL;
 using AbstUI.SDL2.Events;
 using AbstUI.SDL2.Core;
+using AbstUI.Components;
 
 namespace AbstUI.SDL2.Components.Containers;
 
@@ -80,6 +81,21 @@ public class AbstSdlWindow : AbstSdlPanel, IAbstFrameworkWindow, IHandleSdlEvent
     public IAbstMouse Mouse => _abstWindow.Mouse;
 
     public IAbstKey AbstKey => _abstWindow.Key;
+
+    private IAbstFrameworkNode? _content;
+    public IAbstFrameworkNode? Content
+    {
+        get => _content;
+        set
+        {
+            if (_content == value) return;
+            RemoveAll();
+            _content = value;
+            if (value is IAbstFrameworkLayoutNode layout)
+                AddItem(layout);
+            _abstWindow.SetContentFromFW(value);
+        }
+    }
 
     public AbstSdlWindow(AbstSdlComponentFactory factory) : base(factory)
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Windowing/IAbstFrameworkWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Windowing/IAbstFrameworkWindow.cs
@@ -20,6 +20,8 @@ namespace AbstUI.Windowing
         IAbstMouse Mouse { get; }
         IAbstKey AbstKey { get; }
 
+        IAbstFrameworkNode? Content { get; set; }
+
         //IAbstMouse Mouse { get; }
         //IAbstKey Key { get; }
         void OpenWindow();

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Windowing/IAbstWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Windowing/IAbstWindow.cs
@@ -1,4 +1,5 @@
 using AbstUI.Inputs;
+using AbstUI.Components;
 
 namespace AbstUI.Windowing;
 
@@ -18,6 +19,7 @@ public interface IAbstWindow : IAbstMouseRectProvider
 
     IAbstFrameworkWindow FrameworkObj { get; }
     int WindowTitleHeight { get; set; }
+    IAbstNode? Content { get; set; }
 
     void Init(IAbstFrameworkWindow frameworkWindow);
     void OpenWindow();


### PR DESCRIPTION
## Summary
- add `Content` property to `IAbstWindow` and `IAbstFrameworkWindow`
- synchronize window content between engine and frameworks
- prevent infinite content sync loops by checking existing content
- implement framework-side content handling for SDL2, Godot, Blazor and ImGui windows

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI/Windowing/AbstWindow.cs --verify-no-changes --verbosity diagnostic`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`
- ⚠️ `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj` (fails: numerous missing types)


------
https://chatgpt.com/codex/tasks/task_e_68a6f1496d448332b6aff329ca40a23a