### PR TITLE
Implement Unity film loop and shape members

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj
@@ -31,8 +31,9 @@
                 <PackageReference Include="Unity3D.UnityEngine.UI" Version="2018.3.5.1" />
         </ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\AbstUI\AbstUI.csproj" />
-	</ItemGroup>
+        <ItemGroup>
+          <ProjectReference Include="..\AbstUI\AbstUI.csproj" />
+          <ProjectReference Include="..\..\..\..\src\LingoEngine\LingoEngine.csproj" />
+        </ItemGroup>
 
 </Project>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Bitmaps/UnityBitmapExtensions.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Bitmaps/UnityBitmapExtensions.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using AbstUI.Primitives;
+using LingoEngine.Tools;
+using UnityEngine;
+using Vec2 = System.Numerics.Vector2;
+
+namespace AbstUI.LUnity.Bitmaps;
+
+public static class UnityBitmapExtensions
+{
+    /// <summary>
+    /// Fills the entire buffer with <paramref name="color"/>.
+    /// </summary>
+    public static void Fill(this Color32[] pix, int totalPixels, Color32 color)
+    {
+        ParallelHelper.For(0, totalPixels, totalPixels, i => pix[i] = color);
+    }
+
+    /// <summary>
+    /// Draws a rectangle on the pixel buffer.
+    /// </summary>
+    public static void DrawRectangle(this Color32[] pix, int w, int h, Color32 fill,
+        Color32 stroke, bool filled, int strokeWidth)
+    {
+        int totalPixels = w * h;
+        if (filled)
+            pix.Fill(totalPixels, fill);
+
+        if (!filled || strokeWidth > 0)
+        {
+            for (int y = 0; y < strokeWidth && y < h; y++)
+                for (int x = 0; x < w; x++)
+                    pix[y * w + x] = stroke;
+            for (int y = h - strokeWidth; y < h; y++)
+                for (int x = 0; x < w; x++)
+                    pix[y * w + x] = stroke;
+            for (int y = 0; y < h; y++)
+            {
+                for (int x = 0; x < strokeWidth && x < w; x++)
+                    pix[y * w + x] = stroke;
+                for (int x = w - strokeWidth; x < w; x++)
+                    if (x >= 0) pix[y * w + x] = stroke;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Draws an oval on the pixel buffer.
+    /// </summary>
+    public static void DrawOval(this Color32[] pix, int w, int h, Color32 fill,
+        Color32 stroke, bool filled, int strokeWidth)
+    {
+        float cx = w / 2f;
+        float cy = h / 2f;
+        float rx = w / 2f;
+        float ry = h / 2f;
+        float maxR = MathF.Max(rx, ry);
+        int totalPixels = w * h;
+
+        ParallelHelper.For(0, h, totalPixels, y =>
+        {
+            for (int x = 0; x < w; x++)
+            {
+                float dx = (x + 0.5f - cx) / rx;
+                float dy = (y + 0.5f - cy) / ry;
+                float d = dx * dx + dy * dy;
+                if (filled && d <= 1f)
+                    pix[y * w + x] = fill;
+                else if (!filled && Math.Abs(d - 1f) <= strokeWidth / maxR)
+                    pix[y * w + x] = stroke;
+            }
+        });
+    }
+
+    /// <summary>
+    /// Draws a single line using Bresenham's algorithm.
+    /// </summary>
+    public static void DrawLine(this Color32[] pix, int w, int h, int x0, int y0,
+        int x1, int y1, Color32 color)
+    {
+        int dx = Math.Abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
+        int dy = -Math.Abs(y1 - y0), sy = y0 < y1 ? 1 : -1;
+        int err = dx + dy;
+        while (true)
+        {
+            if (x0 >= 0 && x0 < w && y0 >= 0 && y0 < h)
+                pix[y0 * w + x0] = color;
+            if (x0 == x1 && y0 == y1) break;
+            int e2 = 2 * err;
+            if (e2 >= dy) { err += dy; x0 += sx; }
+            if (e2 <= dx) { err += dx; y0 += sy; }
+        }
+    }
+
+    /// <summary>
+    /// Draws a polyline defined by <paramref name="points"/>.
+    /// </summary>
+    public static void DrawPolyLine(this Color32[] pix, int w, int h,
+        IReadOnlyList<APoint> points, bool closed, Color32 stroke)
+    {
+        if (points.Count < 2) return;
+        for (int i = 0; i < points.Count - 1; i++)
+        {
+            var p0 = points[i];
+            var p1 = points[i + 1];
+            pix.DrawLine(w, h, (int)p0.X, (int)p0.Y, (int)p1.X, (int)p1.Y, stroke);
+        }
+        if (closed)
+        {
+            var p0 = points[^1];
+            var p1 = points[0];
+            pix.DrawLine(w, h, (int)p0.X, (int)p0.Y, (int)p1.X, (int)p1.Y, stroke);
+        }
+    }
+
+    /// <summary>
+    /// Draws a rounded rectangle on the pixel buffer.
+    /// </summary>
+    public static void DrawRoundRect(this Color32[] pix, int w, int h, Color32 fill,
+        Color32 stroke, bool filled, int strokeWidth)
+    {
+        int r = Math.Min(Math.Min(w, h) / 5, 20);
+        int totalPixels = w * h;
+        ParallelHelper.For(0, h, totalPixels, y =>
+        {
+            for (int x = 0; x < w; x++)
+            {
+                bool inside = true;
+                if (x < r && y < r)
+                    inside = (x - r) * (x - r) + (y - r) * (y - r) <= r * r;
+                else if (x >= w - r && y < r)
+                    inside = (x - (w - r - 1)) * (x - (w - r - 1)) + (y - r) * (y - r) <= r * r;
+                else if (x < r && y >= h - r)
+                    inside = (x - r) * (x - r) + (y - (h - r - 1)) * (y - (h - r - 1)) <= r * r;
+                else if (x >= w - r && y >= h - r)
+                    inside = (x - (w - r - 1)) * (x - (w - r - 1)) + (y - (h - r - 1)) * (y - (h - r - 1)) <= r * r;
+
+                if (filled)
+                {
+                    if (inside)
+                        pix[y * w + x] = fill;
+                    else if (Math.Abs((x - r) * (x - r) + (y - r) * (y - r) - r * r) < r && x < r && y < r)
+                        pix[y * w + x] = stroke;
+                }
+                else if (!inside && ((x >= r && x < w - r) || (y >= r && y < h - r)))
+                {
+                    pix[y * w + x] = stroke;
+                }
+            }
+        });
+    }
+
+    /// <summary>
+    /// Scales the source pixel buffer to the specified destination size using nearest-neighbor sampling.
+    /// </summary>
+    public static Color32[] ScalePixels(this Color32[] src, int srcW, int srcH, int destW, int destH)
+    {
+        var dst = new Color32[destW * destH];
+        float ratioX = srcW / (float)destW;
+        float ratioY = srcH / (float)destH;
+        for (int y = 0; y < destH; y++)
+        {
+            int sy = (int)(y * ratioY);
+            for (int x = 0; x < destW; x++)
+            {
+                int sx = (int)(x * ratioX);
+                dst[y * destW + x] = src[sy * srcW + sx];
+            }
+        }
+        return dst;
+    }
+
+    /// <summary>
+    /// Draws <paramref name="src"/> onto the destination pixel buffer applying
+    /// the provided transformation matrix and opacity.
+    /// </summary>
+    /// <param name="dest">Destination pixel buffer.</param>
+    /// <param name="destWidth">Width of the destination buffer.</param>
+    /// <param name="destHeight">Height of the destination buffer.</param>
+    /// <param name="src">Source pixel buffer.</param>
+    /// <param name="srcWidth">Width of the source buffer.</param>
+    /// <param name="srcHeight">Height of the source buffer.</param>
+    /// <param name="transform">Matrix that transforms points from source space into destination space.</param>
+    /// <param name="alpha">Additional opacity applied to the source pixels.</param>
+    public static void DrawWithMatrix(this Color32[] dest, int destWidth, int destHeight,
+        Color32[] src, int srcWidth, int srcHeight, Matrix3x2 transform, float alpha)
+    {
+        Matrix3x2.Invert(transform, out var inv);
+
+        Vec2[] pts =
+        {
+            Vec2.Transform(Vec2.Zero, transform),
+            Vec2.Transform(new Vec2(srcWidth, 0), transform),
+            Vec2.Transform(new Vec2(srcWidth, srcHeight), transform),
+            Vec2.Transform(new Vec2(0, srcHeight), transform)
+        };
+        int minX = (int)MathF.Floor(pts[0].X);
+        int maxX = (int)MathF.Ceiling(pts[0].X);
+        int minY = (int)MathF.Floor(pts[0].Y);
+        int maxY = (int)MathF.Ceiling(pts[0].Y);
+        for (int i = 1; i < pts.Length; i++)
+        {
+            if (pts[i].X < minX) minX = (int)MathF.Floor(pts[i].X);
+            if (pts[i].X > maxX) maxX = (int)MathF.Ceiling(pts[i].X);
+            if (pts[i].Y < minY) minY = (int)MathF.Floor(pts[i].Y);
+            if (pts[i].Y > maxY) maxY = (int)MathF.Ceiling(pts[i].Y);
+        }
+
+        int totalPixels = (maxX - minX) * (maxY - minY);
+        ParallelHelper.For(minY, maxY, totalPixels, y =>
+        {
+            if ((uint)y >= (uint)destHeight) return;
+            int row = y * destWidth;
+            for (int x = minX; x < maxX; x++)
+            {
+                if ((uint)x >= (uint)destWidth) continue;
+                var srcPos = Vec2.Transform(new Vec2(x + 0.5f, y + 0.5f), inv);
+                int sx = (int)MathF.Floor(srcPos.X);
+                int sy = (int)MathF.Floor(srcPos.Y);
+                if ((uint)sx >= (uint)srcWidth || (uint)sy >= (uint)srcHeight)
+                    continue;
+                var c = src[sy * srcWidth + sx];
+                float a = c.a / 255f * alpha;
+                if (a <= 0f) continue;
+                int idx = row + x;
+                var dst = dest[idx];
+                float invA = 1f - a;
+                dest[idx] = new Color32(
+                    (byte)(c.r * a + dst.r * invA),
+                    (byte)(c.g * a + dst.g * invA),
+                    (byte)(c.b * a + dst.b * invA),
+                    (byte)(c.a * a + dst.a * invA));
+            }
+        });
+    }
+}
+
+

--- a/src/LingoEngine.Unity/Core/UnityFactory.cs
+++ b/src/LingoEngine.Unity/Core/UnityFactory.cs
@@ -18,6 +18,8 @@ using LingoEngine.Unity.Bitmaps;
 using LingoEngine.Unity.Movies;
 using LingoEngine.Unity.Texts;
 using LingoEngine.Unity.Sounds;
+using LingoEngine.Unity.FilmLoops;
+using LingoEngine.Unity.Shapes;
 using AbstUI.Styles;
 using Microsoft.Extensions.DependencyInjection;
 using AbstUI.Primitives;
@@ -94,8 +96,20 @@ public class UnityFactory : ILingoFrameworkFactory, IDisposable
         impl.Init(member);
         return member;
     }
-    public LingoFilmLoopMember CreateMemberFilmLoop(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
-    public LingoMemberShape CreateMemberShape(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
+    public LingoFilmLoopMember CreateMemberFilmLoop(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default)
+    {
+        var impl = new UnityFilmLoopMember();
+        var member = new LingoFilmLoopMember((LingoCast)cast, impl, numberInCast, name, fileName ?? string.Empty, regPoint);
+        impl.Init(member);
+        return member;
+    }
+    public LingoMemberShape CreateMemberShape(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default)
+    {
+        var impl = new UnityMemberShape();
+        var member = new LingoMemberShape((LingoCast)cast, impl, numberInCast, name, fileName ?? string.Empty, regPoint);
+        impl.Init(member);
+        return member;
+    }
     public LingoMemberField CreateMemberField(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default)
     {
         var fontManager = _serviceProvider.GetRequiredService<IAbstFontManager>();
@@ -114,7 +128,12 @@ public class UnityFactory : ILingoFrameworkFactory, IDisposable
         _disposables.Add(impl);
         return member;
     }
-    public LingoMember CreateScript(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
+    public LingoMember CreateScript(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default)
+    {
+        var impl = new UnityFrameworkMemberScript();
+        var member = new LingoMemberScript(impl, (LingoCast)cast, numberInCast, name, fileName ?? string.Empty, regPoint);
+        return member;
+    }
     public LingoMember CreateEmpty(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default)
     {
         var impl = new UnityFrameworkMemberEmpty();
@@ -163,26 +182,40 @@ public class UnityFactory : ILingoFrameworkFactory, IDisposable
     public AbstTabContainer CreateTabContainer(string name) => _gfxFactory.CreateTabContainer(name);
     public AbstTabItem CreateTabItem(string name, string title) => _gfxFactory.CreateTabItem(name, title);
     public AbstScrollContainer CreateScrollContainer(string name) => _gfxFactory.CreateScrollContainer(name);
-    public AbstInputSlider<float> CreateInputSliderFloat(AOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null) => throw new NotImplementedException();
-    public AbstInputSlider<int> CreateInputSliderInt(AOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null) => throw new NotImplementedException();
+    public AbstInputSlider<float> CreateInputSliderFloat(AOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null)
+        => _gfxFactory.CreateInputSliderFloat(orientation, name, min, max, step, onChange);
+    public AbstInputSlider<int> CreateInputSliderInt(AOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null)
+        => _gfxFactory.CreateInputSliderInt(orientation, name, min, max, step, onChange);
     public AbstInputText CreateInputText(string name, int maxLength = 0, Action<string>? onChange = null, bool multiLine = false)
         => _gfxFactory.CreateInputText(name, maxLength, onChange, multiLine);
-    public AbstInputNumber<float> CreateInputNumberFloat(string name, float? min = null, float? max = null, Action<float>? onChange = null) => throw new NotImplementedException();
-    public AbstInputNumber<int> CreateInputNumberInt(string name, int? min = null, int? max = null, Action<int>? onChange = null) => throw new NotImplementedException();
-    public AbstInputNumber<TValue> CreateInputNumber<TValue>(string name, NullableNum<TValue> min, NullableNum<TValue> max, Action<TValue>? onChange = null) where TValue : System.Numerics.INumber<TValue> => throw new NotImplementedException();
-    public AbstInputSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null) => throw new NotImplementedException();
+    public AbstInputNumber<float> CreateInputNumberFloat(string name, float? min = null, float? max = null, Action<float>? onChange = null)
+        => _gfxFactory.CreateInputNumberFloat(name, min, max, onChange);
+    public AbstInputNumber<int> CreateInputNumberInt(string name, int? min = null, int? max = null, Action<int>? onChange = null)
+        => _gfxFactory.CreateInputNumberInt(name, min, max, onChange);
+    public AbstInputNumber<TValue> CreateInputNumber<TValue>(string name, NullableNum<TValue> min, NullableNum<TValue> max, Action<TValue>? onChange = null) where TValue : System.Numerics.INumber<TValue>
+        => _gfxFactory.CreateInputNumber(name, min, max, onChange);
+    public AbstInputSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null)
+        => _gfxFactory.CreateSpinBox(name, min, max, onChange);
     public AbstInputCheckbox CreateInputCheckbox(string name, Action<bool>? onChange = null) => _gfxFactory.CreateInputCheckbox(name, onChange);
     public AbstInputCombobox CreateInputCombobox(string name, Action<string?>? onChange = null) => _gfxFactory.CreateInputCombobox(name, onChange);
-    public AbstItemList CreateItemList(string name, Action<string?>? onChange = null) => throw new NotImplementedException();
-    public AbstColorPicker CreateColorPicker(string name, Action<AColor>? onChange = null) => throw new NotImplementedException();
+    public AbstItemList CreateItemList(string name, Action<string?>? onChange = null)
+        => _gfxFactory.CreateItemList(name, onChange);
+    public AbstColorPicker CreateColorPicker(string name, Action<AColor>? onChange = null)
+        => _gfxFactory.CreateColorPicker(name, onChange);
     public AbstLabel CreateLabel(string name, string text = "") => _gfxFactory.CreateLabel(name, text);
     public AbstButton CreateButton(string name, string text = "") => _gfxFactory.CreateButton(name, text);
-    public AbstStateButton CreateStateButton(string name, IAbstTexture2D? texture = null, string text = "", Action<bool>? onChange = null) => throw new NotImplementedException();
-    public AbstMenu CreateMenu(string name) => throw new NotImplementedException();
-    public AbstMenuItem CreateMenuItem(string name, string? shortcut = null) => throw new NotImplementedException();
-    public AbstMenu CreateContextMenu(object window) => throw new NotImplementedException();
-    public AbstHorizontalLineSeparator CreateHorizontalLineSeparator(string name) => throw new NotImplementedException();
-    public AbstVerticalLineSeparator CreateVerticalLineSeparator(string name) => throw new NotImplementedException();
+    public AbstStateButton CreateStateButton(string name, IAbstTexture2D? texture = null, string text = "", Action<bool>? onChange = null)
+        => _gfxFactory.CreateStateButton(name, texture, text, onChange);
+    public AbstMenu CreateMenu(string name)
+        => _gfxFactory.CreateMenu(name);
+    public AbstMenuItem CreateMenuItem(string name, string? shortcut = null)
+        => _gfxFactory.CreateMenuItem(name, shortcut);
+    public AbstMenu CreateContextMenu(object window)
+        => _gfxFactory.CreateContextMenu(window);
+    public AbstHorizontalLineSeparator CreateHorizontalLineSeparator(string name)
+        => _gfxFactory.CreateHorizontalLineSeparator(name);
+    public AbstVerticalLineSeparator CreateVerticalLineSeparator(string name)
+        => _gfxFactory.CreateVerticalLineSeparator(name);
     //public AbstWindow CreateWindow(string name, string title = "") => throw new NotImplementedException();
     #endregion
 
@@ -195,8 +228,10 @@ public class UnityFactory : ILingoFrameworkFactory, IDisposable
         return sprite;
     }
 
-    public T CreateBehavior<T>(LingoMovie lingoMovie) where T : LingoSpriteBehavior => throw new NotImplementedException();
-    public T CreateMovieScript<T>(LingoMovie lingoMovie) where T : LingoMovieScript => throw new NotImplementedException();
+    public T CreateBehavior<T>(LingoMovie lingoMovie) where T : LingoSpriteBehavior
+        => lingoMovie.GetServiceProvider().GetRequiredService<T>();
+    public T CreateMovieScript<T>(LingoMovie lingoMovie) where T : LingoMovieScript
+        => lingoMovie.GetServiceProvider().GetRequiredService<T>();
 
     public void Dispose()
     {

--- a/src/LingoEngine.Unity/FilmLoops/UnityFilmLoopMember.cs
+++ b/src/LingoEngine.Unity/FilmLoops/UnityFilmLoopMember.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using AbstUI.LUnity.Bitmaps;
+using AbstUI.Primitives;
+using LingoEngine.Bitmaps;
+using LingoEngine.FilmLoops;
+using LingoEngine.Members;
+using LingoEngine.Primitives;
+using LingoEngine.Sprites;
+using LingoEngine.Tools;
+using UnityEngine;
+
+namespace LingoEngine.Unity.FilmLoops;
+
+/// <summary>
+/// Unity implementation of a film loop member. It composes sprite layers into
+/// a single <see cref="Texture2D"/> using the <see cref="LingoFilmLoopComposer"/>.
+/// </summary>
+public class UnityFilmLoopMember : ILingoFrameworkMemberFilmLoop, IDisposable
+{
+    private LingoFilmLoopMember _member = null!;
+    private UnityTexture2D? _texture;
+
+    /// <inheritdoc/>
+    public bool IsLoaded { get; private set; }
+
+    /// <inheritdoc/>
+    public byte[]? Media { get; set; }
+
+    /// <inheritdoc/>
+    public LingoFilmLoopFraming Framing { get; set; } = LingoFilmLoopFraming.Auto;
+
+    /// <inheritdoc/>
+    public bool Loop { get; set; } = true;
+
+    /// <inheritdoc/>
+    public APoint Offset { get; private set; }
+
+    /// <inheritdoc/>
+    public IAbstTexture2D? TextureLingo => _texture;
+
+    /// <summary>
+    /// Initializes this instance with its owning member.
+    /// </summary>
+    internal void Init(LingoFilmLoopMember member)
+    {
+        _member = member;
+    }
+
+    /// <inheritdoc/>
+    public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
+
+    /// <inheritdoc/>
+    public void Preload() => IsLoaded = true;
+
+    /// <inheritdoc/>
+    public void Unload()
+    {
+        _texture?.Dispose();
+        _texture = null;
+        IsLoaded = false;
+    }
+
+    /// <inheritdoc/>
+    public void Erase()
+    {
+        Media = null;
+        Unload();
+    }
+
+    /// <inheritdoc/>
+    public void ImportFileInto() { }
+
+    /// <inheritdoc/>
+    public void CopyToClipboard()
+    {
+        if (Media == null) return;
+        var base64 = Convert.ToBase64String(Media);
+        var guiUtilityType = Type.GetType("UnityEngine.GUIUtility, UnityEngine");
+        var prop = guiUtilityType?.GetProperty("systemCopyBuffer", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public);
+        prop?.SetValue(null, base64);
+    }
+
+    /// <inheritdoc/>
+    public void PasteClipboardInto()
+    {
+        var guiUtilityType = Type.GetType("UnityEngine.GUIUtility, UnityEngine");
+        var prop = guiUtilityType?.GetProperty("systemCopyBuffer", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public);
+        var data = prop?.GetValue(null) as string;
+        if (string.IsNullOrEmpty(data)) return;
+        try
+        {
+            Media = Convert.FromBase64String(data);
+        }
+        catch
+        {
+        }
+    }
+
+    /// <inheritdoc/>
+    public IAbstTexture2D? RenderToTexture(LingoInkType ink, AColor transparentColor) => _texture;
+
+    /// <inheritdoc/>
+    public IAbstTexture2D ComposeTexture(ILingoSprite2DLight hostSprite, IReadOnlyList<LingoSprite2DVirtual> layers, int frame)
+    {
+        var prep = LingoFilmLoopComposer.Prepare(_member, Framing, layers);
+        Offset = prep.Offset;
+        int width = prep.Width;
+        int height = prep.Height;
+
+        var dest = new Color32[width * height];
+
+        foreach (var info in prep.Layers)
+        {
+            Texture2D? srcTex = null;
+            if (info.Sprite2D.Member is ILingoMemberWithTexture m)
+            {
+                if (m.RenderToTexture(info.Ink, info.BackColor) is UnityTexture2D ut)
+                    srcTex = ut.Texture;
+            }
+            else if (info.Sprite2D.Texture is UnityTexture2D t)
+            {
+                srcTex = t.Texture;
+            }
+            if (srcTex == null)
+                continue;
+
+            var srcPixels = srcTex.GetPixels32(info.SrcX, srcTex.height - info.SrcY - info.SrcH, info.SrcW, info.SrcH);
+            if (info.DestW != info.SrcW || info.DestH != info.SrcH)
+                srcPixels = srcPixels.ScalePixels(info.SrcW, info.SrcH, info.DestW, info.DestH);
+
+            dest.DrawWithMatrix(width, height, srcPixels, info.DestW, info.DestH, info.Transform.Matrix, info.Alpha);
+        }
+
+        var tex = new Texture2D(width, height, TextureFormat.RGBA32, false);
+        tex.SetPixels32(dest);
+        tex.Apply();
+        _texture?.Dispose();
+        _texture = new UnityTexture2D(tex, $"Filmloop_{frame}_Member_{_member.Name}");
+        return _texture;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => Unload();
+}
+

--- a/src/LingoEngine.Unity/Shapes/UnityMemberShape.cs
+++ b/src/LingoEngine.Unity/Shapes/UnityMemberShape.cs
@@ -1,0 +1,167 @@
+using System;
+using LingoEngine.Primitives;
+using LingoEngine.Shapes;
+using LingoEngine.Sprites;
+using LingoEngine.Members;
+using AbstUI.Primitives;
+using AbstUI.LUnity.Bitmaps;
+using UnityEngine;
+
+namespace LingoEngine.Unity.Shapes;
+
+/// <summary>
+/// Unity implementation for shape members that renders primitives into a
+/// <see cref="Texture2D"/> similar to the Godot version.
+/// </summary>
+public class UnityMemberShape : ILingoFrameworkMemberShape, IDisposable
+{
+    private LingoList<APoint> _vertexList = new();
+    private LingoShapeType _shapeType = LingoShapeType.Rectangle;
+    private AColor _fillColor = AColor.FromRGB(255, 255, 255);
+    private int _strokeWidth = 1;
+    private UnityTexture2D? _texture;
+
+    internal void Init(LingoMemberShape member) { }
+
+    /// <inheritdoc/>
+    public bool IsLoaded { get; private set; }
+
+    /// <inheritdoc/>
+    public bool IsDirty { get; private set; } = true;
+
+    /// <inheritdoc/>
+    public LingoList<APoint> VertexList
+    {
+        get => _vertexList;
+        set { _vertexList = value; IsDirty = true; IsLoaded = false; }
+    }
+
+    /// <inheritdoc/>
+    public LingoShapeType ShapeType
+    {
+        get => _shapeType;
+        set { _shapeType = value; IsDirty = true; IsLoaded = false; }
+    }
+
+    /// <inheritdoc/>
+    public AColor FillColor
+    {
+        get => _fillColor;
+        set { _fillColor = value; IsDirty = true; IsLoaded = false; }
+    }
+
+    /// <inheritdoc/>
+    public AColor EndColor { get; set; } = AColor.FromRGB(255, 255, 255);
+
+    /// <inheritdoc/>
+    public AColor StrokeColor { get; set; } = AColor.FromRGB(0, 0, 0);
+
+    /// <inheritdoc/>
+    public int StrokeWidth
+    {
+        get => _strokeWidth;
+        set => _strokeWidth = value;
+    }
+
+    /// <inheritdoc/>
+    public bool Closed { get; set; } = true;
+
+    /// <inheritdoc/>
+    public bool AntiAlias { get; set; } = true;
+
+    /// <inheritdoc/>
+    public float Width { get; set; }
+
+    /// <inheritdoc/>
+    public float Height { get; set; }
+
+    /// <inheritdoc/>
+    public (int TL, int TR, int BR, int BL) CornerRadius { get; set; } = (5, 5, 5, 5);
+
+    /// <inheritdoc/>
+    public bool Filled { get; set; } = true;
+
+    /// <inheritdoc/>
+    public IAbstTexture2D? TextureLingo => _texture;
+
+    /// <inheritdoc/>
+    public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
+
+    /// <inheritdoc/>
+    public void CopyToClipboard() { }
+
+    /// <inheritdoc/>
+    public void Erase() => VertexList.Clear();
+
+    /// <inheritdoc/>
+    public void ImportFileInto() { }
+
+    /// <inheritdoc/>
+    public void PasteClipboardInto() { }
+
+    /// <inheritdoc/>
+    public void Preload()
+    {
+        if (IsLoaded && !IsDirty) return;
+        int w = Math.Max(1, (int)Width);
+        int h = Math.Max(1, (int)Height);
+        var pixels = new Color32[w * h];
+
+        var fill = new Color32(FillColor.R, FillColor.G, FillColor.B, FillColor.A);
+        var stroke = new Color32(StrokeColor.R, StrokeColor.G, StrokeColor.B, StrokeColor.A);
+
+        switch (ShapeType)
+        {
+            case LingoShapeType.Rectangle:
+                pixels.DrawRectangle(w, h, fill, stroke, Filled, StrokeWidth);
+                break;
+            case LingoShapeType.Oval:
+                pixels.DrawOval(w, h, fill, stroke, Filled, StrokeWidth);
+                break;
+            case LingoShapeType.Line:
+                if (VertexList.Count >= 2)
+                {
+                    var p0 = VertexList[0];
+                    var p1 = VertexList[1];
+                    pixels.DrawLine(w, h, (int)p0.X, (int)p0.Y, (int)p1.X, (int)p1.Y, stroke);
+                }
+                break;
+            case LingoShapeType.PolyLine:
+                if (VertexList.Count >= 2)
+                    pixels.DrawPolyLine(w, h, VertexList, Closed, stroke);
+                break;
+            case LingoShapeType.RoundRect:
+                pixels.DrawRoundRect(w, h, fill, stroke, Filled, StrokeWidth);
+                break;
+        }
+
+        var tex = new Texture2D(w, h, TextureFormat.RGBA32, false);
+        tex.SetPixels32(pixels);
+        tex.Apply();
+        _texture?.Dispose();
+        _texture = new UnityTexture2D(tex, "Shape");
+        IsLoaded = true;
+        IsDirty = false;
+    }
+
+    /// <inheritdoc/>
+    public void Unload()
+    {
+        _texture?.Dispose();
+        _texture = null;
+        IsLoaded = false;
+        IsDirty = true;
+    }
+
+    /// <inheritdoc/>
+    public IAbstTexture2D? RenderToTexture(LingoInkType ink, AColor transparentColor)
+    {
+        if (_texture == null || !IsLoaded || IsDirty)
+            Preload();
+        return _texture;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => Unload();
+}
+


### PR DESCRIPTION
## Summary
- consolidate Unity bitmap extension helpers into a single `UnityBitmapExtensions` class
- expose a reusable `ScalePixels` helper and remove inline scaler from `UnityFilmLoopMember`

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj`
- `dotnet format src/LingoEngine.Unity/LingoEngine.Unity.csproj`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a815ddba348332998565388c68fcff