### PR TITLE
Resolve transition player via DI and add pixel helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ These instructions apply to the entire repository.
 - Prefer `rg` (ripgrep) over `grep` for searching the codebase.
 - Do not remove existing comments from code.
 - When writing new classes, place members in the order: fields, then properties, then constructors.
+- Avoid adding business logic or default implementations inside interfaces to preserve .NET Framework 4.8 compatibility.
 
 ## Project Structure
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Bitmaps/AbstGodotImageTexture.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Bitmaps/AbstGodotImageTexture.cs
@@ -1,5 +1,6 @@
 using AbstUI.Bitmaps;
 using AbstUI.Primitives;
+using AbstUI.Tools;
 using Godot;
 
 namespace AbstUI.LGodot.Bitmaps;
@@ -23,6 +24,22 @@ public class AbstGodotTexture2D : AbstBaseTexture2D<Texture2D>
         _texture.Dispose();
     }
 
+    public override byte[] GetPixels()
+    {
+        var img = _texture.GetImage();
+        img.Convert(Image.Format.Rgba8);
+        var rgba = img.GetData();
+        var argb = new byte[rgba.Length];
+        for (int i = 0; i < rgba.Length; i += 4)
+        {
+            argb[i] = rgba[i + 3];
+            argb[i + 1] = rgba[i];
+            argb[i + 2] = rgba[i + 1];
+            argb[i + 3] = rgba[i + 2];
+        }
+        return argb;
+    }
+
     public IAbstTexture2D Clone()
     {
         // Get the pixel data from the existing texture
@@ -30,5 +47,26 @@ public class AbstGodotTexture2D : AbstBaseTexture2D<Texture2D>
         ImageTexture newTex = ImageTexture.CreateFromImage(img);
 
         return new AbstGodotTexture2D(newTex);
+    }
+
+    public override void SetARGBPixels(byte[] argbPixels)
+    {
+        APixel.ToRGBA(argbPixels);
+        var img = Image.CreateFromData(Width, Height, false, Image.Format.Rgba8, argbPixels);
+        _texture.Update(img);
+    }
+
+    public override void SetRGBAPixels(byte[] rgbaPixels)
+    {
+        var img = Image.CreateFromData(Width, Height, false, Image.Format.Rgba8, rgbaPixels);
+        _texture.Update(img);
+    }
+
+    public static AbstGodotTexture2D FromARGBPixels(int width, int height, byte[] argbPixels, string? name = null)
+    {
+        APixel.ToRGBA(argbPixels);
+        var img = Image.CreateFromData(width, height, false, Image.Format.Rgba8, argbPixels);
+        var tex = ImageTexture.CreateFromImage(img);
+        return new AbstGodotTexture2D(tex, name ?? string.Empty);
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Bitmaps/AbstBaseTexture2D.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Bitmaps/AbstBaseTexture2D.cs
@@ -44,6 +44,21 @@ public abstract class AbstBaseTexture2D<TFrameworkTexture> : IAbstTexture2D
 
     protected abstract void DisposeTexture();
 
+    public virtual byte[] GetPixels()
+    {
+        throw new NotImplementedException();
+    }
+
+    public virtual void SetARGBPixels(byte[] argbPixels)
+    {
+        throw new NotImplementedException();
+    }
+
+    public virtual void SetRGBAPixels(byte[] rgbaPixels)
+    {
+        throw new NotImplementedException();
+    }
+
     protected class TextureSubscription : IAbstUITextureUserSubscription
     {
         private readonly Action _onRelease;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Primitives/IAbstTexture2D.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Primitives/IAbstTexture2D.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace AbstUI.Primitives;
 
 public interface IAbstUITextureUserSubscription
@@ -15,6 +17,21 @@ public interface IAbstTexture2D : IDisposable
     string Name { get; set; }
 
     IAbstUITextureUserSubscription AddUser(object user);
+
+    /// <summary>
+    /// Returns the pixel data in ARGB byte order.
+    /// </summary>
+    byte[] GetPixels();
+
+    /// <summary>
+    /// Replaces the pixel data using the provided ARGB byte array.
+    /// </summary>
+    void SetARGBPixels(byte[] argbPixels);
+
+    /// <summary>
+    /// Replaces the pixel data using the provided RGBA byte array.
+    /// </summary>
+    void SetRGBAPixels(byte[] rgbaPixels);
 
 }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Tools/APixel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Tools/APixel.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace AbstUI.Tools;
+
+/// <summary>
+/// Utility methods for pixel data manipulation.
+/// </summary>
+public static class APixel
+{
+    /// <summary>
+    /// Converts a pixel buffer from ARGB to RGBA in place.
+    /// </summary>
+    public static void ToRGBA(byte[] argbPixels)
+    {
+        int pixelCount = argbPixels.Length / 4;
+        ParallelHelper.For(0, pixelCount, pixelCount, i =>
+        {
+            int idx = i * 4;
+            byte a = argbPixels[idx];
+            byte r = argbPixels[idx + 1];
+            byte g = argbPixels[idx + 2];
+            byte b = argbPixels[idx + 3];
+            argbPixels[idx] = r;
+            argbPixels[idx + 1] = g;
+            argbPixels[idx + 2] = b;
+            argbPixels[idx + 3] = a;
+        });
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Scores/DirScoreGridTopContainer.cs
+++ b/src/Director/LingoEngine.Director.Core/Scores/DirScoreGridTopContainer.cs
@@ -6,6 +6,7 @@ using LingoEngine.Director.Core.Scores.FrameScripts;
 using LingoEngine.Director.Core.Scores.Sounds;
 using LingoEngine.Director.Core.Scores.Tempos;
 using LingoEngine.Director.Core.Scores.Transitions;
+using LingoEngine.Transitions.TransitionLibrary;
 
 
 namespace LingoEngine.Director.Core.Scores
@@ -26,14 +27,14 @@ namespace LingoEngine.Director.Core.Scores
         }
 
 
-        public DirScoreGridTopContainer(IDirScoreManager scoreManager, ILingoColorPaletteDefinitions paletteDefinitions, Func<string, IAbstFrameworkPanel, IAbstWindowDialogReference?> showConfirmDialog)
-            :base(scoreManager, 6, showConfirmDialog) 
+        public DirScoreGridTopContainer(IDirScoreManager scoreManager, ILingoColorPaletteDefinitions paletteDefinitions, ILingoTransitionLibrary transitionLibrary, Func<string, IAbstFrameworkPanel, IAbstWindowDialogReference?> showConfirmDialog)
+            : base(scoreManager, 6, showConfirmDialog)
         {
             SetChannels(
             [
                 new DirScoreTempoGridChannel(_scoreManager),
-                new DirScoreColorPaletteGridChannel(_scoreManager,paletteDefinitions),
-                new DirScoreTransitionGridChannel(_scoreManager),
+                new DirScoreColorPaletteGridChannel(_scoreManager, paletteDefinitions),
+                new DirScoreTransitionGridChannel(_scoreManager, transitionLibrary),
                 new DirScoreAudioGridChannel(1, _scoreManager),
                 new DirScoreAudioGridChannel(2, _scoreManager),
                 new DirScoreFrameScriptGridChannel(_scoreManager),
@@ -46,7 +47,7 @@ namespace LingoEngine.Director.Core.Scores
 
         protected override DirScoreChannel? GetChannelByDisplayIndex(int index)
         {
-            if (_collapsed) return _channelsDic[_frameScriptIndex+1];
+            if (_collapsed) return _channelsDic[_frameScriptIndex + 1];
             return base.GetChannelByDisplayIndex(index);
         }
         protected void UpdateChannelsVisibility()
@@ -58,7 +59,7 @@ namespace LingoEngine.Director.Core.Scores
             UpdateChannelsPosition();
         }
 
-        
+
     }
 
 }

--- a/src/Director/LingoEngine.Director.Core/Scores/DirectorScoreWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Scores/DirectorScoreWindow.cs
@@ -15,6 +15,7 @@ using AbstUI.Inputs;
 using AbstUI.Windowing;
 using AbstUI.Components.Inputs;
 using AbstUI.Components.Containers;
+using LingoEngine.Transitions.TransitionLibrary;
 
 
 namespace LingoEngine.Director.Core.Scores
@@ -25,6 +26,7 @@ namespace LingoEngine.Director.Core.Scores
         private readonly DirScoreManager _scoreManager;
         private readonly IAbstWindowManager _windowManager;
         private readonly ILingoColorPaletteDefinitions _paletteDefinitions;
+        private readonly ILingoTransitionLibrary _transitionLibrary;
         private readonly LingoPlayer _player;
         private readonly IAbstMouse<AbstMouseEvent> _globalMouse;
         private readonly DirScoreLabelsBar _labelsBar;
@@ -60,13 +62,14 @@ namespace LingoEngine.Director.Core.Scores
         public float ScollY { get => _scollY; set => _scollY = value; }
 
 #pragma warning disable CS8618
-        public DirectorScoreWindow(IServiceProvider serviceProvider, IDirSpritesManager spritesManager, ILingoPlayer player, ILingoFrameworkFactory factory, DirScoreManager scoreManager, IAbstWindowManager windowManager, ILingoColorPaletteDefinitions paletteDefinitions, IAbstCommandManager commandManager, IAbstGlobalMouse globalMouse, IDirectorEventMediator mediator, IAbstComponentFactory componentFactory) : base(serviceProvider, DirectorMenuCodes.ScoreWindow)
+        public DirectorScoreWindow(IServiceProvider serviceProvider, IDirSpritesManager spritesManager, ILingoPlayer player, ILingoFrameworkFactory factory, DirScoreManager scoreManager, IAbstWindowManager windowManager, ILingoColorPaletteDefinitions paletteDefinitions, ILingoTransitionLibrary transitionLibrary, IAbstCommandManager commandManager, IAbstGlobalMouse globalMouse, IDirectorEventMediator mediator, IAbstComponentFactory componentFactory) : base(serviceProvider, DirectorMenuCodes.ScoreWindow)
 #pragma warning restore CS8618
         {
             _spritesManager = spritesManager;
             _scoreManager = scoreManager;
             _windowManager = windowManager;
             _paletteDefinitions = paletteDefinitions;
+            _transitionLibrary = transitionLibrary;
             _player = (LingoPlayer)player;
             _globalMouse = (IAbstMouse<AbstMouseEvent>)globalMouse;
             _player.ActiveMovieChanged += OnActiveMovieChanged;
@@ -108,7 +111,7 @@ namespace LingoEngine.Director.Core.Scores
             var mouse = (AbstMouse<AbstMouseEvent>)Mouse;
             _mouseSub = mouse.OnMouseEvent(HandleMouseEvent);
             _globalMouseUpSub = _globalMouse.OnMouseUp(GlobalHandleMouseEvent);
-            TopContainer = new DirScoreGridTopContainer(_scoreManager, _paletteDefinitions, ShowConfirmDialog);
+            TopContainer = new DirScoreGridTopContainer(_scoreManager, _paletteDefinitions, _transitionLibrary, ShowConfirmDialog);
             Sprites2DContainer = new DirScoreGridSprites2DContainer(_scoreManager, ShowConfirmDialog);
         }
 

--- a/src/Director/LingoEngine.Director.Core/Scores/Transitions/DirScoreTransitionGridChannel.cs
+++ b/src/Director/LingoEngine.Director.Core/Scores/Transitions/DirScoreTransitionGridChannel.cs
@@ -1,18 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using LingoEngine.Movies;
 using LingoEngine.Transitions;
+using LingoEngine.Transitions.TransitionLibrary;
 using LingoEngine.Director.Core.Sprites;
+using LingoEngine.Director.Core.Windowing;
+using LingoEngine.Primitives;
+using LingoEngine.Sprites;
+using AbstUI.Primitives;
+using AbstUI.Windowing;
+using AbstUI.Components.Graphics;
+using AbstUI.Components.Containers;
 
 namespace LingoEngine.Director.Core.Scores.Transitions;
 
 internal partial class DirScoreTransitionGridChannel : DirScoreChannel<ILingoSpriteTransitionManager, DirScoreTransitionSprite, LingoTransitionSprite>
 {
-    public DirScoreTransitionGridChannel(IDirScoreManager scoreManager)
-        : base(LingoTransitionSprite.SpriteNumOffset+1, scoreManager)
+    private readonly ILingoTransitionLibrary _transitionLibrary;
+    private IAbstWindowDialogReference? _dialog;
+    private readonly IList<KeyValuePair<string, string>> _transitionOptions;
+
+    public DirScoreTransitionGridChannel(IDirScoreManager scoreManager, ILingoTransitionLibrary transitionLibrary)
+        : base(LingoTransitionSprite.SpriteNumOffset + 1, scoreManager)
     {
+        _transitionLibrary = transitionLibrary;
+        _transitionOptions = _transitionLibrary.GetAll()
+            .Select(t => new KeyValuePair<string, string>(t.Id.ToString(), t.Name))
+            .ToList();
         IsSingleFrame = true;
     }
 
-    protected override DirScoreTransitionSprite CreateUISprite(LingoTransitionSprite sprite, IDirSpritesManager spritesManager) => new DirScoreTransitionSprite(sprite, spritesManager);
+    protected override DirScoreTransitionSprite CreateUISprite(LingoTransitionSprite sprite, IDirSpritesManager spritesManager)
+        => new DirScoreTransitionSprite(sprite, spritesManager);
 
     protected override ILingoSpriteTransitionManager GetManager(LingoMovie movie) => movie.Transitions;
+
+    internal override void ShowCreateSpriteDialog(int frameNumber, Action<LingoSprite?> newSprite)
+    {
+        var first = _transitionOptions.First();
+        var settings = new LingoTransitionFrameSettings
+        {
+            TransitionId = int.Parse(first.Key),
+            TransitionName = first.Value
+        };
+        Action okAction = () =>
+        {
+            var sprite = _manager!.Add(frameNumber, settings);
+            newSprite(sprite);
+            _hasDirtySpriteList = true;
+            MarkDirty();
+        };
+        ShowDialog(settings, okAction);
+    }
+
+    internal override void ShowSpriteDialog(LingoSprite sprite)
+    {
+        if (sprite is not LingoTransitionSprite transitionSprite) return;
+        var settings = transitionSprite.GetSettings() ?? new LingoTransitionFrameSettings();
+        Action okAction = () =>
+        {
+            transitionSprite.SetSettings(settings);
+            MarkDirty();
+        };
+        ShowDialog(settings, okAction);
+    }
+
+    private void ShowDialog(LingoTransitionFrameSettings settings, Action okAction)
+    {
+        var panel = _scoreManager.Factory.CreatePanel("Panel Transition Sprite");
+        panel.Width = 250;
+        panel.Height = 150;
+
+        panel.SetLabelAt("TransitionLabel", 10, 10, "Transition:", 11, 80, AbstUI.Texts.AbstTextAlignment.Right);
+        panel.SetInputListAt(_transitionOptions, "TransitionList", 100, 10, 120, settings.TransitionId.ToString(), key =>
+        {
+            if (int.TryParse(key, out var id))
+            {
+                settings.TransitionId = id;
+                var tr = _transitionLibrary.Get(id);
+                settings.TransitionName = tr.Name;
+            }
+        });
+
+        panel.AddPopupButtons(okAction, CloseDialog);
+
+        _dialog = _showConfirmDialog?.Invoke("Frame Properties: Transition", (IAbstFrameworkPanel)panel.FrameworkObj);
+    }
+
+    private void CloseDialog()
+    {
+        if (_dialog == null) return;
+        _dialog.Close();
+        _dialog = null;
+    }
 }
+

--- a/src/LingoEngine.Blazor/Stages/LingoBlazorStage.cs
+++ b/src/LingoEngine.Blazor/Stages/LingoBlazorStage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using AbstUI.Primitives;
 using LingoEngine.Core;
 using LingoEngine.Movies;
 using LingoEngine.Stages;
@@ -58,6 +59,15 @@ public class LingoBlazorStage : ILingoFrameworkStage, IDisposable
 
     /// <inheritdoc />
     public void ApplyPropertyChanges() { }
+
+    public IAbstTexture2D GetScreenshot()
+        => throw new NotImplementedException();
+
+    public void ShowTransition(IAbstTexture2D startTexture) { }
+
+    public void UpdateTransitionFrame(IAbstTexture2D texture, ARect targetRect) { }
+
+    public void HideTransition() { }
 
     public void Dispose()
     {

--- a/src/LingoEngine.LGodot/Core/GodotFactory.cs
+++ b/src/LingoEngine.LGodot/Core/GodotFactory.cs
@@ -37,6 +37,7 @@ using AbstUI.Components.Menus;
 using AbstUI.Components.Buttons;
 using AbstUI.Components.Texts;
 using AbstUI.LGodot.Components;
+using LingoEngine.Transitions.TransitionLibrary;
 
 namespace LingoEngine.LGodot.Core
 {
@@ -321,7 +322,7 @@ namespace LingoEngine.LGodot.Core
         public AbstVerticalLineSeparator CreateVerticalLineSeparator(string name)
             => _gfxFactory.CreateVerticalLineSeparator(name);
 
-        
+
 
         #endregion
 

--- a/src/LingoEngine.SDL2/Stages/SdlStage.cs
+++ b/src/LingoEngine.SDL2/Stages/SdlStage.cs
@@ -1,3 +1,5 @@
+using System;
+using AbstUI.Primitives;
 using LingoEngine.Core;
 using LingoEngine.Movies;
 using LingoEngine.SDL2.Movies;
@@ -18,7 +20,7 @@ public class SdlStage : ILingoFrameworkStage, IDisposable
     {
         _rootContext = rootContext;
         _clock = clock;
-        
+
     }
 
     internal LingoSdlRootContext RootContext => _rootContext;
@@ -28,7 +30,7 @@ public class SdlStage : ILingoFrameworkStage, IDisposable
     internal void Init(LingoStage stage)
     {
         _stage = stage;
-        
+
     }
 
     internal void ShowMovie(SdlMovie movie)
@@ -53,6 +55,21 @@ public class SdlStage : ILingoFrameworkStage, IDisposable
 
     public void ApplyPropertyChanges()
     {
-        
+
+    }
+
+    public IAbstTexture2D GetScreenshot()
+        => throw new NotImplementedException();
+
+    public void ShowTransition(IAbstTexture2D startTexture)
+    {
+    }
+
+    public void UpdateTransitionFrame(IAbstTexture2D texture, ARect targetRect)
+    {
+    }
+
+    public void HideTransition()
+    {
     }
 }

--- a/src/LingoEngine.Unity/Stages/UnityStage.cs
+++ b/src/LingoEngine.Unity/Stages/UnityStage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using AbstUI.Primitives;
 using LingoEngine.Core;
 using LingoEngine.Movies;
 using LingoEngine.Stages;
@@ -61,6 +62,15 @@ public class UnityStage : MonoBehaviour, ILingoFrameworkStage, IDisposable
     public void ApplyPropertyChanges()
     {
     }
+
+    public IAbstTexture2D GetScreenshot()
+        => throw new NotImplementedException();
+
+    public void ShowTransition(IAbstTexture2D startTexture) { }
+
+    public void UpdateTransitionFrame(IAbstTexture2D texture, ARect targetRect) { }
+
+    public void HideTransition() { }
 
     public void Dispose()
     {

--- a/src/LingoEngine/LingoEngine.csproj
+++ b/src/LingoEngine/LingoEngine.csproj
@@ -38,7 +38,7 @@
 		<InternalsVisibleTo Include="LingoEngine.Lingo.Tests" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\..\WillMoveToOwnRepo\AbstUI\src\AbstUI\AbstUI.csproj" />
-	</ItemGroup>
+        <ItemGroup>
+          <ProjectReference Include="..\..\WillMoveToOwnRepo\AbstUI\src\AbstUI\AbstUI.csproj" />
+        </ItemGroup>
 </Project>

--- a/src/LingoEngine/LingoEngineSetup.cs
+++ b/src/LingoEngine/LingoEngineSetup.cs
@@ -9,6 +9,7 @@ using AbstUI.Commands;
 using LingoEngine.Projects;
 using LingoEngine.ColorPalettes;
 using LingoEngine.Inputs;
+using LingoEngine.Transitions.TransitionLibrary;
 
 namespace LingoEngine
 {
@@ -26,7 +27,8 @@ namespace LingoEngine
                    .AddSingleton<LingoSystem>()
                    .AddSingleton<LingoFrameLabelManager>()
                    .AddSingleton<ILingoColorPaletteDefinitions, LingoColorPaletteDefinitions>()
-                   .AddTransient<ILingoPlayer>(p => p.GetRequiredService<LingoPlayer>())
+                   .AddSingleton<ILingoTransitionLibrary, LingoTransitionLibrary>()
+                    .AddTransient<ILingoPlayer>(p => p.GetRequiredService<LingoPlayer>())
                    .AddTransient<ILingoCastLibsContainer>(p => p.GetRequiredService<LingoCastLibsContainer>())
                    .AddTransient<ILingoWindow>(p => p.GetRequiredService<LingoWindow>())
                    .AddTransient<ILingoClock>(p => p.GetRequiredService<LingoClock>())
@@ -38,7 +40,7 @@ namespace LingoEngine
                    .AddScoped<ILingoEventMediator, LingoEventMediator>()
                    // Xtras
                    .AddScoped<IBuddyAPI, BuddyAPI>()
-                   
+
                    .AddTransient<LingoJoystickKeyboard>()
                    ;
 

--- a/src/LingoEngine/Movies/LingoMovieEnvironment.cs
+++ b/src/LingoEngine/Movies/LingoMovieEnvironment.cs
@@ -8,6 +8,7 @@ using LingoEngine.Projects;
 using LingoEngine.Sounds;
 using LingoEngine.Stages;
 using Microsoft.Extensions.DependencyInjection;
+using LingoEngine.Transitions;
 
 namespace LingoEngine.Movies
 {
@@ -92,7 +93,8 @@ namespace LingoEngine.Movies
             _mouse.Subscribe(_eventMediator);
             _key.Subscribe(_eventMediator);
             _castLibsContainer = lingoCastLibsContainer;
-            _movie = new LingoMovie(this, stage, _castLibsContainer, _memberFactory.Value, name, number, _eventMediator, m =>
+            var transitionPlayer = _serviceProvider.GetRequiredService<ILingoTransitionPlayer>();
+            _movie = new LingoMovie(this, stage, transitionPlayer, _castLibsContainer, _memberFactory.Value, name, number, _eventMediator, m =>
             {
                 onRemoveMe(m);
                 Dispose();

--- a/src/LingoEngine/Stages/ILingoFrameworkMovieStage.cs
+++ b/src/LingoEngine/Stages/ILingoFrameworkMovieStage.cs
@@ -1,20 +1,31 @@
-﻿using LingoEngine.Movies;
-using LingoEngine.Primitives;
+using AbstUI.Primitives;
+using LingoEngine.Core;
+using LingoEngine.Movies;
 
-namespace LingoEngine.Stages
+namespace LingoEngine.Stages;
+
+/// <summary>
+/// Represents the top-level window or stage. Implementations update the
+/// display when the active <see cref="LingoMovie"/> changes.
+/// </summary>
+public interface ILingoFrameworkStage
 {
-    /// <summary>
-    /// Represents the top-level window or stage. Implementations update the
-    /// display when the active <see cref="LingoMovie"/> changes.
-    /// </summary>
-    public interface ILingoFrameworkStage
-    {
-        LingoStage LingoStage { get; }
-        /// <summary>Sets the currently active movie.</summary>
-        void SetActiveMovie(LingoMovie? lingoMovie);
-        void ApplyPropertyChanges();
+    LingoStage LingoStage { get; }
+    /// <summary>Sets the currently active movie.</summary>
+    void SetActiveMovie(LingoMovie? lingoMovie);
+    void ApplyPropertyChanges();
 
-        float Scale { get; set; }
-        
-    }
+    float Scale { get; set; }
+
+    /// <summary>Captures a screenshot of the current stage.</summary>
+    IAbstTexture2D GetScreenshot();
+
+    /// <summary>Shows the transition overlay above the sprite layer.</summary>
+    void ShowTransition(IAbstTexture2D startTexture);
+
+    /// <summary>Updates the displayed transition frame.</summary>
+    void UpdateTransitionFrame(IAbstTexture2D texture, ARect targetRect);
+
+    /// <summary>Hides the transition overlay and returns rendering to sprites.</summary>
+    void HideTransition();
 }

--- a/src/LingoEngine/Stages/ILingoStage.cs
+++ b/src/LingoEngine/Stages/ILingoStage.cs
@@ -1,30 +1,41 @@
-﻿using AbstUI.Primitives;
+using AbstUI.Primitives;
 using LingoEngine.Animations;
 using LingoEngine.Members;
 using LingoEngine.Movies;
 using LingoEngine.Sprites;
 
-namespace LingoEngine.Stages
+namespace LingoEngine.Stages;
+
+/// <summary>
+/// Lingo Stage interface.
+/// </summary>
+public interface ILingoStage
 {
-    /// <summary>
-    /// Lingo Stage interface.
-    /// </summary>
-    public interface ILingoStage
-    {
-        LingoMovie? ActiveMovie { get; }
-        AColor BackgroundColor { get; set; }
-        int Height { get; set; }
-        LingoMember? MouseMemberUnderMouse { get; }
-        int Width { get; set; }
+    LingoMovie? ActiveMovie { get; }
+    AColor BackgroundColor { get; set; }
+    int Height { get; set; }
+    LingoMember? MouseMemberUnderMouse { get; }
+    int Width { get; set; }
 
-        void AddKeyFrame(LingoSprite2D sprite);
+    void AddKeyFrame(LingoSprite2D sprite);
 
-        T Framework<T>() where T : class, ILingoFrameworkStage;
-        ILingoFrameworkStage FrameworkObj();
-        LingoSpriteMotionPath? GetSpriteMotionPath(LingoSprite2D sprite);
-        LingoSprite2D? GetSpriteUnderMouse();
-        void SetActiveMovie(LingoMovie? lingoMovie);
-        void SetSpriteTweenOptions(LingoSprite2D sprite, bool positionEnabled, bool sizeEnabled, bool rotationEnabled, bool skewEnabled, bool foregroundColorEnabled, bool backgroundColorEnabled, bool blendEnabled, float curvature, bool continuousAtEnds, bool speedSmooth, float easeIn, float easeOut);
-        void UpdateKeyFrame(LingoSprite2D sprite);
-    }
+    T Framework<T>() where T : class, ILingoFrameworkStage;
+    ILingoFrameworkStage FrameworkObj();
+    LingoSpriteMotionPath? GetSpriteMotionPath(LingoSprite2D sprite);
+    LingoSprite2D? GetSpriteUnderMouse();
+    void SetActiveMovie(LingoMovie? lingoMovie);
+    void SetSpriteTweenOptions(LingoSprite2D sprite, bool positionEnabled, bool sizeEnabled, bool rotationEnabled, bool skewEnabled, bool foregroundColorEnabled, bool backgroundColorEnabled, bool blendEnabled, float curvature, bool continuousAtEnds, bool speedSmooth, float easeIn, float easeOut);
+    void UpdateKeyFrame(LingoSprite2D sprite);
+
+    /// <summary>Captures the current contents of the stage.</summary>
+    IAbstTexture2D GetScreenshot();
+
+    /// <summary>Shows the transition overlay above the sprite layer.</summary>
+    void ShowTransition(IAbstTexture2D startTexture);
+
+    /// <summary>Updates the transition frame.</summary>
+    void UpdateTransitionFrame(IAbstTexture2D texture, ARect targetRect);
+
+    /// <summary>Hides the transition overlay and returns rendering to sprites.</summary>
+    void HideTransition();
 }

--- a/src/LingoEngine/Stages/LingoStage.cs
+++ b/src/LingoEngine/Stages/LingoStage.cs
@@ -1,92 +1,99 @@
-﻿using AbstUI.Primitives;
-using LingoEngine.Animations;
 using LingoEngine.Members;
+using AbstUI.Primitives;
 using LingoEngine.Movies;
 using LingoEngine.Sprites;
 
-namespace LingoEngine.Stages
+namespace LingoEngine.Stages;
+
+/// <summary>
+/// You have one stage for all movies
+/// </summary>
+public class LingoStage : ILingoStage
 {
-    /// <summary>
-    /// You have one stage for all movies
-    /// </summary>
-    public class LingoStage : ILingoStage
+    private readonly ILingoFrameworkStage _lingoFrameworkMovieStage;
+
+    public int Width { get; set; } = 640;
+    public int Height { get; set; } = 480;
+    public AColor BackgroundColor { get; set; }
+
+    public LingoMovie? ActiveMovie { get; private set; }
+    public LingoMember? MouseMemberUnderMouse
     {
-        private readonly ILingoFrameworkStage _lingoFrameworkMovieStage;
-
-        public int Width { get; set; } = 640;
-        public int Height { get; set; } = 480;
-        public AColor BackgroundColor { get; set; }
-
-        public LingoMovie? ActiveMovie { get; private set; }
-        public LingoMember? MouseMemberUnderMouse
+        get
         {
-            get
-            {
-                if (ActiveMovie == null) return null;
-                return ActiveMovie.MouseMemberUnderMouse();
-            }
-        }
-
-
-        public ILingoFrameworkStage FrameworkObj() => _lingoFrameworkMovieStage;
-        public T Framework<T>() where T : class, ILingoFrameworkStage => (T)_lingoFrameworkMovieStage;
-        public LingoStage(ILingoFrameworkStage godotInstance)
-        {
-            _lingoFrameworkMovieStage = godotInstance;
-            BackgroundColor = AColors.Black;
-        }
-
-       
-        public void AddKeyFrame(LingoSprite2D sprite)
-        {
-            if (ActiveMovie == null)
-                return;
-            int frame = ActiveMovie.CurrentFrame;
-            sprite.AddKeyframes(sprite.ToKeyFrameSetting(frame));
-        }
-
-        public void UpdateKeyFrame(LingoSprite2D sprite)
-        {
-            if (ActiveMovie == null)
-                return;
-            int frame = ActiveMovie.CurrentFrame;
-            sprite.UpdateKeyframe(sprite.ToKeyFrameSetting(frame));
-        }
-
-        public void SetSpriteTweenOptions(LingoSprite2D sprite, bool positionEnabled, bool sizeEnabled, bool rotationEnabled,
-            bool skewEnabled, bool foregroundColorEnabled, bool backgroundColorEnabled, bool blendEnabled,
-            float curvature, bool continuousAtEnds, bool speedSmooth, float easeIn, float easeOut)
-        {
-            sprite.SetSpriteTweenOptions(positionEnabled, sizeEnabled, rotationEnabled, skewEnabled,
-                foregroundColorEnabled, backgroundColorEnabled, blendEnabled,
-                curvature, continuousAtEnds, speedSmooth, easeIn, easeOut);
-        }
-
-        public void SetActiveMovie(LingoMovie? lingoMovie)
-        {
-            if (ActiveMovie != null)
-                ActiveMovie.Hide();
-            ActiveMovie = lingoMovie;
-            if (lingoMovie != null)
-                lingoMovie.Show();
-            _lingoFrameworkMovieStage.SetActiveMovie(lingoMovie);
-        }
-
-
-        public LingoSprite2D? GetSpriteUnderMouse()
-        {
-            if (ActiveMovie == null)
-                return null;
-
-            bool skipLockedSprites = !ActiveMovie.IsPlaying;
-            return ActiveMovie.GetSpriteUnderMouse(skipLockedSprites);
-        }
-
-        public Animations.LingoSpriteMotionPath? GetSpriteMotionPath(LingoSprite2D sprite)
-        {
-            if (sprite == null) return null;
-            return sprite.CallActor<Animations.LingoSpriteAnimator, Animations.LingoSpriteMotionPath>(
-                a => a.GetMotionPath(sprite.BeginFrame, sprite.EndFrame));
+            if (ActiveMovie == null) return null;
+            return ActiveMovie.MouseMemberUnderMouse();
         }
     }
+
+    public ILingoFrameworkStage FrameworkObj() => _lingoFrameworkMovieStage;
+    public T Framework<T>() where T : class, ILingoFrameworkStage => (T)_lingoFrameworkMovieStage;
+    public LingoStage(ILingoFrameworkStage godotInstance)
+    {
+        _lingoFrameworkMovieStage = godotInstance;
+        BackgroundColor = AColors.Black;
+    }
+
+    public void AddKeyFrame(LingoSprite2D sprite)
+    {
+        if (ActiveMovie == null)
+            return;
+        int frame = ActiveMovie.CurrentFrame;
+        sprite.AddKeyframes(sprite.ToKeyFrameSetting(frame));
+    }
+
+    public void UpdateKeyFrame(LingoSprite2D sprite)
+    {
+        if (ActiveMovie == null)
+            return;
+        int frame = ActiveMovie.CurrentFrame;
+        sprite.UpdateKeyframe(sprite.ToKeyFrameSetting(frame));
+    }
+
+    public void SetSpriteTweenOptions(LingoSprite2D sprite, bool positionEnabled, bool sizeEnabled, bool rotationEnabled,
+        bool skewEnabled, bool foregroundColorEnabled, bool backgroundColorEnabled, bool blendEnabled,
+        float curvature, bool continuousAtEnds, bool speedSmooth, float easeIn, float easeOut)
+    {
+        sprite.SetSpriteTweenOptions(positionEnabled, sizeEnabled, rotationEnabled, skewEnabled,
+            foregroundColorEnabled, backgroundColorEnabled, blendEnabled,
+            curvature, continuousAtEnds, speedSmooth, easeIn, easeOut);
+    }
+
+    public void SetActiveMovie(LingoMovie? lingoMovie)
+    {
+        if (ActiveMovie != null)
+            ActiveMovie.Hide();
+        ActiveMovie = lingoMovie;
+        if (lingoMovie != null)
+            lingoMovie.Show();
+        _lingoFrameworkMovieStage.SetActiveMovie(lingoMovie);
+    }
+
+    public LingoSprite2D? GetSpriteUnderMouse()
+    {
+        if (ActiveMovie == null)
+            return null;
+
+        bool skipLockedSprites = !ActiveMovie.IsPlaying;
+        return ActiveMovie.GetSpriteUnderMouse(skipLockedSprites);
+    }
+
+    public Animations.LingoSpriteMotionPath? GetSpriteMotionPath(LingoSprite2D sprite)
+    {
+        if (sprite == null) return null;
+        return sprite.CallActor<Animations.LingoSpriteAnimator, Animations.LingoSpriteMotionPath>(
+            a => a.GetMotionPath(sprite.BeginFrame, sprite.EndFrame));
+    }
+
+    public IAbstTexture2D GetScreenshot()
+        => _lingoFrameworkMovieStage.GetScreenshot();
+
+    public void ShowTransition(IAbstTexture2D startTexture)
+        => _lingoFrameworkMovieStage.ShowTransition(startTexture);
+
+    public void UpdateTransitionFrame(IAbstTexture2D texture, ARect targetRect)
+        => _lingoFrameworkMovieStage.UpdateTransitionFrame(texture, targetRect);
+
+    public void HideTransition()
+        => _lingoFrameworkMovieStage.HideTransition();
 }

--- a/src/LingoEngine/Transitions/ILingoTransitionPlayer.cs
+++ b/src/LingoEngine/Transitions/ILingoTransitionPlayer.cs
@@ -1,0 +1,33 @@
+using LingoEngine.Movies;
+
+namespace LingoEngine.Transitions;
+
+/// <summary>
+/// Abstraction for playing transition animations between movie frames.
+/// </summary>
+public interface ILingoTransitionPlayer
+{
+    /// <summary>Starts a transition based on the provided sprite.</summary>
+    /// <returns><c>true</c> if the transition was successfully started; otherwise, <c>false</c>.</returns>
+    bool Start(LingoTransitionSprite sprite);
+
+    /// <summary>Captures the destination frame once it has been rendered.</summary>
+    void CaptureToFrame();
+
+    /// <summary>Advances the transition by one tick.</summary>
+    void Tick();
+
+    /// <summary>Indicates whether the player is currently capturing or playing.</summary>
+    bool IsActive { get; }
+}
+
+/// <summary>
+/// Fallback implementation used on frameworks without transition support.
+/// </summary>
+internal sealed class NullTransitionPlayer : ILingoTransitionPlayer
+{
+    public bool IsActive => false;
+    public bool Start(LingoTransitionSprite sprite) => false;
+    public void CaptureToFrame() { }
+    public void Tick() { }
+}

--- a/src/LingoEngine/Transitions/LingoSpriteTransitionManager.cs
+++ b/src/LingoEngine/Transitions/LingoSpriteTransitionManager.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using LingoEngine.Members;
 using LingoEngine.Movies;
 using LingoEngine.Sprites;
@@ -11,6 +12,7 @@ public interface ILingoSpriteTransitionManager : ILingoSpriteManager<LingoTransi
 {
     LingoTransitionSprite Add(int frameNumber, LingoTransitionFrameSettings? settings = null);
     LingoTransitionSprite Add(int begin, LingoTransitionMember transitionMember);
+    LingoTransitionSprite? GetFrameSprite(int frame);
 }
 internal class LingoSpriteTransitionManager : LingoSpriteManager<LingoTransitionSprite>, ILingoSpriteTransitionManager
 {
@@ -39,6 +41,9 @@ internal class LingoSpriteTransitionManager : LingoSpriteManager<LingoTransition
         sprite.SetMember(transitionMember);
         return sprite;
     }
+
+    public LingoTransitionSprite? GetFrameSprite(int frame)
+        => _allTimeSprites.FirstOrDefault(t => t.BeginFrame == frame);
 
     protected override LingoSprite? OnAdd(int spriteNum, int begin, int end, ILingoMember? member)
     {

--- a/src/LingoEngine/Transitions/TransitionLibrary/FadeTransition.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/FadeTransition.cs
@@ -1,0 +1,37 @@
+using AbstUI.Tools;
+
+namespace LingoEngine.Transitions.TransitionLibrary;
+
+public sealed class FadeTransition : LingoBaseTransition
+{
+    public FadeTransition() : base(1, "Fade", "fade", "Linear fade between frames")
+    {
+    }
+
+    public override byte[] StepFrame(int width, int height, byte[] from, byte[] to, float progress)
+    {
+        var length = from.Length;
+        var dest = new byte[length];
+        int pixelCount = length / 4;
+        ParallelHelper.For(0, pixelCount, length, idx =>
+        {
+            int i = idx * 4;
+
+            byte aF = from[i];
+            byte rF = from[i + 1];
+            byte gF = from[i + 2];
+            byte bF = from[i + 3];
+
+            byte aT = to[i];
+            byte rT = to[i + 1];
+            byte gT = to[i + 2];
+            byte bT = to[i + 3];
+
+            dest[i] = (byte)(aF + (aT - aF) * progress);
+            dest[i + 1] = (byte)(rF + (rT - rF) * progress);
+            dest[i + 2] = (byte)(gF + (gT - gF) * progress);
+            dest[i + 3] = (byte)(bF + (bT - bF) * progress);
+        });
+        return dest;
+    }
+}

--- a/src/LingoEngine/Transitions/TransitionLibrary/ILingoTransitionLibrary.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/ILingoTransitionLibrary.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace LingoEngine.Transitions.TransitionLibrary;
+
+public interface ILingoTransitionLibrary
+{
+    LingoBaseTransition Get(int id);
+    IEnumerable<LingoBaseTransition> GetAll();
+}
+

--- a/src/LingoEngine/Transitions/TransitionLibrary/LingoBaseTransition.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/LingoBaseTransition.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace LingoEngine.Transitions.TransitionLibrary;
+
+public abstract class LingoBaseTransition
+{
+    public int Id { get; }
+    public string Name { get; }
+    public string Code { get; }
+    public string Description { get; }
+
+    protected LingoBaseTransition(int id, string name, string code, string description)
+    {
+        Id = id;
+        Name = name;
+        Code = code;
+        Description = description;
+    }
+
+    public abstract byte[] StepFrame(int width, int height, byte[] from, byte[] to, float progress);
+}

--- a/src/LingoEngine/Transitions/TransitionLibrary/LingoTransitionLibrary.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/LingoTransitionLibrary.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace LingoEngine.Transitions.TransitionLibrary;
+
+public class LingoTransitionLibrary : ILingoTransitionLibrary
+{
+    private readonly Dictionary<int, LingoBaseTransition> _transitions =
+        new() { { 1, new FadeTransition() } };
+
+    public LingoBaseTransition Get(int id)
+    {
+        if (_transitions.TryGetValue(id, out var transition))
+            return transition;
+        return _transitions[1];
+    }
+
+    public IEnumerable<LingoBaseTransition> GetAll() => _transitions.Values;
+}
+


### PR DESCRIPTION
## Summary
- add pixel conversion utility and ARGB/RGBA setters on texture abstraction
- resolve transition player via dependency injection and remove stage-level knowledge
- keep Godot stage focused on overlay rendering

## Testing
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/Movies/LingoMovieEnvironment.cs`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj` *(fails: no argument for parameter 'name' of `LingoScriptFile`)*

------
https://chatgpt.com/codex/tasks/task_e_68a96190f124833292b7bfd730d55822