### PR TITLE
feat(unity): add missing abstui components

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUIUnitySetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUIUnitySetup.cs
@@ -2,6 +2,8 @@
 using AbstUI.LUnity.Components;
 using AbstUI.LUnity.Styles;
 using AbstUI.LUnity.Windowing;
+using AbstUI.Inputs;
+using AbstUI.LUnity.Inputs;
 using AbstUI.Styles;
 using AbstUI.Windowing;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +21,8 @@ namespace AbstUI.LUnity
                 .AddSingleton<IAbstFrameworkWindowManager, AbstUnityWindowManager>()
                 .AddSingleton<IAbstFrameworkMainWindow, AbstUnityMainWindow>()
                 .AddTransient<IAbstFrameworkDialog, AbstUnityDialog>()
+                .AddSingleton<IAbstGlobalMouse, GlobalUnityAbstMouse>()
+                .AddSingleton<IAbstGlobalKey, GlobalUnityAbstKey>()
                 .WithAbstUI();
 
             return services;
@@ -26,6 +30,16 @@ namespace AbstUI.LUnity
         public static IServiceProvider WithAbstUIUnity(this IServiceProvider services)
         {
             services.WithAbstUI(); // need to be first to register all the windows in the windows factory.
+
+            var factory = services.GetRequiredService<IAbstComponentFactory>();
+            factory
+                .Register<AbstMouse, AbstUnityMouse>()
+                .Register<GlobalUnityAbstMouse, AbstUnityGlobalMouse>()
+                .Register<AbstKey, AbstUIUnityKey>()
+                .Register<AbstDialog, AbstUnityDialog>()
+                .Register<AbstMainWindow, AbstUnityMainWindow>()
+                .Register<AbstWindowManager, AbstUnityWindowManager>();
+
             return services;
         }
     }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityComponentFactory.cs
@@ -1,3 +1,4 @@
+using UnityEngine;
 using System;
 using AbstUI.Components;
 using AbstUI.Primitives;
@@ -15,6 +16,7 @@ using AbstUI.LUnity.Components.Texts;
 using AbstUI.LUnity.Components.Buttons;
 using AbstUI.LUnity.Components.Graphics;
 
+using AbstUI.LUnity.Components.Menus;
 namespace AbstUI.LUnity.Components;
 
 /// <summary>
@@ -178,7 +180,19 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         return input;
     }
 
-    public AbstInputSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null) => throw new NotImplementedException();
+    public AbstInputSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null)
+    {
+        var spin = new AbstInputSpinBox();
+        var impl = new AbstUnityInputSpinBox();
+        if (onChange != null)
+            impl.ValueChanged += () => onChange(spin.Value);
+        spin.Init(impl);
+        InitComponent(spin);
+        spin.Name = name;
+        if (min.HasValue) spin.Min = min.Value;
+        if (max.HasValue) spin.Max = max.Value;
+        return spin;
+    }
 
     public AbstInputCheckbox CreateInputCheckbox(string name, Action<bool>? onChange = null)
     {
@@ -204,9 +218,29 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         return input;
     }
 
-    public AbstItemList CreateItemList(string name, Action<string?>? onChange = null) => throw new NotImplementedException();
+    public AbstItemList CreateItemList(string name, Action<string?>? onChange = null)
+    {
+        var list = new AbstItemList();
+        var impl = new AbstUnityItemList();
+        if (onChange != null)
+            impl.ValueChanged += () => onChange(impl.SelectedValue);
+        list.Init(impl);
+        InitComponent(list);
+        list.Name = name;
+        return list;
+    }
 
-    public AbstColorPicker CreateColorPicker(string name, Action<AColor>? onChange = null) => throw new NotImplementedException();
+    public AbstColorPicker CreateColorPicker(string name, Action<AColor>? onChange = null)
+    {
+        var picker = new AbstColorPicker();
+        var impl = new AbstUnityColorPicker();
+        if (onChange != null)
+            impl.ValueChanged += () => onChange(impl.Color);
+        picker.Init(impl);
+        InitComponent(picker);
+        picker.Name = name;
+        return picker;
+    }
 
     public AbstLabel CreateLabel(string name, string text = "")
     {
@@ -245,11 +279,31 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         return button;
     }
 
