### PR TITLE
Add IFrameworkFor mappings to Blazor components

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIBlazorSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIBlazorSetup.cs
@@ -53,9 +53,6 @@ public static class AbstUIBlazorSetup
     public static IServiceProvider WithAbstUIBlazor(this IServiceProvider services)
     {
         services.WithAbstUI();// need to be first to register all the windows in the windows factory.
-        services.GetRequiredService<IAbstComponentFactory>()
-            .DiscoverInAssembly(typeof(AbstUIBlazorSetup).Assembly)
-            ;
         return services;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Buttons/AbstBlazorButtonComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Buttons/AbstBlazorButtonComponent.cs
@@ -1,10 +1,11 @@
 using System;
 using AbstUI.Components.Buttons;
 using AbstUI.Primitives;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Buttons;
 
-public class AbstBlazorButtonComponent : IAbstFrameworkButton
+public class AbstBlazorButtonComponent : IAbstFrameworkButton, IFrameworkFor<AbstButton>
 {
     public event Action? Pressed;
     public event Action? Changed;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Buttons/AbstBlazorStateButtonComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Buttons/AbstBlazorStateButtonComponent.cs
@@ -2,10 +2,11 @@ using System;
 using AbstUI.Components.Buttons;
 using AbstUI.Primitives;
 using AbstUI.Styles;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Buttons;
 
-public class AbstBlazorStateButtonComponent : AbstBlazorComponentModelBase, IAbstFrameworkStateButton
+public class AbstBlazorStateButtonComponent : AbstBlazorComponentModelBase, IAbstFrameworkStateButton, IFrameworkFor<AbstStateButton>
 {
     private string _text = string.Empty;
     public string Text

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorLayoutWrapperComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorLayoutWrapperComponent.cs
@@ -1,9 +1,10 @@
 using Microsoft.AspNetCore.Components;
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Containers;
 
-public class AbstBlazorLayoutWrapperComponent : AbstBlazorComponentModelBase, IAbstFrameworkLayoutWrapper
+public class AbstBlazorLayoutWrapperComponent : AbstBlazorComponentModelBase, IAbstFrameworkLayoutWrapper, IFrameworkFor<AbstLayoutWrapper>
 {
     public RenderFragment? ContentFragment { get; }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorPanelComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorPanelComponent.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using AbstUI.Components;
 using AbstUI.Components.Containers;
 using AbstUI.Primitives;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Containers;
 
-public class AbstBlazorPanelComponent : AbstBlazorComponentModelBase, IAbstFrameworkPanel, IAbstBlazorRegistryAware
+public class AbstBlazorPanelComponent : AbstBlazorComponentModelBase, IAbstFrameworkPanel, IFrameworkFor<AbstPanel>, IAbstBlazorRegistryAware
 {
     private AbstBlazorComponentContainer _registry;
     private readonly AbstBlazorComponentContainer _children;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorScrollContainerComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorScrollContainerComponent.cs
@@ -2,10 +2,11 @@ using System;
 using System.Collections.Generic;
 using AbstUI.Components;
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Containers;
 
-public class AbstBlazorScrollContainerComponent : AbstBlazorComponentModelBase, IAbstFrameworkScrollContainer, IAbstBlazorRegistryAware
+public class AbstBlazorScrollContainerComponent : AbstBlazorComponentModelBase, IAbstFrameworkScrollContainer, IFrameworkFor<AbstScrollContainer>, IAbstBlazorRegistryAware
 {
     private AbstBlazorComponentContainer _registry;
     private readonly AbstBlazorComponentContainer _children;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorTabContainerComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorTabContainerComponent.cs
@@ -1,9 +1,10 @@
 using System.Collections.Generic;
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Containers;
 
-public class AbstBlazorTabContainerComponent : AbstBlazorComponentModelBase, IAbstFrameworkTabContainer, IAbstBlazorRegistryAware
+public class AbstBlazorTabContainerComponent : AbstBlazorComponentModelBase, IAbstFrameworkTabContainer, IFrameworkFor<AbstTabContainer>, IAbstBlazorRegistryAware
 {
     private AbstBlazorComponentContainer _registry;
     private readonly AbstBlazorComponentContainer _children;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorTabItemComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorTabItemComponent.cs
@@ -1,10 +1,11 @@
 using System;
 using AbstUI.Components;
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Containers;
 
-internal class AbstBlazorTabItemComponent : AbstBlazorComponentModelBase, IAbstFrameworkTabItem
+internal class AbstBlazorTabItemComponent : AbstBlazorComponentModelBase, IAbstFrameworkTabItem, IFrameworkFor<AbstTabItem>
 {
     private string _title = string.Empty;
     public string Title

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorWrapPanelComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorWrapPanelComponent.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using AbstUI.Components;
 using AbstUI.Components.Containers;
 using AbstUI.Primitives;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Containers;
 
-public class AbstBlazorWrapPanelComponent : AbstBlazorComponentModelBase, IAbstFrameworkWrapPanel, IAbstBlazorRegistryAware
+public class AbstBlazorWrapPanelComponent : AbstBlazorComponentModelBase, IAbstFrameworkWrapPanel, IFrameworkFor<AbstWrapPanel>, IAbstBlazorRegistryAware
 {
     private AbstBlazorComponentContainer _registry;
     private readonly AbstBlazorComponentContainer _children;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Graphics/AbstBlazorGfxCanvasComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Graphics/AbstBlazorGfxCanvasComponent.cs
@@ -6,10 +6,11 @@ using Microsoft.JSInterop;
 using AbstUI.Components.Graphics;
 using AbstUI.Primitives;
 using AbstUI.Texts;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Graphics;
 
-public class AbstBlazorGfxCanvasComponent : AbstBlazorComponentModelBase, IAbstFrameworkGfxCanvas
+public class AbstBlazorGfxCanvasComponent : AbstBlazorComponentModelBase, IAbstFrameworkGfxCanvas, IFrameworkFor<AbstGfxCanvas>
 {
     private readonly IJSRuntime _js;
     private ElementReference _canvasRef;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Graphics/AbstBlazorHorizontalLineSeparatorComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Graphics/AbstBlazorHorizontalLineSeparatorComponent.cs
@@ -1,10 +1,11 @@
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Graphics;
 
 /// <summary>
 /// Blazor implementation of <see cref="IAbstFrameworkHorizontalLineSeparator"/>.
 /// </summary>
-public class AbstBlazorHorizontalLineSeparatorComponent : AbstBlazorComponentModelBase, IAbstFrameworkHorizontalLineSeparator
+public class AbstBlazorHorizontalLineSeparatorComponent : AbstBlazorComponentModelBase, IAbstFrameworkHorizontalLineSeparator, IFrameworkFor<AbstHorizontalLineSeparator>
 {
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Graphics/AbstBlazorVerticalLineSeparatorComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Graphics/AbstBlazorVerticalLineSeparatorComponent.cs
@@ -1,10 +1,11 @@
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Graphics;
 
 /// <summary>
 /// Blazor implementation of <see cref="IAbstFrameworkVerticalLineSeparator"/>.
 /// </summary>
-public class AbstBlazorVerticalLineSeparatorComponent : AbstBlazorComponentModelBase, IAbstFrameworkVerticalLineSeparator
+public class AbstBlazorVerticalLineSeparatorComponent : AbstBlazorComponentModelBase, IAbstFrameworkVerticalLineSeparator, IFrameworkFor<AbstVerticalLineSeparator>
 {
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorColorPickerComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorColorPickerComponent.cs
@@ -1,10 +1,11 @@
 using System;
 using AbstUI.Components.Inputs;
 using AbstUI.Primitives;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
-public class AbstBlazorColorPickerComponent : AbstBlazorComponentModelBase, IAbstFrameworkColorPicker
+public class AbstBlazorColorPickerComponent : AbstBlazorComponentModelBase, IAbstFrameworkColorPicker, IFrameworkFor<AbstColorPicker>
 {
     private AColor _color = AColor.FromRGB(0, 0, 0);
     public AColor Color

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCheckboxComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputCheckboxComponent.cs
@@ -1,9 +1,10 @@
 using System;
 using AbstUI.Components.Inputs;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
-public class AbstBlazorInputCheckboxComponent : AbstBlazorComponentModelBase, IAbstFrameworkInputCheckbox
+public class AbstBlazorInputCheckboxComponent : AbstBlazorComponentModelBase, IAbstFrameworkInputCheckbox, IFrameworkFor<AbstInputCheckbox>
 {
     private bool _checked;
     public bool Checked

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputComboboxComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputComboboxComponent.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using AbstUI.Components.Inputs;
 using AbstUI.Primitives;
 using AbstUI.Styles;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
-public class AbstBlazorInputComboboxComponent : AbstBlazorComponentModelBase, IAbstFrameworkInputCombobox, IHasTextBackgroundBorderColor
+public class AbstBlazorInputComboboxComponent : AbstBlazorComponentModelBase, IAbstFrameworkInputCombobox, IFrameworkFor<AbstInputCombobox>, IHasTextBackgroundBorderColor
 {
     private readonly List<KeyValuePair<string, string>> _items = new();
     public IReadOnlyList<KeyValuePair<string, string>> Items => _items;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputNumberComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputNumberComponent.cs
@@ -3,10 +3,11 @@ using System.Numerics;
 using AbstUI.Components.Inputs;
 using AbstUI.Primitives;
 using AbstUI.Styles;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
-public class AbstBlazorInputNumberComponent<TValue> : AbstBlazorComponentModelBase, IAbstFrameworkInputNumber<TValue>, IHasTextBackgroundBorderColor
+public class AbstBlazorInputNumberComponent<TValue> : AbstBlazorComponentModelBase, IAbstFrameworkInputNumber<TValue>, IFrameworkFor<AbstInputNumber<TValue>>, IHasTextBackgroundBorderColor
     where TValue : INumber<TValue>
 {
     private TValue _value = TValue.Zero;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputSliderComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputSliderComponent.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Numerics;
 using AbstUI.Components.Inputs;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
-public class AbstBlazorInputSliderComponent<TValue> : AbstBlazorComponentModelBase, IAbstFrameworkInputSlider<TValue>
+public class AbstBlazorInputSliderComponent<TValue> : AbstBlazorComponentModelBase, IAbstFrameworkInputSlider<TValue>, IFrameworkFor<AbstInputSlider<TValue>>
     where TValue : INumber<TValue>
 {
     private TValue _value = TValue.Zero;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputTextComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorInputTextComponent.cs
@@ -2,10 +2,11 @@ using System;
 using AbstUI.Components.Inputs;
 using AbstUI.Primitives;
 using AbstUI.Styles;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
-public class AbstBlazorInputTextComponent : AbstBlazorComponentModelBase, IAbstFrameworkInputText, IHasTextBackgroundBorderColor
+public class AbstBlazorInputTextComponent : AbstBlazorComponentModelBase, IAbstFrameworkInputText, IFrameworkFor<AbstInputText>, IHasTextBackgroundBorderColor
 {
     private string _text = string.Empty;
     public string Text

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorItemListComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorItemListComponent.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using AbstUI.Components.Inputs;
 using AbstUI.Primitives;
 using AbstUI.Styles;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
-public class AbstBlazorItemListComponent : AbstBlazorComponentModelBase, IAbstFrameworkItemList
+public class AbstBlazorItemListComponent : AbstBlazorComponentModelBase, IAbstFrameworkItemList, IFrameworkFor<AbstItemList>
 {
     private readonly List<KeyValuePair<string, string>> _items = new();
     public IReadOnlyList<KeyValuePair<string, string>> Items => _items;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorSpinBoxComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstBlazorSpinBoxComponent.cs
@@ -2,10 +2,11 @@ using System;
 using AbstUI.Components.Inputs;
 using AbstUI.Primitives;
 using AbstUI.Styles;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Inputs;
 
-public class AbstBlazorSpinBoxComponent : AbstBlazorComponentModelBase, IAbstFrameworkSpinBox, IHasTextBackgroundBorderColor
+public class AbstBlazorSpinBoxComponent : AbstBlazorComponentModelBase, IAbstFrameworkSpinBox, IFrameworkFor<AbstInputSpinBox>, IHasTextBackgroundBorderColor
 {
     private float _value;
     public float Value

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Menus/AbstBlazorMenu.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Menus/AbstBlazorMenu.cs
@@ -2,10 +2,11 @@ using System;
 using AbstUI.Components.Buttons;
 using AbstUI.Components.Menus;
 using AbstUI.Primitives;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Menus;
 
-internal class AbstBlazorMenu : IAbstFrameworkMenu, IDisposable
+internal class AbstBlazorMenu : IAbstFrameworkMenu, IFrameworkFor<AbstMenu>, IDisposable
 {
     public string Name { get; set; } = string.Empty;
     public bool Visibility { get; set; } = true;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Menus/AbstBlazorMenuItem.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Menus/AbstBlazorMenuItem.cs
@@ -1,9 +1,10 @@
 using System;
 using AbstUI.Components.Menus;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Menus;
 
-internal class AbstBlazorMenuItem : IAbstFrameworkMenuItem, IDisposable
+internal class AbstBlazorMenuItem : IAbstFrameworkMenuItem, IFrameworkFor<AbstMenuItem>, IDisposable
 {
     public string Name { get; set; } = string.Empty;
     public bool Enabled { get; set; } = true;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Texts/AbstBlazorLabelComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Texts/AbstBlazorLabelComponent.cs
@@ -1,10 +1,11 @@
 using AbstUI.Components.Texts;
 using AbstUI.Primitives;
 using AbstUI.Texts;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Components.Texts;
 
-public class AbstBlazorLabelComponent : AbstBlazorComponentModelBase, IAbstFrameworkLabel
+public class AbstBlazorLabelComponent : AbstBlazorComponentModelBase, IAbstFrameworkLabel, IFrameworkFor<AbstLabel>
 {
     private string _text = string.Empty;
     public string Text

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Inputs/BlazorKey.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Inputs/BlazorKey.cs
@@ -1,12 +1,13 @@
 using AbstUI.Inputs;
 using Microsoft.AspNetCore.Components.Web;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Inputs;
 
 /// <summary>
 /// Keyboard wrapper using standard DOM events provided by Blazor.
 /// </summary>
-public class BlazorKey : IAbstFrameworkKey
+public class BlazorKey : IAbstFrameworkKey, IFrameworkFor<AbstKey>
 {
     private readonly HashSet<string> _keys = new();
     private AbstKey? _lingoKey;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Inputs/BlazorMouse.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Inputs/BlazorMouse.cs
@@ -2,13 +2,14 @@ using AbstUI.Inputs;
 using AbstUI.Primitives;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Inputs;
 
 /// <summary>
 /// Mouse wrapper using DOM events in Blazor.
 /// </summary>
-public class BlazorMouse<TAbstUIMouseEvent> : IAbstFrameworkMouse where TAbstUIMouseEvent : AbstMouseEvent
+public class BlazorMouse<TAbstUIMouseEvent> : IAbstFrameworkMouse, IFrameworkFor<AbstMouse<TAbstUIMouseEvent>> where TAbstUIMouseEvent : AbstMouseEvent
 {
     private Lazy<AbstMouse<TAbstUIMouseEvent>> _lingoMouse;
     private readonly IJSRuntime _js;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Windowing/AbstBlazorMainWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Windowing/AbstBlazorMainWindow.cs
@@ -1,9 +1,10 @@
 using AbstUI.Primitives;
 using AbstUI.Windowing;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Blazor.Windowing;
 
-public class AbstBlazorMainWindow : IAbstFrameworkMainWindow
+public class AbstBlazorMainWindow : IAbstFrameworkMainWindow, IFrameworkFor<AbstMainWindow>
 {
     private AbstMainWindow _window = null!;
     private APoint _size;


### PR DESCRIPTION
## Summary
- implement `IFrameworkFor<T>` on Blazor framework components and inputs
- remove component factory discovery from Blazor setup

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj` *(fails: /usr/bin/dotnet: No such file or directory)*
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj` *(fails: /usr/bin/dotnet: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8001558a48332a866778161cc0a5d