### PR TITLE
feat: add shared texture base with subscription

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Bitmaps/ImGuiTexture2D.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Bitmaps/ImGuiTexture2D.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using AbstUI.Bitmaps;
 using AbstUI.Primitives;
 
 namespace AbstUI.ImGui.Bitmaps;
@@ -7,44 +7,21 @@ namespace AbstUI.ImGui.Bitmaps;
 /// <summary>
 /// Minimal texture wrapper with no native dependencies.
 /// </summary>
-public class ImGuiTexture2D : IAbstTexture2D
+public class ImGuiTexture2D : AbstBaseTexture2D<nint>
 {
     public nint Handle { get; private set; }
-    public int Width { get; }
-    public int Height { get; }
-    public bool IsDisposed { get; private set; }
-    public string Name { get; set; } = "";
+    public override int Width { get; }
+    public override int Height { get; }
 
-    private readonly Dictionary<object, TextureSubscription> _users = new();
-
-    public ImGuiTexture2D(nint texture, int width, int height, string name = "")
+    public ImGuiTexture2D(nint texture, int width, int height, string name = "") : base(name)
     {
         Handle = texture;
         Width = width;
         Height = height;
-        Name = name;
     }
 
-    public IAbstUITextureUserSubscription AddUser(object user)
+    protected override void DisposeTexture()
     {
-        if (IsDisposed) throw new Exception("Texture is disposed and cannot be used anymore.");
-        var sub = new TextureSubscription(this, () => RemoveUser(user));
-        _users.Add(user, sub);
-        return sub;
-    }
-
-    private void RemoveUser(object user)
-    {
-        _users.Remove(user);
-        if (_users.Count == 0 && Handle != nint.Zero)
-            Dispose();
-    }
-
-    public void Dispose()
-    {
-        if (IsDisposed)
-            return;
-        IsDisposed = true;
         Handle = nint.Zero;
         // TODO: release texture resources
     }
@@ -65,19 +42,4 @@ public class ImGuiTexture2D : IAbstTexture2D
     public static void DebugToDisk(nint renderer, nint texture, string fileName) => throw new NotImplementedException();
     public static void DebugToDisk(nint renderer, nint texture, string folder, string fileName) => throw new NotImplementedException();
 #endif
-
-    private class TextureSubscription : IAbstUITextureUserSubscription
-    {
-        private readonly Action _onRelease;
-        public IAbstTexture2D Texture { get; }
-
-        public TextureSubscription(ImGuiTexture2D texture, Action onRelease)
-        {
-            Texture = texture;
-            _onRelease = onRelease;
-        }
-
-        public void Release() => _onRelease();
-    }
 }
-

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Bitmaps/AbstGodotImageTexture.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Bitmaps/AbstGodotImageTexture.cs
@@ -1,49 +1,28 @@
+using AbstUI.Bitmaps;
 using AbstUI.Primitives;
 using Godot;
 
 namespace AbstUI.LGodot.Bitmaps;
 
-public class AbstGodotTexture2D : IAbstTexture2D
+public class AbstGodotTexture2D : AbstBaseTexture2D<Texture2D>
 {
     private readonly Texture2D _texture;
     public Texture2D Texture => _texture;
 
-    private readonly Dictionary<object, TextureSubscription> _users = new();
-    public string Name { get; set; } = "";
-    public AbstGodotTexture2D(Texture2D imageTexture)
+    public AbstGodotTexture2D(Texture2D imageTexture, string name = "") : base(name)
     {
         _texture = imageTexture;
     }
 
-    public int Width => _texture.GetWidth();
+    public override int Width => _texture.GetWidth();
 
-    public int Height => _texture._GetHeight();
+    public override int Height => _texture._GetHeight();
 
-    public bool IsDisposed { get; private set; }
-
-    public IAbstUITextureUserSubscription AddUser(object user)
+    protected override void DisposeTexture()
     {
-        if (IsDisposed)
-            throw new Exception("Texture is disposed and cannot be used anymore.");
-        var sub = new TextureSubscription(this, () => RemoveUser(user));
-        _users.Add(user, sub);
-        return sub;
-    }
-
-    private void RemoveUser(object user)
-    {
-        _users.Remove(user);
-        if (_users.Count == 0 && !IsDisposed)
-            Dispose();
-    }
-
-    public void Dispose()
-    {
-        if (IsDisposed)
-            return;
-        IsDisposed = true;
         _texture.Dispose();
     }
+
     public IAbstTexture2D Clone()
     {
         // Get the pixel data from the existing texture
@@ -52,17 +31,4 @@ public class AbstGodotTexture2D : IAbstTexture2D
 
         return new AbstGodotTexture2D(newTex);
     }
-    private class TextureSubscription : IAbstUITextureUserSubscription
-    {
-        private readonly Action _onRelease;
-        public IAbstTexture2D Texture { get; }
-        public TextureSubscription(IAbstTexture2D texture, Action onRelease)
-        {
-            _onRelease = onRelease;
-            Texture = texture;
-        }
-
-        public void Release() => _onRelease();
-    }
 }
