### PR TITLE
feat: convert XMED text to custom markdown

### DIFF
--- a/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/XmedReaderTests.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/XmedReaderTests.cs
@@ -11,7 +11,41 @@ public class XmedReaderTests
     [Fact]
     public void ParsesHalloTextAndStyles()
     {
-        var data = XmedTestData.HalloDefault;
+        var view = CreateView(XmedTestData.HalloDefault);
+        var doc = XmedReader.Read(view);
+        Assert.StartsWith("Hallo", doc.Text);
+        Assert.Equal("Hallo", doc.Runs[0].Text);
+        Assert.Contains(doc.Styles, s => s.FontName == "Arial" && s.ColorIndex == 5);
+        Assert.Contains(doc.Styles, s => s.FontName == "Arcade *" && s.ColorIndex == 8);
+    }
+
+    [Fact]
+    public void ParsesMultiStyleSingleLineStyles()
+    {
+        var view = CreateView(XmedTestData.MultiStyleSingleLine);
+        var doc = XmedReader.Read(view);
+        Assert.True(doc.Styles.Count > 1);
+        Assert.Contains(doc.Styles, s => s.FontName == "Arcade *");
+        Assert.Contains(doc.Styles, s => s.FontName == "arial");
+        Assert.Contains(doc.Styles, s => s.FontName == "Tahoma");
+        Assert.Contains(doc.Styles, s => s.FontName == "Terminal");
+    }
+
+    [Fact]
+    public void ParsesWiderWidth4Text()
+    {
+        var view = CreateView(XmedTestData.WiderWidth4);
+        var doc = XmedReader.Read(view);
+        Assert.Equal("HalloHallo", doc.Text);
+        Assert.Equal("Hallo", doc.Runs[0].Text);
+        Assert.Equal((uint)203, doc.Width);
+        Assert.Contains(doc.Styles, s => s.FontName == "Arial");
+        Assert.Contains(doc.Styles, s => s.FontName == "Arcade *");
+    }
+
+    private static BufferView CreateView(byte[] data)
+    {
+        // Test data may contain a preamble, so locate the DEMX header first.
         var pattern = new byte[] { (byte)'D', (byte)'E', (byte)'M', (byte)'X' };
         var start = Array.IndexOf(data, pattern[0]);
         while (start >= 0 && start + 3 < data.Length)
@@ -21,11 +55,6 @@ public class XmedReaderTests
             start = Array.IndexOf(data, pattern[0], start + 1);
         }
         Assert.True(start >= 0, "XMED header not found");
-        var view = new BufferView(data, start, data.Length - start);
-        var doc = XmedReader.Read(view);
-        Assert.StartsWith("Hallo", doc.Text);
-        Assert.Equal("Hallo", doc.Runs[0].Text);
-        Assert.Contains(doc.Styles, s => s.FontName == "Arial" && s.ColorIndex == 5);
-        Assert.Contains(doc.Styles, s => s.FontName == "Arcade *" && s.ColorIndex == 8);
+        return new BufferView(data, start, data.Length - start);
     }
 }

--- a/src/Director/LingoEngine.Director.Core/Texts/XmedMarkdownConverter.cs
+++ b/src/Director/LingoEngine.Director.Core/Texts/XmedMarkdownConverter.cs
@@ -1,0 +1,76 @@
+using System.Text;
+using ProjectorRays.CastMembers;
+
+namespace LingoEngine.Director.Core.Texts;
+
+public static class XmedMarkdownConverter
+{
+    public static string ToCustomMarkdown(XmedDocument doc)
+    {
+        var sb = new StringBuilder();
+
+        if (doc.Styles.Count > 0)
+        {
+            var align = doc.Styles[0].Alignment switch
+            {
+                XmedAlignment.Left => "left",
+                XmedAlignment.Right => "right",
+                _ => "center"
+            };
+            sb.Append("{{ALIGN:").Append(align).Append("}}");
+        }
+
+        string? currentFont = null;
+        ushort currentSize = 0;
+        RayColor currentColor = default;
+        bool hasColor = false;
+
+        foreach (var run in doc.Runs)
+        {
+            if (string.IsNullOrEmpty(run.Text))
+                continue;
+
+            if (!string.IsNullOrEmpty(run.FontName) && run.FontName != currentFont)
+            {
+                sb.Append("{{FONT-FAMILY:").Append(run.FontName).Append("}}");
+                currentFont = run.FontName;
+            }
+
+            if (run.FontSize > 0 && run.FontSize != currentSize)
+            {
+                sb.Append("{{FONT-SIZE:").Append(run.FontSize).Append("}}");
+                currentSize = run.FontSize;
+            }
+
+            if ((!hasColor) || run.ForeColor.R != currentColor.R || run.ForeColor.G != currentColor.G || run.ForeColor.B != currentColor.B)
+            {
+                sb.Append("{{COLOR:").Append(run.ForeColor.ToHex()).Append("}}");
+                currentColor = run.ForeColor;
+                hasColor = true;
+            }
+
+            var text = EscapeMarkdown(run.Text);
+
+            if (run.Bold) sb.Append("**");
+            if (run.Italic) sb.Append("*");
+            if (run.Underline) sb.Append("__");
+            sb.Append(text);
+            if (run.Underline) sb.Append("__");
+            if (run.Italic) sb.Append("*");
+            if (run.Bold) sb.Append("**");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string EscapeMarkdown(string text)
+    {
+        return text
+            .Replace("\\", "\\\\")
+            .Replace("*", "\\*")
+            .Replace("_", "\\_")
+            .Replace("{", "\\{")
+            .Replace("}", "\\}");
+    }
+}
+


### PR DESCRIPTION
## Summary
- expand ProjectorRays XmedReader tests using additional sample data
- annotate helper to locate DEMX header and keep original XMED bytes
- verify multi-style font parsing and wider width text handling
- convert XMED document runs into AbstUI custom markdown within Director core

## Testing
- `dotnet format src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj --include src/Director/LingoEngine.Director.Core/Texts/XmedMarkdownConverter.cs` *(fails: The server disconnected unexpectedly)*
- `dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj`
- `dotnet test WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/ProjectorRays.DotNet.Test.csproj --filter FullyQualifiedName~XmedReaderTests`


------
https://chatgpt.com/codex/tasks/task_e_68aa987723708332a43408b9a844a8c0