### PR TITLE
feat: link LGodot components to abstractions

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUIGodotSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUIGodotSetup.cs
@@ -1,6 +1,14 @@
-﻿using AbstUI.Components;
+using AbstUI.Components;
+using AbstUI.Components.Buttons;
+using AbstUI.Components.Containers;
+using AbstUI.Components.Graphics;
+using AbstUI.Components.Inputs;
+using AbstUI.Components.Menus;
+using AbstUI.Components.Texts;
 using AbstUI.Inputs;
 using AbstUI.LGodot.Components;
+using AbstUI.LGodot.Components.Inputs;
+using AbstUI.LGodot.Components.Menus;
 using AbstUI.LGodot.Inputs;
 using AbstUI.LGodot.Styles;
 using AbstUI.LGodot.Windowing;
@@ -12,7 +20,7 @@ namespace AbstUI.LGodot
 {
     public static class AbstUIGodotSetup
     {
-       
+
         public static IServiceCollection WithAbstUIGodot(this IServiceCollection services, Action<IAbstFameworkComponentWinRegistrator>? windowRegistrations = null)
         {
             services
@@ -40,11 +48,17 @@ namespace AbstUI.LGodot
         public static IServiceProvider WithAbstUIGodot(this IServiceProvider services)
         {
             services.WithAbstUI(); // need to be first to register all the windows in the windows factory.
-            services.GetRequiredService<IAbstComponentFactory>()
-                .DiscoverInAssembly(typeof(AbstUIGodotSetup).Assembly)
+            var factory = services.GetRequiredService<IAbstComponentFactory>();
+            factory
+                .Register<AbstMouse, AbstGodotMouse>()
+                .Register<GlobalGodotAbstMouse, AbstGodotGlobalMouse>()
+                .Register<AbstKey, AbstGodotKey>()
+                .Register<AbstDialog, AbstGodotDialog>()
+                .Register<AbstMainWindow, AbstGodotMainWindow>()
+                .Register<AbstWindowManager, AbstGodotWindowManager>()
                 ;
             var windowManager = services.GetRequiredService<IAbstGodotWindowManager>();// we need to resolve the framework window manager to link him
-           
+
             return services;
         }
     }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Buttons/AbstGodotButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Buttons/AbstGodotButton.cs
@@ -5,13 +5,14 @@ using AbstUI.Styles;
 using AbstUI.LGodot.Bitmaps;
 using AbstUI.Components.Buttons;
 using AbstUI.LGodot.Primitives;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkButton"/>.
     /// </summary>
-    public partial class AbstGodotButton : Button, IAbstFrameworkButton, IDisposable
+    public partial class AbstGodotButton : Button, IAbstFrameworkButton, IDisposable, IFrameworkFor<AbstButton>
     {
         private AMargin _margin = AMargin.Zero;
         private IAbstTexture2D? _texture;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Buttons/AbstGodotStateButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Buttons/AbstGodotStateButton.cs
@@ -6,13 +6,14 @@ using AbstUI.Components.Inputs;
 using AbstUI.Components.Buttons;
 using AbstUI.Styles;
 using AbstUI.LGodot.Primitives;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkStateButton"/>.
     /// </summary>
-    public partial class AbstGodotStateButton : Button, IAbstFrameworkStateButton, IDisposable
+    public partial class AbstGodotStateButton : Button, IAbstFrameworkStateButton, IDisposable, IFrameworkFor<AbstStateButton>
     {
         private AMargin _margin = AMargin.Zero;
         private IAbstTexture2D? _texture;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Containers/AbstGodotPanel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Containers/AbstGodotPanel.cs
@@ -3,18 +3,19 @@ using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.LGodot.Primitives;
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkPanel"/>.
     /// </summary>
-    public partial class AbstGodotPanel : Panel, IAbstFrameworkPanel, IDisposable
+    public partial class AbstGodotPanel : Panel, IAbstFrameworkPanel, IDisposable, IFrameworkFor<AbstPanel>
     {
         private AMargin _margin = AMargin.Zero;
         private AColor? _background = null;
         private AColor? _borderColor = null;
-        private float _borderWidth =0;
+        private float _borderWidth = 0;
         private readonly StyleBoxFlat _style = new StyleBoxFlat();
 
         public AbstGodotPanel(AbstPanel panel)
@@ -67,7 +68,7 @@ namespace AbstUI.LGodot.Components
 
                 }
             }
-            _nodes.Add(child);  
+            _nodes.Add(child);
         }
 
 
@@ -146,12 +147,12 @@ namespace AbstUI.LGodot.Components
 
         private void ApplyStyle()
         {
-            _style.BgColor = _background != null? _background.Value.ToGodotColor() : Colors.Transparent;
+            _style.BgColor = _background != null ? _background.Value.ToGodotColor() : Colors.Transparent;
             _style.BorderColor = _borderColor != null ? _borderColor.Value.ToGodotColor() : Colors.Transparent;
             _style.BorderWidthTop = _style.BorderWidthBottom = _style.BorderWidthLeft = _style.BorderWidthRight = (int)_borderWidth;
         }
     }
-    public partial class AbstGodotLayoutWrapper : MarginContainer, IAbstFrameworkLayoutWrapper
+    public partial class AbstGodotLayoutWrapper : MarginContainer, IAbstFrameworkLayoutWrapper, IFrameworkFor<AbstLayoutWrapper>
     {
         private AbstLayoutWrapper _lingoLayoutWrapper;
         public object FrameworkNode => this;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Containers/AbstGodotScrollContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Containers/AbstGodotScrollContainer.cs
@@ -3,10 +3,11 @@ using AbstUI.Components;
 using AbstUI.Primitives;
 using System.Linq;
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
-    public partial class AbstGodotScrollContainer : ScrollContainer, IAbstFrameworkScrollContainer, IDisposable
+    public partial class AbstGodotScrollContainer : ScrollContainer, IAbstFrameworkScrollContainer, IDisposable, IFrameworkFor<AbstScrollContainer>
     {
         private AMargin _margin = AMargin.Zero;
         private AbstScrollbarMode _scrollModeH = AbstScrollbarMode.Auto;
@@ -79,10 +80,10 @@ namespace AbstUI.LGodot.Components
                 AddThemeConstantOverride("margin_bottom", (int)_margin.Bottom);
             }
         }
-       
 
 
-        
+
+
 
 
         public AbstGodotScrollContainer(AbstScrollContainer container)
@@ -106,7 +107,7 @@ namespace AbstUI.LGodot.Components
             _nodes.Remove(lingoFrameworkGfxNode);
         }
 
