### PR TITLE
Add MathCompat shim for .NET 4.8 compatibility

### DIFF
--- a/src/LingoEngine/Core/LingoPlayer.cs
+++ b/src/LingoEngine/Core/LingoPlayer.cs
@@ -147,7 +147,7 @@ namespace LingoEngine.Core
 
             // Create a new movies scope, needed for behaviours.
             var scope = _serviceProvider.CreateScope();
-            var transitionPlayer = new LingoTransitionPlayer(_Stage,_clock, _serviceProvider.GetRequiredService<ILingoTransitionLibrary>());
+            var transitionPlayer = new LingoTransitionPlayer(_Stage, _clock, _serviceProvider.GetRequiredService<ILingoTransitionLibrary>());
 
             // Create the movie.
             var movieEnv = (LingoMovieEnvironment)scope.ServiceProvider.GetRequiredService<ILingoMovieEnvironment>();
@@ -255,11 +255,7 @@ namespace LingoEngine.Core
             }
             else
             {
-#if NET48
                 var target = MathCompat.Clamp(movie.Frame + offset, 1, movie.FrameCount);
-#else
-                var target = Math.Clamp(movie.Frame + offset, 1, movie.FrameCount);
-#endif
                 movie.GoToAndStop(target);
             }
             return true;

--- a/src/LingoEngine/Core/NETFramework4/Polyfills.cs
+++ b/src/LingoEngine/Core/NETFramework4/Polyfills.cs
@@ -1,8 +1,9 @@
-#if NET48
 using System;
+using System.Runtime.CompilerServices;
 
 namespace System
 {
+#if NET48
     internal static class MathF
     {
         public const float PI = (float)Math.PI;
@@ -13,12 +14,6 @@ namespace System
         public static float Min(float x, float y) => Math.Min(x, y);
         public static float Max(float x, float y) => Math.Max(x, y);
         public static float Ceiling(float x) => (float)Math.Ceiling(x);
-    }
-
-    internal static class MathCompat
-    {
-        public static int Clamp(int value, int min, int max) => Math.Min(Math.Max(value, min), max);
-        public static float Clamp(float value, float min, float max) => Math.Min(Math.Max(value, min), max);
     }
 
     internal struct HashCode
@@ -43,5 +38,43 @@ namespace System
             return hash;
         }
     }
-}
 #endif
+
+    internal static class MathCompat
+    {
+#if NET48
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Clamp(int value, int min, int max)
+        {
+            if (value < min) return min;
+            if (value > max) return max;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Clamp(float value, float min, float max)
+        {
+            if (value < min) return min;
+            if (value > max) return max;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Clamp(double value, double min, double max)
+        {
+            if (value < min) return min;
+            if (value > max) return max;
+            return value;
+        }
+#else
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Clamp(int value, int min, int max) => Math.Clamp(value, min, max);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Clamp(float value, float min, float max) => Math.Clamp(value, min, max);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Clamp(double value, double min, double max) => Math.Clamp(value, min, max);
+#endif
+    }
+}

--- a/src/LingoEngine/FilmLoops/LingoFilmLoopComposer.cs
+++ b/src/LingoEngine/FilmLoops/LingoFilmLoopComposer.cs
@@ -126,11 +126,7 @@ public static class LingoFilmLoopComposer
                 destW,
                 destH,
                 transform,
-#if NET48
                 MathCompat.Clamp(layer.Blend / 100f, 0f, 1f),
-#else
-                Math.Clamp(layer.Blend / 100f, 0f, 1f),
-#endif
                 layer.InkType,
                 layer.BackColor,
                 layer));

