### PR TITLE
feat: map AbstUI.SDL2 components with IFrameworkFor

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUISDLSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUISDLSetup.cs
@@ -47,8 +47,6 @@ namespace AbstUI.SDL2
             // We need to resolve once the SDL window manager to init
             services.GetRequiredService<IAbstSdlWindowManager>();
 
-            //Console.WriteLine("AbstUIGodotSetup: Is this still needed?");
-            services.GetRequiredService<AbstSdlComponentFactory>().DiscoverInAssembly(typeof(AbstUISDLSetup).Assembly);
             //services.GetRequiredService<IAbstComponentFactory>()
             //     .Register<IAbstDialog,AbstGodotDialog>()
             //    ;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Buttons/AbstSdlButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Buttons/AbstSdlButton.cs
@@ -7,10 +7,11 @@ using AbstUI.SDL2.Components.Base;
 using AbstUI.SDL2.Events;
 using AbstUI.SDL2.Core;
 using AbstUI.Styles;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Buttons
 {
-    internal class AbstSdlButton : AbstSdlComponent, IAbstFrameworkButton, IHandleSdlEvent, ISdlFocusable, IDisposable
+    internal class AbstSdlButton : AbstSdlComponent, IAbstFrameworkButton, IFrameworkFor<AbstButton>, IHandleSdlEvent, ISdlFocusable, IDisposable
     {
         private ISdlFontLoadedByUser? _font;
         private nint _texture;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Buttons/AbstSdlStateButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Buttons/AbstSdlStateButton.cs
@@ -7,10 +7,11 @@ using AbstUI.Components.Buttons;
 using AbstUI.SDL2.Components.Base;
 using AbstUI.SDL2.Core;
 using AbstUI.SDL2.Events;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Buttons
 {
-    internal class AbstSdlStateButton : AbstSdlComponent, IAbstFrameworkStateButton, IHandleSdlEvent, ISdlFocusable, IDisposable
+    internal class AbstSdlStateButton : AbstSdlComponent, IAbstFrameworkStateButton, IFrameworkFor<AbstStateButton>, IHandleSdlEvent, ISdlFocusable, IDisposable
     {
         private ISdlFontLoadedByUser? _font;
         private readonly SdlFontManager _fontManager;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlLayoutWrapper.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlLayoutWrapper.cs
@@ -3,10 +3,11 @@ using AbstUI.Primitives;
 using AbstUI.SDL2.Components.Base;
 using AbstUI.SDL2.Core;
 using AbstUI.SDL2.Events;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Containers
 {
-    public partial class AbstSdlLayoutWrapper : AbstSdlComponent, IAbstFrameworkLayoutWrapper, IHandleSdlEvent
+    public partial class AbstSdlLayoutWrapper : AbstSdlComponent, IAbstFrameworkLayoutWrapper, IFrameworkFor<AbstLayoutWrapper>, IHandleSdlEvent
     {
         private AbstLayoutWrapper _lingoLayoutWrapper;
         public object FrameworkNode => this;
@@ -17,7 +18,7 @@ namespace AbstUI.SDL2.Components.Containers
             _lingoLayoutWrapper.Init(this);
             var content = layoutWrapper.Content.FrameworkObj;
         }
-        public override float Width 
+        public override float Width
         {
             get => _lingoLayoutWrapper.Width;
             set
@@ -27,7 +28,7 @@ namespace AbstUI.SDL2.Components.Containers
                 ComponentContext.TargetWidth = (int)value;
             }
         }
-        public override float Height 
+        public override float Height
         {
             get => _lingoLayoutWrapper.Height;
             set
@@ -37,7 +38,7 @@ namespace AbstUI.SDL2.Components.Containers
                 ComponentContext.TargetHeight = (int)value;
             }
         }
-       
+
         public AMargin Margin { get; set; }
 
         public override AbstSDLRenderResult Render(AbstSDLRenderContext context)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlPanel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlPanel.cs
@@ -7,10 +7,11 @@ using AbstUI.SDL2.Events;
 using AbstUI.SDL2.SDLL;
 using System;
 using System.Collections.Generic;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Containers
 {
-    public class AbstSdlPanel : AbstSdlComponent, IAbstFrameworkPanel, IDisposable, IHandleSdlEvent
+    public class AbstSdlPanel : AbstSdlComponent, IAbstFrameworkPanel, IFrameworkFor<AbstPanel>, IDisposable, IHandleSdlEvent
     {
         public AbstSdlPanel(AbstSdlComponentFactory factory) : base(factory)
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlScrollContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlScrollContainer.cs
@@ -6,11 +6,12 @@ using AbstUI.SDL2.Core;
 using AbstUI.SDL2.Events;
 using System;
 using System.Collections.Generic;
+using AbstUI.FrameworkCommunication;
 using static AbstUI.SDL2.SDLL.SDL;
 
 namespace AbstUI.SDL2.Components.Containers
 {
-    internal class AbstSdlScrollContainer : AbstSdlScrollViewer, IAbstFrameworkScrollContainer, IDisposable, IHandleSdlEvent
+    internal class AbstSdlScrollContainer : AbstSdlScrollViewer, IAbstFrameworkScrollContainer, IFrameworkFor<AbstScrollContainer>, IDisposable, IHandleSdlEvent
     {
         public AbstSdlScrollContainer(AbstSdlComponentFactory factory) : base(factory)
         {
@@ -18,7 +19,7 @@ namespace AbstUI.SDL2.Components.Containers
 
         public object FrameworkNode => this;
 
-       
+
 
         private readonly List<IAbstFrameworkLayoutNode> _children = new();
 
@@ -66,7 +67,7 @@ namespace AbstUI.SDL2.Components.Containers
         protected override void HandleContentEvent(AbstSDLEvent e)
         {
             // Forward mouse events to children accounting for current scroll offset
-            
+
             for (int i = _children.Count - 1; i >= 0 && !e.StopPropagation; i--)
             {
                 if (_children[i].FrameworkNode is not AbstSdlComponent comp ||
@@ -77,7 +78,7 @@ namespace AbstUI.SDL2.Components.Containers
             }
         }
 
-        
+
 
         public override void Dispose()
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlTabContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlTabContainer.cs
@@ -7,10 +7,11 @@ using AbstUI.Components.Containers;
 using AbstUI.SDL2.Components.Base;
 using AbstUI.SDL2.Events;
 using AbstUI.SDL2.Core;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Containers
 {
-    public class AbstSdlTabContainer : AbstSdlComponent, IAbstFrameworkTabContainer, IHandleSdlEvent, ISdlFocusable, IDisposable
+    public class AbstSdlTabContainer : AbstSdlComponent, IAbstFrameworkTabContainer, IFrameworkFor<AbstTabContainer>, IHandleSdlEvent, ISdlFocusable, IDisposable
     {
         private readonly List<IAbstFrameworkTabItem> _children = new();
         private int _selectedIndex = -1;
@@ -291,7 +292,7 @@ namespace AbstUI.SDL2.Components.Containers
         }
     }
 
-    public class AbstSdlTabItem : AbstSdlComponent, IAbstFrameworkTabItem
+    public class AbstSdlTabItem : AbstSdlComponent, IAbstFrameworkTabItem, IFrameworkFor<AbstTabItem>
     {
         public AbstSdlTabItem(AbstSdlComponentFactory factory, AbstTabItem tab) : base(factory)
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlWrapPanel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlWrapPanel.cs
@@ -7,10 +7,11 @@ using AbstUI.SDL2.Events;
 using AbstUI.SDL2.SDLL;
 using System;
 using System.Collections.Generic;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Containers
 {
-    internal class AbstSdlWrapPanel : AbstSdlComponent, IAbstFrameworkWrapPanel, IDisposable, IHandleSdlEvent
+    internal class AbstSdlWrapPanel : AbstSdlComponent, IAbstFrameworkWrapPanel, IFrameworkFor<AbstWrapPanel>, IDisposable, IHandleSdlEvent
     {
         public AOrientation Orientation { get; set; }
         public APoint ItemMargin { get; set; }
@@ -163,6 +164,6 @@ namespace AbstUI.SDL2.Components.Containers
             }
         }
 
-      
+
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Graphics/AbstSdlGfxCanvas.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Graphics/AbstSdlGfxCanvas.cs
@@ -7,12 +7,14 @@ using AbstUI.SDL2.SDLL;
 using AbstUI.SDL2.Styles;
 using AbstUI.Styles;
 using AbstUI.Texts;
+using AbstUI.Components.Graphics;
+using AbstUI.FrameworkCommunication;
 using System.Numerics;
 using System.Runtime.InteropServices;
 
 namespace AbstUI.SDL2.Components.Graphics
 {
-    public class AbstSdlGfxCanvas : AbstSdlComponent, IAbstFrameworkGfxCanvas, IDisposable
+    public class AbstSdlGfxCanvas : AbstSdlComponent, IAbstFrameworkGfxCanvas, IFrameworkFor<AbstGfxCanvas>, IDisposable
     {
         public AMargin Margin { get; set; } = AMargin.Zero;
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlColorPicker.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlColorPicker.cs
@@ -6,10 +6,11 @@ using AbstUI.SDL2.Components.Base;
 using AbstUI.SDL2.Core;
 using AbstUI.SDL2.Events;
 using AbstUI.SDL2.SDLL;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Inputs
 {
-    internal class AbstSdlColorPicker : AbstSdlComponent, IAbstFrameworkColorPicker, ISdlFocusable, IHandleSdlEvent, IDisposable
+    internal class AbstSdlColorPicker : AbstSdlComponent, IAbstFrameworkColorPicker, IFrameworkFor<AbstColorPicker>, ISdlFocusable, IHandleSdlEvent, IDisposable
     {
 
         public bool Enabled { get; set; } = true;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputCheckbox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputCheckbox.cs
@@ -7,10 +7,11 @@ using AbstUI.SDL2.Core;
 using AbstUI.SDL2.Events;
 using AbstUI.SDL2.SDLL;
 using AbstUI.Styles;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Inputs
 {
-    internal class AbstSdlInputCheckbox : AbstSdlComponent, IAbstFrameworkInputCheckbox, IHandleSdlEvent, ISdlFocusable, IDisposable
+    internal class AbstSdlInputCheckbox : AbstSdlComponent, IAbstFrameworkInputCheckbox, IFrameworkFor<AbstInputCheckbox>, IHandleSdlEvent, ISdlFocusable, IDisposable
     {
 
         public bool Enabled { get; set; } = true;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputCombobox.cs
@@ -7,10 +7,11 @@ using AbstUI.Components.Inputs;
 using AbstUI.SDL2.Events;
 using AbstUI.SDL2.Core;
 using AbstUI.SDL2.Components.Containers;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Inputs
 {
-    internal class AbstSdlInputCombobox : AbstSdlSelectableCollection, IAbstFrameworkInputCombobox, IHandleSdlEvent, ISdlFocusable, IDisposable, IHasTextBackgroundBorderColor
+    internal class AbstSdlInputCombobox : AbstSdlSelectableCollection, IAbstFrameworkInputCombobox, IFrameworkFor<AbstInputCombobox>, IHandleSdlEvent, ISdlFocusable, IDisposable, IHasTextBackgroundBorderColor
     {
 
         private AbstSdlInputItemList? _popup;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputItemList.cs
@@ -6,10 +6,11 @@ using AbstUI.Styles;
 using AbstUI.Components.Inputs;
 using AbstUI.SDL2.Events;
 using AbstUI.SDL2.Core;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Inputs
 {
-    internal class AbstSdlInputItemList : AbstSdlSelectableCollection, IAbstFrameworkItemList, ISdlFocusable, IDisposable
+    internal class AbstSdlInputItemList : AbstSdlSelectableCollection, IAbstFrameworkItemList, IFrameworkFor<AbstItemList>, ISdlFocusable, IDisposable
     {
         private bool _focused;
         public bool HasFocus => _focused;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputNumber.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputNumber.cs
@@ -7,10 +7,11 @@ using AbstUI.SDL2.Core;
 using AbstUI.SDL2.Events;
 using AbstUI.SDL2.SDLL;
 using AbstUI.Styles;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Inputs;
 
-internal class AbstSdlInputNumber<TValue> : AbstSdlComponent, IAbstFrameworkInputNumber<TValue>, IHandleSdlEvent, ISdlFocusable, IDisposable, IHasTextBackgroundBorderColor
+internal class AbstSdlInputNumber<TValue> : AbstSdlComponent, IAbstFrameworkInputNumber<TValue>, IFrameworkFor<AbstInputNumber<TValue>>, IHandleSdlEvent, ISdlFocusable, IDisposable, IHasTextBackgroundBorderColor
 #if NET48
     where TValue : struct
 #else

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputSlider.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputSlider.cs
@@ -7,10 +7,12 @@ using AbstUI.SDL2.Core;
 using AbstUI.SDL2.Events;
 using AbstUI.SDL2.SDLL;
 using AbstUI.Styles;
+using AbstUI.Components.Inputs;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Inputs
 {
-    internal class AbstSdlInputSlider<TValue> : AbstSdlComponent, IAbstFrameworkInputSlider<TValue>, IHandleSdlEvent, ISdlFocusable, IDisposable where TValue : struct
+    internal class AbstSdlInputSlider<TValue> : AbstSdlComponent, IAbstFrameworkInputSlider<TValue>, IFrameworkFor<AbstInputSlider<TValue>>, IHandleSdlEvent, ISdlFocusable, IDisposable where TValue : struct
     {
 
         public AMargin Margin { get; set; } = AMargin.Zero;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputText.cs
@@ -11,10 +11,11 @@ using AbstUI.Components.Inputs;
 using AbstUI.SDL2.Components.Base;
 using AbstUI.SDL2.Events;
 using AbstUI.SDL2.Core;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Inputs
 {
-    internal class AbstSdlInputText : AbstSdlComponent, IAbstFrameworkInputText, IHandleSdlEvent, ISdlFocusable, IDisposable, IHasTextBackgroundBorderColor
+    internal class AbstSdlInputText : AbstSdlComponent, IAbstFrameworkInputText, IFrameworkFor<AbstInputText>, IHandleSdlEvent, ISdlFocusable, IDisposable, IHasTextBackgroundBorderColor
     {
         private readonly bool _multiLine;
         private readonly List<int> _codepoints = new();

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlSpinBox.cs
@@ -6,10 +6,11 @@ using AbstUI.SDL2.Core;
 using AbstUI.SDL2.Events;
 using AbstUI.SDL2.SDLL;
 using AbstUI.Styles;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Inputs;
 
-internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IHandleSdlEvent, ISdlFocusable, IDisposable, IHasTextBackgroundBorderColor
+internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IFrameworkFor<AbstInputSpinBox>, IHandleSdlEvent, ISdlFocusable, IDisposable, IHasTextBackgroundBorderColor
 {
     private readonly AbstSdlInputNumber<float> _number;
     private const int ButtonWidth = 16;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Menus/AbstSdlMenu.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Menus/AbstSdlMenu.cs
@@ -10,10 +10,11 @@ using AbstUI.SDL2.Events;
 using AbstUI.SDL2.SDLL;
 using AbstUI.SDL2.Styles;
 using AbstUI.Styles;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Menus
 {
-    internal class AbstSdlMenu : AbstSdlComponent, IAbstFrameworkMenu, IHandleSdlEvent, IDisposable
+    internal class AbstSdlMenu : AbstSdlComponent, IAbstFrameworkMenu, IFrameworkFor<AbstMenu>, IHandleSdlEvent, IDisposable
     {
         private readonly List<AbstSdlMenuItem> _items = new();
         private readonly SdlFontManager _fontManager;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Menus/AbstSdlMenuItem.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Menus/AbstSdlMenuItem.cs
@@ -2,10 +2,11 @@ using System;
 using AbstUI.Components.Menus;
 using AbstUI.SDL2.Components.Base;
 using AbstUI.SDL2.Core;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Menus
 {
-    internal class AbstSdlMenuItem : AbstSdlComponent, IAbstFrameworkMenuItem, IDisposable
+    internal class AbstSdlMenuItem : AbstSdlComponent, IAbstFrameworkMenuItem, IFrameworkFor<AbstMenuItem>, IDisposable
     {
         public bool Enabled { get; set; } = true;
         public bool CheckMark { get; set; }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Texts/AbstSdlLabel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Texts/AbstSdlLabel.cs
@@ -6,10 +6,12 @@ using AbstUI.SDL2.SDLL;
 using AbstUI.SDL2.Styles;
 using AbstUI.Texts;
 using System.Runtime.InteropServices;
+using AbstUI.Components.Texts;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Texts
 {
-    public class AbstSdlLabel : AbstSdlComponent, IAbstFrameworkLabel, IDisposable
+    public class AbstSdlLabel : AbstSdlComponent, IAbstFrameworkLabel, IFrameworkFor<AbstLabel>, IDisposable
     {
         private float _lastWidth;
         private float _lastHeight;
@@ -50,7 +52,7 @@ namespace AbstUI.SDL2.Components.Texts
 
         public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
         {
-            if (!Visibility || string.IsNullOrEmpty(Text) )
+            if (!Visibility || string.IsNullOrEmpty(Text))
                 return default;
 
             EnsureResources(context);
@@ -70,7 +72,7 @@ namespace AbstUI.SDL2.Components.Texts
                 // build texture
                 // render glyphs
                 SDL.SDL_Color col = FontColor.ToSDLColor();
-                var (tex, textW, textH) = CreateTextTextureBox(context.Renderer, _font!.FontHandle,Text, (int)boxW, (int)boxH, TextAlignment, col);
+                var (tex, textW, textH) = CreateTextTextureBox(context.Renderer, _font!.FontHandle, Text, (int)boxW, (int)boxH, TextAlignment, col);
                 _texture = tex;
                 SDL.SDL_SetTextureBlendMode(_texture, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
                 //SDL.SDL_FreeSurface(tex); // this breaks the texture, so we need keep it.
@@ -169,7 +171,7 @@ namespace AbstUI.SDL2.Components.Texts
             nint box = SDL.SDL_CreateRGBSurfaceWithFormat(0, boxW, boxH, 32, FMT);
             if (box == nint.Zero) throw new Exception(SDL.SDL_GetError());
             SDL.SDL_FillRect(box, nint.Zero, 0x00000000); // Transparent background
-           // SDL.SDL_FillRect(box, nint.Zero, 0xFFFFFFFF); // DEBUG white bg
+                                                          // SDL.SDL_FillRect(box, nint.Zero, 0xFFFFFFFF); // DEBUG white bg
 
             // vertical start (centered)
             int startY = Math.Max(0, (boxH - totalH) / 2);
@@ -239,13 +241,13 @@ namespace AbstUI.SDL2.Components.Texts
         {
             // normalize + drop trailing newlines (matches render)
             string s = (text ?? string.Empty).Replace("\r\n", "\n").Replace('\r', '\n');
-            int end = s.Length; 
+            int end = s.Length;
             while (end > 0 && s[end - 1] == '\n') end--;
             var result = s.Substring(0, end);
             return result;
         }
 
-        
+
         public static (int w, int h) MeasureSDLText(nint fontHandle, string text, uint wrapWidth = 0)
         {
             string s = text;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Inputs/GlobalSDLAbstMouse.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Inputs/GlobalSDLAbstMouse.cs
@@ -1,6 +1,8 @@
 using AbstUI.Inputs;
 using AbstUI.Primitives;
 using AbstUI.SDL2.SDLL;
+using AbstUI.FrameworkCommunication;
+using AbstUI.Inputs;
 
 namespace AbstUI.SDL2.Inputs
 {
@@ -20,7 +22,7 @@ namespace AbstUI.SDL2.Inputs
         }
     }
 
-    public class AbstSdlGlobalMouse<TAbstMouseType, TAbstUIMouseEvent> : IAbstFrameworkMouse
+    public class AbstSdlGlobalMouse<TAbstMouseType, TAbstUIMouseEvent> : IAbstFrameworkMouse, IFrameworkFor<AbstMouse<TAbstUIMouseEvent>>
         where TAbstMouseType : AbstMouse<TAbstUIMouseEvent>
         where TAbstUIMouseEvent : AbstMouseEvent
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Inputs/SdlKey.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Inputs/SdlKey.cs
@@ -1,9 +1,10 @@
 using AbstUI.Inputs;
 using AbstUI.SDL2.SDLL;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Inputs;
 
-public class SdlKey : IAbstFrameworkKey
+public class SdlKey : IAbstFrameworkKey, IFrameworkFor<AbstKey>
 {
     private readonly HashSet<SDL.SDL_Keycode> _keys = new();
     private AbstKey? _lingoKey;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Inputs/SdlMouse.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Inputs/SdlMouse.cs
@@ -1,9 +1,11 @@
 using AbstUI.Inputs;
 using AbstUI.Primitives;
 using AbstUI.SDL2.SDLL;
+using AbstUI.FrameworkCommunication;
+using AbstUI.Inputs;
 
 namespace AbstUI.SDL2.Inputs;
-public class SdlMouse<TAbstUIMouseEvent> : IAbstFrameworkMouse
+public class SdlMouse<TAbstUIMouseEvent> : IAbstFrameworkMouse, IFrameworkFor<AbstMouse<TAbstUIMouseEvent>>
         where TAbstUIMouseEvent : AbstMouseEvent
 {
     private Lazy<AbstMouse<TAbstUIMouseEvent>> _lingoMouse;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Windowing/AbstSdlDialog.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Windowing/AbstSdlDialog.cs
@@ -10,13 +10,14 @@ using AbstUI.SDL2.Components.Containers;
 using AbstUI.SDL2.Components;
 using AbstUI.SDL2.Events;
 using AbstUI.SDL2.Core;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Windowing
 {
     /// <summary>
     /// SDL2 implementation of a generic dialog window.
     /// </summary>
-    internal class AbstSdlDialog : AbstSdlPanel, IAbstFrameworkDialog, IHandleSdlEvent, IDisposable
+    internal class AbstSdlDialog : AbstSdlPanel, IAbstFrameworkDialog, IFrameworkFor<AbstDialog>, IHandleSdlEvent, IDisposable
     {
         private readonly AbstSdlComponentFactory _factory;
         private IAbstDialog _dialog = null!;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Windowing/AbstSdlMainWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Windowing/AbstSdlMainWindow.cs
@@ -1,10 +1,11 @@
 using AbstUI.Primitives;
 using AbstUI.SDL2.Core;
 using AbstUI.Windowing;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Windowing;
 
-internal class AbstSdlMainWindow : IAbstFrameworkMainWindow
+internal class AbstSdlMainWindow : IAbstFrameworkMainWindow, IFrameworkFor<AbstMainWindow>
 {
     private readonly ISdlRootComponentContext _context;
     private AbstMainWindow _window = null!;


### PR DESCRIPTION
## Summary
- implement IFrameworkFor<T> on SDL2 framework components and inputs
- drop component factory discovery call from AbstUISDLSetup

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a7fb1e2ce083328a4644fd2a77833d