### PR TITLE
Add fast path to AbstMarkdownRenderer

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/Docs/MarkDownRenderer.md
+++ b/WillMoveToOwnRepo/AbstUI/Docs/MarkDownRenderer.md
@@ -41,12 +41,17 @@ This paragraph uses a predefined style.
 {{/STYLE}}
 ```
 
-Styles are provided when creating the renderer:
+Styles are supplied when preparing the renderer:
 
 ```csharp
 var styles = new Dictionary<string, AbstTextStyle>
 {
     ["quote"] = new AbstTextStyle { FontSize = 14, MarginLeft = 20, Italic = true }
 };
-var renderer = new AbstMarkdownRenderer(canvas, fontManager, imageLoader, styles);
+var renderer = new AbstMarkdownRenderer(fontManager, imageLoader);
+renderer.SetText(markdown, styles);
+renderer.Render(canvas, new APoint(0, 0));
 ```
+
+When only one style is provided and the text has no special tags, `DoFastRendering`
+is enabled and the renderer draws the text in a single fast pass.

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstMarkdownRendererTests.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstMarkdownRendererTests.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using AbstUI.Components.Graphics;
+using AbstUI.Styles;
+using AbstUI.Texts;
+using AbstUI.Primitives;
+
+namespace AbstUI.Tests;
+
+public class AbstMarkdownRendererTests
+{
+    private class TestFontManager : IAbstFontManager
+    {
+        private readonly int _topIndent;
+
+        public TestFontManager(int topIndent = 0)
+            => _topIndent = topIndent;
+
+        public IAbstFontManager AddFont(string name, string pathAndName) => this;
+        public void LoadAll() { }
+        public T? Get<T>(string name) where T : class => null;
+        public T GetDefaultFont<T>() where T : class => null!;
+        public void SetDefaultFont<T>(T font) where T : class { }
+        public IEnumerable<string> GetAllNames() => System.Array.Empty<string>();
+        public float MeasureTextWidth(string text, string fontName, int fontSize) => text.Length * fontSize;
+        public FontInfo GetFontInfo(string fontName, int fontSize) => new(fontSize, _topIndent);
+    }
+
+    private class RecordingCanvas : IAbstFrameworkGfxCanvas
+    {
+        public List<APoint> TextPositions { get; } = new();
+
+        public bool Pixilated { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public bool Visibility { get; set; } = true;
+        public float Width { get; set; }
+        public float Height { get; set; }
+        public AMargin Margin { get; set; }
+        public float X { get; set; }
+        public float Y { get; set; }
+        public object FrameworkNode => this;
+
+        public void Clear(AColor color) { }
+        public void SetPixel(APoint point, AColor color) { }
+        public void DrawLine(APoint start, APoint end, AColor color, float width = 1) { }
+        public void DrawRect(ARect rect, AColor color, bool filled = true, float width = 1) { }
+        public void DrawCircle(APoint center, float radius, AColor color, bool filled = true, float width = 1) { }
+        public void DrawArc(APoint center, float radius, float startDeg, float endDeg, int segments, AColor color, float width = 1) { }
+        public void DrawPolygon(IReadOnlyList<APoint> points, AColor color, bool filled = true, float width = 1) { }
+        public void DrawText(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, AbstTextAlignment alignment = default)
+            => TextPositions.Add(position);
+        public void DrawPicture(byte[] data, int width, int height, APoint position, APixelFormat format) { }
+        public void DrawPicture(IAbstTexture2D texture, int width, int height, APoint position) { }
+        public void Dispose() { }
+    }
+
+    private static AbstMarkdownRenderer CreateRenderer(int topIndent = 0)
+        => new(new TestFontManager(topIndent));
+
+    private static AbstTextStyle CreateDefaultStyle()
+        => new() { Name = "default", Font = "Arial", FontSize = 12, Color = AColors.Black };
+
+    [Fact]
+    public void DoFastRendering_True_ForPlainTextWithSingleStyle()
+    {
+        var renderer = CreateRenderer();
+        renderer.SetText("Hello world", new[] { CreateDefaultStyle() });
+        Assert.True(renderer.DoFastRendering);
+    }
+
+    [Fact]
+    public void DoFastRendering_False_WhenSpecialTagsPresent()
+    {
+        var renderer = CreateRenderer();
+        renderer.SetText("# Heading", new[] { CreateDefaultStyle() });
+        Assert.False(renderer.DoFastRendering);
+    }
+
+    [Fact]
+    public void DoFastRendering_False_WithMultipleStyles()
+    {
+        var renderer = CreateRenderer();
+        var styles = new[]
+        {
+            CreateDefaultStyle(),
+            new AbstTextStyle { Name = "other", Font = "Arial", FontSize = 12 }
+        };
+        renderer.SetText("Hello world", styles);
+        Assert.False(renderer.DoFastRendering);
+    }
+
+    [Fact]
+    public void FastRender_SingleLine_UsesTopIndentation()
+    {
+        var renderer = CreateRenderer(topIndent: 4);
+        var style = CreateDefaultStyle();
+        renderer.SetText("Hello world", new[] { style });
+        Assert.True(renderer.DoFastRendering);
+
+        var recording = new RecordingCanvas();
+        var canvas = new AbstGfxCanvas();
+        canvas.Init(recording);
+
+        var start = new APoint(0, 20);
+        renderer.Render(canvas, start);
+
+        Assert.Single(recording.TextPositions);
+        Assert.Equal(start.Y - 4, recording.TextPositions[0].Y);
+    }
+
+    [Fact]
+    public void FastRender_MultiLine_ComputesLinePositions()
+    {
+        var renderer = CreateRenderer(topIndent: 4);
+        var style = CreateDefaultStyle();
+        renderer.SetText("Line1\nLine2\nLine3", new[] { style });
+        Assert.True(renderer.DoFastRendering);
+
+        var recording = new RecordingCanvas();
+        var canvas = new AbstGfxCanvas();
+        canvas.Init(recording);
+
+        var start = new APoint(0, 20);
+        renderer.Render(canvas, start);
+
+        Assert.Equal(3, recording.TextPositions.Count);
+        int lineHeight = style.FontSize + 4;
+        Assert.Equal(start.Y - 4, recording.TextPositions[0].Y);
+        Assert.Equal(start.Y + lineHeight, recording.TextPositions[1].Y);
+    }
+
+    [Fact]
+    public void SlowRender_SingleLine_UsesTopIndentation()
+    {
+        var renderer = CreateRenderer(topIndent: 4);
+        var style = CreateDefaultStyle();
+        renderer.SetText("Hello#", new[] { style });
+        Assert.False(renderer.DoFastRendering);
+
+        var recording = new RecordingCanvas();
+        var canvas = new AbstGfxCanvas();
+        canvas.Init(recording);
+
+        var start = new APoint(0, 20);
+        renderer.Render(canvas, start);
+
+        Assert.Single(recording.TextPositions);
+        Assert.Equal(start.Y - 4, recording.TextPositions[0].Y);
+    }
+
+    [Fact]
+    public void SlowRender_MultiLine_ComputesLinePositions()
+    {
+        var renderer = CreateRenderer(topIndent: 4);
+        var style = CreateDefaultStyle();
+        renderer.SetText("Line1#\nLine2\nLine3", new[] { style });
+        Assert.False(renderer.DoFastRendering);
+
+        var recording = new RecordingCanvas();
+        var canvas = new AbstGfxCanvas();
+        canvas.Init(recording);
+
+        var start = new APoint(0, 20);
+        renderer.Render(canvas, start);
+
+        Assert.Equal(3, recording.TextPositions.Count);
+        int lineHeight = style.FontSize + 4;
+        Assert.Equal(start.Y - 4, recording.TextPositions[0].Y);
+        Assert.Equal(start.Y + lineHeight, recording.TextPositions[1].Y);
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/AbstUI/AbstUI.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- separate text/style setup from rendering
- add `DoFastRendering` to quickly draw plain text
- replace regex-based detection with faster `HasSpecialTags`
- document new API and fast rendering behavior
- add unit tests ensuring fast path only activates for plain text with a single style
- add tests validating line indentation for fast and slow rendering paths

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj --include WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstMarkdownRendererTests.cs -v normal`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a7efb4e6748332a48494b4a2a6373a