--- a/src/LingoEngine/Sounds/LingoAudioSpriteManager.cs
+++ b/src/LingoEngine/Sounds/LingoAudioSpriteManager.cs
@@ -31,11 +31,7 @@ namespace LingoEngine.Sounds
         public LingoSpriteSound Add(int channel, int startFrame, LingoMemberSound sound)
         {
             int lengthFrames = (int)Math.Ceiling(sound.Length * _movie.Tempo);
-#if NET48
             int end = MathCompat.Clamp(startFrame + lengthFrames - 1, startFrame, _movie.FrameCount);
-#else
-            int end = Math.Clamp(startFrame + lengthFrames - 1, startFrame, _movie.FrameCount);
-#endif
             return AddSprite(channel, "Audio " + channel, c =>
             {
                 c.Init(channel, startFrame, end, sound);

--- a/src/LingoEngine/Sprites/LingoSprite2DManager.cs
+++ b/src/LingoEngine/Sprites/LingoSprite2DManager.cs
@@ -4,7 +4,7 @@ using LingoEngine.Movies;
 
 namespace LingoEngine.Sprites
 {
-    public class LingoSprite2DManager : LingoSpriteManager<LingoSprite2D> , ILingoSpriteManager<LingoSprite2D>
+    public class LingoSprite2DManager : LingoSpriteManager<LingoSprite2D>, ILingoSpriteManager<LingoSprite2D>
     {
         //protected readonly Dictionary<int, LingoSprite2D> _frameSpriteBehaviors = new();
         protected LingoStageMouse _lingoMouse;
@@ -38,7 +38,7 @@ namespace LingoEngine.Sprites
 
         protected override LingoSprite? OnAdd(int spriteNum, int begin, int end, ILingoMember? member)
         {
-            var sprite = AddSprite(spriteNum, begin, end,0,0,null);
+            var sprite = AddSprite(spriteNum, begin, end, 0, 0, null);
             if (member != null)
                 sprite.SetMember(member);
             return sprite;
@@ -67,7 +67,7 @@ namespace LingoEngine.Sprites
             _spriteChannels[newChannel].SetSprite(spriteTyped);
             _activeSprites[sprite.SpriteNum] = spriteTyped;
 
-            RaiseSpriteListChanged(sprite.SpriteNum+SpriteNumChannelOffset);
+            RaiseSpriteListChanged(sprite.SpriteNum + SpriteNumChannelOffset);
         }
 
 
@@ -83,7 +83,7 @@ namespace LingoEngine.Sprites
         protected override void OnBeginSprite(LingoSprite2D sprite)
         {
             sprite.FrameworkObj.Show();
-            
+
             if (!_lingoMouse.IsSubscribed(sprite))
                 _lingoMouse.Subscribe(sprite);
             base.OnBeginSprite(sprite);
@@ -93,7 +93,7 @@ namespace LingoEngine.Sprites
             base.OnEndSprite(sprite);
             if (_lingoMouse.IsSubscribed(sprite))
                 _lingoMouse.Unsubscribe(sprite);
-            
+
         }
 
 
@@ -166,7 +166,7 @@ namespace LingoEngine.Sprites
             var sprite = _spriteChannels.Values.FirstOrDefault(x => x.Name == name);
             if (sprite == null) return;
             actionOnSprite(sprite);
-        } 
+        }
         #endregion
 
 
@@ -191,22 +191,14 @@ namespace LingoEngine.Sprites
         {
             if (!_activeSprites.TryGetValue(spriteNumber, out var sprite))
                 return pos;
-#if NET48
             return (int)MathCompat.Clamp(pos, sprite.Left, sprite.Right);
-#else
-            return (int)Math.Clamp(pos, sprite.Left, sprite.Right);
-#endif
         }
 
         internal int ConstrainV(int spriteNumber, int pos)
         {
             if (!_activeSprites.TryGetValue(spriteNumber, out var sprite))
                 return pos;
-#if NET48
             return (int)MathCompat.Clamp(pos, sprite.Top, sprite.Bottom);
-#else
-            return (int)Math.Clamp(pos, sprite.Top, sprite.Bottom);
-#endif
         }
 
         internal LingoSprite2D? GetSpriteUnderMouse(bool skipLockedSprites = false)
@@ -230,7 +222,7 @@ namespace LingoEngine.Sprites
 
         internal LingoSprite2D? GetSpriteAtPoint(float x, float y, bool skipLockedSprites = false)
             => GetSpritesAtPoint(x, y, skipLockedSprites).FirstOrDefault();
-       
+
         internal int GetMaxLocZ() => _activeSpritesOrdered.Max(x => x.LocZ);
 
 

--- a/src/LingoEngine/Transitions/TransitionLibrary/BlindsTransition.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/BlindsTransition.cs
@@ -21,7 +21,7 @@ public sealed class BlindsTransition : LingoBaseTransition
         var dest = new byte[from.Length];
         Array.Copy(from, dest, from.Length);
 
-        progress = Math.Clamp(progress, 0f, 1f);
+        progress = MathCompat.Clamp(progress, 0f, 1f);
 
         if (_orientation == BlindOrientation.Horizontal)
         {

--- a/src/LingoEngine/Transitions/TransitionLibrary/BoxTransition.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/BoxTransition.cs
@@ -17,7 +17,7 @@ public sealed class BoxTransition : LingoBaseTransition
 
     public override byte[] StepFrame(int width, int height, byte[] from, byte[] to, float progress)
     {
-        progress = Math.Clamp(progress, 0f, 1f);
+        progress = MathCompat.Clamp(progress, 0f, 1f);
         var dest = new byte[from.Length];
 
         if (_direction == BoxDirection.Out)

--- a/src/LingoEngine/Transitions/TransitionLibrary/CenterSplitTransition.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/CenterSplitTransition.cs
@@ -19,7 +19,7 @@ public sealed class CenterSplitTransition : LingoBaseTransition
 
     public override byte[] StepFrame(int width, int height, byte[] from, byte[] to, float progress)
     {
-        progress = Math.Clamp(progress, 0f, 1f);
+        progress = MathCompat.Clamp(progress, 0f, 1f);
         byte[] dest = _direction == SplitDirection.Out ? (byte[])from.Clone() : (byte[])to.Clone();
 
         if (_orientation == SplitOrientation.Horizontal)

--- a/src/LingoEngine/Transitions/TransitionLibrary/CheckerboardTransition.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/CheckerboardTransition.cs
@@ -16,7 +16,7 @@ public sealed class CheckerboardTransition : LingoBaseTransition
 
     public override byte[] StepFrame(int width, int height, byte[] from, byte[] to, float progress)
     {
-        progress = Math.Clamp(progress, 0f, 1f);
+        progress = MathCompat.Clamp(progress, 0f, 1f);
         var dest = new byte[from.Length];
         Array.Copy(from, dest, from.Length);
 

--- a/src/LingoEngine/Transitions/TransitionLibrary/CoverTransition.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/CoverTransition.cs
@@ -17,7 +17,7 @@ public sealed class CoverTransition : LingoBaseTransition
 
     public override byte[] StepFrame(int width, int height, byte[] from, byte[] to, float progress)
     {
-        progress = Math.Clamp(progress, 0f, 1f);
+        progress = MathCompat.Clamp(progress, 0f, 1f);
         var dest = new byte[from.Length];
         Array.Copy(from, dest, from.Length);
 

--- a/src/LingoEngine/Transitions/TransitionLibrary/DissolveTransition.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/DissolveTransition.cs
@@ -14,7 +14,7 @@ public sealed class DissolveTransition : LingoBaseTransition
 
     public override byte[] StepFrame(int width, int height, byte[] from, byte[] to, float progress)
     {
-        progress = Math.Clamp(progress, 0f, 1f);
+        progress = MathCompat.Clamp(progress, 0f, 1f);
         var dest = new byte[from.Length];
         int pixelCount = width * height;
         for (int p = 0; p < pixelCount; p++)

--- a/src/LingoEngine/Transitions/TransitionLibrary/PushTransition.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/PushTransition.cs
@@ -17,7 +17,7 @@ public sealed class PushTransition : LingoBaseTransition
 
     public override byte[] StepFrame(int width, int height, byte[] from, byte[] to, float progress)
     {
-        progress = Math.Clamp(progress, 0f, 1f);
+        progress = MathCompat.Clamp(progress, 0f, 1f);
         var dest = new byte[from.Length];
 
         int shiftX = 0;

--- a/src/LingoEngine/Transitions/TransitionLibrary/RandomLinesTransition.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/RandomLinesTransition.cs
@@ -18,7 +18,7 @@ public sealed class RandomLinesTransition : LingoBaseTransition
 
     public override byte[] StepFrame(int width, int height, byte[] from, byte[] to, float progress)
     {
-        progress = Math.Clamp(progress, 0f, 1f);
+        progress = MathCompat.Clamp(progress, 0f, 1f);
         var dest = (byte[])from.Clone();
 
         int lines = _orientation == RandomLineOrientation.Horizontal ? height : width;

--- a/src/LingoEngine/Transitions/TransitionLibrary/RevealTransition.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/RevealTransition.cs
@@ -17,7 +17,7 @@ public sealed class RevealTransition : LingoBaseTransition
 
     public override byte[] StepFrame(int width, int height, byte[] from, byte[] to, float progress)
     {
-        progress = Math.Clamp(progress, 0f, 1f);
+        progress = MathCompat.Clamp(progress, 0f, 1f);
         var dest = (byte[])to.Clone();
 
         int shiftX = (int)(width * progress);

--- a/src/LingoEngine/Transitions/TransitionLibrary/StripsTransition.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/StripsTransition.cs
@@ -18,7 +18,7 @@ public sealed class StripsTransition : LingoBaseTransition
 
     public override byte[] StepFrame(int width, int height, byte[] from, byte[] to, float progress)
     {
-        progress = Math.Clamp(progress, 0f, 1f);
+        progress = MathCompat.Clamp(progress, 0f, 1f);
         var dest = new byte[from.Length];
         Array.Copy(from, dest, from.Length);
 

--- a/src/LingoEngine/Transitions/TransitionLibrary/WipeTransition.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/WipeTransition.cs
@@ -21,7 +21,7 @@ public sealed class WipeTransition : LingoBaseTransition
         var dest = new byte[length];
         Array.Copy(from, dest, length);
 
-        progress = Math.Clamp(progress, 0f, 1f);
+        progress = MathCompat.Clamp(progress, 0f, 1f);
 
         switch (_direction)
         {

--- a/src/LingoEngine/Transitions/TransitionLibrary/ZoomTransition.cs
+++ b/src/LingoEngine/Transitions/TransitionLibrary/ZoomTransition.cs
@@ -17,7 +17,7 @@ public sealed class ZoomTransition : LingoBaseTransition
 
     public override byte[] StepFrame(int width, int height, byte[] from, byte[] to, float progress)
     {
-        progress = Math.Clamp(progress, 0f, 1f);
+        progress = MathCompat.Clamp(progress, 0f, 1f);
         var dest = _open ? (byte[])from.Clone() : (byte[])to.Clone();
         var source = _open ? to : from;
 


### PR DESCRIPTION
## Summary
- consolidate MathCompat into existing NET48 polyfills and add double overload
- wrap Math.Clamp on modern runtimes while providing manual clamp for .NET Framework

## Testing
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/Core/NETFramework4/Polyfills.cs`
- `dotnet test Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b5614d411083328ef223c76a3b9d4e