### PR TITLE
Refactor property inspector to use window content

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
+++ b/src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs
@@ -64,6 +64,7 @@ namespace LingoEngine.Director.Core.Inspector
         private AbstPanel? _header;
         private IDirectorIconManager _iconManager;
         private AbstPanel _headerPanel;
+        private AbstPanel _rootPanel;
         private IDirectorEventMediator _mediator;
         private readonly IDirectorBehaviorDescriptionManager _descriptionManager;
         private readonly ILogger<DirectorPropertyInspectorWindow> _logger;
@@ -111,18 +112,27 @@ namespace LingoEngine.Director.Core.Inspector
         {
             base.OnInit(frameworkWindow);
             Title = "Property Inspector";
-           
+
         }
         public void Init(int titleBarHeight)
         {
             CreateHeaderElements();
             _tabs = _factory.CreateTabContainer("InspectorTabs");
             CreateBehaviorPanel();
-            
+
+            _headerPanel.Y = 0;
+            _tabs.Y = HeaderHeight;
+
+            _rootPanel = _factory.CreatePanel("InspectorRoot");
+            _rootPanel.Y = titleBarHeight;
+            _rootPanel.AddItem(_headerPanel);
+            _rootPanel.AddItem(_tabs);
+            Content = _rootPanel;
+
             AddMovieTab(_player.ActiveMovie);
         }
 
-      
+
         private AbstPanel CreateHeaderElements()
         {
             var thumb = new DirectorMemberThumbnail(36, 36, _factory, _iconManager);
@@ -157,9 +167,9 @@ namespace LingoEngine.Director.Core.Inspector
             return _headerPanel;
         }
 
-        
 
-       
+
+
 
 
         public void SpriteSelected(ILingoSpriteBase sprite) => ShowObject(sprite);
@@ -174,6 +184,9 @@ namespace LingoEngine.Director.Core.Inspector
             if (_tabs == null || _header == null)
                 return;
 
+            _rootPanel.Width = width;
+            _rootPanel.Height = height;
+            _headerPanel.Width = width;
             _header.Width = width - 10;
             _header.Height = HeaderHeight;
             _tabs.Width = width - 10;
@@ -224,13 +237,13 @@ namespace LingoEngine.Director.Core.Inspector
                     AddGuidesTab(_guides);
                     if (sp2.Member != null)
                         AddMemberTabs(sp2.Member);
-                    
+
                     break;
                 case ILingoMember member2:
                     AddMemberTabs(member2);
                     AddCastTab(member2.Cast);
                     break;
-                case ILingoCast cast:AddCastTab(cast);break;
+                case ILingoCast cast: AddCastTab(cast); break;
                 case LingoSpriteSound sound:
                     AddSpriteTab(sound);
                     if (sound.Sound != null)
@@ -239,18 +252,18 @@ namespace LingoEngine.Director.Core.Inspector
                         AddSoundTab(sound.Sound);
                     }
                     break;
-                case LingoTempoSprite tempo:AddSpriteTab(tempo);break;
-                case LingoColorPaletteSprite colorPalette:AddSpriteTab(colorPalette);if (colorPalette.Member != null) AddMemberTabs(colorPalette.Member); break;
-                case LingoTransitionSprite transition:AddSpriteTab(transition);if (transition.Member != null) AddMemberTabs(transition.Member); break;
-                case LingoFrameScriptSprite frameScript:AddSpriteTab(frameScript);if (frameScript.Member != null) AddMemberTabs(frameScript.Member); break;
+                case LingoTempoSprite tempo: AddSpriteTab(tempo); break;
+                case LingoColorPaletteSprite colorPalette: AddSpriteTab(colorPalette); if (colorPalette.Member != null) AddMemberTabs(colorPalette.Member); break;
+                case LingoTransitionSprite transition: AddSpriteTab(transition); if (transition.Member != null) AddMemberTabs(transition.Member); break;
+                case LingoFrameScriptSprite frameScript: AddSpriteTab(frameScript); if (frameScript.Member != null) AddMemberTabs(frameScript.Member); break;
 
                 default:
                     //AddTab(obj.GetType().Name, obj);
                     break;
             }
             if (obj is LingoSprite && _player.ActiveMovie != null)
