### PR TITLE
Enable injectable score parser and add test helper

### DIFF
--- a/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/DirectorFileTests.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/DirectorFileTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using ProjectorRays.CastMembers;
 using ProjectorRays.Common;
 using ProjectorRays.director.Chunks;
+using ProjectorRays.director.Scores;
 using ProjectorRays.Director;
 using ProjectorRays.IO;
 using Xunit;
@@ -43,6 +44,29 @@ public class DirectorFileTests
         var stream = new ReadStream(data, data.Length, Endianness.BigEndian);
         var dir = new RaysDirectorFile(_logger, fileName);
         Assert.True(dir.Read(stream));
+    }
+
+    [Fact]
+    public void WritesScoreBytesToFile()
+    {
+        var path = GetPath("Sprites/5spritesTest.dir");
+        var output = Path.ChangeExtension(path, ".score.txt");
+        if (File.Exists(output)) File.Delete(output);
+
+        var previous = RaysScoreChunk.FrameParserFactory;
+        try
+        {
+            RaysScoreChunk.FrameParserFactory = (logger, annotator) => new RaysScoreFrameParserV2ToFile(logger, annotator, path);
+            var data = File.ReadAllBytes(path);
+            var stream = new ReadStream(data, data.Length, Endianness.BigEndian);
+            var dir = new RaysDirectorFile(_logger, path);
+            Assert.True(dir.Read(stream));
+            Assert.True(File.Exists(output));
+        }
+        finally
+        {
+            RaysScoreChunk.FrameParserFactory = previous;
+        }
     }
 
 

--- a/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/RaysScoreFrameParserV2ToFile.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/RaysScoreFrameParserV2ToFile.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Logging;
+using ProjectorRays.Common;
+using ProjectorRays.director.Scores;
+using ProjectorRays.director.Scores.Data;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace ProjectorRays.DotNet.Test;
+
+public class RaysScoreFrameParserV2ToFile : IRaysScoreFrameParserV2
+{
+    private readonly ILogger _logger;
+    private readonly RayStreamAnnotatorDecorator _annotator;
+    private readonly string _sourceFile;
+
+    public RaysScoreFrameParserV2ToFile(ILogger logger, RayStreamAnnotatorDecorator annotator, string sourceFile)
+    {
+        _logger = logger;
+        _annotator = annotator;
+        _sourceFile = sourceFile;
+    }
+
+    public List<RaySprite> ParseScore(ReadStream stream)
+    {
+        var data = stream.ReadBytes(stream.BytesLeft);
+        WriteHex(data);
+        return new();
+    }
+
+    private void WriteHex(byte[] data)
+    {
+        string path = Path.ChangeExtension(_sourceFile, ".score.txt");
+        using var writer = new StreamWriter(path, false, Encoding.UTF8);
+        for (int i = 0; i < data.Length; i += 32)
+        {
+            int len = Math.Min(32, data.Length - i);
+            var sb = new StringBuilder(len * 3);
+            for (int j = 0; j < len; j++)
+            {
+                if (j > 0) sb.Append(' ');
+                sb.Append(data[i + j].ToString("X2"));
+            }
+            writer.WriteLine(sb.ToString());
+        }
+    }
+}
+

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/director/Scores/IRaysScoreFrameParserV2.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/director/Scores/IRaysScoreFrameParserV2.cs
@@ -1,0 +1,11 @@
+using ProjectorRays.Common;
+using ProjectorRays.director.Scores.Data;
+using System.Collections.Generic;
+
+namespace ProjectorRays.director.Scores;
+
+public interface IRaysScoreFrameParserV2
+{
+    List<RaySprite> ParseScore(ReadStream stream);
+}
+

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/director/Scores/RaysScoreChunk.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/director/Scores/RaysScoreChunk.cs
@@ -4,6 +4,7 @@ using ProjectorRays.director.Chunks;
 using ProjectorRays.director.Old;
 using ProjectorRays.director.Scores.Data;
 using ProjectorRays.Director;
+using System;
 using System.Reflection.PortableExecutable;
 using static ProjectorRays.director.Old.RaysScoreFrameParserOld;
 using static ProjectorRays.director.Scores.RaysScoreFrameParserV2;
