### PR TITLE
Handle single-line if-then with following else

### DIFF
--- a/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
@@ -449,6 +449,27 @@ end";
     }
 
     [Fact]
+    public void SingleLineIfWithElseIsConverted()
+    {
+        var lingo = string.Join('\n',
+            "if a = 1 then x = 1",
+            "else",
+            "  x = 2",
+            "end if");
+        var result = _converter.Convert(lingo);
+        var expected = string.Join('\n',
+            "if (a == 1)",
+            "{",
+            "    x = 1;",
+            "}",
+            "else",
+            "{",
+            "    x = 2;",
+            "}");
+        Assert.Equal(expected.Trim(), result.Trim());
+    }
+
+    [Fact]
     public void NestedIfInsideElseIsConverted()
     {
         var lingo = string.Join('\n',


### PR DESCRIPTION
## Summary
- allow `LingoAstParser` to parse single-line `if ... then` statements that are followed by an `else`
- add regression test for converting single-line `if` with `else`

## Testing
- `dotnet format src/LingoEngine.Lingo.Core/LingoEngine.Lingo.Core.csproj --verbosity diagnostic`
- `dotnet format Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj --verbosity diagnostic`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj` *(fails: KeyNotFoundException in CompleteScriptWithSendSpriteIsConverted)*
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj --filter SingleLineIfWithElseIsConverted`


------
https://chatgpt.com/codex/tasks/task_e_68a9d0d8ce88833280e7ea53ea8efacb