### PR TITLE
Fix SDL2 popups alignment and centering

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/TestSdlRootComponentContext.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/TestSdlRootComponentContext.cs
@@ -51,8 +51,8 @@ public sealed class TestSdlRootComponentContext : AbstUISdlRootContext<AbstMouse
 
     protected override void Render()
     {
-        //SDL.SDL_SetRenderDrawColor(Renderer, 200, 200, 150, 255);
-        //SDL.SDL_RenderClear(Renderer);
+        SDL.SDL_SetRenderDrawColor(Renderer, 200, 200, 150, 255);
+        SDL.SDL_RenderClear(Renderer);
         base.Render();
     }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlControlPopupExtensions.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlControlPopupExtensions.cs
@@ -1,0 +1,32 @@
+using AbstUI.SDL2.Components.Base;
+using AbstUI.SDL2.Core;
+
+namespace AbstUI.SDL2.Components.Containers;
+
+internal static class AbstSdlControlPopupExtensions
+{
+    public static (int x, int y) GetScreenPosition(this AbstSDLComponentContext ctx)
+    {
+        int x = 0, y = 0;
+        while (ctx != null)
+        {
+            x += ctx.X + (int)ctx.OffsetX;
+            y += ctx.Y + (int)ctx.OffsetY;
+            if (ctx.Component is AbstSdlScrollViewer sv)
+            {
+                x -= (int)sv.ScrollHorizontal;
+                y -= (int)sv.ScrollVertical;
+            }
+            ctx = ctx.Parent;
+        }
+        return (x, y);
+    }
+
+    public static void PositionBelow(this AbstSdlComponent popup, AbstSDLComponentContext ownerContext, float offsetY)
+    {
+        var (sx, sy) = ownerContext.GetScreenPosition();
+        popup.X = sx;
+        popup.Y = sy + offsetY;
+    }
+}
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlColorPicker.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlColorPicker.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using AbstUI.Components.Inputs;
 using AbstUI.Primitives;
 using AbstUI.SDL2.Components.Base;
+using AbstUI.SDL2.Components.Containers;
 using AbstUI.SDL2.Core;
 using AbstUI.SDL2.Events;
 using AbstUI.SDL2.SDLL;
@@ -94,8 +95,7 @@ namespace AbstUI.SDL2.Components.Inputs
             }
 
             _popup.SetColor(Color);
-            _popup.X = X;
-            _popup.Y = Y + Height + 2;
+            UpdatePopupPosition();
             _popup.Visibility = true;
             Factory.RootContext.ComponentContainer.Activate(_popup.ComponentContext);
             _open = true;
@@ -114,8 +114,17 @@ namespace AbstUI.SDL2.Components.Inputs
             Color = c;
             ComponentContext.QueueRedraw(this);
         }
+
+        private void UpdatePopupPosition()
+        {
+            if (_popup == null) return;
+            _popup.PositionBelow(ComponentContext, Height + 2);
+        }
+
         public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
         {
+            if (_open)
+                UpdatePopupPosition();
             if (!Visibility)
                 return default;
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputCombobox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputCombobox.cs
@@ -137,27 +137,7 @@ namespace AbstUI.SDL2.Components.Inputs
         private void UpdatePopupPosition()
         {
             if (_popup == null) return;
-            var (sx, sy) = GetScreenPosition();
-            _popup.X = sx;
-            _popup.Y = sy + Height;
-        }
-
-        private (int x, int y) GetScreenPosition()
-        {
-            int x = 0, y = 0;
-            var ctx = ComponentContext;
-            while (ctx != null)
-            {
-                x += ctx.X;
-                y += ctx.Y;
-                if (ctx.Component is AbstSdlScrollViewer sv)
-                {
-                    x -= (int)sv.ScrollHorizontal;
-                    y -= (int)sv.ScrollVertical;
-                }
-                ctx = ctx.Parent;
-            }
-            return (x, y);
+            _popup.PositionBelow(ComponentContext, Height);
         }
 
         protected override void RenderContent(AbstSDLRenderContext context) { }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Windowing/AbstSdlDialog.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Windowing/AbstSdlDialog.cs
@@ -29,6 +29,7 @@ namespace AbstUI.SDL2.Windowing
         private string _title = string.Empty;
         private bool _isPopup;
         private bool _borderless;
+        private bool _centered;
         private ISdlFontLoadedByUser? _font;
         private SDL.SDL_Rect _closeRect;
         private const int TitleBarHeight = 24;
@@ -89,10 +90,16 @@ namespace AbstUI.SDL2.Windowing
 
         public void PopupCentered()
         {
+            _centered = true;
+            UpdateCenterPosition();
+            Popup();
+        }
+
+        private void UpdateCenterPosition()
+        {
             var size = _factory.RootContext.GetWindowSize();
             X = (size.X - Width) / 2f;
             Y = (size.Y - Height) / 2f;
-            Popup();
         }
 
         public void Hide()
@@ -101,6 +108,7 @@ namespace AbstUI.SDL2.Windowing
             ComponentContext.AlwaysOnTop = false;
             _factory.RootContext.ComponentContainer.Deactivate(ComponentContext);
             OnWindowStateChanged?.Invoke(false);
+            _centered = false;
         }
 
         public void SetPositionAndSize(int x, int y, int width, int height)
@@ -124,6 +132,8 @@ namespace AbstUI.SDL2.Windowing
         {
             if (!Visibility)
                 return default;
+            if (_centered)
+                UpdateCenterPosition();
 
             var tex = (nint)base.Render(context);
             int w = (int)Width;


### PR DESCRIPTION
## Summary
- convert popup helpers to extension methods and include scroll offsets
- align color picker and combobox popups with their controls
- clear SDL visual test renderer each frame so content is visible

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --verbosity diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/AbstUI.GfxVisualTest.SDL2.csproj --verbosity diagnostic`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/AbstUI.GfxVisualTest.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a88adf58b08332baa577cc8c25a43d