### PR TITLE
Manual registration for Godot UI components

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUIGodotSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUIGodotSetup.cs
@@ -12,7 +12,7 @@ namespace AbstUI.LGodot
 {
     public static class AbstUIGodotSetup
     {
-       
+
         public static IServiceCollection WithAbstUIGodot(this IServiceCollection services, Action<IAbstFameworkComponentWinRegistrator>? windowRegistrations = null)
         {
             services
@@ -40,11 +40,12 @@ namespace AbstUI.LGodot
         public static IServiceProvider WithAbstUIGodot(this IServiceProvider services)
         {
             services.WithAbstUI(); // need to be first to register all the windows in the windows factory.
-            services.GetRequiredService<IAbstComponentFactory>()
-                .DiscoverInAssembly(typeof(AbstUIGodotSetup).Assembly)
-                ;
+            var factory = services.GetRequiredService<IAbstComponentFactory>();
+            factory
+                .Register<IAbstDialog, AbstGodotDialog>()
+                .Register<AbstMainWindow, AbstGodotMainWindow>();
             var windowManager = services.GetRequiredService<IAbstGodotWindowManager>();// we need to resolve the framework window manager to link him
-           
+
             return services;
         }
     }


### PR DESCRIPTION
## Summary
- avoid reflection-based discovery in Godot UI setup
- register dialog and main window implementations manually

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj --verbosity minimal`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a7febdf9d88332b2d98c9bd99d9416