### PR TITLE
Add IAbstResourceManager with framework implementations

### DIFF
--- a/Test/LingoEngine.Tests/CsvImporterTests.cs
+++ b/Test/LingoEngine.Tests/CsvImporterTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using LingoEngine.Members;
 using LingoEngine.Tools;
 using Xunit;
+using AbstUI.Resources;
 
 public class CsvImporterTests
 {
@@ -14,7 +15,7 @@ public class CsvImporterTests
         var tempFile = Path.GetTempFileName();
         File.WriteAllText(tempFile, csvContent);
 
-        var importer = new CsvImporter();
+        var importer = new CsvImporter(new TestResourceManager());
         var rows = importer.ImportCsvCastFile(tempFile);
 
         var row = Assert.Single(rows);
@@ -24,5 +25,11 @@ public class CsvImporterTests
         Assert.Equal(1, row.RegPoint.X);
         Assert.Equal(2, row.RegPoint.Y);
         Assert.Equal("sample.txt", row.FileName);
+    }
+    private class TestResourceManager : IAbstResourceManager
+    {
+        public string? ReadTextFile(string fileName) => File.Exists(fileName) ? File.ReadAllText(fileName) : null;
+
+        public byte[]? ReadBytes(string fileName) => File.Exists(fileName) ? File.ReadAllBytes(fileName) : null;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIBlazorSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIBlazorSetup.cs
@@ -8,6 +8,8 @@ using AbstUI.Blazor.Windowing;
 using AbstUI.Components;
 using AbstUI.Components.Containers;
 using AbstUI.Styles;
+using AbstUI.Resources;
+using AbstUI.Blazor.Resources;
 using AbstUI.Windowing;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,6 +22,7 @@ public static class AbstUIBlazorSetup
         services
             .AddSingleton<IAbstFontManager, AbstBlazorFontManager>()
             .AddSingleton<IAbstStyleManager, AbstStyleManager>()
+            .AddSingleton<IAbstResourceManager, BlazorResourceManager>()
             .AddSingleton<IAbstBlazorStyleManager, AbstBlazorStyleManager>()
             .AddSingleton<AbstUIScriptResolver>()
             .AddSingleton<AbstBlazorComponentMapper>()

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Resources/BlazorResourceManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Resources/BlazorResourceManager.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using AbstUI.Resources;
+
+namespace AbstUI.Blazor.Resources
+{
+    public class BlazorResourceManager : IAbstResourceManager
+    {
+        public string? ReadTextFile(string fileName)
+        {
+            return File.Exists(fileName) ? File.ReadAllText(fileName) : null;
+        }
+
+        public byte[]? ReadBytes(string fileName)
+        {
+            return File.Exists(fileName) ? File.ReadAllBytes(fileName) : null;
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUIImGuiSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUIImGuiSetup.cs
@@ -1,5 +1,7 @@
 using AbstUI.ImGui.Styles;
 using AbstUI.Styles;
+using AbstUI.Resources;
+using AbstUI.ImGui.Resources;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AbstUI.ImGui;
@@ -13,7 +15,8 @@ public static class AbstUIImGuiSetup
     {
         services
             .AddSingleton<IAbstFontManager, ImGuiFontManager>()
-            .AddSingleton<IAbstStyleManager, AbstStyleManager>();
+            .AddSingleton<IAbstStyleManager, AbstStyleManager>()
+            .AddSingleton<IAbstResourceManager, ImGuiResourceManager>();
         return services;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Resources/ImGuiResourceManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Resources/ImGuiResourceManager.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using AbstUI.Resources;
+
+namespace AbstUI.ImGui.Resources
+{
+    public class ImGuiResourceManager : IAbstResourceManager
+    {
+        public string? ReadTextFile(string fileName)
+        {
+            return File.Exists(fileName) ? File.ReadAllText(fileName) : null;
+        }
+
+        public byte[]? ReadBytes(string fileName)
+        {
+            return File.Exists(fileName) ? File.ReadAllBytes(fileName) : null;
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUIGodotSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUIGodotSetup.cs
@@ -13,6 +13,8 @@ using AbstUI.LGodot.Inputs;
 using AbstUI.LGodot.Styles;
 using AbstUI.LGodot.Windowing;
 using AbstUI.Styles;
+using AbstUI.Resources;
+using AbstUI.LGodot.Resources;
 using AbstUI.Windowing;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -36,6 +38,7 @@ namespace AbstUI.LGodot
 
                 .AddSingleton<IAbstFontManager, AbstGodotFontManager>()
                 .AddSingleton<IAbstStyleManager, AbstGodotStyleManager>()
+                .AddSingleton<IAbstResourceManager, AbstGodotResourceManager>()
                 .AddTransient(p => (AbstGodotFontManager)p.GetRequiredService<IAbstFontManager>())
                 .AddTransient(p => (AbstGodotStyleManager)p.GetRequiredService<IAbstStyleManager>())
                 .AddTransient(p => (IAbstGodotStyleManager)p.GetRequiredService<IAbstStyleManager>())

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Resources/AbstGodotResourceManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Resources/AbstGodotResourceManager.cs
@@ -1,0 +1,19 @@
+using AbstUI.Resources;
+using AbstUI.LGodot.Helpers;
+
+namespace AbstUI.LGodot.Resources
+{
+    public class AbstGodotResourceManager : IAbstResourceManager
+    {
+        public string? ReadTextFile(string fileName) => GodotHelper.ReadFile(fileName);
+
+        public byte[]? ReadBytes(string fileName)
+        {
+            var filePath = GodotHelper.EnsureGodotUrl(fileName);
+            var file = Godot.FileAccess.Open(filePath, Godot.FileAccess.ModeFlags.Read);
+            if (file == null)
+                return null;
+            return file.GetBuffer((long)file.GetLength());
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUIUnitySetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUIUnitySetup.cs
@@ -5,6 +5,8 @@ using AbstUI.LUnity.Windowing;
 using AbstUI.Inputs;
 using AbstUI.LUnity.Inputs;
 using AbstUI.Styles;
+using AbstUI.Resources;
+using AbstUI.LUnity.Resources;
 using AbstUI.Windowing;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,6 +19,7 @@ namespace AbstUI.LUnity
             services
                 .AddSingleton<IAbstFontManager, UnityFontManager>()
                 .AddSingleton<IAbstStyleManager, AbstStyleManager>()
+                .AddSingleton<IAbstResourceManager, UnityResourceManager>()
                 .AddSingleton<IAbstComponentFactory, AbstUnityComponentFactory>()
                 .AddSingleton<IAbstFrameworkWindowManager, AbstUnityWindowManager>()
                 .AddSingleton<IAbstFrameworkMainWindow, AbstUnityMainWindow>()

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Resources/UnityResourceManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Resources/UnityResourceManager.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using AbstUI.Resources;
+
+namespace AbstUI.LUnity.Resources
+{
+    public class UnityResourceManager : IAbstResourceManager
+    {
+        public string? ReadTextFile(string fileName)
+        {
+            return File.Exists(fileName) ? File.ReadAllText(fileName) : null;
+        }
+
+        public byte[]? ReadBytes(string fileName)
+        {
+            return File.Exists(fileName) ? File.ReadAllBytes(fileName) : null;
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUISDLSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUISDLSetup.cs
@@ -6,6 +6,8 @@ using AbstUI.SDL2.Inputs;
 using AbstUI.SDL2.Styles;
 using AbstUI.SDL2.Windowing;
 using AbstUI.Styles;
+using AbstUI.Resources;
+using AbstUI.SDL2.Resources;
 using AbstUI.Windowing;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -26,6 +28,7 @@ namespace AbstUI.SDL2
 
                 .AddSingleton<IAbstFontManager, SdlFontManager>()
                 .AddSingleton<IAbstStyleManager, AbstStyleManager>()
+                .AddSingleton<IAbstResourceManager, SdlResourceManager>()
                 .AddTransient(p => (SdlFontManager)p.GetRequiredService<IAbstFontManager>())
                 .AddTransient(p => (AbstStyleManager)p.GetRequiredService<IAbstStyleManager>())
                 .AddSingleton<SdlFocusManager>()

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Resources/SdlResourceManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Resources/SdlResourceManager.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using AbstUI.Resources;
+
+namespace AbstUI.SDL2.Resources
+{
+    public class SdlResourceManager : IAbstResourceManager
+    {
+        public string? ReadTextFile(string fileName)
+        {
+            return File.Exists(fileName) ? File.ReadAllText(fileName) : null;
+        }
+
+        public byte[]? ReadBytes(string fileName)
+        {
+            return File.Exists(fileName) ? File.ReadAllBytes(fileName) : null;
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Resources/IAbstResourceManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Resources/IAbstResourceManager.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Resources
+{
+    public interface IAbstResourceManager
+    {
+        string? ReadTextFile(string fileName);
+        byte[]? ReadBytes(string fileName);
+    }
+}

--- a/src/LingoEngine/Core/LingoPlayer.cs
+++ b/src/LingoEngine/Core/LingoPlayer.cs
@@ -2,6 +2,7 @@
 using AbstUI.Primitives;
 using LingoEngine.Casts;
 using AbstUI.Commands;
+using AbstUI.Resources;
 using LingoEngine.Events;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Inputs;
@@ -18,12 +19,12 @@ namespace LingoEngine.Core
 {
 
 
-    public class LingoPlayer : ILingoPlayer,IDisposable,
+    public class LingoPlayer : ILingoPlayer, IDisposable,
         IAbstCommandHandler<RewindMovieCommand>,
         IAbstCommandHandler<PlayMovieCommand>,
         IAbstCommandHandler<StepFrameCommand>
     {
-        private Lazy<CsvImporter> _csvImporter = new Lazy<CsvImporter>(() => new CsvImporter());
+        private readonly Lazy<CsvImporter> _csvImporter;
         private readonly LingoCastLibsContainer _castLibsContainer;
         private readonly LingoSound _sound;
         private readonly ILingoWindow _window;
@@ -82,8 +83,9 @@ namespace LingoEngine.Core
         public ILingoMovie? ActiveMovie { get; private set; }
         public event Action<ILingoMovie?>? ActiveMovieChanged;
 
-        public LingoPlayer(ILingoServiceProvider serviceProvider, ILingoFrameworkFactory factory, ILingoCastLibsContainer castLibsContainer, ILingoWindow window, ILingoClock lingoClock, ILingoSystem lingoSystem)
+        public LingoPlayer(ILingoServiceProvider serviceProvider, ILingoFrameworkFactory factory, ILingoCastLibsContainer castLibsContainer, ILingoWindow window, ILingoClock lingoClock, ILingoSystem lingoSystem, IAbstResourceManager resourceManager)
         {
+            _csvImporter = new Lazy<CsvImporter>(() => new CsvImporter(resourceManager));
             _actionOnNewMovie = m => { };
             _serviceProvider = serviceProvider;
             Factory = factory;
@@ -290,7 +292,7 @@ namespace LingoEngine.Core
                 movie.SetMouse(newMouse);
         }
 
-       
+
 
 
 


### PR DESCRIPTION
## Summary
- introduce `IAbstResourceManager` with `ReadTextFile` and `ReadBytes`
- implement resource managers for Godot, SDL2, Unity, ImGui and Blazor
- register the resource managers as singletons in each framework setup

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj` *(fails: UnityTexture2D not implemented)*
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj` *(fails: component factory return types)*
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj` *(fails: texture and canvas methods missing)*


------
https://chatgpt.com/codex/tasks/task_e_68b921b910588332947b040614b20662