### PR TITLE
Add Unity state button and windowing scaffolding

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUIUnitySetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUIUnitySetup.cs
@@ -16,7 +16,9 @@ namespace AbstUI.LUnity
                 .AddSingleton<IAbstFontManager, UnityFontManager>()
                 .AddSingleton<IAbstStyleManager, AbstStyleManager>()
                 .AddSingleton<IAbstComponentFactory, AbstUnityComponentFactory>()
+                .AddSingleton<IAbstFrameworkWindowManager, AbstUnityWindowManager>()
                 .AddSingleton<IAbstFrameworkMainWindow, AbstUnityMainWindow>()
+                .AddTransient<IAbstFrameworkDialog, AbstUnityDialog>()
                 .WithAbstUI();
 
             return services;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityComponentFactory.cs
@@ -32,7 +32,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         var canvas = new AbstGfxCanvas();
         var impl = new AbstUnityGfxCanvas(width, height);
         canvas.Init(impl);
-            InitComponent(canvas);
+        InitComponent(canvas);
         canvas.Name = name;
         canvas.Width = width;
         canvas.Height = height;
@@ -44,7 +44,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         var panel = new AbstWrapPanel(this);
         var impl = new AbstUnityWrapPanel(orientation);
         panel.Init(impl);
-            InitComponent(panel);
+        InitComponent(panel);
         panel.Name = name;
         panel.Orientation = orientation;
         return panel;
@@ -55,7 +55,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         var panel = new AbstPanel(this);
         var impl = new AbstUnityPanel();
         panel.Init(impl);
-            InitComponent(panel);
+        InitComponent(panel);
         panel.Name = name;
         return panel;
     }
@@ -63,9 +63,9 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
     public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y)
     {
         var wrapper = new AbstLayoutWrapper(content);
-        var impl = new AbstUnityLayoutWrapper();
+        var impl = new AbstUnityLayoutWrapper(wrapper);
         wrapper.Init(impl);
-            InitComponent(wrapper);
+        InitComponent(wrapper);
         if (x.HasValue) wrapper.X = x.Value;
         if (y.HasValue) wrapper.Y = y.Value;
         return wrapper;
@@ -76,7 +76,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         var container = new AbstTabContainer();
         var impl = new AbstUnityTabContainer();
         container.Init(impl);
-            InitComponent(container);
+        InitComponent(container);
         container.Name = name;
         return container;
     }
@@ -86,7 +86,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         var tab = new AbstTabItem();
         var impl = new AbstUnityTabItem();
         tab.Init(impl);
-            InitComponent(tab);
+        InitComponent(tab);
         tab.Name = name;
         tab.Title = title;
         return tab;
@@ -97,7 +97,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         var scroll = new AbstScrollContainer();
         var impl = new AbstUnityScrollContainer();
         scroll.Init(impl);
-            InitComponent(scroll);
+        InitComponent(scroll);
         scroll.Name = name;
         return scroll;
     }
@@ -107,7 +107,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         var slider = new AbstInputSlider<float>();
         var impl = new AbstUnityInputSlider<float>(orientation);
         slider.Init(impl);
-            InitComponent(slider);
+        InitComponent(slider);
         slider.Name = name;
         if (min.HasValue) slider.MinValue = min.Value;
         if (max.HasValue) slider.MaxValue = max.Value;
@@ -122,7 +122,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         var slider = new AbstInputSlider<int>();
         var impl = new AbstUnityInputSlider<int>(orientation);
         slider.Init(impl);
-            InitComponent(slider);
+        InitComponent(slider);
         slider.Name = name;
         if (min.HasValue) slider.MinValue = min.Value;
         if (max.HasValue) slider.MaxValue = max.Value;
@@ -143,7 +143,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         if (onChange != null)
             impl.ValueChanged += () => onChange(impl.Text);
         input.Init(impl);
-            InitComponent(input);
+        InitComponent(input);
         input.Name = name;
         return input;
     }
@@ -153,7 +153,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         var input = new AbstInputNumber<float>();
         var impl = new AbstUnityInputNumber<float>();
         input.Init(impl);
