### PR TITLE
Fix SDL2 UI component interactions and positioning

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Base/AbstSdlComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Base/AbstSdlComponent.cs
@@ -9,10 +9,10 @@ namespace AbstUI.SDL2.Components.Base;
 /// </summary>
 public abstract class AbstSdlComponent : IAbstSDLComponent, IDisposable
 {
-    protected AbstSdlComponent(AbstSdlComponentFactory factory)
+    protected AbstSdlComponent(AbstSdlComponentFactory factory, AbstSDLComponentContext? parent = null)
     {
         Factory = factory;
-        ComponentContext = factory.CreateContext(this);
+        ComponentContext = factory.CreateContext(this, parent);
         ComponentContext.Visible = _visibility;
     }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlScrollViewer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlScrollViewer.cs
@@ -10,10 +10,10 @@ using static AbstUI.SDL2.SDLL.SDL;
 
 namespace AbstUI.SDL2.Components.Containers
 {
-   
+
     internal abstract class AbstSdlScrollViewer : AbstSdlComponent, IHandleSdlEvent, IDisposable
     {
-        protected AbstSdlScrollViewer(AbstSdlComponentFactory factory) : base(factory)
+        protected AbstSdlScrollViewer(AbstSdlComponentFactory factory, AbstSDLComponentContext? parent = null) : base(factory, parent)
         {
         }
 
@@ -21,7 +21,7 @@ namespace AbstUI.SDL2.Components.Containers
         public float ScrollHorizontal { get; set; }
         public float ScrollVertical { get; set; }
         public bool ClipContents { get; set; } = true;
-        public AbstScrollbarMode ScollbarModeH { get; set; }  = AbstScrollbarMode.Auto;
+        public AbstScrollbarMode ScollbarModeH { get; set; } = AbstScrollbarMode.Auto;
         public AbstScrollbarMode ScollbarModeV { get; set; } = AbstScrollbarMode.Auto;
         protected float ContentWidth { get; set; }
         protected float ContentHeight { get; set; }
@@ -71,7 +71,7 @@ namespace AbstUI.SDL2.Components.Containers
             _maxScrollV = MathF.Max(0, ContentHeight - viewH);
             var showHScrollBar = ScollbarModeH == AbstScrollbarMode.AlwaysVisible || (ScollbarModeH == AbstScrollbarMode.Auto && _maxScrollH > 0);
             var showVScrollBar = ScollbarModeV == AbstScrollbarMode.AlwaysVisible || (ScollbarModeV == AbstScrollbarMode.Auto && _maxScrollV > 0);
-            
+
 
             if (ScrollHorizontal < 0) ScrollHorizontal = 0; else if (ScrollHorizontal > _maxScrollH) ScrollHorizontal = _maxScrollH;
             if (ScrollVertical < 0) ScrollVertical = 0; else if (ScrollVertical > _maxScrollV) ScrollVertical = _maxScrollV;
@@ -114,14 +114,14 @@ namespace AbstUI.SDL2.Components.Containers
 
                 // Draw bg scrollbars
                 SDL.SDL_SetRenderDrawColor(context.Renderer, Color_Bars_Bg.R, Color_Bars_Bg.G, Color_Bars_Bg.B, Color_Bars_Bg.A);
-               
+
                 SDL.SDL_Rect hbar = new SDL.SDL_Rect { x = 0, y = h - sbSize, w = viewW, h = sbSize };
                 if (showHScrollBar)
                     SDL.SDL_RenderFillRect(context.Renderer, ref hbar);
                 SDL.SDL_Rect vbar = new SDL.SDL_Rect { x = w - sbSize, y = 0, w = sbSize, h = viewH };
                 if (showVScrollBar)
                     SDL.SDL_RenderFillRect(context.Renderer, ref vbar);
-                
+
                 SDL.SDL_Rect corner = new SDL.SDL_Rect { x = w - sbSize, y = h - sbSize, w = sbSize, h = sbSize };
                 SDL.SDL_RenderFillRect(context.Renderer, ref corner);
 
@@ -139,7 +139,7 @@ namespace AbstUI.SDL2.Components.Containers
                     SDL.SDL_Rect vhandle = new SDL.SDL_Rect { x = w - sbSize + 2, y = (int)(arrowSize + vPos) + 2, w = sbSize - 4, h = (int)_handleH - 4 };
                     SDL.SDL_RenderFillRect(context.Renderer, ref vhandle);
                 }
-                
+
                 // draw arrows
                 SDL.SDL_SetRenderDrawColor(context.Renderer, Color_Handle.R, Color_Handle.G, Color_Handle.B, Color_Handle.A);
                 int cx = w - sbSize / 2;
@@ -159,13 +159,13 @@ namespace AbstUI.SDL2.Components.Containers
                     for (int i = 0; i < ah; i++)
                         SDL.SDL_RenderDrawLine(context.Renderer, cx - i, viewH - 3 - i, cx + i, viewH - 3 - i);
                 }
-               
+
                 SDL.SDL_SetRenderDrawColor(context.Renderer, Color_ScollBorder.R, Color_ScollBorder.G, Color_ScollBorder.B, Color_ScollBorder.A);
                 if (showHScrollBar)
                     SDL.SDL_RenderDrawRect(context.Renderer, ref hbar);
                 if (showVScrollBar)
                     SDL.SDL_RenderDrawRect(context.Renderer, ref vbar);
-               
+
                 SDL.SDL_RenderDrawRect(context.Renderer, ref corner);
 
                 SDL.SDL_SetRenderTarget(context.Renderer, prevTarget);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlTabContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlTabContainer.cs
@@ -109,7 +109,7 @@ namespace AbstUI.SDL2.Components.Containers
             EnsureResources(context);
             int w = (int)Width;
             int h = (int)Height;
-            
+
 
             bool needRender = _texture == nint.Zero || _texW != w || _texH != h;
             if (needRender)
@@ -198,8 +198,8 @@ namespace AbstUI.SDL2.Components.Containers
                     var ctx = comp.ComponentContext;
                     var oldOffX = ctx.OffsetX;
                     var oldOffY = ctx.OffsetY;
-                    ctx.OffsetX += -ComponentContext.X + BorderThickness;
-                    ctx.OffsetY += -ComponentContext.Y - _tabHeight + BorderThickness;
+                    ctx.OffsetX += BorderThickness;
+                    ctx.OffsetY += _tabHeight + BorderThickness;
                     ctx.RenderToTexture(context);
                     ctx.OffsetX = oldOffX;
                     ctx.OffsetY = oldOffY;
@@ -262,7 +262,7 @@ namespace AbstUI.SDL2.Components.Containers
                     }
                     break;
             }