-                  AddMovieTab(_player.ActiveMovie);
-            
+                AddMovieTab(_player.ActiveMovie);
+
             try
             {
                 if (_tabs.GetChildren().Any(x => x.Name == lastSelectedTab.ToString()))
@@ -258,23 +271,23 @@ namespace LingoEngine.Director.Core.Inspector
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error selecting tab:" + lastSelectedTab+":"+ex.Message);
+                _logger.LogError(ex, "Error selecting tab:" + lastSelectedTab + ":" + ex.Message);
             }
         }
 
-      
+
 
         private void AddMemberTabs(ILingoMember member)
         {
             AddMemberTab(member);
             switch (member)
             {
-                case LingoMemberText text:AddTextTab(text);break;
-                case LingoMemberField text:AddTextTab(text);break;
-                case LingoMemberBitmap pic:AddBitmapTab(pic);break;
-                case LingoMemberSound sound:AddSoundTab(sound);break;
-                case LingoMemberShape shape:AddShapeTab(shape);break;
-                case LingoFilmLoopMember film:AddTab(PropetyTabNames.FilmLoop, film);break;
+                case LingoMemberText text: AddTextTab(text); break;
+                case LingoMemberField text: AddTextTab(text); break;
+                case LingoMemberBitmap pic: AddBitmapTab(pic); break;
+                case LingoMemberSound sound: AddSoundTab(sound); break;
+                case LingoMemberShape shape: AddShapeTab(shape); break;
+                case LingoFilmLoopMember film: AddTab(PropetyTabNames.FilmLoop, film); break;
             }
         }
 
@@ -310,7 +323,7 @@ namespace LingoEngine.Director.Core.Inspector
                        .AddNumericInputFloat("SpriteLocV", "Y:", sprite2D, s => s.LocV)
                        .AddNumericInputFloat("SpriteLocZ", "Z:", sprite2D, s => s.LocZ, inputSpan: 3)
                        .AddNumericInputFloat("SpriteLeft", "L:", sprite2D, s => s.Left)
-                       .AddNumericInputFloat("SpriteTop", "T:",  sprite2D, s => s.Top)
+                       .AddNumericInputFloat("SpriteTop", "T:", sprite2D, s => s.Top)
                        .AddNumericInputFloat("SpriteRight", "R:", sprite2D, s => s.Right)
                        .AddNumericInputFloat("SpriteBottom", "B:", sprite2D, s => s.Bottom)
                        .AddNumericInputFloat("SpriteWidth", "W:", sprite2D, s => s.Width)
@@ -324,24 +337,25 @@ namespace LingoEngine.Director.Core.Inspector
                    ;
             _behaviorList.ClearItems();
             _behaviors.Clear();