-    public AbstMenu CreateMenu(string name) => throw new NotImplementedException();
+    public AbstMenu CreateMenu(string name)
+    {
+        var menu = new AbstMenu();
+        var impl = new AbstUnityMenu(name);
+        menu.Init(impl);
+        InitComponent(menu);
+        menu.Name = name;
+        return menu;
+    }
 
-    public AbstMenuItem CreateMenuItem(string name, string? shortcut = null) => throw new NotImplementedException();
+    public AbstMenuItem CreateMenuItem(string name, string? shortcut = null)
+    {
+        var item = new AbstMenuItem();
+        var impl = new AbstUnityMenuItem(name, shortcut);
+        item.Init(impl);
+        return item;
+    }
 
-    public AbstMenu CreateContextMenu(object window) => throw new NotImplementedException();
+    public AbstMenu CreateContextMenu(object window)
+    {
+        var menu = CreateMenu("ContextMenu");
+        if (window is GameObject go)
+            ((GameObject)menu.Framework<AbstUnityMenu>().FrameworkNode).transform.SetParent(go.transform);
+        return menu;
+    }
 
     public AbstHorizontalLineSeparator CreateHorizontalLineSeparator(string name)
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityColorPicker.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityColorPicker.cs
@@ -1,0 +1,52 @@
+using System;
+using AbstUI.Components.Inputs;
+using AbstUI.FrameworkCommunication;
+using AbstUI.LUnity.Components.Base;
+using AbstUI.LUnity.Primitives;
+using AbstUI.Primitives;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace AbstUI.LUnity.Components.Inputs;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkColorPicker"/>.
+/// </summary>
+internal class AbstUnityColorPicker : AbstUnityComponent, IAbstFrameworkColorPicker, IFrameworkFor<AbstColorPicker>
+{
+    private readonly Image _image;
+    private AColor _color = AColor.FromRGB(0, 0, 0);
+
+    public AbstUnityColorPicker() : base(CreateGameObject(out var image))
+    {
+        _image = image;
+    }
+
+    private static GameObject CreateGameObject(out Image image)
+    {
+        var go = new GameObject("ColorPicker");
+        image = go.AddComponent<Image>();
+        return go;
+    }
+
+    public bool Enabled
+    {
+        get => _image.raycastTarget;
+        set => _image.raycastTarget = value;
+    }
+
+    public AColor Color
+    {
+        get => _color;
+        set
+        {
+            if (_color.Equals(value))
+                return;
+            _color = value;
+            _image.color = value.ToUnityColor();
+            ValueChanged?.Invoke();
+        }
+    }
+
+    public event Action? ValueChanged;
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityInputSpinBox.cs
@@ -1,0 +1,17 @@
+using AbstUI.Components.Inputs;
+using AbstUI.FrameworkCommunication;
+
+namespace AbstUI.LUnity.Components.Inputs;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkSpinBox"/>.
+/// </summary>
+internal class AbstUnityInputSpinBox : AbstUnityInputNumber<float>, IAbstFrameworkSpinBox, IFrameworkFor<AbstInputSpinBox>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AbstUnityInputSpinBox"/> class.
+    /// </summary>
+    public AbstUnityInputSpinBox() : base()
+    {
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityItemList.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Inputs/AbstUnityItemList.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Components.Inputs;
+using AbstUI.FrameworkCommunication;
+using AbstUI.LUnity.Components.Base;
+using AbstUI.Primitives;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace AbstUI.LUnity.Components.Inputs;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkItemList"/>.
+/// </summary>
+internal class AbstUnityItemList : AbstUnityComponent, IAbstFrameworkItemList, IFrameworkFor<AbstItemList>
+{
+    private readonly Dropdown _dropdown;
+    private readonly List<KeyValuePair<string, string>> _items = new();
+
+    private string? _itemFont;
+    private int _itemFontSize;
+    private AColor _itemTextColor = AColor.FromRGB(0, 0, 0);
+    private AColor _itemSelectedTextColor = AColor.FromRGB(0, 0, 0);
+    private AColor _itemSelectedBackgroundColor = AColor.FromRGB(255, 255, 255);
+    private AColor _itemSelectedBorderColor = AColor.FromRGB(0, 0, 0);
+    private AColor _itemHoverTextColor = AColor.FromRGB(0, 0, 0);
+    private AColor _itemHoverBackgroundColor = AColor.FromRGB(255, 255, 255);
+    private AColor _itemHoverBorderColor = AColor.FromRGB(0, 0, 0);
+    private AColor _itemPressedTextColor = AColor.FromRGB(0, 0, 0);
+    private AColor _itemPressedBackgroundColor = AColor.FromRGB(255, 255, 255);
+    private AColor _itemPressedBorderColor = AColor.FromRGB(0, 0, 0);
+
+    public AbstUnityItemList() : base(CreateGameObject(out var dropdown))
+    {
+        _dropdown = dropdown;
+        _dropdown.onValueChanged.AddListener(_ => ValueChanged?.Invoke());
+    }
+
+    private static GameObject CreateGameObject(out Dropdown dropdown)
+    {
+        var go = new GameObject("ItemList");
+        dropdown = go.AddComponent<Dropdown>();
+        return go;
+    }
+
+    public IReadOnlyList<KeyValuePair<string, string>> Items => _items;
+
+    public void AddItem(string key, string value)
+    {
+        _items.Add(new KeyValuePair<string, string>(key, value));
+        _dropdown.options.Add(new Dropdown.OptionData(value));
+    }
+
+    public void ClearItems()
+    {
+        _items.Clear();
+        _dropdown.options.Clear();
+    }
+
+    public int SelectedIndex
+    {
+        get => _dropdown.value;
+        set => _dropdown.value = value;
+    }
+
+    public string? SelectedKey
+    {
+        get => SelectedIndex >= 0 && SelectedIndex < _items.Count ? _items[SelectedIndex].Key : null;
+        set
+        {
+            var idx = _items.FindIndex(kv => kv.Key == value);
+            if (idx >= 0)
+                SelectedIndex = idx;
+        }
+    }
+
+    public string? SelectedValue
+    {
+        get => SelectedIndex >= 0 && SelectedIndex < _items.Count ? _items[SelectedIndex].Value : null;
+        set
+        {
+            var idx = _items.FindIndex(kv => kv.Value == value);
+            if (idx >= 0)
+                SelectedIndex = idx;
+        }
+    }
+
+    public bool Enabled
+    {
+        get => _dropdown.interactable;
+        set => _dropdown.interactable = value;
+    }
+
+    public event Action? ValueChanged;
+
+    public string? ItemFont
+    {
+        get => _itemFont;
+        set => _itemFont = value;
+    }
+
+    public int ItemFontSize
+    {
+        get => _itemFontSize;
+        set => _itemFontSize = value;
+    }
+
+    public AColor ItemTextColor
+    {
+        get => _itemTextColor;
+        set => _itemTextColor = value;
+    }
+
+    public AColor ItemSelectedTextColor
+    {
+        get => _itemSelectedTextColor;
+        set => _itemSelectedTextColor = value;
+    }
+
+    public AColor ItemSelectedBackgroundColor
+    {
+        get => _itemSelectedBackgroundColor;
+        set => _itemSelectedBackgroundColor = value;
+    }
+
+    public AColor ItemSelectedBorderColor
+    {
+        get => _itemSelectedBorderColor;
+        set => _itemSelectedBorderColor = value;
+    }
+
+    public AColor ItemHoverTextColor
+    {
+        get => _itemHoverTextColor;
+        set => _itemHoverTextColor = value;
+    }
+
+    public AColor ItemHoverBackgroundColor
+    {
+        get => _itemHoverBackgroundColor;
+        set => _itemHoverBackgroundColor = value;
+    }
+
+    public AColor ItemHoverBorderColor
+    {
+        get => _itemHoverBorderColor;
+        set => _itemHoverBorderColor = value;
+    }
+
+    public AColor ItemPressedTextColor
+    {
+        get => _itemPressedTextColor;
+        set => _itemPressedTextColor = value;
+    }
+
+    public AColor ItemPressedBackgroundColor
+    {
+        get => _itemPressedBackgroundColor;
+        set => _itemPressedBackgroundColor = value;
+    }
+
+    public AColor ItemPressedBorderColor
+    {
+        get => _itemPressedBorderColor;
+        set => _itemPressedBorderColor = value;
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Menus/AbstUnityMenu.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Menus/AbstUnityMenu.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using AbstUI.Components.Buttons;
+using AbstUI.Components.Menus;
+using AbstUI.FrameworkCommunication;
+using AbstUI.LUnity.Components.Base;
+using UnityEngine;
+
+namespace AbstUI.LUnity.Components.Menus;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkMenu"/>.
+/// </summary>
+internal class AbstUnityMenu : AbstUnityComponent, IAbstFrameworkMenu, IFrameworkFor<AbstMenu>
+{
+    private readonly List<IAbstFrameworkMenuItem> _items = new();
+
+    public AbstUnityMenu(string name) : base(new GameObject(name))
+    {
+    }
+
+    public void AddItem(IAbstFrameworkMenuItem item)
+    {
+        _items.Add(item);
+    }
+
+    public void ClearItems()
+    {
+        _items.Clear();
+    }
+
+    public void PositionPopup(IAbstFrameworkButton button)
+    {
+        // Popup positioning is handled by Unity's layout; nothing required here.
+    }
+
+    public void Popup()
+    {
+        // No default popup behaviour in plain Unity; component acts as container only.
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Menus/AbstUnityMenuItem.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Menus/AbstUnityMenuItem.cs
@@ -1,0 +1,58 @@
+using System;
+using AbstUI.Components.Menus;
+using AbstUI.FrameworkCommunication;
+using AbstUI.LUnity.Components.Base;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace AbstUI.LUnity.Components.Menus;
+
+/// <summary>
+/// Unity implementation of <see cref="IAbstFrameworkMenuItem"/>.
+/// </summary>
+internal class AbstUnityMenuItem : AbstUnityComponent, IAbstFrameworkMenuItem, IFrameworkFor<AbstMenuItem>
+{
+    private readonly Button _button;
+    private readonly Text _text;
+
+    public AbstUnityMenuItem(string name, string? shortcut)
+        : base(CreateGameObject(name, out var button, out var text))
+    {
+        _button = button;
+        _text = text;
+        Shortcut = shortcut;
+        _button.onClick.AddListener(() => Activated?.Invoke());
+    }
+
+    private static GameObject CreateGameObject(string name, out Button button, out Text text)
+    {
+        var go = new GameObject(name);
+        button = go.AddComponent<Button>();
+        var textGo = new GameObject("Text");
+        textGo.transform.parent = go.transform;
+        text = textGo.AddComponent<Text>();
+        return go;
+    }
+
+    public new string Name
+    {
+        get => base.Name;
+        set
+        {
+            base.Name = value;
+            _text.text = value;
+        }
+    }
+
+    public bool Enabled
+    {
+        get => _button.interactable;
+        set => _button.interactable = value;
+    }
+
+    public bool CheckMark { get; set; }
+
+    public string? Shortcut { get; set; }
+
+    public event Action? Activated;
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Inputs/AbstUnityMouse.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Inputs/AbstUnityMouse.cs
@@ -97,3 +97,19 @@ public class AbstUnityMouse<TAbstMouseType, TAbstUIMouseEvent> : IAbstFrameworkM
         _lingoMouse.Value.DoMouseWheel(delta);
     }
 }
+
+public class AbstUnityMouse : AbstUnityMouse<AbstMouse, AbstMouseEvent>
+{
+    private static AbstMouse? _mouse;
+
+    public AbstUnityMouse()
+        : base(new Lazy<AbstMouse>(() => _mouse!))
+    {
+    }
+
+    public new void ReplaceMouseObj(IAbstMouse lingoMouse)
+    {
+        _mouse = (AbstMouse)lingoMouse;
+        base.ReplaceMouseObj(lingoMouse);
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Inputs/GlobalUnityAbstKey.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Inputs/GlobalUnityAbstKey.cs
@@ -1,0 +1,19 @@
+using AbstUI.Inputs;
+
+namespace AbstUI.LUnity.Inputs;
+
+/// <summary>
+/// Global key handler for Unity, bridging <see cref="AbstKey"/> to Unity's input system.
+/// </summary>
+public sealed class GlobalUnityAbstKey : AbstKey, IAbstGlobalKey
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GlobalUnityAbstKey"/> class.
+    /// </summary>
+    public GlobalUnityAbstKey()
+    {
+        var framework = new AbstUIUnityKey();
+        framework.SetKeyObj(this);
+        Init(framework);
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Inputs/GlobalUnityAbstMouse.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Inputs/GlobalUnityAbstMouse.cs
@@ -1,0 +1,46 @@
+using System;
+using AbstUI.Inputs;
+using AbstUI.Primitives;
+
+namespace AbstUI.LUnity.Inputs;
+
+/// <summary>
+/// Global mouse implementation for Unity.
+/// </summary>
+public sealed class GlobalUnityAbstMouse : AbstMouse, IAbstGlobalMouse
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GlobalUnityAbstMouse"/> class.
+    /// </summary>
+    public GlobalUnityAbstMouse()
+        : base(CreateFrameworkMouse(out var framework))
+    {
+        framework.ReplaceMouseObj(this);
+    }
+
+    private static IAbstFrameworkMouse CreateFrameworkMouse(out AbstUnityGlobalMouse framework)
+    {
+        framework = new AbstUnityGlobalMouse();
+        return framework;
+    }
+}
+
+/// <summary>
+/// Framework mouse used by <see cref="GlobalUnityAbstMouse"/>.
+/// </summary>
+public sealed class AbstUnityGlobalMouse : AbstUnityMouse<GlobalUnityAbstMouse, AbstMouseEvent>
+{
+    private static GlobalUnityAbstMouse? _mouse;
+
+    public AbstUnityGlobalMouse()
+        : base(new Lazy<GlobalUnityAbstMouse>(() => _mouse!))
+    {
+    }
+
+    /// <inheritdoc />
+    public new void ReplaceMouseObj(IAbstMouse lingoMouse)
+    {
+        _mouse = (GlobalUnityAbstMouse)lingoMouse;
+        base.ReplaceMouseObj(lingoMouse);
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Windowing/AbstUnityDialog.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Windowing/AbstUnityDialog.cs
@@ -5,6 +5,7 @@ using AbstUI.Primitives;
 using AbstUI.Windowing;
 using AbstUI.LUnity.Components.Containers;
 using AbstUI.Inputs;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LUnity.Windowing;
 
@@ -12,7 +13,7 @@ namespace AbstUI.LUnity.Windowing;
 /// Simplistic Unity implementation of <see cref="IAbstFrameworkDialog"/>.
 /// Provides basic popup behaviour for custom dialogs.
 /// </summary>
-internal class AbstUnityDialog : AbstUnityPanel, IAbstFrameworkDialog
+internal class AbstUnityDialog : AbstUnityPanel, IAbstFrameworkDialog, IFrameworkFor<AbstDialog>
 {
     private IAbstDialog _dialog = null!;
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Windowing/AbstUnityMainWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Windowing/AbstUnityMainWindow.cs
@@ -1,17 +1,18 @@
 using UnityEngine;
 using AbstUI.Primitives;
 using AbstUI.Windowing;
+using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.LUnity.Windowing;
 
-public class AbstUnityMainWindow : IAbstFrameworkMainWindow
+public class AbstUnityMainWindow : IAbstFrameworkMainWindow, IFrameworkFor<AbstMainWindow>
 {
     private AbstMainWindow _window = null!;
 
     public string Title
     {
         get => Application.productName;
-        set  { } // Application.productName = value;
+        set { } // Application.productName = value;
     }
 
     public void Init(AbstMainWindow instance)


### PR DESCRIPTION
## Summary
- implement global key and mouse support for Unity backend
- add Unity versions of spin box, item list, color picker, and menu components
- wire Unity setup and component factory to use new classes
- manually register Unity framework types in startup

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj --verify-no-changes`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a801195958833283cdc6d69166fedf