### PR TITLE
Parse XMED unknown text run bytes

### DIFF
--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/CastMembers/RaysCastMemberTextRead.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/CastMembers/RaysCastMemberTextRead.cs
@@ -2,7 +2,6 @@
 using ProjectorRays.Common;
 using ProjectorRays.Director;
 using System;
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
@@ -26,7 +25,17 @@ namespace ProjectorRays.CastMembers
             public ushort FontId { get; set; }
             public RayColor ForeColor { get; set; }
             public RayColor BackColor { get; set; }
-            public byte[]? UnknownData { get; set; }
+            public ushort Unknown1 { get; set; }
+            public uint Unknown2 { get; set; }
+            public uint Unknown3 { get; set; }
+            public uint Unknown4 { get; set; }
+            public uint Unknown5 { get; set; }
+            public uint Unknown6 { get; set; }
+            public uint Unknown7 { get; set; }
+            public uint Unknown8 { get; set; }
+            public uint Unknown9 { get; set; }
+            public uint Unknown10 { get; set; }
+            public uint Unknown11 { get; set; }
         }
 
         public static List<TextStyleRun> Parse(BufferView view)

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/CastMembers/XmedReader.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/CastMembers/XmedReader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
 using ProjectorRays.Common;
@@ -248,8 +249,29 @@ public static class XmedReader
                             }
                             else
                             {
-                                run.UnknownData = new byte[len];
-                                Array.Copy(data, textStart, run.UnknownData, 0, len);
+                                var span = data.AsSpan(textStart, len);
+                                if (len >= 2)
+                                    run.Unknown1 = BinaryPrimitives.ReadUInt16LittleEndian(span);
+                                if (len >= 6)
+                                    run.Unknown2 = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(2));
+                                if (len >= 10)
+                                    run.Unknown3 = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(6));
+                                if (len >= 14)
+                                    run.Unknown4 = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(10));
+                                if (len >= 18)
+                                    run.Unknown5 = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(14));
+                                if (len >= 22)
+                                    run.Unknown6 = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(18));
+                                if (len >= 26)
+                                    run.Unknown7 = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(22));
+                                if (len >= 30)
+                                    run.Unknown8 = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(26));
+                                if (len >= 34)
+                                    run.Unknown9 = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(30));
+                                if (len >= 38)
+                                    run.Unknown10 = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(34));
+                                if (len >= 42)
+                                    run.Unknown11 = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(38));
                             }
 
                             doc.Runs.Add(run);


### PR DESCRIPTION
## Summary
- treat first XMED text run value as 16-bit `Unknown1` field
- parse remaining non-printable run data into ten 32-bit `Unknown*` values

## Testing
- `dotnet format WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/ProjectorRays.DotNet.csproj --include WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/CastMembers/XmedReader.cs --include WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/CastMembers/RaysCastMemberTextRead.cs --verbosity diagnostic`
- `dotnet test WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/ProjectorRays.DotNet.Test.csproj` *(fails: Could not find file '.../TextCast.cst')*

------
https://chatgpt.com/codex/tasks/task_e_68a9d3c5fd68833288dd5899f977afd0