-            if (sprite is LingoSprite2D sprite2D1) {
+            if (sprite is LingoSprite2D sprite2D1)
+            {
                 composer
                    .AddNumericInputFloat("SpriteRotation", "Rotation:", sprite2D1, s => s.Rotation, labelSpan: 3)
                    .AddNumericInputFloat("SpriteSkew", "Skew:", sprite2D1, s => s.Skew, inputSpan: 1, labelSpan: 3)
                    .AddColorPicker("SpriteForeColor", "Foreground:", sprite2D1, s => s.ForeColor, inputSpan: 1, labelSpan: 3)
                    .AddColorPicker("SpriteBackColor", "Background:", sprite2D1, s => s.BackColor, inputSpan: 1, labelSpan: 3)
-                  
+
                 ;
                 var index = 0;
                 _behaviors = sprite2D1.Behaviors.ToDictionary(b =>
                 {
                     index++;
-                    return $"{index}.{b.Name} {(b.ScriptMember != null? $"{b.ScriptMember.CastLibNum},{b.ScriptMember.NumberInCast}":"")}";
+                    return $"{index}.{b.Name} {(b.ScriptMember != null ? $"{b.ScriptMember.CastLibNum},{b.ScriptMember.NumberInCast}" : "")}";
                 });
             }
             if (sprite is LingoFrameScriptSprite frameScript && frameScript.Behavior != null)
-                _behaviors.Add("1."+frameScript.Behavior.Name + $"{(frameScript.Member != null ? $"{frameScript.Member.CastLibNum},{frameScript.Member.NumberInCast}" : "")}", frameScript.Behavior);
-            
+                _behaviors.Add("1." + frameScript.Behavior.Name + $"{(frameScript.Member != null ? $"{frameScript.Member.CastLibNum},{frameScript.Member.NumberInCast}" : "")}", frameScript.Behavior);
+
             foreach (var item in _behaviors)
                 _behaviorList.AddItem(item.Key, item.Value.Name);
 
@@ -513,7 +527,7 @@ namespace LingoEngine.Director.Core.Inspector
                 //    };
                 //})
                 //.NewLine("t")
-                .AddLabel("StageSizeLbl","Stage size:")
+                .AddLabel("StageSizeLbl", "Stage size:")
                 .AddNumericInputInt("MovieStageWidth", _player.Stage, m => m.Width, 40)
                 .AddLabel("StageSizeLblX", "x")
                 .AddNumericInputInt("MovieStageHeight", _player.Stage, m => m.Height, 40)
@@ -766,6 +780,6 @@ namespace LingoEngine.Director.Core.Inspector
 
         #endregion
 
-       
+
     }
 }

--- a/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs
@@ -1,10 +1,6 @@
+using System;
 using AbstEngine.Director.LGodot;
 using AbstUI.FrameworkCommunication;
-using AbstUI.LGodot.Components;
-using Godot;
-using LingoEngine.Core;
-using LingoEngine.Director.Core.Icons;
-using LingoEngine.Director.Core.Importer;
 using LingoEngine.Director.Core.Inspector;
 
 namespace LingoEngine.Director.LGodot.Inspector;
@@ -13,9 +9,8 @@ public partial class DirGodotPropertyInspector : BaseGodotWindow, IDirFrameworkP
 {
 
     private readonly DirectorPropertyInspectorWindow _inspectorWindow;
-    private AbstGodotPanel _headerPanel;
 
-    public DirGodotPropertyInspector(DirectorPropertyInspectorWindow inspectorWindow, ILingoPlayer player, IServiceProvider serviceProvider, IDirectorIconManager iconManager)
+    public DirGodotPropertyInspector(DirectorPropertyInspectorWindow inspectorWindow, IServiceProvider serviceProvider)
         : base("Property Inspector", serviceProvider)
     {
         _inspectorWindow = inspectorWindow;
@@ -23,25 +18,7 @@ public partial class DirGodotPropertyInspector : BaseGodotWindow, IDirFrameworkP
         _inspectorWindow.Init(TitleBarHeight);
         CustomMinimumSize = Size;
 
-        _headerPanel = _inspectorWindow.HeaderPanel.Framework<AbstGodotPanel>();
-        _headerPanel.Position = new Vector2(0, TitleBarHeight);
-        _headerPanel.Width = Size.X - 10;
-        AddChild(_headerPanel);
-
-
-        var tabs = _inspectorWindow.Tabs.Framework<AbstGodotTabContainer>();
-        tabs.Position = new Vector2(0, TitleBarHeight + DirectorPropertyInspectorWindow.HeaderHeight);
-        tabs.Size = new Vector2(Size.X, Size.Y - 30 - DirectorPropertyInspectorWindow.HeaderHeight);
-        AddChild(tabs);
-
-        //var behaviorPanel = _inspectorWindow.BehaviorPanel.Framework<LingoGodotPanel>();
-        //behaviorPanel.Visibility = false;
-        //behaviorPanel.Position = new Vector2(0, TitleBarHeight + DirectorPropertyInspectorWindow.HeaderHeight);
-        //behaviorPanel.Size = new Vector2(Size.X - 10, 0);
-        //AddChild(behaviorPanel);
-
+        _inspectorWindow.ResizeFromFW(true, (int)Size.X, (int)Size.Y - TitleBarHeight);
     }
-
-   
 
 }

