### PR TITLE
Remove Director-specific flag from AbstUI

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/README.md
+++ b/WillMoveToOwnRepo/AbstUI/README.md
@@ -31,8 +31,7 @@ run across multiple engines with minimal changes.
 `AbstEngineGlobal` stores runtime flags that are shared across backends. The
 static `RunFramework` value indicates which host (SDL2, Godot, Unity, etc.) is
 currently driving the UI and allows components to branch on framework‑specific
-behaviour. `IsRunningDirector` toggles extra features when the UI is embedded in
-the Director‑style editor.
+behaviour.
 
 ### Mouse Input
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Core/AbstEngineGlobal.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Core/AbstEngineGlobal.cs
@@ -13,6 +13,5 @@
     public class AbstEngineGlobal
     {
         public static AbstEngineRunFramework RunFramework { get; set; } = AbstEngineRunFramework.None;
-        public static bool IsRunningDirector { get; set; }
     }
 }

--- a/src/LingoEngine/Core/LingoEngineGlobal.cs
+++ b/src/LingoEngine/Core/LingoEngineGlobal.cs
@@ -5,6 +5,6 @@ namespace LingoEngine.Core
 
     public class LingoEngineGlobal : AbstEngineGlobal
     {
-
+        public static bool IsRunningDirector { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- remove IsRunningDirector flag from AbstUI's engine globals and docs
- keep IsRunningDirector flag in LingoEngine-specific globals

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj`
- `dotnet build src/LingoEngine/LingoEngine.csproj`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a80645bff48332b60ddc5ddb64a349