### PR TITLE
Implement window manager features across platforms

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIBlazorSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIBlazorSetup.cs
@@ -45,7 +45,9 @@ public static class AbstUIBlazorSetup
             .AddTransient<AbstBlazorHorizontalLineSeparatorComponent>()
             .AddTransient<AbstBlazorVerticalLineSeparatorComponent>()
             .AddSingleton<IAbstComponentFactory, AbstBlazorComponentFactory>()
+            .AddSingleton<IAbstFrameworkWindowManager, AbstBlazorWindowManager>()
             .AddSingleton<IAbstFrameworkMainWindow, AbstBlazorMainWindow>()
+            .AddTransient<IAbstFrameworkDialog, AbstBlazorDialog>()
             .WithAbstUI(windowRegistrations);
         return services;
     }
@@ -53,6 +55,11 @@ public static class AbstUIBlazorSetup
     public static IServiceProvider WithAbstUIBlazor(this IServiceProvider services)
     {
         services.WithAbstUI();// need to be first to register all the windows in the windows factory.
+        var factory = services.GetRequiredService<IAbstComponentFactory>();
+        factory
+            .Register<AbstMainWindow, AbstBlazorMainWindow>()
+            .Register<AbstWindowManager, AbstBlazorWindowManager>()
+            .Register<AbstDialog, AbstBlazorDialog>();
         return services;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Windowing/AbstBlazorDialog.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Windowing/AbstBlazorDialog.cs
@@ -1,0 +1,132 @@
+using AbstUI.Components;
+using AbstUI.Components.Containers;
+using AbstUI.Blazor.Components.Containers;
+using AbstUI.FrameworkCommunication;
+using AbstUI.Inputs;
+using AbstUI.Primitives;
+using AbstUI.Windowing;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using System;
+using System.Collections.Generic;
+
+namespace AbstUI.Blazor.Windowing;
+
+/// <summary>
+/// Blazor implementation of <see cref="IAbstFrameworkDialog"/> based on Bootstrap modals.
+/// </summary>
+internal class AbstBlazorDialog : AbstBlazorPanel, IAbstFrameworkDialog, IFrameworkFor<AbstDialog>, IDisposable
+{
+    private readonly AbstBlazorComponentFactory _factory;
+    private IAbstDialog _dialog = null!;
+    private string _title = string.Empty;
+    private bool _isPopup;
+    private bool _borderless;
+    private IJSObjectReference? _module;
+
+    [Inject] private IJSRuntime JS { get; set; } = default!;
+
+    public string Title
+    {
+        get => _title;
+        set => _title = value;
+    }
+
+    public AColor BackgroundColor { get; set; }
+
+    public bool IsOpen => Visibility;
+
+    public bool IsPopup
+    {
+        get => _isPopup;
+        set => _isPopup = value;
+    }
+
+    public bool Borderless
+    {
+        get => _borderless;
+        set => _borderless = value;
+    }
+
+    public bool IsActiveWindow => Visibility;
+
+    public IAbstMouse Mouse => _dialog.Mouse;
+
+    public IAbstKey Key => _dialog.Key;
+
+    public event Action<bool>? OnWindowStateChanged;
+
+    public AbstBlazorDialog(AbstBlazorComponentFactory factory)
+    {
+        _factory = factory;
+        Visibility = false;
+    }
+
+    public void Init(IAbstDialog instance)
+    {
+        _dialog = instance;
+        instance.Init(this);
+    }
+
+    private void EnsureModule()
+    {
+        _module ??= JS.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/AbstUI.Blazor/scripts/abstUIScripts.js")
+            .AsTask().GetAwaiter().GetResult();
+    }
+
+    public void Popup()
+    {
+        EnsureModule();
+        _module!.InvokeVoidAsync("AbstUIWindow.showBootstrapModal", Name);
+        Visibility = true;
+        OnWindowStateChanged?.Invoke(true);
+    }
+
+    public void PopupCentered()
+    {
+        Popup();
+    }
+
+    public void Hide()
+    {
+        EnsureModule();
+        _module!.InvokeVoidAsync("AbstUIWindow.hideBootstrapModal", Name);
+        Visibility = false;
+        OnWindowStateChanged?.Invoke(false);
+    }
+
+    public void SetPositionAndSize(int x, int y, int width, int height)
+    {
+        X = x;
+        Y = y;
+        Width = width;
+        Height = height;
+    }
+
+    public APoint GetPosition() => new(X, Y);
+
+    public APoint GetSize() => new(Width, Height);
+
+    public void SetSize(int width, int height)
+    {
+        Width = width;
+        Height = height;
+    }
+
+    public void AddItem(IAbstFrameworkLayoutNode abstFrameworkLayoutNode)
+        => Component.AddItem(abstFrameworkLayoutNode);
+
+    public void RemoveItem(IAbstFrameworkLayoutNode abstFrameworkLayoutNode)
+        => Component.RemoveItem(abstFrameworkLayoutNode);
+
+    public IEnumerable<IAbstFrameworkLayoutNode> GetItems()
+        => Component.GetItems();
+
+    public override void Dispose()
+    {
+        _module?.DisposeAsync();
+        base.Dispose();
+    }
+}
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Windowing/AbstBlazorWindowManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Windowing/AbstBlazorWindowManager.cs
@@ -1,0 +1,96 @@
+using AbstUI.Windowing;
+using AbstUI.Components.Containers;
+using AbstUI.Components;
+using AbstUI.FrameworkCommunication;
+using AbstUI.Blazor.Components.Containers;
+using Microsoft.JSInterop;
+using System;
+using System.Collections.Generic;
+
+namespace AbstUI.Blazor.Windowing;
+
+internal class AbstBlazorWindowManager : IAbstFrameworkWindowManager, IFrameworkFor<AbstWindowManager>
+{
+    private readonly IAbstWindowManager _windowManager;
+    private readonly IJSRuntime _js;
+    private readonly IAbstComponentFactory _factory;
+    private readonly Dictionary<string, IAbstWindow> _windows = new();
+    private IJSObjectReference? _module;
+
+    public AbstBlazorWindowManager(IAbstWindowManager windowManager, IJSRuntime js, IAbstComponentFactory factory)
+    {
+        _windowManager = windowManager;
+        _js = js;
+        _factory = factory;
+        windowManager.NewWindowCreated += NewWindowCreated;
+        windowManager.Init(this);
+    }
+
+    private void NewWindowCreated(IAbstWindow window)
+        => _windows[window.WindowCode] = window;
+
+    public void SetActiveWindow(IAbstWindow window)
+    {
+        if (window.FrameworkObj is AbstBlazorWindow blazorWindow)
+            blazorWindow.Popup();
+    }
+
+    public IAbstWindowDialogReference? ShowConfirmDialog(string title, string message, Action<bool> onResult)
+    {
+        EnsureModule();
+        var result = _module!.InvokeAsync<bool>("AbstUIWindow.showBootstrapConfirm", title, message)
+            .AsTask().GetAwaiter().GetResult();
+        onResult(result);
+        return new AbstWindowDialogReference(() => { });
+    }
+
+    public IAbstWindowDialogReference? ShowCustomDialog(string title, IAbstFrameworkPanel panel)
+    {
+        var dialogAbst = _factory.CreateElement<IAbstDialog>();
+        var dialog = dialogAbst.FrameworkObj<AbstBlazorDialog>();
+        dialog.Title = title;
+        dialog.SetSize((int)panel.Width, (int)panel.Height);
+        dialog.AddItem(panel);
+        dialog.PopupCentered();
+        return new AbstWindowDialogReference(() => { dialog.Hide(); dialog.Dispose(); }, dialog);
+    }
+
+    public IAbstWindowDialogReference? ShowCustomDialog<TDialog>(string title, IAbstFrameworkPanel panel, TDialog? dialog = null)
+        where TDialog : class, IAbstDialog
+    {
+        AbstBlazorDialog blazorDialog;
+        if (dialog != null)
+            blazorDialog = dialog.FrameworkObj<AbstBlazorDialog>();
+        else
+        {
+            dialog = _factory.CreateElement<TDialog>();
+            blazorDialog = dialog.FrameworkObj<AbstBlazorDialog>();
+        }
+
+        blazorDialog.Title = title;
+        blazorDialog.SetSize((int)panel.Width, (int)panel.Height);
+        blazorDialog.AddItem(panel);
+        blazorDialog.PopupCentered();
+        return new AbstWindowDialogReference(() => { blazorDialog.Hide(); blazorDialog.Dispose(); }, blazorDialog);
+    }
+
+    public IAbstWindowDialogReference? ShowNotification(string message, AbstUINotificationType type)
+    {
+        EnsureModule();
+        var typeStr = type switch
+        {
+            AbstUINotificationType.Error => "error",
+            AbstUINotificationType.Info => "info",
+            _ => "warning"
+        };
+        _module!.InvokeVoidAsync("AbstUIWindow.showBootstrapToast", message, typeStr);
+        return new AbstWindowDialogReference(() => { });
+    }
+
+    private void EnsureModule()
+    {
+        _module ??= _js.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/AbstUI.Blazor/scripts/abstUIScripts.js")
+            .AsTask().GetAwaiter().GetResult();
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
@@ -141,4 +141,62 @@ export class AbstUIWindow {
         const modal = bootstrap.Modal.getOrCreateInstance(el);
         modal.hide();
     }
+
+    static showBootstrapConfirm(title, message) {
+        return new Promise(resolve => {
+            const id = `abstui-confirm-${crypto.randomUUID()}`;
+            document.body.insertAdjacentHTML('beforeend', `
+<div class="modal" tabindex="-1" id="${id}">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">${title}</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body"><p>${message}</p></div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="${id}-ok">OK</button>
+      </div>
+    </div>
+  </div>
+</div>`);
+            const modalEl = document.getElementById(id);
+            const modal = new bootstrap.Modal(modalEl);
+            let confirmed = false;
+            document.getElementById(`${id}-ok`).addEventListener('click', () => {
+                confirmed = true;
+                resolve(true);
+                modal.hide();
+            });
+            modalEl.addEventListener('hidden.bs.modal', () => {
+                if (!confirmed) resolve(false);
+                modalEl.remove();
+            });
+            modal.show();
+        });
+    }
+
+    static showBootstrapToast(message, type) {
+        const container = document.getElementById('abstui-toast-container') ?? (() => {
+            const div = document.createElement('div');
+            div.id = 'abstui-toast-container';
+            div.className = 'toast-container position-fixed top-0 end-0 p-3';
+            document.body.appendChild(div);
+            return div;
+        })();
+        const id = `abstui-toast-${crypto.randomUUID()}`;
+        const cls = type === 'error' ? 'bg-danger text-white' : type === 'info' ? 'bg-info text-white' : 'bg-warning text-dark';
+        container.insertAdjacentHTML('beforeend', `
+<div id="${id}" class="toast ${cls}" role="alert" aria-live="assertive" aria-atomic="true">
+  <div class="d-flex">
+    <div class="toast-body">${message}</div>
+    <button type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+  </div>
+</div>`);
+        const toastEl = document.getElementById(id);
+        const toast = new bootstrap.Toast(toastEl);
+        toastEl.addEventListener('hidden.bs.toast', () => toastEl.remove());
+        toast.show();
+    }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Windowing/AbstSdlWindowManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Windowing/AbstSdlWindowManager.cs
@@ -1,6 +1,8 @@
 using AbstUI.Windowing;
 using AbstUI.Components.Containers;
 using AbstUI.Components;
+using AbstUI.SDL2.SDLL;
+using System;
 
 namespace AbstUI.SDL2.Windowing
 {
@@ -36,7 +38,24 @@ namespace AbstUI.SDL2.Windowing
         }
 
         public IAbstWindowDialogReference? ShowConfirmDialog(string title, string message, Action<bool> onResult)
-            => null;
+        {
+            var buttons = new SDL.SDL_MessageBoxButtonData[]
+            {
+                new SDL.SDL_MessageBoxButtonData { buttonid = 1, text = "OK" },
+                new SDL.SDL_MessageBoxButtonData { buttonid = 0, text = "Cancel" }
+            };
+            var data = new SDL.SDL_MessageBoxData
+            {
+                flags = SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_WARNING,
+                title = title,
+                message = message,
+                numbuttons = buttons.Length,
+                buttons = buttons
+            };
+            SDL.SDL_ShowMessageBox(ref data, out int buttonId);
+            onResult(buttonId == 1);
+            return new AbstWindowDialogReference(() => { });
+        }
 
         public IAbstWindowDialogReference? ShowCustomDialog(string title, IAbstFrameworkPanel panel)
         {
@@ -71,6 +90,15 @@ namespace AbstUI.SDL2.Windowing
         }
 
         public IAbstWindowDialogReference? ShowNotification(string message, AbstUINotificationType type)
-            => null;
+        {
+            var flag = type switch
+            {
+                AbstUINotificationType.Error => SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR,
+                AbstUINotificationType.Info => SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_INFORMATION,
+                _ => SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_WARNING
+            };
+            SDL.SDL_ShowSimpleMessageBox(flag, "Notification", message, IntPtr.Zero);
+            return new AbstWindowDialogReference(() => { });
+        }
     }
 }


### PR DESCRIPTION
## Summary
- register Blazor dialog implementation and bootstrap helpers
- enable bootstrap confirm dialogs, custom popups, and toast notifications

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --no-restore`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a806ae69c083328b8b9a40720e7376