-            InitComponent(input);
+        InitComponent(input);
         input.Name = name;
         input.NumberType = ANumberType.Float;
         if (min.HasValue) input.Min = min.Value;
@@ -168,7 +168,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         var input = new AbstInputNumber<int>();
         var impl = new AbstUnityInputNumber<int>();
         input.Init(impl);
-            InitComponent(input);
+        InitComponent(input);
         input.Name = name;
         input.NumberType = ANumberType.Integer;
         if (min.HasValue) input.Min = min.Value;
@@ -187,7 +187,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         if (onChange != null)
             impl.ValueChanged += () => onChange(impl.Checked);
         input.Init(impl);
-            InitComponent(input);
+        InitComponent(input);
         input.Name = name;
         return input;
     }
@@ -199,7 +199,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         if (onChange != null)
             impl.ValueChanged += () => onChange(impl.SelectedValue);
         input.Init(impl);
-            InitComponent(input);
+        InitComponent(input);
         input.Name = name;
         return input;
     }
@@ -213,7 +213,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         var label = new AbstLabel();
         var impl = new AbstUnityLabel();
         label.Init(impl);
-            InitComponent(label);
+        InitComponent(label);
         label.Name = name;
         label.Text = text;
         return label;
@@ -224,13 +224,26 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         var button = new AbstButton();
         var impl = new AbstUnityButton();
         button.Init(impl);
-            InitComponent(button);
+        InitComponent(button);
         button.Name = name;
         button.Text = text;
         return button;
     }
 
-    public AbstStateButton CreateStateButton(string name, IAbstTexture2D? texture = null, string text = "", Action<bool>? onChange = null) => throw new NotImplementedException();
+    public AbstStateButton CreateStateButton(string name, IAbstTexture2D? texture = null, string text = "", Action<bool>? onChange = null)
+    {
+        var button = new AbstStateButton();
+        var impl = new AbstUnityStateButton();
+        if (onChange != null)
+            impl.ValueChanged += () => onChange(impl.IsOn);
+        button.Init(impl);
+        InitComponent(button);
+        button.Name = name;
+        button.Text = text;
+        if (texture != null)
+            button.TextureOn = texture;
+        return button;
+    }
 
     public AbstMenu CreateMenu(string name) => throw new NotImplementedException();
 
@@ -243,7 +256,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         var sep = new AbstHorizontalLineSeparator();
         var impl = new AbstUnityHorizontalLineSeparator();
         sep.Init(impl);
-            InitComponent(sep);
+        InitComponent(sep);
         sep.Name = name;
         return sep;
     }
@@ -253,7 +266,7 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         var sep = new AbstVerticalLineSeparator();
         var impl = new AbstUnityVerticalLineSeparator();
         sep.Init(impl);
-            InitComponent(sep);
+        InitComponent(sep);
         sep.Name = name;
         return sep;
     }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Buttons/AbstUnityButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Buttons/AbstUnityButton.cs
@@ -4,6 +4,7 @@ using AbstUI.LUnity.Bitmaps;
 using UnityEngine;
 using UnityEngine.UI;
 using AbstUI.Components.Buttons;
+using AbstUI.FrameworkCommunication;
 using AbstUI.LUnity.Components.Base;
 
 namespace AbstUI.LUnity.Components.Buttons;
@@ -11,7 +12,7 @@ namespace AbstUI.LUnity.Components.Buttons;
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkButton"/>.
 /// </summary>