-       
+
 
 
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Containers/AbstGodotTabContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Containers/AbstGodotTabContainer.cs
@@ -3,24 +3,27 @@ using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.LGodot.Styles;
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkTabContainer"/>.
     /// </summary>
-    public partial class AbstGodotTabContainer : TabContainer, IAbstFrameworkTabContainer, IDisposable
+    public partial class AbstGodotTabContainer : TabContainer, IAbstFrameworkTabContainer, IDisposable, IFrameworkFor<AbstTabContainer>
     {
         private AMargin _margin = AMargin.Zero;
         private Theme _theme;
         private readonly List<IAbstFrameworkTabItem> _nodes = new List<IAbstFrameworkTabItem>();
         private readonly IAbstGodotStyleManager _lingoGodotStyleManager;
-        
+
 
 
         public float X { get => Position.X; set => Position = new Vector2(value, Position.Y); }
         public float Y { get => Position.Y; set => Position = new Vector2(Position.X, value); }
-        public float Width { get => Size.X; 
+        public float Width
+        {
+            get => Size.X;
             set
             {
                 CustomMinimumSize = new Vector2(value, Size.Y);
@@ -51,12 +54,12 @@ namespace AbstUI.LGodot.Components
 
             // Apply the Director tab styling
             _theme = _lingoGodotStyleManager.GetTheme(AbstGodotThemeElementType.Tabs) ?? new Theme();
-            
+
             Theme = Theme;
             ClipTabs = true;
 
         }
- 
+
 
 
 
@@ -73,7 +76,7 @@ namespace AbstUI.LGodot.Components
             }
         }
 
-        
+
 
         public void AddTab(IAbstFrameworkTabItem tabItem)
         {
@@ -122,7 +125,7 @@ namespace AbstUI.LGodot.Components
             CurrentTab = _nodes.FindIndex(x => x.Title == tabName);
         }
     }