--- a/src/Director/LingoEngine.Director.SDL2/Inspector/DirSdlPropertyInspectorWindow.cs
+++ b/src/Director/LingoEngine.Director.SDL2/Inspector/DirSdlPropertyInspectorWindow.cs
@@ -1,10 +1,9 @@
+using System;
 using AbstUI.Components;
 using AbstUI.FrameworkCommunication;
 using AbstUI.SDL2.Components;
-using AbstUI.SDL2.Components.Containers;
 using AbstUI.SDL2.Windowing;
 using LingoEngine.Director.Core.Inspector;
-using LingoEngine.Director.Core.Scores;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LingoEngine.Director.SDL2.Inspector;
@@ -12,8 +11,6 @@ namespace LingoEngine.Director.SDL2.Inspector;
 internal class DirSdlPropertyInspectorWindow : AbstSdlWindow, IDirFrameworkPropertyInspectorWindow, IFrameworkFor<DirectorPropertyInspectorWindow>
 {
     private readonly DirectorPropertyInspectorWindow _directorInspectorWindow;
-    private readonly AbstSdlPanel _headerPanel;
-    private readonly AbstSdlTabContainer _tabs;
     private const int TitleBarHeight = 24;
 
     public DirSdlPropertyInspectorWindow(DirectorPropertyInspectorWindow directorInspectorWindow, IServiceProvider services)
@@ -23,20 +20,7 @@ internal class DirSdlPropertyInspectorWindow : AbstSdlWindow, IDirFrameworkPrope
         Init(_directorInspectorWindow);
         _directorInspectorWindow.Init(TitleBarHeight);
 
-        _headerPanel = _directorInspectorWindow.HeaderPanel.Framework<AbstSdlPanel>();
-        _tabs = _directorInspectorWindow.Tabs.Framework<AbstSdlTabContainer>();
-
-        _headerPanel.Y = TitleBarHeight;
-        _headerPanel.Width = Width;
-
-        _tabs.Y = TitleBarHeight + _headerPanel.Height;
-        _tabs.Width = Width;
-        _tabs.Height = Height - TitleBarHeight - _headerPanel.Height;
-
-        AddItem(_headerPanel);
-        AddItem(_tabs);
-
-        _directorInspectorWindow.ResizeFromFW(true, (int)Width, (int)Height - TitleBarHeight - (int)_headerPanel.Height);
+        _directorInspectorWindow.ResizeFromFW(true, (int)Width, (int)Height - TitleBarHeight);
     }
 }
 


### PR DESCRIPTION
## Summary
- build property inspector content once in core and expose through AbstWindow
- simplify Godot and SDL2 inspector windows to rely on shared content

## Testing
- `/root/.dotnet/dotnet format src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj --include src/Director/LingoEngine.Director.Core/Inspector/DirectorPropertyInspectorWindow.cs --verbosity diagnostic`
- `/root/.dotnet/dotnet format src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj --include src/Director/LingoEngine.Director.LGodot/Inspector/DirGodotPropertyInspector.cs --verbosity diagnostic`
- `/root/.dotnet/dotnet format src/Director/LingoEngine.Director.SDL2/LingoEngine.Director.SDL2.csproj --include src/Director/LingoEngine.Director.SDL2/Inspector/DirSdlPropertyInspectorWindow.cs --verbosity diagnostic`
- `/root/.dotnet/dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj`
- `/root/.dotnet/dotnet build src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj` *(fails: 'DirGodotMainMenu' does not implement interface member 'IAbstFrameworkWindow.BackgroundTitleColor')*
- `/root/.dotnet/dotnet build src/Director/LingoEngine.Director.SDL2/LingoEngine.Director.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b67d16431483329dc3227eb7003ad9