### PR TITLE
Refactor AbstUI canvases to use framework image painters

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/GodotControlExtensions.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/GodotControlExtensions.cs
@@ -1,0 +1,45 @@
+using System;
+using AbstUI.Bitmaps;
+using AbstUI.LGodot.Bitmaps;
+using Godot;
+
+namespace AbstUI.LGodot.Components.Graphics;
+
+public static class GodotControlExtensions
+{
+    public static IAbstTexture2D CreateAbstTexture(this Control control, string? name = null)
+    {
+        var sizeI = new Vector2I((int)control.Size.X, (int)control.Size.Y);
+
+        var holder = new Node { Name = "__tmp_vp_holder" + name };
+        var tree = Engine.GetMainLoop() as SceneTree ?? throw new InvalidOperationException("No SceneTree available.");
+        tree.Root.AddChild(holder);
+
+        var vp = new SubViewport
+        {
+            Disable3D = true,
+            TransparentBg = true,
+            RenderTargetUpdateMode = SubViewport.UpdateMode.Once,
+            Size = sizeI
+        };
+        holder.AddChild(vp);
+
+        var clone = (Control)control.Duplicate((int)DuplicateFlags.UseInstantiation);
+        clone.Position = Vector2.Zero;
+        clone.Size = control.Size;
+        vp.AddChild(clone);
+
+        RenderingServer.ForceDraw();
+
+        using var img = vp.GetTexture().GetImage();
+        img.Convert(Image.Format.Rgba8);
+        var tex = ImageTexture.CreateFromImage(img);
+
+        clone.QueueFree();
+        vp.QueueFree();
+        holder.QueueFree();
+
+        return new AbstGodotTexture2D(tex, name ?? $"{control.Name}_Snapshot");
+    }
+}
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityComponentFactory.cs
@@ -35,7 +35,8 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
     public AbstGfxCanvas CreateGfxCanvas(string name, int width, int height)
     {
         var canvas = new AbstGfxCanvas();
-        var impl = new AbstUnityGfxCanvas(width, height);
+        var painter = (UnityImagePainter)CreateImagePainter(width, height);
+        var impl = new AbstUnityGfxCanvas(painter);
         canvas.Init(impl);
         InitComponent(canvas);
         canvas.Name = name;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Graphics/AbstUnityGfxCanvas.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Graphics/AbstUnityGfxCanvas.cs
@@ -1,43 +1,36 @@
 using System;
-using System.Collections.Generic;
-using AbstUI.Primitives;
-using AbstUI.LUnity.Bitmaps;
-using AbstUI.LUnity.Primitives;
-using AbstUI.Texts;
-using UnityEngine;
-using UnityEngine.UI;
 using AbstUI.Components.Graphics;
 using AbstUI.FrameworkCommunication;
 using AbstUI.LUnity.Components.Base;
+using AbstUI.LUnity.Primitives;
+using AbstUI.Primitives;
+using AbstUI.Texts;
+using UnityEngine;
+using UnityEngine.UI;
+using AbstUI.Components;
 
 namespace AbstUI.LUnity.Components.Graphics;
 
 /// <summary>
-/// Unity implementation of <see cref="IAbstFrameworkGfxCanvas"/> that records paint actions
-/// and executes them onto a <see cref="Texture2D"/>.
+/// Unity implementation of <see cref="IAbstFrameworkGfxCanvas"/> that delegates drawing
+/// to a <see cref="UnityImagePainter"/> and displays the resulting <see cref="Texture2D"/>.
 /// </summary>
 internal class AbstUnityGfxCanvas : AbstUnityComponent, IAbstFrameworkGfxCanvas, IFrameworkFor<AbstGfxCanvas>, IDisposable
 {
     private readonly RawImage _image;
-    private readonly Texture2D _texture;
+    private readonly UnityImagePainter _painter;
     private readonly GfxCanvasBehaviour _behaviour;
-    private readonly List<Action<Texture2D>> _drawActions = new();
-    private Color? _clearColor;
-    private bool _dirty = true;
 
-    public AbstUnityGfxCanvas(int width, int height)
+    public AbstUnityGfxCanvas(UnityImagePainter painter)
         : base(CreateGameObject(out var image, out var behaviour))
     {
+        _painter = painter;
         _image = image;
         _behaviour = behaviour;
-        _texture = new Texture2D(width, height, TextureFormat.RGBA32, false)
-        {
-            filterMode = FilterMode.Point
-        };
-        _image.texture = _texture;
+        _image.texture = _painter.Texture;
         _behaviour.Init(this);
-        Width = width;
-        Height = height;
+        Width = _painter.Width;
+        Height = _painter.Height;
     }
 
     private static GameObject CreateGameObject(out RawImage image, out GfxCanvasBehaviour behaviour)
@@ -50,265 +43,90 @@ internal class AbstUnityGfxCanvas : AbstUnityComponent, IAbstFrameworkGfxCanvas,
 
     public bool Pixilated
     {
-        get => _texture.filterMode == FilterMode.Point;
-        set => _texture.filterMode = value ? FilterMode.Point : FilterMode.Bilinear;
+        get => _painter.Pixilated;
+        set => _painter.Pixilated = value;
     }
 
-    private void MarkDirty() => _dirty = true;
+    public new float Width
+    {
+        get => base.Width;
+        set
+        {
+            if (Math.Abs(base.Width - value) < float.Epsilon)
+                return;
+            base.Width = value;
+            _painter.Resize((int)value, _painter.Height);
+            Redraw();
+        }
+    }
+
+    public new float Height
+    {
+        get => base.Height;
+        set
+        {
+            if (Math.Abs(base.Height - value) < float.Epsilon)
+                return;
+            base.Height = value;
+            _painter.Resize(_painter.Width, (int)value);
+            Redraw();
+        }
+    }
 
     internal void Redraw()
     {
-        if (!_dirty) return;
-
-        if (_clearColor.HasValue)
-        {
-            var col = _clearColor.Value;
-            var arr = new Color[_texture.width * _texture.height];
-            for (int i = 0; i < arr.Length; i++) arr[i] = col;
-            _texture.SetPixels(arr);
-        }
-
-        foreach (var act in _drawActions)
-            act(_texture);
-
-        _texture.Apply();
-        _dirty = false;
+        _painter.Render();
+        _image.texture = _painter.Texture;
+        base.Width = _painter.Width;
+        base.Height = _painter.Height;
     }
 
-    public void Clear(AColor color)
-    {
-        _drawActions.Clear();
-        _clearColor = color.ToUnityColor();
-        MarkDirty();
-    }
+    public void Clear(AColor color) => _painter.Clear(color);
 
-    private static void SetPixel(Texture2D tex, int x, int y, Color col)
-    {
-        if (x < 0 || x >= tex.width || y < 0 || y >= tex.height) return;
-        tex.SetPixel(x, tex.height - 1 - y, col);
-    }
-
-    public void SetPixel(APoint point, AColor color)
-    {
-        var p = point;
-        var c = color.ToUnityColor();
-        _drawActions.Add(tex => SetPixel(tex, (int)p.X, (int)p.Y, c));
-        MarkDirty();
-    }
-
-    private static void DrawLine(Texture2D tex, int x0, int y0, int x1, int y1, Color col, float width)
-    {
-        int dx = Mathf.Abs(x1 - x0);
-        int dy = Mathf.Abs(y1 - y0);
-        int sx = x0 < x1 ? 1 : -1;
-        int sy = y0 < y1 ? 1 : -1;
-        int err = dx - dy;
-        int w = Mathf.Max(1, Mathf.RoundToInt(width));
-        while (true)
-        {
-            for (int wx = -w / 2; wx <= w / 2; wx++)
-                for (int wy = -w / 2; wy <= w / 2; wy++)
-                    SetPixel(tex, x0 + wx, y0 + wy, col);
-            if (x0 == x1 && y0 == y1) break;
-            int e2 = 2 * err;
-            if (e2 > -dy) { err -= dy; x0 += sx; }
-            if (e2 < dx) { err += dx; y0 += sy; }
-        }
-    }
+    public void SetPixel(APoint point, AColor color) => _painter.SetPixel(point, color);
 
     public void DrawLine(APoint start, APoint end, AColor color, float width = 1)
-    {
-        var s = start; var e = end; var col = color.ToUnityColor(); var w = width;
-        _drawActions.Add(tex => DrawLine(tex, (int)s.X, (int)s.Y, (int)e.X, (int)e.Y, col, w));
-        MarkDirty();
-    }
+        => _painter.DrawLine(start, end, color, width);
 
     public void DrawRect(ARect rect, AColor color, bool filled = true, float width = 1)
-    {
-        var r = rect; var col = color.ToUnityColor(); var w = width;
-        _drawActions.Add(tex =>
-        {
-            int x0 = Mathf.RoundToInt(r.Left);
-            int y0 = Mathf.RoundToInt(r.Top);
-            int x1 = Mathf.RoundToInt(r.Right);
-            int y1 = Mathf.RoundToInt(r.Bottom);
-            if (filled)
-            {
-                int rw = x1 - x0;
-                int rh = y1 - y0;
-                var arr = new Color[rw * rh];
-                for (int i = 0; i < arr.Length; i++) arr[i] = col;
-                tex.SetPixels(x0, tex.height - y1, rw, rh, arr);
-            }
-            else
-            {
-                DrawLine(tex, x0, y0, x1, y0, col, w);
-                DrawLine(tex, x1, y0, x1, y1, col, w);
-                DrawLine(tex, x1, y1, x0, y1, col, w);
-                DrawLine(tex, x0, y1, x0, y0, col, w);
-            }
-        });
-        MarkDirty();
-    }
+        => _painter.DrawRect(rect, color, filled, width);
 
     public void DrawCircle(APoint center, float radius, AColor color, bool filled = true, float width = 1)
-    {
-        var c = center; var rad = Mathf.RoundToInt(radius); var col = color.ToUnityColor(); var w = width;
-        _drawActions.Add(tex =>
-        {
-            int cx = Mathf.RoundToInt(c.X);
-            int cy = Mathf.RoundToInt(c.Y);
-            for (int y = -rad; y <= rad; y++)
-            {
-                int xx = (int)Mathf.Sqrt(rad * rad - y * y);
-                if (filled)
-                {
-                    for (int x = -xx; x <= xx; x++)
-                        SetPixel(tex, cx + x, cy + y, col);
-                }
-                else
-                {
-                    DrawLine(tex, cx - xx, cy + y, cx - xx, cy + y, col, w);
-                    DrawLine(tex, cx + xx, cy + y, cx + xx, cy + y, col, w);
-                }
-            }
-        });
-        MarkDirty();
-    }
+        => _painter.DrawCircle(center, radius, color, filled, width);
 
     public void DrawArc(APoint center, float radius, float startDeg, float endDeg, int segments, AColor color, float width = 1)
-    {
-        var c = center; var rad = radius; var s = startDeg; var e = endDeg; var segs = segments; var col = color.ToUnityColor(); var w = width;
-        _drawActions.Add(tex =>
-        {
-            float start = s * Mathf.Deg2Rad;
-            float end = e * Mathf.Deg2Rad;
-            float step = (end - start) / segs;
-            int prevX = Mathf.RoundToInt(c.X + Mathf.Cos(start) * rad);
-            int prevY = Mathf.RoundToInt(c.Y + Mathf.Sin(start) * rad);
-            for (int i = 1; i <= segs; i++)
-            {
-                float ang = start + step * i;
-                int nx = Mathf.RoundToInt(c.X + Mathf.Cos(ang) * rad);
-                int ny = Mathf.RoundToInt(c.Y + Mathf.Sin(ang) * rad);
-                DrawLine(tex, prevX, prevY, nx, ny, col, w);
-                prevX = nx; prevY = ny;
-            }
-        });
-        MarkDirty();
-    }
-
-    private static bool PointInTriangle(int px, int py, APoint a, APoint b, APoint c)
-    {
-        float Area(APoint p1, APoint p2, APoint p3) =>
-            (p1.X * (p2.Y - p3.Y) + p2.X * (p3.Y - p1.Y) + p3.X * (p1.Y - p2.Y)) / 2f;
-        float A = Math.Abs(Area(a, b, c));
-        float A1 = Math.Abs(Area(new APoint(px, py), b, c));
-        float A2 = Math.Abs(Area(a, new APoint(px, py), c));
-        float A3 = Math.Abs(Area(a, b, new APoint(px, py)));
-        return Math.Abs(A - (A1 + A2 + A3)) < 0.01f;
-    }
-
-    private static void FillTriangle(Texture2D tex, APoint p0, APoint p1, APoint p2, Color col)
-    {
-        int minX = Mathf.FloorToInt(Mathf.Min(p0.X, Mathf.Min(p1.X, p2.X)));
-        int maxX = Mathf.CeilToInt(Mathf.Max(p0.X, Mathf.Max(p1.X, p2.X)));
-        int minY = Mathf.FloorToInt(Mathf.Min(p0.Y, Mathf.Min(p1.Y, p2.Y)));
-        int maxY = Mathf.CeilToInt(Mathf.Max(p0.Y, Mathf.Max(p1.Y, p2.Y)));
-        for (int y = minY; y <= maxY; y++)
-            for (int x = minX; x <= maxX; x++)
-                if (PointInTriangle(x, y, p0, p1, p2))
-                    SetPixel(tex, x, y, col);
-    }
+        => _painter.DrawArc(center, radius, startDeg, endDeg, segments, color, width);
 
     public void DrawPolygon(IReadOnlyList<APoint> points, AColor color, bool filled = true, float width = 1)
-    {
-        if (points.Count < 2) return;
-        var pts = new APoint[points.Count];
-        for (int i = 0; i < points.Count; i++) pts[i] = points[i];
-        var col = color.ToUnityColor(); var w = width;
-        _drawActions.Add(tex =>
-        {
-            for (int i = 0; i < pts.Length - 1; i++)
-                DrawLine(tex, (int)pts[i].X, (int)pts[i].Y, (int)pts[i + 1].X, (int)pts[i + 1].Y, col, w);
-            DrawLine(tex, (int)pts[^1].X, (int)pts[^1].Y, (int)pts[0].X, (int)pts[0].Y, col, w);
-            if (filled)
-            {
-                var p0 = pts[0];
-                for (int i = 1; i < pts.Length - 1; i++)
-                    FillTriangle(tex, p0, pts[i], pts[i + 1], col);
-            }
-        });
-        MarkDirty();
-    }
+        => _painter.DrawPolygon(points, color, filled, width);
 
-    public void DrawText(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, AbstTextAlignment alignment = default)
-    {
-        var pos = position; var txt = text; var col = (color ?? new AColor(0, 0, 0)).ToUnityColor();
-        var fnt = Resources.GetBuiltinResource<Font>("Arial.ttf");
-        var w = width;
-        var align = alignment;
-        _drawActions.Add(tex =>
-        {
-            var rt = RenderTexture.GetTemporary(tex.width, tex.height, 0, RenderTextureFormat.ARGB32);
-            UnityEngine.Graphics.Blit(tex, rt);
-            var prev = RenderTexture.active;
-            RenderTexture.active = rt;
-            GL.PushMatrix();
-            GL.LoadPixelMatrix(0, tex.width, tex.height, 0);
-            var style = new GUIStyle { font = fnt, fontSize = fontSize, normal = new GUIStyleState { textColor = col } };
-            style.alignment = align switch
-            {
-                AbstTextAlignment.Center => TextAnchor.MiddleCenter,
-                AbstTextAlignment.Right => TextAnchor.MiddleRight,
-                _ => TextAnchor.UpperLeft
-            };
-            var rect = new Rect(pos.X, pos.Y, w >= 0 ? w : tex.width, tex.height);
-            GUI.Label(rect, txt, style);
-            GL.PopMatrix();
-            tex.ReadPixels(new Rect(0, 0, tex.width, tex.height), 0, 0);
-            tex.Apply();
-            RenderTexture.active = prev;
-            RenderTexture.ReleaseTemporary(rt);
-        });
-        MarkDirty();
-    }
+    public void DrawText(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12,
+        int width = -1, AbstTextAlignment alignment = default)
+        => _painter.DrawText(position, text, font, color, fontSize, width, alignment);
 
     public void DrawPicture(byte[] data, int width, int height, APoint position, APixelFormat format)
-    {
-        var dat = data; var w = width; var h = height; var pos = position; var fmt = format;
-        _drawActions.Add(tex =>
-        {
-            var t = new Texture2D(w, h, fmt.ToUnityFormat(), false);
-            t.LoadRawTextureData(dat);
-            t.Apply();
-            var colors = t.GetPixels(0, 0, w, h);
-            int dstX = Mathf.RoundToInt(pos.X);
-            int dstY = tex.height - Mathf.RoundToInt(pos.Y) - h;
-            tex.SetPixels(dstX, dstY, w, h, colors);
-            UnityEngine.Object.Destroy(t);
-        });
-        MarkDirty();
-    }
+        => _painter.DrawPicture(data, width, height, position, format);
 
     public void DrawPicture(IAbstTexture2D texture, int width, int height, APoint position)
+        => _painter.DrawPicture(texture, width, height, position);
+
+    public IAbstTexture2D GetTexture(string? name = null) => _painter.GetTexture(name);
+
+    float IAbstFrameworkNode.Width
     {
-        if (texture is not UnityTexture2D ut || ut.Texture == null) return;
-        var w = width; var h = height; var pos = position; var src = ut.Texture;
-        _drawActions.Add(tex =>
-        {
-            var colors = src.GetPixels(0, 0, w, h);
-            int dstX = Mathf.RoundToInt(pos.X);
-            int dstY = tex.height - Mathf.RoundToInt(pos.Y) - h;
-            tex.SetPixels(dstX, dstY, w, h, colors);
-        });
-        MarkDirty();
+        get => Width;
+        set => Width = value;
+    }
+
+    float IAbstFrameworkNode.Height
+    {
+        get => Height;
+        set => Height = value;
     }
 
     public new void Dispose()
     {
-        _drawActions.Clear();
-        UnityEngine.Object.Destroy(_texture);
+        _painter.Dispose();
         base.Dispose();
     }
 
@@ -319,3 +137,4 @@ internal class AbstUnityGfxCanvas : AbstUnityComponent, IAbstFrameworkGfxCanvas,
         private void LateUpdate() => _canvas?.Redraw();
     }
 }
