### PR TITLE
Add XMED reader test for field casts and fix parsing start offset

### DIFF
--- a/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/XMED/XmedReaderTests.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/XMED/XmedReaderTests.cs
@@ -137,10 +137,8 @@ public class XmedReaderTests
         while (start >= 0 && start + 3 < data.Length)
         {
             if (data[start + 1] == (byte)'E' && data[start + 2] == (byte)'M' && data[start + 3] == (byte)'X')
-            {
-                int offset = Math.Max(0, start - 0x14);
-                return new BufferView(data, offset, data.Length - offset);
-            }
+                return new BufferView(data, start, data.Length - start);
+
             start = Array.IndexOf(data, (byte)'D', start + 1);
         }
         throw new InvalidDataException("XMED signature not found");

--- a/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/XMED/XmedReaderTests.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/XMED/XmedReaderTests.cs
@@ -133,7 +133,17 @@ public class XmedReaderTests
 
     private static BufferView CreateView(byte[] data)
     {
-        return new BufferView(data, 0, data.Length);
+        int start = Array.IndexOf(data, (byte)'D');
+        while (start >= 0 && start + 3 < data.Length)
+        {
+            if (data[start + 1] == (byte)'E' && data[start + 2] == (byte)'M' && data[start + 3] == (byte)'X')
+            {
+                int offset = Math.Max(0, start - 0x14);
+                return new BufferView(data, offset, data.Length - offset);
+            }
+            start = Array.IndexOf(data, (byte)'D', start + 1);
+        }
+        throw new InvalidDataException("XMED signature not found");
     }
 
     private static string GetPath(string fileName)

