### PR TITLE
Add DrawSingleLine text rendering optimization

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstMarkdownRendererTests.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstMarkdownRendererTests.cs
@@ -43,6 +43,8 @@ public class AbstMarkdownRendererTests
         public void DrawPolygon(IReadOnlyList<APoint> points, AColor color, bool filled = true, float width = 1) { }
         public void DrawText(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, AbstTextAlignment alignment = AbstTextAlignment.Left, AbstFontStyle style = AbstFontStyle.Regular)
             => TextPositions.Add(position);
+        public void DrawSingleLine(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, int height = -1, AbstTextAlignment alignment = AbstTextAlignment.Left, AbstFontStyle style = AbstFontStyle.Regular)
+            => TextPositions.Add(position);
         public void DrawPicture(byte[] data, int width, int height, APoint position, APixelFormat format) { }
         public void DrawPicture(IAbstTexture2D texture, int width, int height, APoint position) { }
         public IAbstTexture2D GetTexture(string? name = null) => null!;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Graphics/BlazorImagePainter.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Graphics/BlazorImagePainter.cs
@@ -233,6 +233,31 @@ public class BlazorImagePainter : IAbstImagePainter
         MarkDirty();
     }
 
+    public void DrawSingleLine(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, int height = -1, AbstTextAlignment alignment = AbstTextAlignment.Left, AbstFontStyle style = AbstFontStyle.Regular)
+    {
+        var pos = position; var txt = text; var fnt = font; var col = color ?? AColors.Black; var fs = fontSize; var w = width; var h = height; var align = alignment;
+        _drawActions.Add((
+            () =>
+            {
+                if (!AutoResize) return null;
+                int needW = w >= 0 ? w : (int)_fontManager.MeasureTextWidth(txt, fnt ?? string.Empty, fs);
+                int needH = h >= 0 ? h : _fontManager.GetFontInfo(fnt ?? string.Empty, fs).FontHeight;
+                return EnsureCapacity((int)(pos.X + needW), (int)(pos.Y + needH));
+            },
+            ctx =>
+            {
+                var alignStr = align switch
+                {
+                    AbstTextAlignment.Center => "center",
+                    AbstTextAlignment.Right => "right",
+                    _ => "left"
+                };
+                return _scripts.CanvasDrawText(ctx, pos.X, pos.Y, txt, fnt ?? string.Empty, ToCss(col), fs, alignStr);
+            }
+        ));
+        MarkDirty();
+    }
+
     public void DrawPicture(byte[] data, int width, int height, APoint position, APixelFormat format)
     {
         var dat = data; var w = width; var h = height; var pos = position;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Graphics/IAbstImagePainter.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Graphics/IAbstImagePainter.cs
@@ -20,6 +20,7 @@ namespace AbstUI.Components.Graphics
         void DrawPolygon(IReadOnlyList<APoint> points, AColor color, bool filled = true, float width = 1);
         void DrawRect(ARect rect, AColor color, bool filled = true, float width = 1);
         void DrawText(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, AbstTextAlignment alignment = AbstTextAlignment.Left, AbstFontStyle style = AbstFontStyle.Regular);
+        void DrawSingleLine(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, int height = -1, AbstTextAlignment alignment = AbstTextAlignment.Left, AbstFontStyle style = AbstFontStyle.Regular);
         void SetPixel(APoint point, AColor color);
         IAbstTexture2D GetTexture(string? name = null);
         void Render();

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
@@ -196,9 +196,9 @@ namespace AbstUI.Texts
                     fontStyle |= AbstFontStyle.Bold;
                 if (style.Italic)
                     fontStyle |= AbstFontStyle.Italic;
-                _canvas!.DrawText(
+                _canvas!.DrawSingleLine(
                     new APoint(lineX, pos.Y - (firstLine ? fontInfo.TopIndentation : 0)),
-                    line, style.Font, style.Color, style.FontSize, -1, style.Alignment, fontStyle);
+                    line, style.Font, style.Color, style.FontSize, (int)MathF.Ceiling(lineW), fontInfo.FontHeight, style.Alignment, fontStyle);
 
                 pos.Offset(0, lineHeight);
                 firstLine = false;
@@ -337,12 +337,13 @@ namespace AbstUI.Texts
                     return;
                 string text = sb.ToString();
                 float width = EstimateWidth(text, fontSize);
+                var fontInfo = _fontManager.GetFontInfo(_fontFamily, fontSize);
                 var fontStyle = AbstFontStyle.Regular;
                 if (bold)
                     fontStyle |= AbstFontStyle.Bold;
                 if (italic)
                     fontStyle |= AbstFontStyle.Italic;
-                _canvas!.DrawText(new APoint(currentX, pos.Y), text, _fontFamily, _color, fontSize, -1, _alignment, fontStyle);
+                _canvas!.DrawSingleLine(new APoint(currentX, pos.Y), text, _fontFamily, _color, fontSize, (int)MathF.Ceiling(width), fontInfo.FontHeight, _alignment, fontStyle);
                 if (underline)
                     _canvas!.DrawLine(new APoint(currentX, pos.Y + fontSize), new APoint(currentX + width, pos.Y + fontSize), _color, 1);
                 currentX += width;


### PR DESCRIPTION
## Summary
- add `DrawSingleLine` API to `IAbstImagePainter`
- implement single-line text drawing for SDL2, Unity, Godot, and Blazor painters
- render markdown text via `DrawSingleLine` to avoid extra width/height calculations
- compute width and height automatically in SDL2 and Godot when auto-resizing without explicit dimensions

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj` *(fails: UnityTexture2D does not implement abstract members)*
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj` *(fails: AbstBlazorTexture2D does not implement abstract members)*
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b901c6d24083329815478ac11deaf2