### PR TITLE
Add Unity graphics visual test project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ StyleCopReport.xml
 *_h.h
 *.ilk
 *.meta
+!WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/**/*.meta
 *.obj
 *.iobj
 *.pch
@@ -203,6 +204,7 @@ PublishScripts/
 *.snupkg
 # The packages folder can be ignored because of Package Restore
 **/[Pp]ackages/*
+!WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Packages/**
 # except build/, which is used as an MSBuild target.
 !**/[Pp]ackages/build/
 # Uncomment if necessary however generally it will be regenerated when needed

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/AbstUI.GfxVisualTest.LUnity.csproj
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/AbstUI.GfxVisualTest.LUnity.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AbstUI.LUnity\AbstUI.LUnity.csproj" />
+    <ProjectReference Include="..\..\src\AbstUI\AbstUI.csproj" />
+    <ProjectReference Include="..\AbstUI.GfxVisualTest\AbstUI.GfxVisualTest.csproj" />
+  </ItemGroup>
+</Project>

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Assets.meta
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Assets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0363162a-d024-46a2-a8a7-79288c5f2ce9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Assets/Scripts.meta
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 199c3cc2-2037-4ebb-afb7-36843caee485
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Assets/Scripts/GfxTest.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Assets/Scripts/GfxTest.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.DependencyInjection;
+using UnityEngine;
+using AbstUI.Components;
+using AbstUI.GfxVisualTest;
+using AbstUI.LUnity;
+using LingoEngine.SDL2.GfxVisualTest;
+
+namespace AbstUI.GfxVisualTest.LUnity;
+
+public class GfxTest : MonoBehaviour
+{
+    // Fields
+    private ServiceProvider _serviceProvider = null!;
+
+    // Methods
+    private void Start()
+    {
+        Screen.SetResolution(800, 600, FullScreenMode.Windowed);
+
+        var services = new ServiceCollection();
+        services.WithAbstUIUnity();
+        services.WithAbstUI(w => w.AddSingletonWindow<GfxTestWindow, UnityTestWindow>(GfxTestWindow.MyWindowCode));
+        services.SetupGfxTest();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _serviceProvider.WithAbstUIUnity();
+        _serviceProvider.SetupGfxTest();
+
+        var factory = _serviceProvider.GetRequiredService<IAbstComponentFactory>();
+        var root = GfxTestScene.Build(factory);
+        if (root.FrameworkObj.FrameworkNode is GameObject go)
+        {
+            go.transform.SetParent(gameObject.transform, false);
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Assets/Scripts/GfxTest.cs.meta
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Assets/Scripts/GfxTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d499c0e-67b5-4bb4-a262-433b61f10b11
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Assets/Scripts/UnityTestWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Assets/Scripts/UnityTestWindow.cs
@@ -1,0 +1,127 @@
+using System;
+using AbstUI.Components;
+using AbstUI.FrameworkCommunication;
+using AbstUI.Inputs;
+using AbstUI.Primitives;
+using AbstUI.Windowing;
+using UnityEngine;
+
+namespace AbstUI.GfxVisualTest.LUnity;
+
+public sealed class UnityTestWindow : IFrameworkTestWindow
+{
+    // Fields
+    private readonly GameObject _root;
+    private readonly RectTransform _rect;
+    private GfxTestWindow _instance = null!;
+    private IAbstFrameworkNode? _content;
+    private bool _isOpen;
+
+    // Properties
+    public string Title { get; set; } = string.Empty;
+    public AColor BackgroundColor { get; set; } = AColors.White;
+    public bool IsActiveWindow => _isOpen;
+    public bool IsOpen => _isOpen;
+    public IAbstMouse Mouse => _instance.Mouse;
+    public IAbstKey AbstKey => _instance.Key;
+
+    public IAbstFrameworkNode? Content
+    {
+        get => _content;
+        set
+        {
+            _content = value;
+            if (value?.FrameworkNode is GameObject go)
+            {
+                go.transform.SetParent(_root.transform, false);
+            }
+        }
+    }
+
+    public string Name
+    {
+        get => _root.name;
+        set => _root.name = value;
+    }
+
+    public bool Visibility
+    {
+        get => _root.activeSelf;
+        set => _root.SetActive(value);
+    }
+
+    public float Width
+    {
+        get => _rect.sizeDelta.x;
+        set => _rect.sizeDelta = new Vector2(value, _rect.sizeDelta.y);
+    }
+
+    public float Height
+    {
+        get => _rect.sizeDelta.y;
+        set => _rect.sizeDelta = new Vector2(_rect.sizeDelta.x, value);
+    }
+
+    public AMargin Margin { get; set; }
+
+    public object FrameworkNode => _root;
+
+    // Constructors
+    public UnityTestWindow()
+    {
+        _root = new GameObject(GfxTestWindow.MyWindowCode);
+        _rect = _root.AddComponent<RectTransform>();
+        _root.SetActive(false);
+    }
+
+    // Methods
+    public void Init(GfxTestWindow instance)
+    {
+        _instance = instance;
+    }
+
+    void IFrameworkForInitializable<IAbstWindow>.Init(IAbstWindow window)
+        => Init((GfxTestWindow)window);
+
+    public void Dispose()
+    {
+        UnityEngine.Object.Destroy(_root);
+    }
+
+    public void OpenWindow()
+    {
+        _isOpen = true;
+        Visibility = true;
+    }
+
+    public void CloseWindow()
+    {
+        _isOpen = false;
+        Visibility = false;
+    }
+
+    public void MoveWindow(int x, int y)
+    {
+        _rect.anchoredPosition = new Vector2(x, -y);
+    }
+
+    public void SetPositionAndSize(int x, int y, int width, int height)
+    {
+        MoveWindow(x, y);
+        SetSize(width, height);
+    }
+
+    public APoint GetPosition()
+    {
+        var pos = _rect.anchoredPosition;
+        return new APoint(pos.x, -pos.y);
+    }
+
+    public APoint GetSize() => new(Width, Height);
+
+    public void SetSize(int width, int height)
+    {
+        Width = width;
+        Height = height;
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Assets/Scripts/UnityTestWindow.cs.meta
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Assets/Scripts/UnityTestWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d74ce641-7372-41f9-877f-c40efb8f95d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Packages/manifest.json
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Packages/manifest.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "com.unity.modules.uielements": "1.0.0",
+    "com.unity.modules.imgui": "1.0.0"
+  }
+}

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Packages/packages-lock.json
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/Packages/packages-lock.json
@@ -1,0 +1,16 @@
+{
+  "dependencies": {
+    "com.unity.modules.uielements": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.imgui": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    }
+  }
+}

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/ProjectSettings/ProjectSettings.asset
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/ProjectSettings/ProjectSettings.asset
@@ -1,0 +1,11 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!129 &1
+PlayerSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 26
+  productName: AbstUI Gfx Visual Test
+  companyName: LingoEngine
+  defaultScreenWidth: 800
+  defaultScreenHeight: 600
+  fullscreenMode: 3

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/ProjectSettings/ProjectVersion.txt
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/ProjectSettings/ProjectVersion.txt
@@ -1,0 +1,2 @@
+m_EditorVersion: 2022.3.21f1
+m_EditorVersionWithRevision: 2022.3.21f1 (revision)


### PR DESCRIPTION
## Summary
- include Unity project assets and configuration for visual test
- set default window size and title in Unity player settings
- configure runtime resolution in test MonoBehaviour

## Testing
- `dotnet format --verify-no-changes WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/AbstUI.GfxVisualTest.LUnity.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/AbstUI.GfxVisualTest.LUnity.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8124004b883329e7d59b0ac8a5038