### PR TITLE
feat: add shift-home/end selection support

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputText.cs
@@ -102,7 +102,7 @@ namespace AbstUI.SDL2.Components.Inputs
             {
                 case SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN:
                     Factory.FocusManager.SetFocus(this);
-                    EnsureResources(Factory.FontManagerTyped,Factory.RootContext.Renderer);
+                    EnsureResources(Factory.FontManagerTyped, Factory.RootContext.Renderer);
                     int innerXDown = (int)X + 4;
                     int clickX = ev.button.x - innerXDown + _scrollX;
                     _caret = GetCaretFromPixel(clickX);
@@ -212,6 +212,26 @@ namespace AbstUI.SDL2.Components.Inputs
                             MoveCaretNextWord();
                         else if (_caret < _codepoints.Count)
                             _caret++;
+                        if (!shift)
+                            _selectionStart = -1;
+                        AdjustScroll();
+                        e.StopPropagation = true;
+                    }
+                    else if (key == SDL.SDL_Keycode.SDLK_HOME)
+                    {
+                        if (shift && _selectionStart == -1)
+                            _selectionStart = _caret;
+                        _caret = 0;
+                        if (!shift)
+                            _selectionStart = -1;
+                        AdjustScroll();
+                        e.StopPropagation = true;
+                    }
+                    else if (key == SDL.SDL_Keycode.SDLK_END)
+                    {
+                        if (shift && _selectionStart == -1)
+                            _selectionStart = _caret;
+                        _caret = _codepoints.Count;
                         if (!shift)
                             _selectionStart = -1;
                         AdjustScroll();


### PR DESCRIPTION
## Summary
- extend SDL2 input text to handle Shift+Home and Shift+End selections

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputText.cs -v diagnostic`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b902ed2a5c83328fb5ec76f1c688a4