-    public partial class AbstGodotTabItem : IAbstFrameworkTabItem
+    public partial class AbstGodotTabItem : IAbstFrameworkTabItem, IFrameworkFor<AbstTabItem>
     {
         private AbstTabItem _tabItem;
         public AbstTabItem TabItem => _tabItem;
@@ -143,7 +146,7 @@ namespace AbstUI.LGodot.Components
         {
             get => ContentFrameWork.Name; set
             {
-                if (ContentFrameWork != null) 
+                if (ContentFrameWork != null)
                     ContentFrameWork.Name = value;
             }
         }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Containers/AbstGodotWrapPanel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Containers/AbstGodotWrapPanel.cs
@@ -2,13 +2,14 @@ using Godot;
 using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkWrapPanel"/>.
     /// </summary>
-    public partial class AbstGodotWrapPanel : MarginContainer, IAbstFrameworkWrapPanel, IDisposable
+    public partial class AbstGodotWrapPanel : MarginContainer, IAbstFrameworkWrapPanel, IDisposable, IFrameworkFor<AbstWrapPanel>
     {
         private FlowContainer _container;
         private AOrientation _orientation;
@@ -55,8 +56,10 @@ namespace AbstUI.LGodot.Components
 
         //public SizeFlags SizeFlagsHorizontal { get => _container.SizeFlagsHorizontal; set => _container.SizeFlagsHorizontal = value; }
         //public Vector2 Position { get => _container.Position; set => _container.Position = value; }
-        string IAbstFrameworkNode.Name { get => Name; set
-                {
+        string IAbstFrameworkNode.Name
+        {
+            get => Name; set
+            {
                 Name = value; _container.Name = value + "_Flow";
             }
         }
@@ -115,7 +118,7 @@ namespace AbstUI.LGodot.Components
         {
             if (child.FrameworkNode is not Node node)
                 return;
-            
+
             if (node is Control ctrl)
                 ApplyItemMargin(ctrl);
             _container.AddChild(node);
@@ -158,12 +161,12 @@ namespace AbstUI.LGodot.Components
 
         private void ApplyMargin()
         {
-           AddThemeConstantOverride("margin_left", (int)_margin.Left);
-           AddThemeConstantOverride("margin_right", (int)_margin.Right);
-           AddThemeConstantOverride("margin_top", (int)_margin.Top);
-           AddThemeConstantOverride("margin_bottom", (int)_margin.Bottom);
+            AddThemeConstantOverride("margin_left", (int)_margin.Left);
+            AddThemeConstantOverride("margin_right", (int)_margin.Right);
+            AddThemeConstantOverride("margin_top", (int)_margin.Top);
+            AddThemeConstantOverride("margin_bottom", (int)_margin.Bottom);
         }
 
-        
+
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/AbstGodotGfxCanvas.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/AbstGodotGfxCanvas.cs
@@ -7,13 +7,14 @@ using AbstUI.LGodot.Texts;
 using AbstUI.LGodot.Bitmaps;
 using AbstUI.LGodot.Primitives;
 using AbstUI.Components.Graphics;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkGfxCanvas"/>.
     /// </summary>
-    public partial class AbstGodotGfxCanvas : Control, IAbstFrameworkGfxCanvas, IDisposable
+    public partial class AbstGodotGfxCanvas : Control, IAbstFrameworkGfxCanvas, IDisposable, IFrameworkFor<AbstGfxCanvas>
     {
         private readonly IAbstFontManager _fontManager;
         private AMargin _margin = AMargin.Zero;
@@ -38,23 +39,26 @@ namespace AbstUI.LGodot.Components
 
         public float X { get => Position.X; set => Position = new Vector2(value, Position.Y); }
         public float Y { get => Position.Y; set => Position = new Vector2(Position.X, value); }
-        public float Width { 
-            get => Size.X; 
-            set { 
-                Size = new Vector2(value, Size.Y); 
-                CustomMinimumSize = Size; _desiredWidth = value; 
+        public float Width
+        {
+            get => Size.X;
+            set
+            {
+                Size = new Vector2(value, Size.Y);
+                CustomMinimumSize = Size; _desiredWidth = value;
                 QueueRedraw();
-                
-            } 
+
+            }
         }
-        public float Height { 
-            get => Size.Y; 
-            set 
-            { 
+        public float Height
+        {
+            get => Size.Y;
+            set
+            {
                 Size = new Vector2(Size.X, value);
                 CustomMinimumSize = Size; _desiredHeight = value;
                 QueueRedraw();
-            } 
+            }
         }
         public bool Visibility { get => Visible; set => Visible = value; }
         public AMargin Margin
@@ -150,7 +154,7 @@ namespace AbstUI.LGodot.Components
         public void DrawPolygon(IReadOnlyList<APoint> points, AColor color, bool filled = true, float width = 1)
         {
             var arr = points.Select(p => p.ToVector2()).ToArray();
-          
+
             if (filled)
                 _drawActions.Add(() => DrawPolygon(arr, [color.ToGodotColor()]));
             else
@@ -198,11 +202,11 @@ namespace AbstUI.LGodot.Components
                 tex.Dispose();
             });
             MarkDirty();
-        } 
-        
+        }
+
         public void DrawPicture(IAbstTexture2D texture, int width, int height, APoint position)
         {
-            var tex = ((AbstGodotTexture2D)texture).Texture;    
+            var tex = ((AbstGodotTexture2D)texture).Texture;
             _drawActions.Add(() =>
             {
                 DrawTextureRect(tex, new Rect2(position.X, position.Y, width, height), false); // don't tile

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/AbstGodotHorizontalLineSeparator.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/AbstGodotHorizontalLineSeparator.cs
@@ -2,13 +2,14 @@ using Godot;
 using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkHorizontalLineSeparator"/>.
     /// </summary>
-    public partial class AbstGodotHorizontalLineSeparator : Control, IAbstFrameworkHorizontalLineSeparator, IDisposable
+    public partial class AbstGodotHorizontalLineSeparator : Control, IAbstFrameworkHorizontalLineSeparator, IDisposable, IFrameworkFor<AbstHorizontalLineSeparator>
     {
         private AMargin _margin = AMargin.Zero;
         private Color _lightColor;
@@ -21,7 +22,7 @@ namespace AbstUI.LGodot.Components
             _darkColor = new Color("#a0a0a0");
         }
 
-       
+
 
         public override void _Draw()
         {
@@ -52,7 +53,7 @@ namespace AbstUI.LGodot.Components
             get => Size.Y; set
             {
                 Size = new Vector2(Size.X, value);
-                CustomMinimumSize = new Vector2(Size.X,value);
+                CustomMinimumSize = new Vector2(Size.X, value);
             }
         }
         public bool Visibility { get => Visible; set => Visible = value; }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/AbstGodotVerticalLineSeparator.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/AbstGodotVerticalLineSeparator.cs
@@ -2,13 +2,14 @@ using Godot;
 using AbstUI.Components;
 using AbstUI.Primitives;
 using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkVerticalLineSeparator"/>.
     /// </summary>
-    public partial class AbstGodotVerticalLineSeparator : Control, IAbstFrameworkVerticalLineSeparator, IDisposable
+    public partial class AbstGodotVerticalLineSeparator : Control, IAbstFrameworkVerticalLineSeparator, IDisposable, IFrameworkFor<AbstVerticalLineSeparator>
     {
         private AMargin _margin = AMargin.Zero;
         private Color _lightColor;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotColorPicker.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotColorPicker.cs
@@ -4,13 +4,14 @@ using AbstUI.Primitives;
 using System;
 using AbstUI.LGodot.Primitives;
 using AbstUI.Components.Inputs;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkColorPicker"/>.
     /// </summary>
-    public partial class AbstGodotColorPicker : ColorPickerButton, IAbstFrameworkColorPicker, IDisposable
+    public partial class AbstGodotColorPicker : ColorPickerButton, IAbstFrameworkColorPicker, IDisposable, IFrameworkFor<AbstColorPicker>
     {
         private AMargin _margin = AMargin.Zero;
         private readonly Action<AColor>? _onChange;
@@ -33,7 +34,7 @@ namespace AbstUI.LGodot.Components
 
         public float X { get => Position.X; set => Position = new Vector2(value, Position.Y); }
         public float Y { get => Position.Y; set => Position = new Vector2(Position.X, value); }
-        public float Width { get => Size.X; set { Size = new Vector2(value, Size.Y); CustomMinimumSize = new Vector2(value, Size.Y); } } 
+        public float Width { get => Size.X; set { Size = new Vector2(value, Size.Y); CustomMinimumSize = new Vector2(value, Size.Y); } }
         public float Height { get => Size.Y; set { Size = new Vector2(Size.X, value); CustomMinimumSize = new Vector2(Size.X, value); } }
         public bool Visibility { get => Visible; set => Visible = value; }
         public bool Enabled { get => !Disabled; set => Disabled = !value; }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputCheckbox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputCheckbox.cs
@@ -3,13 +3,14 @@ using System;
 using AbstUI.Primitives;
 using AbstUI.Components;
 using AbstUI.Components.Inputs;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkInputCheckbox"/>.
     /// </summary>
-    public partial class AbstGodotInputCheckbox : CheckBox, IAbstFrameworkInputCheckbox, IDisposable
+    public partial class AbstGodotInputCheckbox : CheckBox, IAbstFrameworkInputCheckbox, IDisposable, IFrameworkFor<AbstInputCheckbox>
     {
         private AMargin _margin = AMargin.Zero;
         private Action<bool>? _onChange;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputCombobox.cs
@@ -4,13 +4,14 @@ using AbstUI.Primitives;
 using AbstUI.Styles;
 using AbstUI.Components.Inputs;
 using AbstUI.LGodot.Primitives;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkInputCombobox"/>.
     /// </summary>
-    public partial class AbstGodotInputCombobox : OptionButton, IAbstFrameworkInputCombobox, IHasTextBackgroundBorderColor, IDisposable
+    public partial class AbstGodotInputCombobox : OptionButton, IAbstFrameworkInputCombobox, IHasTextBackgroundBorderColor, IDisposable, IFrameworkFor<AbstInputCombobox>
     {
         private readonly List<KeyValuePair<string, string>> _items = new();
         private AMargin _margin = AMargin.Zero;
@@ -157,7 +158,7 @@ namespace AbstUI.LGodot.Components
             ItemSelected += idx => _onValueChanged?.Invoke();
             _onChange = onChange;
             if (_onChange != null) ItemSelected += _ => _onChange(SelectedKey);
-            
+
         }
         private void UpdatePopupStyle()
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputNumber.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputNumber.cs
@@ -4,13 +4,14 @@ using AbstUI.Primitives;
 using AbstUI.Styles;
 using AbstUI.Components.Inputs;
 using AbstUI.LGodot.Primitives;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkInputNumber"/>.
     /// </summary>
-    public partial class AbstGodotInputNumber<TValue> : LineEdit, IAbstFrameworkInputNumber<TValue>, IHasTextBackgroundBorderColor, IDisposable
+    public partial class AbstGodotInputNumber<TValue> : LineEdit, IAbstFrameworkInputNumber<TValue>, IHasTextBackgroundBorderColor, IDisposable, IFrameworkFor<AbstInputNumber<TValue>>
         where TValue : System.Numerics.INumber<TValue>
     {
         private AMargin _margin = AMargin.Zero;
@@ -27,7 +28,7 @@ namespace AbstUI.LGodot.Components
         {
             _onChange = onChange;
             _fontManager = fontManager;
-            Func<string, (bool IsValid,TValue Value)> valueParse;
+            Func<string, (bool IsValid, TValue Value)> valueParse;
             // Switch case to set Min and Max based on type  
             switch (Type.GetTypeCode(typeof(TValue)))
             {
@@ -58,7 +59,7 @@ namespace AbstUI.LGodot.Components
                 if (!parsedValue.IsValid)
                 {
                     if (_value != null)
-                    Value = _value;
+                        Value = _value;
                     return;
                 }
                 if (_value == parsedValue.Value) return;
@@ -74,16 +75,19 @@ namespace AbstUI.LGodot.Components
         public float X { get => Position.X; set => Position = new Vector2(value, Position.Y); }
         public float Y { get => Position.Y; set => Position = new Vector2(Position.X, value); }
         private float _wantedWidth = 10;
-        public float Width { get => Size.X;
+        public float Width
+        {
+            get => Size.X;
             set
             {
                 _wantedWidth = value;
                 CustomMinimumSize = new Vector2(_wantedWidth, _wantedHeight);
                 Size = new Vector2(value, _wantedHeight);
-                
+
                 var test = Size;
-                
-            } }
+
+            }
+        }
         private float _wantedHeight = 10;
         public float Height
         {
@@ -122,8 +126,8 @@ namespace AbstUI.LGodot.Components
                 Text = _value.ToString();
             }
         }
-        public TValue Min { get; set; } 
-        public TValue Max { get; set; } 
+        public TValue Min { get; set; }
+        public TValue Max { get; set; }
         string IAbstFrameworkNode.Name { get => Name; set => Name = value; }
         public ANumberType NumberType
         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputSlider.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputSlider.cs
@@ -3,12 +3,13 @@ using System;
 using AbstUI.Primitives;
 using AbstUI.Components;
 using AbstUI.Components.Inputs;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
     /// Godot implementation of <see cref="IAbstFrameworkInputSlider{TValue}"/>.
     /// </summary>
-    public partial class AbstGodotInputSlider<TValue> : Control, IAbstFrameworkInputSlider<TValue>, System.IDisposable
+    public partial class AbstGodotInputSlider<TValue> : Control, IAbstFrameworkInputSlider<TValue>, System.IDisposable, IFrameworkFor<AbstInputSlider<TValue>>
         where TValue : struct, System.IConvertible
     {
         private readonly Slider _slider;
@@ -25,7 +26,7 @@ namespace AbstUI.LGodot.Components
             AddChild(_slider);
             slider.Init(this);
             _slider.ValueChanged += OnSliderValueChanged;
-            CustomMinimumSize = new Vector2(2,2);
+            CustomMinimumSize = new Vector2(2, 2);
             SizeFlagsHorizontal = 0;
             SizeFlagsVertical = 0;
         }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputSpinBox.cs
@@ -4,10 +4,11 @@ using AbstUI.Primitives;
 using AbstUI.Styles;
 using AbstUI.Components.Inputs;
 using AbstUI.LGodot.Primitives;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
-    public partial class AbstGodotSpinBox : SpinBox, IAbstFrameworkSpinBox, IHasTextBackgroundBorderColor, IDisposable
+    public partial class AbstGodotSpinBox : SpinBox, IAbstFrameworkSpinBox, IHasTextBackgroundBorderColor, IDisposable, IFrameworkFor<AbstInputSpinBox>
     {
         private AMargin _margin = AMargin.Zero;
         private Action<float>? _onChange;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotInputText.cs
@@ -5,13 +5,14 @@ using AbstUI.Primitives;
 using AbstUI.Styles;
 using AbstUI.LGodot.Primitives;
 using AbstUI.Components.Inputs;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components.Inputs
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkInputText"/> using composition.
     /// </summary>
-    public class AbstGodotInputText : IAbstFrameworkInputText, IHasTextBackgroundBorderColor, IDisposable
+    public class AbstGodotInputText : IAbstFrameworkInputText, IHasTextBackgroundBorderColor, IDisposable, IFrameworkFor<AbstInputText>
     {
         private readonly Action<string>? _onChange;
         private readonly IAbstFontManager _fontManager;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Inputs/AbstGodotItemList.cs
@@ -4,13 +4,14 @@ using AbstUI.Primitives;
 using AbstUI.Components.Inputs;
 using AbstUI.Styles;
 using AbstUI.LGodot.Primitives;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkItemList"/>.
     /// </summary>
-    public partial class AbstGodotItemList : ItemList, IAbstFrameworkItemList, IDisposable
+    public partial class AbstGodotItemList : ItemList, IAbstFrameworkItemList, IDisposable, IFrameworkFor<AbstItemList>
     {
         private readonly List<KeyValuePair<string, string>> _items = new();
         private AMargin _margin = AMargin.Zero;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Menus/AbstGodotMenu.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Menus/AbstGodotMenu.cs
@@ -3,13 +3,14 @@ using AbstUI.Primitives;
 using AbstUI.Components.Buttons;
 using AbstUI.Components.Menus;
 using AbstUI.LGodot.Components.Menus;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkMenu"/>.
     /// </summary>
-    public partial class AbstGodotMenu : PopupMenu, IAbstFrameworkMenu, IDisposable
+    public partial class AbstGodotMenu : PopupMenu, IAbstFrameworkMenu, IDisposable, IFrameworkFor<AbstMenu>
     {
         private readonly Dictionary<int, AbstGodotMenuItem> _items = new();
         private string _name;
@@ -21,7 +22,7 @@ namespace AbstUI.LGodot.Components
             _margin = AMargin.Zero;
             menu.Init(this);
             IdPressed += OnIdPressed;
-            
+
         }
 
         public new string Name { get => _name; set => _name = value; }
@@ -64,7 +65,7 @@ namespace AbstUI.LGodot.Components
             _items.Clear();
         }
 
-       
+
         public void PositionPopup(IAbstFrameworkButton button)
         {
             if (button is not Button btn)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Menus/AbstGodotMenuItem.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Menus/AbstGodotMenuItem.cs
@@ -1,11 +1,12 @@
 using AbstUI.Components.Menus;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Components.Menus
 {
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkMenuItem"/>.
     /// </summary>
-    public partial class AbstGodotMenuItem : IAbstFrameworkMenuItem, IDisposable
+    public partial class AbstGodotMenuItem : IAbstFrameworkMenuItem, IDisposable, IFrameworkFor<AbstMenuItem>
     {
         private readonly AbstMenuItem _abstMenuItem;
         private string _name;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Texts/AbstGodotLabel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Texts/AbstGodotLabel.cs
@@ -7,6 +7,7 @@ using AbstUI.Texts;
 using AbstUI.LGodot.Texts;
 using AbstUI.LGodot.Primitives;
 using AbstUI.Components.Texts;
+using AbstUI.FrameworkCommunication;
 
 
 namespace AbstUI.LGodot.Components
@@ -14,7 +15,7 @@ namespace AbstUI.LGodot.Components
     /// <summary>
     /// Godot implementation of <see cref="IAbstFrameworkLabel"/>.
     /// </summary>
-    public partial class AbstGodotLabel : Label, IAbstFrameworkLabel, IDisposable
+    public partial class AbstGodotLabel : Label, IAbstFrameworkLabel, IDisposable, IFrameworkFor<AbstLabel>
     {
         private readonly IAbstFontManager _fontManager;
         private AMargin _margin = AMargin.Zero;
@@ -33,7 +34,7 @@ namespace AbstUI.LGodot.Components
         //public float Y { get => Position.Y; set => Position = new Vector2(Position.X, value); }
         public float Width { get => Size.X; set { Size = new Vector2(value, Size.Y); CustomMinimumSize = new Vector2(value, Size.Y); } }
         public float Height { get => Size.Y; set { Size = new Vector2(Size.X, value); CustomMinimumSize = new Vector2(Size.X, value); } }
-    
+
         public bool Visibility { get => Visible; set => Visible = value; }
         public AbstTextAlignment TextAlignment { get => HorizontalAlignment.ToAbst(); set => HorizontalAlignment = value.ToGodot(); }
         string IAbstFrameworkNode.Name { get => Name; set => Name = value; }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Inputs/AbstGodotKey.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Inputs/AbstGodotKey.cs
@@ -1,9 +1,10 @@
 ﻿using AbstUI.Inputs;
 using Godot;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Inputs;
 
-public partial class AbstGodotKey : Node, IAbstFrameworkKey
+public partial class AbstGodotKey : Node, IAbstFrameworkKey, IFrameworkFor<AbstKey>
 {
     private readonly List<Key> _pressed = new();
     private Lazy<AbstKey> _lingoKey;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Inputs/AbstUIGodotMouse.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Inputs/AbstUIGodotMouse.cs
@@ -2,17 +2,18 @@
 using static Godot.Input;
 using AbstUI.Primitives;
 using AbstUI.Inputs;
+using AbstUI.FrameworkCommunication;
 
 
 namespace AbstUI.LGodot.Inputs
 {
-    public interface IAbstGodotMouseHandler: IAbstFrameworkMouse
+    public interface IAbstGodotMouseHandler : IAbstFrameworkMouse
     {
         void HandleMouseMoveEvent(InputEventMouseMotion mouseMotionEvent, bool isInsideRect, float x, float y);
         void HandleMouseButtonEvent(InputEventMouseButton mouseButtonEvent, bool isInsideRect, float x, float y);
-        
+
     }
-    public class AbstGodotMouse : IAbstFrameworkMouse, IAbstGodotMouseHandler
+    public class AbstGodotMouse : IAbstFrameworkMouse, IAbstGodotMouseHandler, IFrameworkFor<AbstMouse>
     {
         private Lazy<IAbstMouseInternal> _lingoMouse;
         private DateTime _lastClickTime = DateTime.MinValue;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Inputs/GlobalGodotAbstKey.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Inputs/GlobalGodotAbstKey.cs
@@ -3,7 +3,7 @@ using AbstUI.LGodot;
 
 namespace AbstUI.LGodot.Inputs
 {
-    public class GlobalAbstKey : AbstKey , IAbstGlobalKey
+    public class GlobalAbstKey : AbstKey, IAbstGlobalKey
     {
         public GlobalAbstKey(IAbstGodotRootNode rootNode)
         {
@@ -11,5 +11,5 @@ namespace AbstUI.LGodot.Inputs
             Init(framework);
         }
     }
-  
+
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Inputs/GlobalGodotAbstMouse.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Inputs/GlobalGodotAbstMouse.cs
@@ -2,6 +2,7 @@ using AbstUI.LGodot;
 using AbstUI.LGodot.Inputs;
 using AbstUI.Primitives;
 using Godot;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.Inputs
 {
@@ -20,7 +21,7 @@ namespace AbstUI.Inputs
         }
     }
 
-    public partial class AbstGodotGlobalMouse : Node, IAbstFrameworkMouse, IAbstGodotMouseHandler
+    public partial class AbstGodotGlobalMouse : Node, IAbstFrameworkMouse, IAbstGodotMouseHandler, IFrameworkFor<GlobalGodotAbstMouse>
     {
         private readonly AbstGodotMouse _handler;
         private IAbstMouse? _mouse;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Windowing/AbstGodotDialog.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Windowing/AbstGodotDialog.cs
@@ -7,7 +7,7 @@ using Godot;
 
 namespace AbstUI.LGodot.Windowing
 {
-    public partial class AbstGodotDialog : Window, IAbstFrameworkDialog
+    public partial class AbstGodotDialog : Window, IAbstFrameworkDialog, IFrameworkFor<AbstDialog>
     {
         private IAbstDialog _lingoDialog;
 
@@ -15,7 +15,7 @@ namespace AbstUI.LGodot.Windowing
         public bool IsOpen { get; set; }
         public bool IsPopup { get; set; }
         public bool IsActiveWindow => IsOpen;
-        public float X { get => Position.X; set { Position = new Vector2I((int)value, Position.Y);} }
+        public float X { get => Position.X; set { Position = new Vector2I((int)value, Position.Y); } }
         public float Y { get => Position.Y; set { Position = new Vector2I(Position.X, (int)value); } }
         public bool Visibility { get; set; }
         public float Width { get; set; }
@@ -30,7 +30,7 @@ namespace AbstUI.LGodot.Windowing
 
         public IAbstKey Key => _lingoDialog.Key;
 
-        public event Action<bool>? OnWindowStateChanged;    
+        public event Action<bool>? OnWindowStateChanged;
 
         public AbstGodotDialog()
         {
@@ -70,7 +70,7 @@ namespace AbstUI.LGodot.Windowing
 
         public void Popup() => base.Popup();
 
-        public void PopupCentered() => 
+        public void PopupCentered() =>
             base.PopupCentered();
 
 
@@ -79,7 +79,7 @@ namespace AbstUI.LGodot.Windowing
 
         public IEnumerable<IAbstFrameworkLayoutNode> GetItems() =>
             GetChildren().OfType<IAbstFrameworkLayoutNode>();
-        public void RemoveItem(IAbstFrameworkLayoutNode abstFrameworkLayoutNode)=> 
+        public void RemoveItem(IAbstFrameworkLayoutNode abstFrameworkLayoutNode) =>
             base.RemoveChild(abstFrameworkLayoutNode.FrameworkNode as Node);
 
         public void SetPositionAndSize(int x, int y, int width, int height)
@@ -96,7 +96,7 @@ namespace AbstUI.LGodot.Windowing
         APoint IAbstFrameworkDialog.GetPosition()
             => new APoint(Position.X, Position.Y);
 
-        APoint IAbstFrameworkDialog.GetSize() 
+        APoint IAbstFrameworkDialog.GetSize()
             => new APoint(Size.X, Size.Y);
 
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Windowing/AbstGodotMainWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Windowing/AbstGodotMainWindow.cs
@@ -1,10 +1,11 @@
 using Godot;
 using AbstUI.Primitives;
 using AbstUI.Windowing;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Windowing;
 
-public class AbstGodotMainWindow : IAbstFrameworkMainWindow
+public class AbstGodotMainWindow : IAbstFrameworkMainWindow, IFrameworkFor<AbstMainWindow>
 {
     private readonly IAbstGodotRootNode _root;
     private AbstMainWindow _window = null!;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Windowing/AbstGodotWindowManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Windowing/AbstGodotWindowManager.cs
@@ -6,6 +6,7 @@ using AbstUI.LGodot.Styles;
 using AbstUI.Styles;
 using AbstUI.Windowing;
 using Godot;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LGodot.Windowing;
 
@@ -16,7 +17,7 @@ public interface IAbstGodotWindowManager : IAbstFrameworkWindowManager
     BaseGodotWindow? ActiveWindow { get; }
     Control RootNode { get; }
 }
-public class AbstGodotWindowManager : IAbstGodotWindowManager , IDisposable
+public class AbstGodotWindowManager : IAbstGodotWindowManager, IDisposable, IFrameworkFor<AbstWindowManager>
 {
     protected BaseGodotWindow? _lastActiveWindow;
     private IAbstWindowManager _windowManager;
@@ -92,7 +93,7 @@ public class AbstGodotWindowManager : IAbstGodotWindowManager , IDisposable
             parent.MoveChild(window, parent.GetChildCount() - 1);
         window.GrabFocus();
         window.QueueRedraw();
-        _lastActiveWindow = window; 
+        _lastActiveWindow = window;
     }
 
     #endregion
@@ -174,10 +175,10 @@ public class AbstGodotWindowManager : IAbstGodotWindowManager , IDisposable
         }
 
         dialog.Title = title;
-        
+
         dialog.Size = new Vector2I((int)panel.Width, (int)panel.Height);
         dialog.Theme = _godotStyleManager.GetTheme(AbstGodotThemeElementType.PopupWindow);
-       
+
         root.AddChild(dialog);
         dialog.CloseRequested += dialog.QueueFree;
         dialog.AddChild(node);
@@ -189,11 +190,11 @@ public class AbstGodotWindowManager : IAbstGodotWindowManager , IDisposable
         //}
         dialog.PopupCentered();
 
-        return new AbstWindowDialogReference( dialog.QueueFree, dialog);
+        return new AbstWindowDialogReference(dialog.QueueFree, dialog);
     }
 
-    
-   
+
+
 
     public IAbstWindowDialogReference? ShowNotification(string message, AbstUINotificationType type)
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Windowing/BaseGodotWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Windowing/BaseGodotWindow.cs
@@ -13,7 +13,7 @@ namespace AbstEngine.Director.LGodot
 {
     public abstract partial class BaseGodotWindow : Panel, IAbstFrameworkWindow
     {
-        
+
         private readonly IAbstWindowManager _windowManager;
         private readonly IHistoryManager? _historyManager;
         //protected readonly AbstUIGodotMouse _MouseFrameworkObj;
@@ -122,7 +122,7 @@ namespace AbstEngine.Director.LGodot
             // IAbstGodotWindowManager windowManager, IHistoryManager? historyManager = null
             Name = $"Window {name}";
             WindowName = name;
-            _windowManager = serviceProvider.GetRequiredService<IAbstWindowManager>(); 
+            _windowManager = serviceProvider.GetRequiredService<IAbstWindowManager>();
             _historyManager = serviceProvider.GetRequiredService<IHistoryManager>();
 
             //MouseFilter = MouseFilterEnum.Stop;
@@ -139,7 +139,7 @@ namespace AbstEngine.Director.LGodot
             Style.BorderWidthRight = 1;
             Style.BorderWidthBottom = 1;
             BackgroundColor = AbstDefaultColors.BG_WhiteMenus;
-            
+
             AddChild(_closeButton);
             _closeButton.Text = "X";
             _closeButton.CustomMinimumSize = new Vector2(16, 16);
@@ -155,7 +155,7 @@ namespace AbstEngine.Director.LGodot
             //    BgColor = new Color(1, 1, 1, 1.0f) // RGBA
             //};
             //AddThemeStyleboxOverride("panel", styleBox);
-            
+
         }
 
         public virtual void Init(IAbstWindow instance)
@@ -168,7 +168,7 @@ namespace AbstEngine.Director.LGodot
                 Size = new Vector2(instance.Width, instance.Height);
                 CustomMinimumSize = Size;
             }
-            if (instance.X > 0 && instance.Y>0)
+            if (instance.X > 0 && instance.Y > 0)
                 Position = new Vector2(instance.X, instance.Y);
             _mouseFrameworkObj = ((IAbstMouse<AbstMouseEvent>)instance.Mouse).Framework<IAbstGodotMouseHandler>();
             OnInit(instance);
@@ -183,11 +183,11 @@ namespace AbstEngine.Director.LGodot
             _closeButton.Position = new Vector2(Size.X - 18, 1);
             // draw resize handle
             DrawLine(new Vector2(Size.X - _resizeHandle, Size.Y), new Vector2(Size.X, Size.Y - _resizeHandle), Colors.DarkGray);
-            DrawLine(new Vector2(Size.X - _resizeHandle/2f, Size.Y), new Vector2(Size.X, Size.Y - _resizeHandle/2f), Colors.DarkGray);
+            DrawLine(new Vector2(Size.X - _resizeHandle / 2f, Size.Y), new Vector2(Size.X, Size.Y - _resizeHandle / 2f), Colors.DarkGray);
         }
 
 
-       
+
         protected void DontUseInputInsteadOfGuiInput()
         {
             // todo : fix this
@@ -199,7 +199,7 @@ namespace AbstEngine.Director.LGodot
         public override void _Input(InputEvent @event)
         {
             base._Input(@event);
-            if (_useGuiInput || !Visible ||!(@event is InputEventFromWindow)) return;
+            if (_useGuiInput || !Visible || !(@event is InputEventFromWindow)) return;
             //if (!_dragging && !_resizing && !GetGlobalRect().HasPoint(GetGlobalMousePosition()))
             //    return;
             OnHandleTheEvent(@event);
@@ -243,8 +243,8 @@ namespace AbstEngine.Director.LGodot
                 }
                 if (!IsActiveWindow)
                     return;
-                
-               // _MouseFrameworkObj.HandleMouseButtonEvent(mouseButtonEvent, isInsideRect, mousePos.X, mousePos.Y - TitleBarHeight);
+
+                // _MouseFrameworkObj.HandleMouseButtonEvent(mouseButtonEvent, isInsideRect, mousePos.X, mousePos.Y - TitleBarHeight);
                 //Console.WriteLine(Name + ":" + mousePos.X + "x" + mousePos.Y+":"+ isInsideRect);
             }
             // Handle Mouse Motion (MouseMove)
@@ -258,7 +258,7 @@ namespace AbstEngine.Director.LGodot
 
             if (@event is InputEventMouseButton mb)
             {
-                
+
                 var pressed = mb.Pressed;
 
                 if (mb.ButtonIndex == MouseButton.Left)
@@ -375,7 +375,7 @@ namespace AbstEngine.Director.LGodot
 
         }
 
-       
+
         public virtual void OpenWindow()
         {
             Visible = true;
@@ -410,14 +410,14 @@ namespace AbstEngine.Director.LGodot
             Vector2 size = Size;
 
             if (pos.X < viewportRect.Position.X)
-                pos.X = viewportRect.Position.X +2;
+                pos.X = viewportRect.Position.X + 2;
             if (pos.Y < viewportRect.Position.Y)
                 pos.Y = viewportRect.Position.Y + 2;
 
             if (pos.X + size.X > viewportRect.Position.X + viewportRect.Size.X)
-                pos.X = viewportRect.Position.X + viewportRect.Size.X - size.X -2;
+                pos.X = viewportRect.Position.X + viewportRect.Size.X - size.X - 2;
             if (pos.Y + size.Y > viewportRect.Position.Y + viewportRect.Size.Y)
-                pos.Y = viewportRect.Position.Y + viewportRect.Size.Y - size.Y -2;
+                pos.Y = viewportRect.Position.Y + viewportRect.Size.Y - size.Y - 2;
 
             SetThePosition(pos);
         }
@@ -426,6 +426,6 @@ namespace AbstEngine.Director.LGodot
         {
             base.Dispose(disposing);
         }
-      
+
     }
 }


### PR DESCRIPTION
## Summary
- connect Godot framework components to their AbstUI counterparts via IFrameworkFor
- wire input and window classes to IFrameworkFor for consistent mapping
- register only framework components not handled by factory Create methods

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUIGodotSetup.cs`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a7fadb622c8332bb0f85e5c043bd20