-internal class AbstUnityButton : AbstUnityComponent, IAbstFrameworkButton
+internal class AbstUnityButton : AbstUnityComponent, IAbstFrameworkButton, IFrameworkFor<AbstButton>
 {
     private readonly Button _button;
     private readonly Image _image;
@@ -19,7 +20,7 @@ internal class AbstUnityButton : AbstUnityComponent, IAbstFrameworkButton
     private string _text = string.Empty;
     private IAbstTexture2D? _iconTexture;
 
-   
+
     public string Text
     {
         get => _text;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Buttons/AbstUnityStateButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Buttons/AbstUnityStateButton.cs
@@ -1,0 +1,100 @@
+using System;
+using AbstUI.Components.Buttons;
+using AbstUI.FrameworkCommunication;
+using AbstUI.LUnity.Components.Base;
+using AbstUI.Primitives;
+using AbstUI.LUnity.Bitmaps;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace AbstUI.LUnity.Components.Buttons;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkStateButton"/>.
+/// </summary>
+internal class AbstUnityStateButton : AbstUnityComponent, IAbstFrameworkStateButton, IFrameworkFor<AbstStateButton>
+{
+    private readonly Toggle _toggle;
+    private readonly Image _image;
+    private readonly Text _textComponent;
+    private IAbstTexture2D? _textureOn;
+    private IAbstTexture2D? _textureOff;
+    private event Action? _valueChanged;
+
+    public AbstUnityStateButton() : base(CreateGameObject(out var toggle, out var image, out var text))
+    {
+        _toggle = toggle;
+        _image = image;
+        _textComponent = text;
+        _toggle.onValueChanged.AddListener(_ => _valueChanged?.Invoke());
+    }
+
+    private static GameObject CreateGameObject(out Toggle toggle, out Image image, out Text text)
+    {
+        var go = new GameObject("StateButton");
+        image = go.AddComponent<Image>();
+        toggle = go.AddComponent<Toggle>();
+        var textGo = new GameObject("Text");
+        textGo.transform.SetParent(go.transform, false);
+        text = textGo.AddComponent<Text>();
+        return go;
+    }
+
+    public string Text
+    {
+        get => _textComponent.text;
+        set => _textComponent.text = value;
+    }
+
+    public bool Enabled
+    {
+        get => _toggle.interactable;
+        set => _toggle.interactable = value;
+    }
+
+    public AColor BorderColor { get; set; }
+    public AColor BorderHoverColor { get; set; }
+    public AColor BorderPressedColor { get; set; }
+    public AColor BackgroundColor { get; set; }
+    public AColor BackgroundHoverColor { get; set; }
+    public AColor BackgroundPressedColor { get; set; }
+    public AColor TextColor { get; set; }
+
+    public IAbstTexture2D? TextureOn
+    {
+        get => _textureOn;
+        set { _textureOn = value; UpdateImage(); }
+    }
+
+    public IAbstTexture2D? TextureOff
+    {
+        get => _textureOff;
+        set { _textureOff = value; UpdateImage(); }
+    }
+
+    public bool IsOn
+    {
+        get => _toggle.isOn;
+        set
+        {
+            if (_toggle.isOn != value)
+            {
+                _toggle.isOn = value;
+                _valueChanged?.Invoke();
+                UpdateImage();
+            }
+        }
+    }
+
+    public event Action? ValueChanged
+    {
+        add => _valueChanged += value;
+        remove => _valueChanged -= value;
+    }
+
+    private void UpdateImage()
+    {
+        var tex = IsOn ? _textureOn : _textureOff;
+        _image.sprite = tex is UnityTexture2D ut ? ut.ToSprite() : null;
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Containers/AbstUnityLayoutWrapper.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Containers/AbstUnityLayoutWrapper.cs
@@ -1,4 +1,5 @@
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 using AbstUI.LUnity.Components.Base;
 using UnityEngine;
 using UnityEngine.UI;
@@ -6,12 +7,48 @@ using UnityEngine.UI;
 namespace AbstUI.LUnity.Components.Containers;
 
 /// <summary>
-/// Unity implementation of <see cref="IAbstFrameworkLayoutWrapper"/>.
+/// Unity implementation of <see cref="IAbstFrameworkLayoutWrapper"/> that wraps a non-layout
+/// component so it can participate in absolute positioning containers like <see cref="AbstPanel"/>.
 /// </summary>
-internal class AbstUnityLayoutWrapper : AbstUnityComponent, IAbstFrameworkLayoutWrapper
+internal class AbstUnityLayoutWrapper : AbstUnityComponent, IAbstFrameworkLayoutWrapper, IFrameworkFor<AbstLayoutWrapper>
 {
-    public AbstUnityLayoutWrapper() : base(CreateGameObject())
+    private readonly AbstLayoutWrapper _layoutWrapper;
+
+    /// <summary>
+    /// Creates a new layout wrapper for the given AbstUI layout wrapper.
+    /// The wrapped content's <see cref="GameObject"/> is parented to this wrapper so it can be
+    /// positioned independently inside Unity.
+    /// </summary>
+    public AbstUnityLayoutWrapper(AbstLayoutWrapper layoutWrapper) : base(CreateGameObject())
     {
+        _layoutWrapper = layoutWrapper;
+        layoutWrapper.Init(this);
+
+        var contentNode = layoutWrapper.Content.FrameworkObj.FrameworkNode;
+        if (contentNode is GameObject go)
+        {
+            go.transform.SetParent(GameObject.transform, false);
+        }
+    }
+
+    public new float Width
+    {
+        get => _layoutWrapper.Width;
+        set
+        {
+            _layoutWrapper.Width = value;
+            base.Width = value;
+        }
+    }
+
+    public new float Height
+    {
+        get => _layoutWrapper.Height;
+        set
+        {
+            _layoutWrapper.Height = value;
+            base.Height = value;
+        }
     }
 
     private static GameObject CreateGameObject()

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Containers/AbstUnityPanel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Containers/AbstUnityPanel.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using AbstUI.Components;
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 using AbstUI.LUnity.Components.Base;
 using AbstUI.LUnity.Primitives;
 using AbstUI.Primitives;
@@ -12,7 +13,7 @@ namespace AbstUI.LUnity.Components.Containers;
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkPanel"/>.
 /// </summary>
-internal class AbstUnityPanel : AbstUnityComponent, IAbstFrameworkPanel
+internal class AbstUnityPanel : AbstUnityComponent, IAbstFrameworkPanel, IFrameworkFor<AbstPanel>
 {
     private readonly List<IAbstFrameworkLayoutNode> _children = new();
     private readonly Image _image;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Containers/AbstUnityScrollContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Containers/AbstUnityScrollContainer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using AbstUI.Components;
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 using AbstUI.LUnity.Components.Base;
 using UnityEngine;
 using UnityEngine.UI;
@@ -10,7 +11,7 @@ namespace AbstUI.LUnity.Components.Containers;
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkScrollContainer"/>.
 /// </summary>
-internal class AbstUnityScrollContainer : AbstUnityComponent, IAbstFrameworkScrollContainer
+internal class AbstUnityScrollContainer : AbstUnityComponent, IAbstFrameworkScrollContainer, IFrameworkFor<AbstScrollContainer>
 {
     private readonly List<IAbstFrameworkLayoutNode> _children = new();
     private readonly ScrollRect _scrollRect;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Containers/AbstUnityTabContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Containers/AbstUnityTabContainer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using AbstUI.Components;
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 using AbstUI.LUnity.Components.Base;
 using AbstUI.Primitives;
 using UnityEngine;
@@ -12,7 +13,7 @@ namespace AbstUI.LUnity.Components.Containers;
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkTabContainer"/>.
 /// </summary>
-internal class AbstUnityTabContainer : AbstUnityComponent, IAbstFrameworkTabContainer
+internal class AbstUnityTabContainer : AbstUnityComponent, IAbstFrameworkTabContainer, IFrameworkFor<AbstTabContainer>
 {
     private readonly List<IAbstFrameworkTabItem> _tabs = new();
     private int _selectedIndex = -1;
@@ -74,7 +75,7 @@ internal class AbstUnityTabContainer : AbstUnityComponent, IAbstFrameworkTabCont
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkTabItem"/>.
 /// </summary>
-internal class AbstUnityTabItem : AbstUnityComponent, IAbstFrameworkTabItem
+internal class AbstUnityTabItem : AbstUnityComponent, IAbstFrameworkTabItem, IFrameworkFor<AbstTabItem>
 {
     private IAbstNode? _content;
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Containers/AbstUnityWrapPanel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Containers/AbstUnityWrapPanel.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using AbstUI.Components;
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 using AbstUI.LUnity.Components.Base;
 using AbstUI.Primitives;
 using UnityEngine;
@@ -11,7 +12,7 @@ namespace AbstUI.LUnity.Components.Containers;
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkWrapPanel"/>.
 /// </summary>
-internal class AbstUnityWrapPanel : AbstUnityComponent, IAbstFrameworkWrapPanel
+internal class AbstUnityWrapPanel : AbstUnityComponent, IAbstFrameworkWrapPanel, IFrameworkFor<AbstWrapPanel>
 {
     private readonly List<IAbstFrameworkNode> _children = new();
     private readonly HorizontalOrVerticalLayoutGroup _layout;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Graphics/AbstUnityGfxCanvas.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Graphics/AbstUnityGfxCanvas.cs
@@ -7,6 +7,7 @@ using AbstUI.Texts;
 using UnityEngine;
 using UnityEngine.UI;
 using AbstUI.Components.Graphics;
+using AbstUI.FrameworkCommunication;
 using AbstUI.LUnity.Components.Base;
 
 namespace AbstUI.LUnity.Components.Graphics;
@@ -15,7 +16,7 @@ namespace AbstUI.LUnity.Components.Graphics;
 /// Unity implementation of <see cref="IAbstFrameworkGfxCanvas"/> that records paint actions
 /// and executes them onto a <see cref="Texture2D"/>.
 /// </summary>
-internal class AbstUnityGfxCanvas : AbstUnityComponent, IAbstFrameworkGfxCanvas, IDisposable
+internal class AbstUnityGfxCanvas : AbstUnityComponent, IAbstFrameworkGfxCanvas, IFrameworkFor<AbstGfxCanvas>, IDisposable
 {
     private readonly RawImage _image;
     private readonly Texture2D _texture;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Graphics/AbstUnityHorizontalLineSeparator.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Graphics/AbstUnityHorizontalLineSeparator.cs
@@ -2,13 +2,14 @@ using AbstUI.Components.Containers;
 using AbstUI.LUnity.Components.Base;
 using UnityEngine;
 using UnityEngine.UI;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LUnity.Components.Graphics;
 
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkHorizontalLineSeparator"/>.
 /// </summary>
-internal sealed class AbstUnityHorizontalLineSeparator : AbstUnityComponent, IAbstFrameworkHorizontalLineSeparator
+internal sealed class AbstUnityHorizontalLineSeparator : AbstUnityComponent, IAbstFrameworkHorizontalLineSeparator, IFrameworkFor<AbstHorizontalLineSeparator>
 {
     public AbstUnityHorizontalLineSeparator() : base(CreateGameObject())
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Graphics/AbstUnityVerticalLineSeparator.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Graphics/AbstUnityVerticalLineSeparator.cs
@@ -2,13 +2,14 @@ using AbstUI.Components.Containers;
 using AbstUI.LUnity.Components.Base;
 using UnityEngine;
 using UnityEngine.UI;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LUnity.Components.Graphics;
 
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkVerticalLineSeparator"/>.
 /// </summary>
-internal sealed class AbstUnityVerticalLineSeparator : AbstUnityComponent, IAbstFrameworkVerticalLineSeparator
+internal sealed class AbstUnityVerticalLineSeparator : AbstUnityComponent, IAbstFrameworkVerticalLineSeparator, IFrameworkFor<AbstVerticalLineSeparator>
 {
     public AbstUnityVerticalLineSeparator() : base(CreateGameObject())
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputCheckbox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputCheckbox.cs
@@ -1,5 +1,6 @@
 using System;
 using AbstUI.Components.Inputs;
+using AbstUI.FrameworkCommunication;
 using AbstUI.LUnity.Components.Base;
 using UnityEngine;
 using UnityEngine.UI;
@@ -9,7 +10,7 @@ namespace AbstUI.LUnity.Components.Inputs;
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkInputCheckbox"/>.
 /// </summary>
-internal class AbstUnityInputCheckbox : AbstUnityComponent, IAbstFrameworkInputCheckbox
+internal class AbstUnityInputCheckbox : AbstUnityComponent, IAbstFrameworkInputCheckbox, IFrameworkFor<AbstInputCheckbox>
 {
     private readonly Toggle _toggle;
     private bool _checked;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputCombobox.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AbstUI.Components.Inputs;
+using AbstUI.FrameworkCommunication;
 using AbstUI.LUnity.Components.Base;
 using AbstUI.LUnity.Primitives;
 using AbstUI.Primitives;
@@ -13,7 +14,7 @@ namespace AbstUI.LUnity.Components.Inputs;
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkInputCombobox"/>.
 /// </summary>
-internal class AbstUnityInputCombobox : AbstUnityComponent, IAbstFrameworkInputCombobox, IHasTextBackgroundBorderColor
+internal class AbstUnityInputCombobox : AbstUnityComponent, IAbstFrameworkInputCombobox, IFrameworkFor<AbstInputCombobox>, IHasTextBackgroundBorderColor
 {
     private readonly Dropdown _dropdown;
     private readonly List<KeyValuePair<string, string>> _items = new();

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputNumber.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputNumber.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
 using AbstUI.Components.Inputs;
+using AbstUI.FrameworkCommunication;
 using AbstUI.LUnity.Components.Base;
 using AbstUI.Primitives;
 using UnityEngine;
@@ -15,7 +16,7 @@ namespace AbstUI.LUnity.Components.Inputs;
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkInputNumber{TValue}"/>.
 /// </summary>
-internal class AbstUnityInputNumber<TValue> : AbstUnityComponent, IAbstFrameworkInputNumber<TValue>, IHasTextBackgroundBorderColor
+internal class AbstUnityInputNumber<TValue> : AbstUnityComponent, IAbstFrameworkInputNumber<TValue>, IFrameworkFor<AbstInputNumber<TValue>>, IHasTextBackgroundBorderColor
     where TValue : struct, INumber<TValue>
 {
     private readonly InputField _inputField;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputSlider.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputSlider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using AbstUI.Components.Inputs;
+using AbstUI.FrameworkCommunication;
 using AbstUI.LUnity.Components.Base;
 using AbstUI.Primitives;
 using UnityEngine;
@@ -12,7 +13,7 @@ namespace AbstUI.LUnity.Components.Inputs;
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkInputSlider{TValue}"/>.
 /// </summary>
-internal class AbstUnityInputSlider<TValue> : AbstUnityComponent, IAbstFrameworkInputSlider<TValue>
+internal class AbstUnityInputSlider<TValue> : AbstUnityComponent, IAbstFrameworkInputSlider<TValue>, IFrameworkFor<AbstInputSlider<TValue>>
     where TValue : struct, INumber<TValue>
 {
     private readonly Slider _slider;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputText.cs
@@ -1,5 +1,6 @@
 using System;
 using AbstUI.Components.Inputs;
+using AbstUI.FrameworkCommunication;
 using AbstUI.LUnity.Components.Base;
 using AbstUI.LUnity.Primitives;
 using AbstUI.Primitives;
@@ -12,7 +13,7 @@ namespace AbstUI.LUnity.Components.Inputs;
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkInputText"/>.
 /// </summary>
-internal class AbstUnityInputText : AbstUnityComponent, IAbstFrameworkInputText, IHasTextBackgroundBorderColor
+internal class AbstUnityInputText : AbstUnityComponent, IAbstFrameworkInputText, IFrameworkFor<AbstInputText>, IHasTextBackgroundBorderColor
 {
     private readonly InputField _inputField;
     private readonly Text _textComponent;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Texts/AbstUnityLabel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Texts/AbstUnityLabel.cs
@@ -5,13 +5,14 @@ using AbstUI.Primitives;
 using AbstUI.Texts;
 using UnityEngine;
 using UnityEngine.UI;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LUnity.Components.Texts;
 
 /// <summary>
 /// Unity implementation of <see cref="IAbstFrameworkLabel"/>.
 /// </summary>
-internal class AbstUnityLabel : AbstUnityComponent, IAbstFrameworkLabel
+internal class AbstUnityLabel : AbstUnityComponent, IAbstFrameworkLabel, IFrameworkFor<AbstLabel>
 {
     private readonly Text _textComponent;
     private string _text = string.Empty;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Inputs/AbstUIUnityKey.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Inputs/AbstUIUnityKey.cs
@@ -1,8 +1,9 @@
 ﻿using AbstUI.Inputs;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LUnity.Inputs;
 
-public class AbstUIUnityKey : IAbstFrameworkKey
+public class AbstUIUnityKey : IAbstFrameworkKey, IFrameworkFor<AbstKey>
 {
     private readonly HashSet<int> _keys = new();
     private AbstKey? _lingoKey;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Inputs/AbstUnityMouse.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Inputs/AbstUnityMouse.cs
@@ -1,10 +1,11 @@
 ﻿using AbstUI.Inputs;
 using AbstUI.Primitives;
 using UnityEngine;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LUnity.Inputs;
 
-public class AbstUnityMouse<TAbstMouseType, TAbstUIMouseEvent> : IAbstFrameworkMouse
+public class AbstUnityMouse<TAbstMouseType, TAbstUIMouseEvent> : IAbstFrameworkMouse, IFrameworkFor<TAbstMouseType>
         where TAbstMouseType : AbstMouse<TAbstUIMouseEvent>
         where TAbstUIMouseEvent : AbstMouseEvent
 {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Texts/UnityLabelExtensions.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Texts/UnityLabelExtensions.cs
@@ -1,8 +1,0 @@
-using AbstUI.Styles;
-
-namespace AbstUI.LUnity.Texts;
-
-public static class UnityLabelExtensions
-{
-    public static object SetAbstFont(this object label, IAbstFontManager manager, string fontName) => label;
-}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Windowing/AbstUnityDialog.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Windowing/AbstUnityDialog.cs
@@ -1,0 +1,68 @@
+using System;
+using AbstUI.Components;
+using AbstUI.Components.Containers;
+using AbstUI.Primitives;
+using AbstUI.Windowing;
+using AbstUI.LUnity.Components.Containers;
+using AbstUI.Inputs;
+
+namespace AbstUI.LUnity.Windowing;
+
+/// <summary>
+/// Simplistic Unity implementation of <see cref="IAbstFrameworkDialog"/>.
+/// Provides basic popup behaviour for custom dialogs.
+/// </summary>
+internal class AbstUnityDialog : AbstUnityPanel, IAbstFrameworkDialog
+{
+    private IAbstDialog _dialog = null!;
+
+    public string Title { get; set; } = string.Empty;
+    public bool IsOpen => Visibility;
+    public bool IsPopup { get; set; }
+    public bool Borderless { get; set; }
+    public bool IsActiveWindow => Visibility;
+    public new AColor BackgroundColor
+    {
+        get => base.BackgroundColor ?? AColors.White;
+        set => base.BackgroundColor = value;
+    }
+    public IAbstMouse Mouse => _dialog.Mouse;
+    public IAbstKey Key => _dialog.Key;
+    public event Action<bool>? OnWindowStateChanged;
+
+    public void Init(IAbstDialog instance)
+    {
+        _dialog = instance;
+        instance.Init(this);
+    }
+
+    public void Popup()
+    {
+        Visibility = true;
+        OnWindowStateChanged?.Invoke(true);
+    }
+
+    public void PopupCentered() => Popup();
+
+    public void Hide()
+    {
+        Visibility = false;
+        OnWindowStateChanged?.Invoke(false);
+    }
+
+    public void SetPositionAndSize(int x, int y, int width, int height)
+    {
+        X = x;
+        Y = y;
+        Width = width;
+        Height = height;
+    }
+
+    public APoint GetPosition() => new(X, Y);
+    public APoint GetSize() => new(Width, Height);
+    public void SetSize(int width, int height)
+    {
+        Width = width;
+        Height = height;
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Windowing/AbstUnityWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Windowing/AbstUnityWindow.cs
@@ -1,0 +1,84 @@
+using AbstUI.Components;
+using AbstUI.Components.Containers;
+using AbstUI.Primitives;
+using AbstUI.Windowing;
+using AbstUI.LUnity.Components.Containers;
+using AbstUI.Inputs;
+
+namespace AbstUI.LUnity.Windowing;
+
+/// <summary>
+/// Basic Unity implementation of <see cref="IAbstFrameworkWindow"/>. This is a light-weight
+/// wrapper around <see cref="AbstUnityPanel"/> that allows the core window system to
+/// manage windows even though Unity itself does not provide native multiple windows.
+/// </summary>
+internal class AbstUnityWindow : AbstUnityPanel, IAbstFrameworkWindow
+{
+    private IAbstWindow _window = null!;
+    private IAbstWindowInternal _internalWindow = null!;
+    private string _title = string.Empty;
+    private IAbstFrameworkNode? _content;
+
+    public string Title
+    {
+        get => _title;
+        set => _title = value;
+    }
+
+    public new AColor BackgroundColor
+    {
+        get => base.BackgroundColor ?? AColors.White;
+        set => base.BackgroundColor = value;
+    }
+
+    public bool IsActiveWindow => Visibility;
+    public bool IsOpen => Visibility;
+
+    public IAbstMouse Mouse => _window.Mouse;
+    public IAbstKey AbstKey => _window.Key;
+
+    public IAbstFrameworkNode? Content
+    {
+        get => _content;
+        set
+        {
+            if (_content == value) return;
+            RemoveAll();
+            _content = value;
+            if (value is IAbstFrameworkLayoutNode layout)
+                AddItem(layout);
+        }
+    }
+
+    public void Init(IAbstWindow instance)
+    {
+        _window = instance;
+        _internalWindow = (IAbstWindowInternal)instance;
+        instance.Init(this);
+    }
+
+    public void OpenWindow() => Visibility = true;
+    public void CloseWindow() => Visibility = false;
+
+    public void MoveWindow(int x, int y)
+    {
+        X = x;
+        Y = y;
+        _internalWindow.SetPositionFromFW(x, y);
+    }
+
+    public void SetPositionAndSize(int x, int y, int width, int height)
+    {
+        MoveWindow(x, y);
+        SetSize(width, height);
+    }
+
+    public APoint GetPosition() => new(X, Y);
+    public APoint GetSize() => new(Width, Height);
+    public void SetSize(int width, int height)
+    {
+        Width = width;
+        Height = height;
+        _internalWindow.ResizeFromFW(false, width, height);
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Windowing/AbstUnityWindowManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Windowing/AbstUnityWindowManager.cs
@@ -1,0 +1,40 @@
+using AbstUI.Windowing;
+using AbstUI.Components.Containers;
+using AbstUI.Components;
+using AbstUI.FrameworkCommunication;
+
+namespace AbstUI.LUnity.Windowing;
+
+/// <summary>
+/// Minimal Unity implementation of <see cref="IAbstFrameworkWindowManager"/>.
+/// Currently provides basic integration with the core window manager but does not
+/// show platform specific dialogs.
+/// </summary>
+internal class AbstUnityWindowManager : IAbstFrameworkWindowManager, IFrameworkFor<AbstWindowManager>
+{
+    private readonly IAbstWindowManager _windowManager;
+
+    public AbstUnityWindowManager(IAbstWindowManager windowManager)
+    {
+        _windowManager = windowManager;
+        windowManager.Init(this);
+    }
+
+    public void SetActiveWindow(IAbstWindow window)
+    {
+        // Unity has no native window ordering; nothing to do here for now.
+    }
+
+    public IAbstWindowDialogReference? ShowConfirmDialog(string title, string message, Action<bool> onResult)
+        => null;
+
+    public IAbstWindowDialogReference? ShowCustomDialog(string title, IAbstFrameworkPanel panel)
+        => null;
+
+    public IAbstWindowDialogReference? ShowCustomDialog<TDialog>(string title, IAbstFrameworkPanel panel, TDialog? dialog = null)
+        where TDialog : class, IAbstDialog
+        => null;
+
+    public IAbstWindowDialogReference? ShowNotification(string message, AbstUINotificationType type)
+        => null;
+}


### PR DESCRIPTION
## Summary
- Expand Unity layout wrapper to host non-layout content and sync dimensions
- Implement Unity state button and wire factory support
- Add minimal Unity window/dialog manager and register services
- Mark Unity framework components with `IFrameworkFor<T>` for auto-mapping

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a7f2bf0a208332a50ccc576a9ffe0a