+

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Graphics/UnityImagePainter.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Graphics/UnityImagePainter.cs
@@ -19,8 +19,32 @@ public class UnityImagePainter : IAbstImagePainter
 
     public int MaxWidth { get; set; } = 16384;
     public int MaxHeight { get; set; } = 16384;
-    public int Width { get; set; }
-    public int Height { get; set; }
+    private int _width;
+    private int _height;
+
+    public int Width
+    {
+        get => _width;
+        set
+        {
+            if (_width == value)
+                return;
+            _width = value;
+            MarkDirty();
+        }
+    }
+
+    public int Height
+    {
+        get => _height;
+        set
+        {
+            if (_height == value)
+                return;
+            _height = value;
+            MarkDirty();
+        }
+    }
     public bool Pixilated
     {
         get => _texture.filterMode == FilterMode.Point;
@@ -32,14 +56,25 @@ public class UnityImagePainter : IAbstImagePainter
     public UnityImagePainter(IAbstFontManager fontManager, int width = 0, int height = 0)
     {
         _fontManager = (UnityFontManager)fontManager;
-        Width = width > 0 ? Math.Min(width, MaxWidth) : 10;
-        Height = height > 0 ? Math.Min(height, MaxHeight) : 10;
-        _texture = new Texture2D(Width, Height, TextureFormat.RGBA32, false)
+        _width = width > 0 ? Math.Min(width, MaxWidth) : 10;
+        _height = height > 0 ? Math.Min(height, MaxHeight) : 10;
+        _texture = new Texture2D(_width, _height, TextureFormat.RGBA32, false)
         {
             filterMode = FilterMode.Point
         };
         ClearTexture();
         _dirty = true;
+    }
+
+    public void Resize(int width, int height)
+    {
+        width = Math.Min(width, MaxWidth);
+        height = Math.Min(height, MaxHeight);
+        if (Width == width && Height == height)
+            return;
+        _width = width;
+        _height = height;
+        MarkDirty();
     }
 
     private void ClearTexture()

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Graphics/SDLImagePainter.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Graphics/SDLImagePainter.cs
@@ -18,10 +18,35 @@ namespace AbstUI.SDL2.Components.Graphics
         protected bool _dirty;
         private readonly int _maxWidth;
         private readonly int _maxHeight;
+        private int _width;
+        private int _height;
 
         public nint Renderer { get; }
-        public int Width { get; set; }
-        public int Height { get; set; }
+
+        public int Width
+        {
+            get => _width;
+            set
+            {
+                if (_width == value)
+                    return;
+                _width = value;
+                MarkDirty();
+            }
+        }
+
+        public int Height
+        {
+            get => _height;
+            set
+            {
+                if (_height == value)
+                    return;
+                _height = value;
+                MarkDirty();
+            }
+        }
+
         public bool Pixilated { get; set; }
         public bool AutoResize { get; set; } = true;
         public nint Texture => _texture;
@@ -30,13 +55,24 @@ namespace AbstUI.SDL2.Components.Graphics
         {
             _fontManager = (SdlFontManager)fontManager;
             (_maxWidth, _maxHeight) = GetMaxTexSize(renderer);
-            Width = width > 0 ? Math.Min(width, _maxWidth) : 10;
-            Height = height > 0 ? Math.Min(height, _maxHeight) : 10;
+            _width = width > 0 ? Math.Min(width, _maxWidth) : 10;
+            _height = height > 0 ? Math.Min(height, _maxHeight) : 10;
 
             _texture = SDL.SDL_CreateTexture(renderer, SDL.SDL_PIXELFORMAT_RGBA8888,
-                (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, Width, Height);
+                (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, _width, _height);
             _dirty = true;
             Renderer = renderer;
+        }
+
+        public void Resize(int width, int height)
+        {
+            width = Math.Min(width, _maxWidth);
+            height = Math.Min(height, _maxHeight);
+            if (Width == width && Height == height)
+                return;
+            _width = width;
+            _height = height;
+            MarkDirty();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- ensure SDL canvas resizes notify image painter and redraw automatically
- add width/height resizing hooks and explicit node implementation for Unity canvas
- queue Godot canvas redraw on size change and provide `CreateAbstTexture` snapshot extension
- return early from canvas and painter resizes when width or height is unchanged
- mark SDL and Unity painters dirty when width or height properties change

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Graphics/SDLImagePainter.cs -v diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Graphics/UnityImagePainter.cs -v diagnostic`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b9130b61908332b28714c3bb550e2b