### PR TITLE
Add media member framework for video playback

### DIFF
--- a/src/LingoEngine.Blazor/BlazorFactory.cs
+++ b/src/LingoEngine.Blazor/BlazorFactory.cs
@@ -33,6 +33,8 @@ using AbstUI.Components.Inputs;
 using AbstUI.Components.Menus;
 using AbstUI.Components.Buttons;
 using AbstUI.Components.Texts;
+using LingoEngine.Medias;
+using LingoEngine.Blazor.Medias;
 
 namespace LingoEngine.Blazor;
 
@@ -106,7 +108,13 @@ public class BlazorFactory : ILingoFrameworkFactory, IDisposable
 
     // The remaining factory methods are not yet required for the Blazor
     // backend. They will be implemented as the Blazor integration evolves.
-    public T CreateMember<T>(ILingoCast cast, int numberInCast, string name = "") where T : LingoMember => throw new NotImplementedException();
+    public T CreateMember<T>(ILingoCast cast, int numberInCast, string name = "") where T : LingoMember => typeof(T) switch
+    {
+        Type t when t == typeof(LingoFilmLoopMember) => (CreateMemberFilmLoop(cast, numberInCast, name) as T)!,
+        Type t when t == typeof(LingoMemberQuickTimeMedia) => (CreateMemberQuickTimeMedia(cast, numberInCast, name) as T)!,
+        Type t when t == typeof(LingoMemberRealMedia) => (CreateMemberRealMedia(cast, numberInCast, name) as T)!,
+        _ => throw new NotImplementedException()
+    };
     public LingoMemberBitmap CreateMemberBitmap(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
     public LingoMemberSound CreateMemberSound(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
     public LingoFilmLoopMember CreateMemberFilmLoop(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default)
@@ -122,6 +130,20 @@ public class BlazorFactory : ILingoFrameworkFactory, IDisposable
     public LingoMemberShape CreateMemberShape(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
     public LingoMemberField CreateMemberField(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
     public LingoMemberText CreateMemberText(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
+    public LingoMemberQuickTimeMedia CreateMemberQuickTimeMedia(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default)
+    {
+        var impl = new LingoBlazorMemberMedia();
+        var member = new LingoMemberQuickTimeMedia(impl, (LingoCast)cast, numberInCast, name, fileName ?? string.Empty, regPoint);
+        impl.Init(member);
+        return member;
+    }
+    public LingoMemberRealMedia CreateMemberRealMedia(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default)
+    {
+        var impl = new LingoBlazorMemberMedia();
+        var member = new LingoMemberRealMedia(impl, (LingoCast)cast, numberInCast, name, fileName ?? string.Empty, regPoint);
+        impl.Init(member);
+        return member;
+    }
     public LingoMember CreateScript(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
     public LingoMember CreateEmpty(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
     public LingoSound CreateSound(ILingoCastLibsContainer castLibsContainer) => throw new NotImplementedException();

--- a/src/LingoEngine.Blazor/Medias/LingoBlazorMemberMedia.cs
+++ b/src/LingoEngine.Blazor/Medias/LingoBlazorMemberMedia.cs
@@ -1,0 +1,63 @@
+using LingoEngine.Medias;
+using LingoEngine.Members;
+using LingoEngine.Sprites;
+using System.IO;
+
+namespace LingoEngine.Blazor.Medias;
+
+/// <summary>
+/// Minimal Blazor implementation of a video media member.
+/// Stores the media file path for use by the sprite.
+/// </summary>
+public class LingoBlazorMemberMedia : ILingoFrameworkMemberMedia
+{
+    private LingoMemberMedia _member = null!;
+
+    internal string? Url { get; private set; }
+    public bool IsLoaded { get; private set; }
+    public int Duration { get; private set; }
+    public int CurrentTime { get; set; }
+    public LingoMediaStatus MediaStatus { get; private set; } = LingoMediaStatus.Closed;
+
+    internal void Init(LingoMemberMedia member)
+    {
+        _member = member;
+    }
+
+    public void Play() => MediaStatus = LingoMediaStatus.Playing;
+    public void Pause() => MediaStatus = LingoMediaStatus.Paused;
+    public void Stop()
+    {
+        MediaStatus = LingoMediaStatus.Closed;
+        CurrentTime = 0;
+    }
+    public void Seek(int milliseconds) => CurrentTime = milliseconds;
+
+    public void CopyToClipboard() { }
+    public void Erase() { }
+    public void ImportFileInto() { }
+    public void PasteClipboardInto() { }
+    public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
+
+    public void Preload()
+    {
+        if (IsLoaded)
+            return;
+        if (!string.IsNullOrEmpty(_member.FileName))
+        {
+            var fullPath = Path.GetFullPath(_member.FileName);
+            Url = new System.Uri(fullPath).AbsoluteUri;
+            MediaStatus = LingoMediaStatus.Opened;
+        }
+        IsLoaded = true;
+    }
+
+    public void Unload()
+    {
+        IsLoaded = false;
+        Url = null;
+        MediaStatus = LingoMediaStatus.Closed;
+    }
+
+    public bool IsPixelTransparent(int x, int y) => false;
+}

--- a/src/LingoEngine.LGodot/Core/GodotFactory.cs
+++ b/src/LingoEngine.LGodot/Core/GodotFactory.cs
@@ -26,6 +26,8 @@ using LingoEngine.LGodot.Scripts;
 using LingoEngine.Scripts;
 using LingoEngine.FilmLoops;
 using LingoEngine.LGodot.FilmLoops;
+using LingoEngine.Medias;
+using LingoEngine.LGodot.Medias;
 using AbstUI.Primitives;
 using AbstUI.Components;
 using AbstUI.Inputs;
@@ -103,6 +105,8 @@ namespace LingoEngine.LGodot.Core
                 Type t when t == typeof(LingoMemberSound) => (CreateMemberSound(cast, numberInCast, name) as T)!,
                 Type t when t == typeof(LingoFilmLoopMember) => (CreateMemberFilmLoop(cast, numberInCast, name) as T)!,
                 Type t when t == typeof(LingoMemberShape) => (CreateMemberShape(cast, numberInCast, name) as T)!,
+                Type t when t == typeof(LingoMemberQuickTimeMedia) => (CreateMemberQuickTimeMedia(cast, numberInCast, name) as T)!,
+                Type t when t == typeof(LingoMemberRealMedia) => (CreateMemberRealMedia(cast, numberInCast, name) as T)!,
             };
         }
         /// <inheritdoc/>
@@ -128,6 +132,24 @@ namespace LingoEngine.LGodot.Core
         {
             var impl = new LingoGodotMemberShape();
             var member = new LingoMemberShape((LingoCast)cast, impl, numberInCast, name, fileName ?? "", regPoint);
+            _disposables.Add(impl);
+            return member;
+        }
+        /// <inheritdoc/>
+        public LingoMemberQuickTimeMedia CreateMemberQuickTimeMedia(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default)
+        {
+            var impl = new LingoGodotMemberMedia();
+            var member = new LingoMemberQuickTimeMedia(impl, (LingoCast)cast, numberInCast, name, fileName ?? "", regPoint);
+            impl.Init(member);
+            _disposables.Add(impl);
+            return member;
+        }
+        /// <inheritdoc/>
+        public LingoMemberRealMedia CreateMemberRealMedia(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default)
+        {
+            var impl = new LingoGodotMemberMedia();
+            var member = new LingoMemberRealMedia(impl, (LingoCast)cast, numberInCast, name, fileName ?? "", regPoint);
+            impl.Init(member);
             _disposables.Add(impl);
             return member;
         }

--- a/src/LingoEngine.LGodot/Medias/LingoGodotMemberMedia.cs
+++ b/src/LingoEngine.LGodot/Medias/LingoGodotMemberMedia.cs
@@ -1,0 +1,63 @@
+using Godot;
+using LingoEngine.Medias;
+using LingoEngine.Sprites;
+using LingoEngine.Members;
+using AbstUI.LGodot.Helpers;
+
+namespace LingoEngine.LGodot.Medias
+{
+    public class LingoGodotMemberMedia : ILingoFrameworkMemberMedia
+    {
+        private LingoMemberMedia _member = null!;
+        internal VideoStream? Stream { get; private set; }
+
+        public bool IsLoaded { get; private set; }
+        public int Duration { get; private set; }
+        public int CurrentTime { get; set; }
+        public LingoMediaStatus MediaStatus { get; private set; } = LingoMediaStatus.Closed;
+
+        internal void Init(LingoMemberMedia member)
+        {
+            _member = member;
+            Preload();
+        }
+
+        public void Play() => MediaStatus = LingoMediaStatus.Playing;
+        public void Pause() => MediaStatus = LingoMediaStatus.Paused;
+        public void Stop()
+        {
+            MediaStatus = LingoMediaStatus.Closed;
+            CurrentTime = 0;
+        }
+        public void Seek(int milliseconds) => CurrentTime = milliseconds;
+
+        public void CopyToClipboard() { }
+        public void Erase() { }
+        public void ImportFileInto() { }
+        public void PasteClipboardInto() { }
+        public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
+
+        public void Preload()
+        {
+            if (IsLoaded)
+                return;
+            var filePath = GodotHelper.EnsureGodotUrl(_member.FileName);
+            Stream = ResourceLoader.Load<VideoStream>(filePath);
+            if (Stream != null)
+            {
+                Duration = (int)(Stream.GetLength() * 1000);
+                MediaStatus = LingoMediaStatus.Opened;
+            }
+            IsLoaded = true;
+        }
+
+        public void Unload()
+        {
+            Stream = null;
+            IsLoaded = false;
+            MediaStatus = LingoMediaStatus.Closed;
+        }
+
+        public bool IsPixelTransparent(int x, int y) => false;
+    }
+}

--- a/src/LingoEngine.Unity/Core/UnityFactory.cs
+++ b/src/LingoEngine.Unity/Core/UnityFactory.cs
@@ -22,6 +22,8 @@ using LingoEngine.Unity.FilmLoops;
 using LingoEngine.Unity.Shapes;
 using LingoEngine.Unity.Scripts;
 using LingoEngine.Scripts;
+using LingoEngine.Medias;
+using LingoEngine.Unity.Medias;
 using AbstUI.Styles;
 using Microsoft.Extensions.DependencyInjection;
 using AbstUI.Primitives;
@@ -80,8 +82,12 @@ public class UnityFactory : ILingoFrameworkFactory, IDisposable
         {
             Type t when t == typeof(LingoMemberBitmap) => (CreateMemberBitmap(cast, numberInCast, name) as T)!,
             Type t when t == typeof(LingoMemberSound) => (CreateMemberSound(cast, numberInCast, name) as T)!,
+            Type t when t == typeof(LingoFilmLoopMember) => (CreateMemberFilmLoop(cast, numberInCast, name) as T)!,
+            Type t when t == typeof(LingoMemberShape) => (CreateMemberShape(cast, numberInCast, name) as T)!,
             Type t when t == typeof(LingoMemberField) => (CreateMemberField(cast, numberInCast, name) as T)!,
             Type t when t == typeof(LingoMemberText) => (CreateMemberText(cast, numberInCast, name) as T)!,
+            Type t when t == typeof(LingoMemberQuickTimeMedia) => (CreateMemberQuickTimeMedia(cast, numberInCast, name) as T)!,
+            Type t when t == typeof(LingoMemberRealMedia) => (CreateMemberRealMedia(cast, numberInCast, name) as T)!,
             _ => throw new NotSupportedException()
         };
     }
@@ -110,6 +116,20 @@ public class UnityFactory : ILingoFrameworkFactory, IDisposable
     {
         var impl = new UnityMemberShape();
         var member = new LingoMemberShape((LingoCast)cast, impl, numberInCast, name, fileName ?? string.Empty, regPoint);
+        impl.Init(member);
+        return member;
+    }
+    public LingoMemberQuickTimeMedia CreateMemberQuickTimeMedia(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default)
+    {
+        var impl = new LingoUnityMemberMedia();
+        var member = new LingoMemberQuickTimeMedia(impl, (LingoCast)cast, numberInCast, name, fileName ?? string.Empty, regPoint);
+        impl.Init(member);
+        return member;
+    }
+    public LingoMemberRealMedia CreateMemberRealMedia(ILingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default)
+    {
+        var impl = new LingoUnityMemberMedia();
+        var member = new LingoMemberRealMedia(impl, (LingoCast)cast, numberInCast, name, fileName ?? string.Empty, regPoint);
         impl.Init(member);
         return member;
     }

--- a/src/LingoEngine.Unity/Medias/LingoUnityMemberMedia.cs
+++ b/src/LingoEngine.Unity/Medias/LingoUnityMemberMedia.cs
@@ -1,0 +1,67 @@
+using System;
+using System.IO;
+using LingoEngine.Medias;
+using LingoEngine.Members;
+using LingoEngine.Sprites;
+
+namespace LingoEngine.Unity.Medias;
+
+/// <summary>
+/// Unity framework implementation for video media members.
+/// Loads the media file path and exposes playback control information.
+/// </summary>
+public class LingoUnityMemberMedia : ILingoFrameworkMemberMedia
+{
+    private LingoMemberMedia _member = null!;
+
+    internal string? Url { get; private set; }
+    public bool IsLoaded { get; private set; }
+    public int Duration { get; private set; }
+    public int CurrentTime { get; set; }
+    public LingoMediaStatus MediaStatus { get; private set; } = LingoMediaStatus.Closed;
+
+    internal void Init(LingoMemberMedia member)
+    {
+        _member = member;
+    }
+
+    public void Play() => MediaStatus = LingoMediaStatus.Playing;
+
+    public void Pause() => MediaStatus = LingoMediaStatus.Paused;
+
+    public void Stop()
+    {
+        MediaStatus = LingoMediaStatus.Closed;
+        CurrentTime = 0;
+    }
+
+    public void Seek(int milliseconds) => CurrentTime = milliseconds;
+
+    public void CopyToClipboard() { }
+    public void Erase() { }
+    public void ImportFileInto() { }
+    public void PasteClipboardInto() { }
+    public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
+
+    public void Preload()
+    {
+        if (IsLoaded)
+            return;
+        if (!string.IsNullOrEmpty(_member.FileName))
+        {
+            var fullPath = Path.GetFullPath(_member.FileName);
+            Url = new Uri(fullPath).AbsoluteUri;
+            MediaStatus = LingoMediaStatus.Opened;
+        }
+        IsLoaded = true;
+    }
+
+    public void Unload()
+    {
+        IsLoaded = false;
+        Url = null;
+        MediaStatus = LingoMediaStatus.Closed;
+    }
+
+    public bool IsPixelTransparent(int x, int y) => false;
+}

--- a/src/LingoEngine.Unity/Medias/UnityVideoStubs.cs
+++ b/src/LingoEngine.Unity/Medias/UnityVideoStubs.cs
@@ -1,0 +1,32 @@
+namespace UnityEngine
+{
+    /// <summary>
+    /// Minimal stub of Unity's VideoClip used for compilation in environments
+    /// where the real Video module is unavailable.
+    /// </summary>
+    public class VideoClip
+    {
+        public double length { get; set; }
+    }
+
+    /// <summary>
+    /// Minimal stub of Unity's VideoPlayer component. Provides just enough
+    /// functionality for the engine to compile and manage simple playback state.
+    /// </summary>
+    public class VideoPlayer : Behaviour
+    {
+        public string url = string.Empty;
+        public bool isPlaying { get; private set; }
+        public double time { get; set; }
+        public VideoClip? clip { get; set; }
+        public bool playOnAwake;
+
+        public void Play() => isPlaying = true;
+        public void Pause() => isPlaying = false;
+        public void Stop()
+        {
+            isPlaying = false;
+            time = 0;
+        }
+    }
+}

--- a/src/LingoEngine/Events/LingoEventMediator.cs
+++ b/src/LingoEngine/Events/LingoEventMediator.cs
@@ -1,5 +1,6 @@
 ﻿using LingoEngine.Inputs;
 using LingoEngine.Inputs.Events;
+using LingoEngine.Medias.Events;
 using LingoEngine.Movies.Events;
 using LingoEngine.Sprites;
 using AbstUI.Inputs;
@@ -32,6 +33,10 @@ namespace LingoEngine.Events
         private readonly List<IHasBlurEvent> _blurs = new();
         private readonly List<IHasKeyUpEvent> _keyUps = new();
         private readonly List<IHasKeyDownEvent> _keyDowns = new();
+        private readonly List<IHasStartVideoEvent> _startVideos = new();
+        private readonly List<IHasStopVideoEvent> _stopVideos = new();
+        private readonly List<IHasPauseVideoEvent> _pauseVideos = new();
+        private readonly List<IHasEndVideoEvent> _endVideos = new();
 
 
         private void Insert<T>(List<T> list, T item) where T : class
@@ -82,6 +87,10 @@ namespace LingoEngine.Events
             if (ms is IHasBlurEvent blurEvent) Insert(_blurs, blurEvent);
             if (ms is IHasKeyUpEvent keyUpEvent) Insert(_keyUps, keyUpEvent);
             if (ms is IHasKeyDownEvent keyDownEvent) Insert(_keyDowns, keyDownEvent);
+            if (ms is IHasStartVideoEvent startVideoEvent) Insert(_startVideos, startVideoEvent);
+            if (ms is IHasStopVideoEvent stopVideoEvent) Insert(_stopVideos, stopVideoEvent);
+            if (ms is IHasPauseVideoEvent pauseVideoEvent) Insert(_pauseVideos, pauseVideoEvent);
+            if (ms is IHasEndVideoEvent endVideoEvent) Insert(_endVideos, endVideoEvent);
         }
         public void Unsubscribe(object ms, bool ignoreMouse = false)
         {
@@ -99,7 +108,7 @@ namespace LingoEngine.Events
             }
             //if (ms is IHasBeginSpriteEvent beginSpriteEvent) _beginSprites.Remove(beginSpriteEvent);
             //if (ms is IHasEndSpriteEvent endSpriteEvent) _endSprites.Remove(endSpriteEvent);
-            
+
             // Not stepframe it seems stepframe is only used through the actor list.
             if (ms is IHasPrepareFrameEvent prepareFrameEvent) _prepareFrames.Remove(prepareFrameEvent);
             if (ms is IHasEnterFrameEvent enterFrameEvent) _enterFrames.Remove(enterFrameEvent);
@@ -108,6 +117,10 @@ namespace LingoEngine.Events
             if (ms is IHasBlurEvent blurEvent) _blurs.Remove(blurEvent);
             if (ms is IHasKeyUpEvent keyUpEvent) _keyUps.Remove(keyUpEvent);
             if (ms is IHasKeyDownEvent keyDownEvent) _keyDowns.Remove(keyDownEvent);
+            if (ms is IHasStartVideoEvent startVideoEvent) _startVideos.Remove(startVideoEvent);
+            if (ms is IHasStopVideoEvent stopVideoEvent) _stopVideos.Remove(stopVideoEvent);
+            if (ms is IHasPauseVideoEvent pauseVideoEvent) _pauseVideos.Remove(pauseVideoEvent);
+            if (ms is IHasEndVideoEvent endVideoEvent) _endVideos.Remove(endVideoEvent);
 
             _priorities.Remove(ms);
         }
@@ -139,6 +152,10 @@ namespace LingoEngine.Events
             FilterList(_blurs);
             FilterList(_keyUps);
             FilterList(_keyDowns);
+            FilterList(_startVideos);
+            FilterList(_stopVideos);
+            FilterList(_pauseVideos);
+            FilterList(_endVideos);
         }
         internal void RaisePrepareMovie() => _prepareMovies.ForEach(x => x.PrepareMovie());
         internal void RaiseStartMovie() => _startMovies.ForEach(x => x.StartMovie());
@@ -157,6 +174,10 @@ namespace LingoEngine.Events
         internal void RaiseExitFrame() => _exitFrames.ForEach(x => x.ExitFrame());
         public void RaiseFocus() => _focuss.ForEach(x => x.Focus());
         public void RaiseBlur() => _blurs.ForEach(x => x.Blur());
+        internal void RaiseStartVideo() => _startVideos.ForEach(x => x.StartVideo());
+        internal void RaiseStopVideo() => _stopVideos.ForEach(x => x.StopVideo());
+        internal void RaisePauseVideo() => _pauseVideos.ForEach(x => x.PauseVideo());
+        internal void RaiseEndVideo() => _endVideos.ForEach(x => x.EndVideo());
         public void RaiseKeyUp(LingoKeyEvent key) => _keyUps.ForEach(x => x.KeyUp(key));
         public void RaiseKeyDown(LingoKeyEvent key) => _keyDowns.ForEach(x => x.KeyDown(key));
 

--- a/src/LingoEngine/Medias/Events/IVideoEvents.cs
+++ b/src/LingoEngine/Medias/Events/IVideoEvents.cs
@@ -1,0 +1,23 @@
+namespace LingoEngine.Medias.Events
+{
+    /// <summary>Event interface triggered when video playback starts.</summary>
+    public interface IHasStartVideoEvent
+    {
+        void StartVideo();
+    }
+    /// <summary>Event interface triggered when video playback stops.</summary>
+    public interface IHasStopVideoEvent
+    {
+        void StopVideo();
+    }
+    /// <summary>Event interface triggered when video playback pauses.</summary>
+    public interface IHasPauseVideoEvent
+    {
+        void PauseVideo();
+    }
+    /// <summary>Event interface triggered when video playback finishes.</summary>
+    public interface IHasEndVideoEvent
+    {
+        void EndVideo();
+    }
+}

--- a/src/LingoEngine/Medias/ILingoFrameworkMemberMedia.cs
+++ b/src/LingoEngine/Medias/ILingoFrameworkMemberMedia.cs
@@ -1,0 +1,26 @@
+using LingoEngine.Members;
+
+namespace LingoEngine.Medias
+{
+    /// <summary>
+    /// Framework specific implementation details for a media (video) member.
+    /// </summary>
+    public interface ILingoFrameworkMemberMedia : ILingoFrameworkMember
+    {
+        /// <summary>Start playback of the media stream.</summary>
+        void Play();
+        /// <summary>Pause playback of the media stream.</summary>
+        void Pause();
+        /// <summary>Stop playback of the media stream.</summary>
+        void Stop();
+        /// <summary>Seek to a position in milliseconds from the start of the stream.</summary>
+        /// <param name="milliseconds">Position in milliseconds.</param>
+        void Seek(int milliseconds);
+        /// <summary>Total length of the media stream in milliseconds.</summary>
+        int Duration { get; }
+        /// <summary>Current position of the media stream in milliseconds.</summary>
+        int CurrentTime { get; set; }
+        /// <summary>Current playback status of the media stream.</summary>
+        LingoMediaStatus MediaStatus { get; }
+    }
+}

--- a/src/LingoEngine/Medias/ILingoFrameworkSpriteVideo.cs
+++ b/src/LingoEngine/Medias/ILingoFrameworkSpriteVideo.cs
@@ -1,0 +1,18 @@
+
+namespace LingoEngine.Medias
+{
+    /// <summary>
+    /// Optional sprite capabilities for video playback.
+    /// Framework sprite implementations may implement this to support media control.
+    /// </summary>
+    public interface ILingoFrameworkSpriteVideo
+    {
+        void Play();
+        void Pause();
+        void Stop();
+        void Seek(int milliseconds);
+        int Duration { get; }
+        int CurrentTime { get; set; }
+        LingoMediaStatus MediaStatus { get; }
+    }
+}

--- a/src/LingoEngine/Medias/LingoMediaStatus.cs
+++ b/src/LingoEngine/Medias/LingoMediaStatus.cs
@@ -1,0 +1,18 @@
+namespace LingoEngine.Medias
+{
+    /// <summary>
+    /// Represents the playback state of a media stream.
+    /// Mirrors the Lingo <c>mediaStatus</c> property.
+    /// </summary>
+    public enum LingoMediaStatus
+    {
+        Closed,
+        Connecting,
+        Opened,
+        Buffering,
+        Playing,
+        Seeking,
+        Paused,
+        Error
+    }
+}

--- a/src/LingoEngine/Medias/LingoMemberMedia.cs
+++ b/src/LingoEngine/Medias/LingoMemberMedia.cs
@@ -1,0 +1,29 @@
+using LingoEngine.Casts;
+using LingoEngine.Members;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.Medias
+{
+    /// <summary>
+    /// Base class for video media cast members.
+    /// </summary>
+    public class LingoMemberMedia : LingoMember
+    {
+        private readonly ILingoFrameworkMemberMedia _frameworkMedia;
+
+        public int Duration => _frameworkMedia.Duration;
+        public int CurrentTime { get => _frameworkMedia.CurrentTime; set => _frameworkMedia.CurrentTime = value; }
+        public LingoMediaStatus MediaStatus => _frameworkMedia.MediaStatus;
+
+        public LingoMemberMedia(ILingoFrameworkMemberMedia frameworkMember, LingoMemberType type, LingoCast cast, int numberInCast, string name = "", string fileName = "", APoint regPoint = default)
+            : base(frameworkMember, type, cast, numberInCast, name, fileName, regPoint)
+        {
+            _frameworkMedia = frameworkMember;
+        }
+
+        public void Play() => _frameworkMedia.Play();
+        public void Pause() => _frameworkMedia.Pause();
+        public void Stop() => _frameworkMedia.Stop();
+        public void Seek(int milliseconds) => _frameworkMedia.Seek(milliseconds);
+    }
+}

--- a/src/LingoEngine/Medias/LingoMemberMedia.cs
+++ b/src/LingoEngine/Medias/LingoMemberMedia.cs
@@ -1,6 +1,6 @@
 using LingoEngine.Casts;
 using LingoEngine.Members;
-using LingoEngine.Primitives;
+using AbstUI.Primitives;
 
 namespace LingoEngine.Medias
 {
@@ -20,6 +20,8 @@ namespace LingoEngine.Medias
         {
             _frameworkMedia = frameworkMember;
         }
+
+        public T Framework<T>() where T : class, ILingoFrameworkMemberMedia => (T)_frameworkMedia;
 
         public void Play() => _frameworkMedia.Play();
         public void Pause() => _frameworkMedia.Pause();

--- a/src/LingoEngine/Medias/LingoMemberQuickTimeMedia.cs
+++ b/src/LingoEngine/Medias/LingoMemberQuickTimeMedia.cs
@@ -1,5 +1,6 @@
 using LingoEngine.Casts;
-using LingoEngine.Primitives;
+using LingoEngine.Members;
+using AbstUI.Primitives;
 
 namespace LingoEngine.Medias
 {

--- a/src/LingoEngine/Medias/LingoMemberQuickTimeMedia.cs
+++ b/src/LingoEngine/Medias/LingoMemberQuickTimeMedia.cs
@@ -1,0 +1,16 @@
+using LingoEngine.Casts;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.Medias
+{
+    /// <summary>
+    /// Represents a QuickTime digital video cast member.
+    /// </summary>
+    public class LingoMemberQuickTimeMedia : LingoMemberMedia
+    {
+        public LingoMemberQuickTimeMedia(ILingoFrameworkMemberMedia frameworkMember, LingoCast cast, int numberInCast, string name = "", string fileName = "", APoint regPoint = default)
+            : base(frameworkMember, LingoMemberType.QuickTimeMedia, cast, numberInCast, name, fileName, regPoint)
+        {
+        }
+    }
+}

--- a/src/LingoEngine/Medias/LingoMemberRealMedia.cs
+++ b/src/LingoEngine/Medias/LingoMemberRealMedia.cs
@@ -1,5 +1,6 @@
 using LingoEngine.Casts;
-using LingoEngine.Primitives;
+using LingoEngine.Members;
+using AbstUI.Primitives;
 
 namespace LingoEngine.Medias
 {

--- a/src/LingoEngine/Medias/LingoMemberRealMedia.cs
+++ b/src/LingoEngine/Medias/LingoMemberRealMedia.cs
@@ -1,0 +1,16 @@
+using LingoEngine.Casts;
+using LingoEngine.Primitives;
+
+namespace LingoEngine.Medias
+{
+    /// <summary>
+    /// Represents a RealMedia digital video cast member.
+    /// </summary>
+    public class LingoMemberRealMedia : LingoMemberMedia
+    {
+        public LingoMemberRealMedia(ILingoFrameworkMemberMedia frameworkMember, LingoCast cast, int numberInCast, string name = "", string fileName = "", APoint regPoint = default)
+            : base(frameworkMember, LingoMemberType.RealMedia, cast, numberInCast, name, fileName, regPoint)
+        {
+        }
+    }
+}

--- a/src/LingoEngine/Members/LingoMemberFactory.cs
+++ b/src/LingoEngine/Members/LingoMemberFactory.cs
@@ -5,6 +5,7 @@ using LingoEngine.Shapes;
 using LingoEngine.Texts;
 using LingoEngine.Bitmaps;
 using LingoEngine.FilmLoops;
+using LingoEngine.Medias;
 
 namespace LingoEngine.Members
 {
@@ -19,6 +20,8 @@ namespace LingoEngine.Members
         LingoFilmLoopMember FilmLoop(int numberInCast = 0, string name = "");
         LingoMemberShape Shape(int numberInCast = 0, string name = "");
         LingoMemberText Text(int numberInCast = 0, string name = "");
+        LingoMemberQuickTimeMedia QuickTimeMedia(int numberInCast = 0, string name = "");
+        LingoMemberRealMedia RealMedia(int numberInCast = 0, string name = "");
     }
 
     internal class LingoMemberFactory : ILingoMemberFactory
@@ -38,5 +41,7 @@ namespace LingoEngine.Members
         public LingoFilmLoopMember FilmLoop(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberFilmLoop(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
         public LingoMemberShape Shape(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberShape(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
         public LingoMemberText Text(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMemberText(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
+        public LingoMemberQuickTimeMedia QuickTimeMedia(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMember<LingoMemberQuickTimeMedia>(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
+        public LingoMemberRealMedia RealMedia(int numberInCast = 0, string name = "") => _frameworkFactory.CreateMember<LingoMemberRealMedia>(_environment.CastLibsContainer.ActiveCast, numberInCast, name);
     }
 }

--- a/src/LingoEngine/Sprites/ILingoSprite.cs
+++ b/src/LingoEngine/Sprites/ILingoSprite.cs
@@ -1,5 +1,6 @@
 ﻿using AbstUI.Primitives;
 using LingoEngine.Casts;
+using LingoEngine.Medias;
 using LingoEngine.Members;
 using LingoEngine.Movies;
 using LingoEngine.Primitives;
@@ -41,7 +42,7 @@ namespace LingoEngine.Sprites
     /// </summary>
     public interface ILingoSprite : ILingoSpriteBase
     {
-       
+
 
         /// <summary>
         /// Background color for the sprite. Read/write.
@@ -68,7 +69,7 @@ namespace LingoEngine.Sprites
         /// </summary>
         bool Editable { get; set; }
 
-       
+
 
         /// <summary>
         /// Foreground color of the sprite, often used in text. Read/write.
@@ -108,6 +109,21 @@ namespace LingoEngine.Sprites
         /// Returns TRUE if the sprite’s media is initialized and ready. Read-only.
         /// </summary>
         bool MediaReady { get; }
+        /// <summary>Starts playback of the associated media.</summary>
+        void Play();
+        /// <summary>Stops playback of the associated media.</summary>
+        void Stop();
+        /// <summary>Pauses playback of the associated media.</summary>
+        void Pause();
+        /// <summary>Seeks the media to a position measured in milliseconds.</summary>
+        /// <param name="milliseconds">Offset in milliseconds.</param>
+        void Seek(int milliseconds);
+        /// <summary>Total duration of the media in milliseconds.</summary>
+        int Duration { get; }
+        /// <summary>Current playback time in milliseconds.</summary>
+        int CurrentTime { get; set; }
+        /// <summary>Current playback status of the media.</summary>
+        LingoMediaStatus MediaStatus { get; }
         float Width { get; }
         float Height { get; }
 
@@ -121,7 +137,7 @@ namespace LingoEngine.Sprites
         /// </summary>
         string ModifiedBy { get; set; }
 
-       
+
         /// <summary>
         /// The rectangular boundary of the sprite (top-left to bottom-right). Read/write.
         /// </summary>
@@ -210,7 +226,7 @@ namespace LingoEngine.Sprites
         /// </summary>
         int Size { get; }
 
-        
+
 
         /// <summary>
         /// Returns or sets a small thumbnail representation of the sprite’s media.
@@ -222,7 +238,7 @@ namespace LingoEngine.Sprites
         /// </summary>
         bool Visibility { get; set; }
         int MemberNum { get; }
-        
+
 
 
         /// <summary>

--- a/src/LingoEngine/Sprites/LingoSprite2D.cs
+++ b/src/LingoEngine/Sprites/LingoSprite2D.cs
@@ -1,6 +1,7 @@
 ﻿using LingoEngine.Events;
 using LingoEngine.Inputs;
 using LingoEngine.Primitives;
+using LingoEngine.Medias;
 using LingoEngine.Animations;
 using LingoEngine.Members;
 using LingoEngine.Casts;
@@ -27,7 +28,7 @@ namespace LingoEngine.Sprites
 
         public IReadOnlyList<LingoSpriteBehavior> Behaviors => _behaviors;
 
-        
+
         private bool isMouseInside = false;
         private bool isDragging = false;
         private bool isDraggable = false;  // A flag to control dragging behavior
@@ -47,7 +48,8 @@ namespace LingoEngine.Sprites
         #region Properties
         public override int SpriteNumWithChannel => SpriteNum + SpriteNumOffset;
         internal LingoSpriteChannel? SpriteChannel { get; set; }
-       
+
+        /// <inheritdoc/>
         public T Framework<T>() where T : class, ILingoFrameworkSprite => (T)_frameworkSprite;
 
 
@@ -168,6 +170,55 @@ namespace LingoEngine.Sprites
         public byte[] Media { get; set; } = new byte[] { };
         public byte[] Thumbnail { get; set; } = new byte[] { };
         public string ModifiedBy { get; set; } = "";
+
+        /// <inheritdoc/>
+        public void Play()
+        {
+            if (_frameworkSprite is ILingoFrameworkSpriteVideo video)
+                video.Play();
+            _eventMediator.RaiseStartVideo();
+        }
+
+        /// <inheritdoc/>
+        public void Stop()
+        {
+            if (_frameworkSprite is ILingoFrameworkSpriteVideo video)
+                video.Stop();
+            _eventMediator.RaiseStopVideo();
+            _eventMediator.RaiseEndVideo();
+        }
+
+        /// <inheritdoc/>
+        public void Pause()
+        {
+            if (_frameworkSprite is ILingoFrameworkSpriteVideo video)
+                video.Pause();
+            _eventMediator.RaisePauseVideo();
+        }
+
+        /// <inheritdoc/>
+        public void Seek(int milliseconds)
+        {
+            if (_frameworkSprite is ILingoFrameworkSpriteVideo video)
+                video.Seek(milliseconds);
+        }
+
+        /// <inheritdoc/>
+        public int Duration => (_frameworkSprite as ILingoFrameworkSpriteVideo)?.Duration ?? 0;
+
+        /// <inheritdoc/>
+        public int CurrentTime
+        {
+            get => (_frameworkSprite as ILingoFrameworkSpriteVideo)?.CurrentTime ?? 0;
+            set
+            {
+                if (_frameworkSprite is ILingoFrameworkSpriteVideo video)
+                    video.CurrentTime = value;
+            }
+        }
+
+        /// <inheritdoc/>
+        public LingoMediaStatus MediaStatus => (_frameworkSprite as ILingoFrameworkSpriteVideo)?.MediaStatus ?? LingoMediaStatus.Closed;
 
         public float Width
         {
@@ -365,7 +416,7 @@ When a movie stops, events occur in the following order:
 #if DEBUG
                 if (_Member.NumberInCast == 44)
                 {
-                    
+
                 }
 #endif
                 _frameworkSprite.ApplyMemberChangesOnStepFrame();

--- a/src/LingoEngine/Sprites/LingoSpriteChannel.cs
+++ b/src/LingoEngine/Sprites/LingoSpriteChannel.cs
@@ -2,6 +2,7 @@
 using AbstUI.Primitives;
 using LingoEngine.Casts;
 using LingoEngine.Members;
+using LingoEngine.Medias;
 using LingoEngine.Movies;
 using LingoEngine.Primitives;
 
@@ -107,6 +108,13 @@ namespace LingoEngine.Sprites
         public bool Loaded => _sprite.Loaded;
         public byte[] Media { get => _sprite.Media; set => _sprite.Media = value; }
         public bool MediaReady => _sprite.MediaReady;
+        public void Play() => _sprite.Play();
+        public void Stop() => _sprite.Stop();
+        public void Pause() => _sprite.Pause();
+        public void Seek(int milliseconds) => _sprite.Seek(milliseconds);
+        public int Duration => _sprite.Duration;
+        public int CurrentTime { get => _sprite.CurrentTime; set => _sprite.CurrentTime = value; }
+        public LingoMediaStatus MediaStatus => _sprite.MediaStatus;
         public float Width => _sprite.Width;
         public float Height => _sprite.Height;
         public ILingoMember? Member


### PR DESCRIPTION
## Summary
- implement Godot media member and integrate with factory
- extend Godot sprite to instantiate a new video player per sprite
- propagate interface docs in sprite by adding `<inheritdoc/>`

## Testing
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/Sprites/LingoSprite2D.cs --verbosity detailed`
- `dotnet format src/LingoEngine.LGodot/LingoEngine.LGodot.csproj --include src/LingoEngine.LGodot/Core/GodotFactory.cs src/LingoEngine.LGodot/Sprites/LingoGodotSprite2D.cs src/LingoEngine.LGodot/Medias/LingoGodotMemberMedia.cs --verbosity detailed`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj` *(failed: The given key 'Counter' was not present in the dictionary)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9761fa5c8332a97c83c1aa52c675