### PR TITLE
Fix castLib save translation and charToNum support

### DIFF
--- a/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
@@ -1220,4 +1220,23 @@ end",
         var prop = Assert.Single(batch.Properties["Example"].Where(p => p.Name == "myProp"));
         Assert.Equal("int", prop.Type);
     }
+
+    [Fact]
+    public void CastLibSaveIsConverted()
+    {
+        var result = _converter.Convert("castLib(\"scores\").save()");
+        Assert.Equal("CastLib(\"scores\").Save();", result.Trim());
+    }
+
+    [Fact]
+    public void CharToNumIsConverted()
+    {
+        var lingo = "if the key.charToNum = 8 then\nend if";
+        var result = _converter.Convert(lingo);
+        var expected = string.Join('\n',
+            "if (_Key.Key.CharToNum() == 8)",
+            "{",
+            "}");
+        Assert.Equal(expected.Trim(), result.Replace("\r", "").Trim());
+    }
 }

--- a/Test/LingoEngine.Lingo.Tests/StringExtensionsTests.cs
+++ b/Test/LingoEngine.Lingo.Tests/StringExtensionsTests.cs
@@ -1,0 +1,13 @@
+using LingoEngine.Primitives;
+using Xunit;
+
+public class StringExtensionsTests
+{
+    [Theory]
+    [InlineData("A", 65)]
+    [InlineData("", 0)]
+    public void CharToNumReturnsAscii(string input, int expected)
+    {
+        Assert.Equal(expected, input.CharToNum());
+    }
+}

--- a/src/LingoEngine.Lingo.Core/CSharpWriter.MethodCall.cs
+++ b/src/LingoEngine.Lingo.Core/CSharpWriter.MethodCall.cs
@@ -240,10 +240,39 @@ public partial class CSharpWriter
             }
         }
 
-        node.Callee.Accept(this);
+        WriteCallExpr(node);
+        AppendLine(";");
+    }
+
+    private void WriteCallExpr(LingoCallNode node)
+    {
+        if (node.Callee is LingoVarNode func)
+        {
+            var name = func.VarName;
+            if (name.Equals("castLib", StringComparison.OrdinalIgnoreCase))
+                Append("CastLib");
+            else
+                Append(name);
+        }
+        else
+        {
+            node.Callee.Accept(this);
+        }
         Append("(");
         node.Arguments.Accept(this);
-        AppendLine(");");
+        Append(")");
+    }
+
+    private void WriteObjCallExpr(LingoObjCallNode node)
+    {
+        var name = node.Name.Value.AsString();
+        if (name.Equals("castLib", StringComparison.OrdinalIgnoreCase))
+            Append("CastLib");
+        else
+            Append(name);
+        Append("(");
+        node.ArgList.Accept(this);
+        Append(")");
     }
 }
 

--- a/src/LingoEngine.Lingo.Core/CSharpWriter.PropertyVisitors.cs
+++ b/src/LingoEngine.Lingo.Core/CSharpWriter.PropertyVisitors.cs
@@ -8,6 +8,13 @@ public partial class CSharpWriter
 {
     public void Visit(LingoObjPropExprNode node)
     {
+        if (node.Property is LingoVarNode prop && prop.VarName.Equals("charToNum", StringComparison.OrdinalIgnoreCase))
+        {
+            node.Object.Accept(this);
+            Append(".CharToNum()");
+            return;
+        }
+
         if (node.Object is LingoMemberExprNode member &&
             node.Property is LingoVarNode propVarText)
         {

--- a/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
+++ b/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
@@ -31,6 +31,15 @@ public class LingoToCSharpConverter
             return $"GetMember<ILingoMemberTextBase>(\"{match.Groups["name"].Value}\").{pascal}";
         }
 
+        match = System.Text.RegularExpressions.Regex.Match(
+            trimmed,
+            @"^castLib\s*\(\s*(?<arg>[^\)]+)\s*\)\.save\s*\(\s*\)\s*$",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        if (match.Success)
+        {
+            return $"CastLib({match.Groups["arg"].Value}).Save();";
+        }
+
         if (TryConvertNewMember(trimmed, out var converted))
             return converted;
 

--- a/src/LingoEngine/Primitives/StringExtensions.cs
+++ b/src/LingoEngine/Primitives/StringExtensions.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.Primitives;
+
+public static class StringExtensions
+{
+    public static int CharToNum(this string value)
+        => string.IsNullOrEmpty(value) ? 0 : value[0];
+}


### PR DESCRIPTION
## Summary
- handle castLib(...).save() conversion directly
- expose CharToNum string helper and map it in converter
- test CharToNum and CastLib.Save conversion

## Testing
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj` *(fails: Unable to load shared library 'SDL2')*


------
https://chatgpt.com/codex/tasks/task_e_68a7048d49f0833292fa5a4185732cc1