-

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Bitmaps/UnityImageTexture.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Bitmaps/UnityImageTexture.cs
@@ -1,26 +1,20 @@
+using AbstUI.Bitmaps;
 using AbstUI.Primitives;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace AbstUI.LUnity.Bitmaps;
 
-public class UnityTexture2D : IAbstTexture2D
+public class UnityTexture2D : AbstBaseTexture2D<Texture2D>
 {
     public Texture2D? Texture { get; private set; }
 
-    private readonly Dictionary<object, TextureSubscription> _users = new();
-    public string Name { get; set; } = string.Empty;
-
-    public UnityTexture2D(Texture2D texture, string name = "")
+    public UnityTexture2D(Texture2D texture, string name = "") : base(name)
     {
         Texture = texture;
-        Name = name;
     }
 
-    public int Width => Texture!.width;
-    public int Height => Texture!.height;
-
-    public bool IsDisposed => throw new NotImplementedException();
+    public override int Width => Texture?.width ?? 0;
+    public override int Height => Texture?.height ?? 0;
 
     public Sprite? ToSprite()
     {
@@ -29,40 +23,12 @@ public class UnityTexture2D : IAbstTexture2D
         return Sprite.Create(Texture, new Rect(0, 0, Texture.width, Texture.height), new Vector2(0.5f, 0.5f));
     }
 
-
-    public IAbstUITextureUserSubscription AddUser(object user)
+    protected override void DisposeTexture()
     {
-        var sub = new TextureSubscription(this, () => RemoveUser(user));
-        _users.Add(user, sub);
-        return sub;
-    }
-
-    private void RemoveUser(object user)
-    {
-        _users.Remove(user);
-        if (_users.Count == 0 && Texture != null)
+        if (Texture != null)
         {
             UnityEngine.Object.Destroy(Texture);
             Texture = null;
         }
-    }
-
-    public void Dispose()
-    {
-        throw new NotImplementedException();
-    }
-
-    private class TextureSubscription : IAbstUITextureUserSubscription
-    {
-        private readonly Action _onRelease;
-        public IAbstTexture2D Texture { get; }
-        public TextureSubscription(IAbstTexture2D texture, Action onRelease)
-        {
-            _onRelease = onRelease;
-            Texture = texture;
-        }
-
-
-        public void Release() => _onRelease();
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Bitmaps/AbstBaseTexture2D.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Bitmaps/AbstBaseTexture2D.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Primitives;
+
+namespace AbstUI.Bitmaps;
+
+public abstract class AbstBaseTexture2D<TFrameworkTexture> : IAbstTexture2D
+{
+    private readonly Dictionary<object, TextureSubscription> _users = new();
+
+    protected AbstBaseTexture2D(string name = "")
+    {
+        Name = name;
+    }
+
+    public abstract int Width { get; }
+    public abstract int Height { get; }
+    public bool IsDisposed { get; private set; }
+    public string Name { get; set; }
+
+    public IAbstUITextureUserSubscription AddUser(object user)
+    {
+        if (IsDisposed)
+            throw new Exception("Texture is disposed and cannot be used anymore.");
+        var sub = new TextureSubscription(this, () => RemoveUser(user));
+        _users.Add(user, sub);
+        return sub;
+    }
+
+    protected virtual void RemoveUser(object user)
+    {
+        _users.Remove(user);
+        if (_users.Count == 0 && !IsDisposed)
+            Dispose();
+    }
+
+    public void Dispose()
+    {
+        if (IsDisposed)
+            return;
+        IsDisposed = true;
+        DisposeTexture();
+    }
+
+    protected abstract void DisposeTexture();
+
+    protected class TextureSubscription : IAbstUITextureUserSubscription
+    {
+        private readonly Action _onRelease;
+        public AbstBaseTexture2D<TFrameworkTexture> Texture { get; }
+        IAbstTexture2D IAbstUITextureUserSubscription.Texture => Texture;
+
+        public TextureSubscription(AbstBaseTexture2D<TFrameworkTexture> texture, Action onRelease)
+        {
+            Texture = texture;
+            _onRelease = onRelease;
+        }
+
+        public void Release() => _onRelease();
+    }
+}
+


### PR DESCRIPTION
## Summary
- centralize texture user management in new `AbstBaseTexture2D`
- update Blazor, Godot, ImGui, SDL2 and Unity textures to inherit from the shared base
- restore descriptive comments in SDL and Godot texture implementations

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj` *(fails: type or namespace name 'AbstGfxCanvas' could not be found, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f0dcd0808332acdfa37498c941a3