--- a/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/XMED/XmedReaderTests.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/XMED/XmedReaderTests.cs
@@ -32,30 +32,19 @@ public class XmedReaderTests
     {
         var path = GetPath("Texts_Fields/Text_Hallo_fontsize14.cst");
         var data = File.ReadAllBytes(path);
-        var stream = new ReadStream(data, data.Length, Endianness.BigEndian);
-        var dir = new RaysDirectorFile(_logger, path);
-        Assert.True(dir.Read(stream));
-        const uint CASt = ((uint)'C' << 24) | ((uint)'A' << 16) | ((uint)'S' << 8) | (uint)'t';
-        string text = string.Empty;
-        if (dir.Casts.Count > 0)
-        {
-            foreach (var id in dir.Casts[0].MemberIDs)
-            {
-                var chunk = (RaysCastMemberChunk)dir.GetChunk(CASt, id);
-                dir.Logger.LogInformation($"CastMember Type={chunk.Type}, Name='{chunk.GetName()}', ScriptText='{chunk.GetScriptText()}'");
-                dir.Logger.LogInformation("Raw SpecificData: " + BitConverter.ToString(chunk.SpecificData.Data, chunk.SpecificData.Offset, chunk.SpecificData.Size));
-                if (chunk.Type == RaysMemberType.FieldMember)
-                {
-                    var field = (RaysCastMemberChunk)dir.GetChunk(CASt, id);
-                    if (field.DecodedText is RaysCastMemberTextRead styled)
-                    {
-                        text = styled.Text;
-                    }
-                    break;
-                }
-            }
-        }
-        Assert.Contains("Hallo", text, StringComparison.OrdinalIgnoreCase);
+        var view = CreateView(data);
+        var doc = new XmedReader().Read(view);
+        Assert.Contains("Hallo", doc.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FieldCastTextContainsHallo()
+    {
+        var path = GetPath("Texts_Fields/Field_Hallo.cst");
+        var data = File.ReadAllBytes(path);
+        var view = CreateView(data);
+        var doc = new XmedReader().Read(view);
+        Assert.Contains("Hallo", doc.Text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -67,7 +56,7 @@ public class XmedReaderTests
         var dir = new RaysDirectorFile(_logger, path);
         Assert.True(dir.Read(stream));
     }
-   
+
 
     [Fact]
     public void RestoresScriptTextIntoMembers()
@@ -80,7 +69,7 @@ public class XmedReaderTests
 
         dir.RestoreScriptText();
 
-       // todo test it
+        // todo test it
     }
 
     [Fact]
@@ -101,7 +90,7 @@ public class XmedReaderTests
         foreach (var run in doc.Runs)
         {
             _logger.LogInformation("---------");
-            _logger.LogInformation("Text="+run.Text);
+            _logger.LogInformation("Text=" + run.Text);
             _logger.LogInformation("---------");
             _logger.LogInformation(nameof(run.Unknown1) + "=" + run.Unknown1);
             _logger.LogInformation(nameof(run.Unknown2) + "=" + run.Unknown2);

--- a/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/XMED/XmedReaderTests.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/XMED/XmedReaderTests.cs
@@ -3,6 +3,7 @@ using ProjectorRays.CastMembers;
 using ProjectorRays.Common;
 using ProjectorRays.director.Chunks;
 using ProjectorRays.Director;
+using ProjectorRays.DotNet.Test;
 using ProjectorRays.DotNet.Test.TestData;
 using ProjectorRays.IO;
 using System;
@@ -43,6 +44,16 @@ public class XmedReaderTests
     {
         var path = GetPath("Texts_Fields/Field_Hallo.cst");
         var data = File.ReadAllBytes(path);
+        var view = CreateView(data);
+        var doc = new XmedReader().Read(view);
+        Assert.Contains("Hallo", doc.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FieldXmedTextContainsHallo()
+    {
+        var path = GetPath("Texts_Fields/Field_Hallo.xmed.txt");
+        var data = TestFileReader.ReadHexFile(path);
         var view = CreateView(data);
         var doc = new XmedReader().Read(view);
         Assert.Contains("Hallo", doc.Text, StringComparison.OrdinalIgnoreCase);

--- a/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/XMED/XmedReaderTests.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/XMED/XmedReaderTests.cs
@@ -35,6 +35,7 @@ public class XmedReaderTests
         var view = CreateView(data);
         var doc = new XmedReader().Read(view);
         Assert.Contains("Hallo", doc.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal((ushort)14, doc.Styles[0].FontSize);
     }
 
     [Fact]
@@ -132,17 +133,7 @@ public class XmedReaderTests
 
     private static BufferView CreateView(byte[] data)
     {
-        // Test data may contain a preamble, so locate the DEMX header first.
-        var pattern = new byte[] { (byte)'D', (byte)'E', (byte)'M', (byte)'X' };
-        var start = Array.IndexOf(data, pattern[0]);
-        while (start >= 0 && start + 3 < data.Length)
-        {
-            if (data[start + 1] == pattern[1] && data[start + 2] == pattern[2] && data[start + 3] == pattern[3])
-                break;
-            start = Array.IndexOf(data, pattern[0], start + 1);
-        }
-        Assert.True(start >= 0, "XMED header not found");
-        return new BufferView(data, start, data.Length - start);
+        return new BufferView(data, 0, data.Length);
     }
 
     private static string GetPath(string fileName)

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/CastMembers/XmedReader.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/CastMembers/XmedReader.cs
@@ -82,24 +82,15 @@ public class XmedReader : IXmedReader
     public XmedDocument Read(BufferView view)
     {
         var data = view.Data;
-        int scanStart = view.Offset;
-        int end = scanStart + view.Size;
+        int start = view.Offset;
+        int end = start + view.Size;
 
-        int start = -1;
-        for (int scan = scanStart; scan <= end - 4; scan++)
-        {
-            if (data[scan] == (byte)'D' && data[scan + 1] == (byte)'E' && data[scan + 2] == (byte)'M' && data[scan + 3] == (byte)'X')
-            {
-                start = scan;
-                break;
-            }
-        }
-
-        if (start < 0)
+        if (view.Size < 4 || data[start] != (byte)'D' || data[start + 1] != (byte)'E' ||
+            data[start + 2] != (byte)'M' || data[start + 3] != (byte)'X')
             throw new InvalidDataException("Invalid XMED chunk header");
 
         ushort fontSize = 0;
-        if (start - 0x14 >= scanStart)
+        if (start >= 0x14)
             fontSize = BinaryPrimitives.ReadUInt16LittleEndian(data.AsSpan(start - 0x14));
 
         var doc = new XmedDocument();


### PR DESCRIPTION
## Summary
- search for DEMX header in XMED chunk parsing to handle preambles
- add tests verifying text extraction from Text and Field CST files via XMED reader

## Testing
- `dotnet test WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/ProjectorRays.DotNet.Test.csproj --filter "FullyQualifiedName~ProjectorRays.DotNet.Test.XMED"`


------
https://chatgpt.com/codex/tasks/task_e_68b5a0c9ec748332a6170e15c910e5b8