@@ -17,11 +18,11 @@ namespace ProjectorRays.director.Scores;
 public class RaysScoreChunk : RaysChunk
 {
 
-  
+
     /// <summary>Reference to a frame behaviour script.</summary>
     public class RaysBehaviourRef
     {
-        public int CastLib {get;set;}
+        public int CastLib { get; set; }
         public int CastMmb { get; set; }
     }
 
@@ -37,11 +38,9 @@ public class RaysScoreChunk : RaysChunk
     public short Constant13;
     public short LastChannelMinus6;
     public static RayStreamAnnotatorDecorator Annotator;
-    
-    
+    public static Func<ILogger, RayStreamAnnotatorDecorator, IRaysScoreFrameParserV2> FrameParserFactory { get; set; }
+        = (logger, annotator) => new RaysScoreFrameParserV2(logger, annotator);
 
-
-   
 
     /// <summary>Default sprite data for a channel.</summary>
     //public class RaysChannelSprite
@@ -90,14 +89,14 @@ public class RaysScoreChunk : RaysChunk
         Annotator = new RayStreamAnnotatorDecorator(stream.Offset);
         Annotator.SetName(Dir.Name);
 
-        var parser = new RaysScoreFrameParserV2(Dir.Logger, Annotator);
+        var parser = FrameParserFactory(Dir.Logger, Annotator);
         try
         {
             Sprites = parser.ParseScore(stream);
         }
         catch (Exception ex)
         {
-            throw ex;
+            throw;
         }
         finally
         {

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/director/Scores/RaysScoreFrameParserV2.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/director/Scores/RaysScoreFrameParserV2.cs
@@ -14,7 +14,7 @@ namespace ProjectorRays.director.Scores;
 /// It parses the main header and reads consecutive keyframe blocks.
 /// The result is a list of sprites each with a single keyframe.
 /// </summary>
-internal class RaysScoreFrameParserV2
+internal class RaysScoreFrameParserV2 : IRaysScoreFrameParserV2
 {
     private readonly ILogger _logger;
     private readonly RayStreamAnnotatorDecorator _annotator;
@@ -46,7 +46,7 @@ internal class RaysScoreFrameParserV2
         // Create new reader
         var newReader = new ReadStream(ctx.FrameDataBufferView, Endianness.BigEndian, annotator: Annotator);
         //LogFullScoreBytes(newReader);
-       // return new List<RaySprite>();
+        // return new List<RaySprite>();
         _reader.ReadHeader(newReader, header);
 
         _reader.ReadFrameDescriptors(ctx);
@@ -61,7 +61,7 @@ internal class RaysScoreFrameParserV2
         return ctx.Sprites;
     }
 
-  
+
     private void LogFullScoreBytes(ReadStream readerSource)
     {
         var frameBytes1 = readerSource.ReadBytes(readerSource.BytesLeft);
@@ -72,7 +72,7 @@ internal class RaysScoreFrameParserV2
         return;
     }
 
-  
+
     private void ParseBlock(ReadStream stream, int length, RayScoreHeader header, RayScoreParseContext ctx)
     {
         long end = stream.Position + length;
@@ -101,7 +101,7 @@ internal class RaysScoreFrameParserV2
 
             if (prefix >= header.SpriteSize)
             {
-                var tagMain = _reader.ReadMainTag(prefix, stream,ctx);
+                var tagMain = _reader.ReadMainTag(prefix, stream, ctx);
                 if (tagMain == null)
                 {
                     if (prefix > 1000)
@@ -137,7 +137,7 @@ internal class RaysScoreFrameParserV2
 
     //    if (tag < 0x0120 || tag > 0x01F6)
     //    {
-    //        _logger.LogInformation($"[FrameTag] Unexpected tag {tag:X} at 0x{pos:X} — possible misalignment");
+    //        _logger.LogInformation($"[FrameTag] Unexpected tag {tag:X} at 0x{pos:X} ï¿½ possible misalignment");
     //    }
     //}
 
@@ -165,11 +165,11 @@ internal class RaysScoreFrameParserV2
         sprite.Behaviors.AddRange(desc.Behaviors);
         sprite.ExtraValues.AddRange(desc.ExtraValues);
         sprite.SpriteNumber = channel;
-        ctx.AddSprite(sprite);  
+        ctx.AddSprite(sprite);
         return sprite;
     }
 
-  
+
 
     private void HandleTag(ushort tag, byte[] data, RayScoreParseContext ctx)
     {
@@ -186,7 +186,7 @@ internal class RaysScoreFrameParserV2
                 ctx.SetCurrentSprite(data[0]);
             return;
         }
-        
+
         int? channel = TryDecodeChannel(tag);
         if (channel.HasValue)
         {
@@ -200,12 +200,12 @@ internal class RaysScoreFrameParserV2
                 const ushort AdvanceFrameMask = 0x7F00;
 
                 bool createKeyframe = (flags & CreateKeyframeBit) != 0;
-                
+
                 int framesToAdvance = (flags & AdvanceFrameMask) >> 8;
 
                 if (framesToAdvance == 0)
                     framesToAdvance = 1;
-                
+
                 ctx.AdvanceFrame(framesToAdvance);
 
                 if (createKeyframe && sprite != null)


### PR DESCRIPTION
## Summary
- introduce `IRaysScoreFrameParserV2` for pluggable score parsing
- add factory on `RaysScoreChunk` with default parser implementation
- create `RaysScoreFrameParserV2ToFile` helper and unit test to dump score bytes

## Testing
- `dotnet format WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/ProjectorRays.DotNet.csproj --no-restore --verbosity diagnostic`
- `dotnet format WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/ProjectorRays.DotNet.Test.csproj --no-restore --verbosity diagnostic`
- `dotnet test WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/ProjectorRays.DotNet.Test.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68aac73013f88332a33d2a4af341fa92