### PR TITLE
Use font style parameter in markdown renderer

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
@@ -156,7 +156,7 @@ namespace AbstUI.Texts
 
             // 1) measure max width of all lines
             float fullWidth = 0f;
-           
+
             var lineWidths = new List<float>(lines.Length);
             foreach (var raw in lines)
             {
@@ -191,9 +191,14 @@ namespace AbstUI.Texts
                 }
 
                 float lineX = originX + xOff;
+                var fontStyle = AbstFontStyle.Regular;
+                if (style.Bold)
+                    fontStyle |= AbstFontStyle.Bold;
+                if (style.Italic)
+                    fontStyle |= AbstFontStyle.Italic;
                 _canvas!.DrawText(
                     new APoint(lineX, pos.Y - (firstLine ? fontInfo.TopIndentation : 0)),
-                    line, style.Font, style.Color, style.FontSize, -1, style.Alignment);
+                    line, style.Font, style.Color, style.FontSize, -1, style.Alignment, fontStyle);
 
                 pos.Offset(0, lineHeight);
                 firstLine = false;
@@ -330,17 +335,14 @@ namespace AbstUI.Texts
             {
                 if (sb.Length == 0)
                     return;
-                string font = _fontFamily;
-                if (bold && italic)
-                    font += " BoldItalic";
-                else if (bold)
-                    font += " Bold";
-                else if (italic)
-                    font += " Italic";
-
                 string text = sb.ToString();
                 float width = EstimateWidth(text, fontSize);
-                _canvas!.DrawText(new APoint(currentX, pos.Y), text, font, _color, fontSize, -1, AbstTextAlignment.Left);
+                var fontStyle = AbstFontStyle.Regular;
+                if (bold)
+                    fontStyle |= AbstFontStyle.Bold;
+                if (italic)
+                    fontStyle |= AbstFontStyle.Italic;
+                _canvas!.DrawText(new APoint(currentX, pos.Y), text, _fontFamily, _color, fontSize, -1, _alignment, fontStyle);
                 if (underline)
                     _canvas!.DrawLine(new APoint(currentX, pos.Y + fontSize), new APoint(currentX + width, pos.Y + fontSize), _color, 1);
                 currentX += width;


### PR DESCRIPTION
## Summary
- Pass `AbstFontStyle` flags to `DrawText` instead of embedding style in font family names.
- Introduce a lightweight `RecordingPainter` in tests to exercise the new `DrawText` signature.
- Forward current text alignment to `DrawText` when flushing inline markdown segments.

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs -v diag`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b8f6fac1688332ad5fef0be6a56eb6