-    
+
             // Forward mouse events to children accounting for current scroll offset
 
             for (int i = _children.Count - 1; i >= 0 && !e.StopPropagation; i--)
@@ -271,10 +271,10 @@ namespace AbstUI.SDL2.Components.Containers
                     comp is not IHandleSdlEvent handler ||
                     !comp.Visibility)
                     continue;
-                ContainerHelpers.HandleChildEvents(comp, e, -(int)ComponentContext.X, -(int)(ComponentContext.Y + _tabHeight));
+                ContainerHelpers.HandleChildEvents(comp, e, -(int)(ComponentContext.X + BorderThickness), -(int)(ComponentContext.Y + _tabHeight + BorderThickness));
             }
         }
-        
+
 
 
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputItemList.cs
@@ -20,7 +20,7 @@ namespace AbstUI.SDL2.Components.Inputs
         private int _hoverIndex = -1;
         private int _pressedIndex = -1;
 
-        public AbstSdlInputItemList(AbstSdlComponentFactory factory) : base(factory)
+        public AbstSdlInputItemList(AbstSdlComponentFactory factory, AbstSDLComponentContext? parent = null) : base(factory, parent)
         {
         }
 
@@ -109,8 +109,12 @@ namespace AbstUI.SDL2.Components.Inputs
             ref var ev = ref e.Event;
             if (ev.type == SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN && ev.button.button == SDL.SDL_BUTTON_LEFT)
             {
-                if (ev.button.x >= ComponentContext.X && ev.button.x <= ComponentContext.X + Width &&
-                    ev.button.y >= ComponentContext.Y && ev.button.y <= ComponentContext.Y + Height)
+                const int sbSize = 16;
+                int viewW = (int)Width - sbSize;
+                int viewH = (int)Height - sbSize;
+                bool inside = ev.button.x >= ComponentContext.X && ev.button.x <= ComponentContext.X + viewW &&
+                              ev.button.y >= ComponentContext.Y && ev.button.y <= ComponentContext.Y + viewH;
+                if (inside)
                 {
                     Factory.FocusManager.SetFocus(this);
                     int idx = (int)((ev.button.y - ComponentContext.Y + ScrollVertical) / _lineHeight);
@@ -133,9 +137,12 @@ namespace AbstUI.SDL2.Components.Inputs
             }
             else if (ev.type == SDL.SDL_EventType.SDL_MOUSEMOTION)
             {
+                const int sbSize = 16;
+                int viewW = (int)Width - sbSize;
+                int viewH = (int)Height - sbSize;
                 int newHover = -1;
-                if (ev.motion.x >= ComponentContext.X && ev.motion.x <= ComponentContext.X + Width &&
-                    ev.motion.y >= ComponentContext.Y && ev.motion.y <= ComponentContext.Y + Height)
+                if (ev.motion.x >= ComponentContext.X && ev.motion.x <= ComponentContext.X + viewW &&
+                    ev.motion.y >= ComponentContext.Y && ev.motion.y <= ComponentContext.Y + viewH)
                 {
                     newHover = (int)((ev.motion.y - ComponentContext.Y + ScrollVertical) / _lineHeight);
                     if (newHover < 0 || newHover >= Items.Count) newHover = -1;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlSelectableCollection.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlSelectableCollection.cs
@@ -12,7 +12,7 @@ namespace AbstUI.SDL2.Components.Inputs
 {
     internal abstract class AbstSdlSelectableCollection : AbstSdlScrollViewer, IAbstSdlHasSelectableCollectionStyle
     {
-        protected AbstSdlSelectableCollection(AbstSdlComponentFactory factory) : base(factory)
+        protected AbstSdlSelectableCollection(AbstSdlComponentFactory factory, AbstSDLComponentContext? parent = null) : base(factory, parent)
         {
         }
 


### PR DESCRIPTION
## Summary
- make SDL2 input slider respond to mouse dragging
- position combobox popup relative to parent and follow scrolling
- prevent list scrollbars from triggering selections and align tab content within container

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/AbstUI.GfxVisualTest.SDL2.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a6fe51d7a08332b8574c9358a3488f