### PR TITLE
feat: support markdown data for text members

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMDSegment.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMDSegment.cs
@@ -1,0 +1,19 @@
+using AbstUI.Primitives;
+
+namespace AbstUI.Texts;
+
+public class AbstMDSegment
+{
+    public string? FontName { get; set; } = "";
+    public int Size { get; set; }
+    public AColor? Color { get; set; }
+    public string Text { get; set; } = "";
+    public AbstTextAlignment Alignment { get; set; } = AbstTextAlignment.Left;
+    public bool Bold { get; set; }
+    public bool Italic { get; set; }
+    public bool Underline { get; set; }
+    public int MarginLeft { get; set; }
+    public int MarginRight { get; set; }
+    public int StyleId { get; set; } = -1;
+    public bool IsParagraph { get; set; }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownData.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownData.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace AbstUI.Texts;
+
+public class AbstMarkdownData
+{
+    public string Markdown { get; set; } = string.Empty;
+    public string PlainText { get; set; } = string.Empty;
+    public List<AbstMDSegment> Segments { get; set; } = new();
+    public Dictionary<string, AbstTextStyle> Styles { get; set; } = new();
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
@@ -69,6 +69,12 @@ namespace AbstUI.Texts
             DoFastRendering = _styles.Count == 1 && !HasSpecialTags(_markdown);
         }
 
+        /// <summary>
+        /// Sets the markdown data including precomputed styles and segments.
+        /// </summary>
+        public void SetText(AbstMarkdownData data)
+            => SetText(data.Markdown, data.Styles.Values);
+
         /// <summary>Renders markdown text on the canvas starting from the given position.</summary>
         public void Render(IAbstImagePainter canvas, APoint start)
         {

--- a/src/LingoEngine/Texts/ILingoMemberTextBase.cs
+++ b/src/LingoEngine/Texts/ILingoMemberTextBase.cs
@@ -17,6 +17,11 @@ namespace LingoEngine.Texts
         string Text { get; set; }
 
         /// <summary>
+        /// Sets the contents using pre-parsed markdown data.
+        /// </summary>
+        void SetTextMD(AbstMarkdownData data);
+
+        /// <summary>
         /// Returns or sets individual lines of the text, 1-based indexing.
         /// </summary>
         LingoLines Line { get; }


### PR DESCRIPTION
## Summary
- add AbstMarkdownData/AbstMDSegment to describe parsed markdown
- allow text members to accept markdown data via SetTextMD
- extend RtfToMarkdown and AbstMarkdownRenderer for new markdown data
- lazily build paragraph collection from markdown segments when accessed

## Testing
- `dotnet test Test/LingoEngine.Tests/LingoEngine.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b92557d17483329b2f41e34e4b0aad