### PR TITLE
Remove initial line gap across UI backends

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Graphics/BlazorImagePainter.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Graphics/BlazorImagePainter.cs
@@ -211,13 +211,13 @@ public class BlazorImagePainter : IAbstImagePainter
     public void DrawText(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, AbstTextAlignment alignment = AbstTextAlignment.Left, AbstFontStyle style = AbstFontStyle.Regular)
     {
         var pos = position; var txt = text; var fnt = font; var col = color ?? AColors.Black; var fs = fontSize; var w = width; var align = alignment;
+        var fi = _fontManager.GetFontInfo(fnt ?? string.Empty, fs);
         _drawActions.Add((
             () =>
             {
                 if (!AutoResize) return null;
                 float textW = w >= 0 ? w : _fontManager.MeasureTextWidth(txt, fnt ?? string.Empty, fs);
-                var fi = _fontManager.GetFontInfo(fnt ?? string.Empty, fs);
-                return EnsureCapacity((int)(pos.X + textW), (int)(pos.Y + fi.FontHeight));
+                return EnsureCapacity((int)(pos.X + textW), (int)(pos.Y + fi.FontHeight - fi.TopIndentation));
             },
             ctx =>
             {
@@ -227,7 +227,7 @@ public class BlazorImagePainter : IAbstImagePainter
                     AbstTextAlignment.Right => "right",
                     _ => "left"
                 };
-                return _scripts.CanvasDrawText(ctx, pos.X, pos.Y, txt, fnt ?? string.Empty, ToCss(col), fs, alignStr);
+                return _scripts.CanvasDrawText(ctx, pos.X, pos.Y - fi.TopIndentation, txt, fnt ?? string.Empty, ToCss(col), fs, alignStr);
             }
         ));
         MarkDirty();
@@ -236,12 +236,13 @@ public class BlazorImagePainter : IAbstImagePainter
     public void DrawSingleLine(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, int height = -1, AbstTextAlignment alignment = AbstTextAlignment.Left, AbstFontStyle style = AbstFontStyle.Regular)
     {
         var pos = position; var txt = text; var fnt = font; var col = color ?? AColors.Black; var fs = fontSize; var w = width; var h = height; var align = alignment;
+        var fi = _fontManager.GetFontInfo(fnt ?? string.Empty, fs);
         _drawActions.Add((
             () =>
             {
                 if (!AutoResize) return null;
                 int needW = w >= 0 ? w : (int)_fontManager.MeasureTextWidth(txt, fnt ?? string.Empty, fs);
-                int needH = h >= 0 ? h : _fontManager.GetFontInfo(fnt ?? string.Empty, fs).FontHeight;
+                int needH = h >= 0 ? h : fi.FontHeight - fi.TopIndentation;
                 return EnsureCapacity((int)(pos.X + needW), (int)(pos.Y + needH));
             },
             ctx =>
@@ -252,7 +253,7 @@ public class BlazorImagePainter : IAbstImagePainter
                     AbstTextAlignment.Right => "right",
                     _ => "left"
                 };
-                return _scripts.CanvasDrawText(ctx, pos.X, pos.Y, txt, fnt ?? string.Empty, ToCss(col), fs, alignStr);
+                return _scripts.CanvasDrawText(ctx, pos.X, pos.Y - fi.TopIndentation, txt, fnt ?? string.Empty, ToCss(col), fs, alignStr);
             }
         ));
         MarkDirty();

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Styles/AbstGodotFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Styles/AbstGodotFontManager.cs
@@ -62,7 +62,9 @@ namespace AbstUI.LGodot.Styles
                 (_loadedFonts.TryGetValue((fontName, AbstFontStyle.Regular), out var f) ? f : _defaultStyle);
             int height = (int)font.GetHeight(fontSize);
             int ascent = (int)font.GetAscent(fontSize);
-            return new FontInfo(height, height - ascent);
+            int descent = (int)font.GetDescent(fontSize);
+            int lineGap = height - (ascent + descent);
+            return new FontInfo(height, lineGap);
         }
 
         public Dictionary<long, Image> GetAtlasCache(string fontName, int fontSize)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Graphics/UnityImagePainter.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Graphics/UnityImagePainter.cs
@@ -352,13 +352,13 @@ public class UnityImagePainter : IAbstImagePainter
     {
         var pos = position; var txt = text; var col = (color ?? new AColor(0, 0, 0)).ToUnityColor();
         var fnt = font; var fs = fontSize; var w = width; var align = alignment; var st = style;
+        var fi = _fontManager.GetFontInfo(fnt ?? string.Empty, fs);
         _drawActions.Add((
             () =>
             {
                 if (!AutoResize) return null;
                 float textW = w >= 0 ? w : _fontManager.MeasureTextWidth(txt, fnt ?? string.Empty, fs);
-                var fi = _fontManager.GetFontInfo(fnt ?? string.Empty, fs);
-                return EnsureCapacity((int)(pos.X + textW), (int)(pos.Y + fi.Height));
+                return EnsureCapacity((int)(pos.X + textW), (int)(pos.Y + fi.FontHeight - fi.TopIndentation));
             },
             tex =>
             {
@@ -380,7 +380,7 @@ public class UnityImagePainter : IAbstImagePainter
                     AbstTextAlignment.Right => TextAnchor.MiddleRight,
                     _ => TextAnchor.UpperLeft
                 };
-                var rect = new Rect(pos.X, pos.Y, w >= 0 ? w : tex.width, tex.height);
+                var rect = new Rect(pos.X, pos.Y - fi.TopIndentation, w >= 0 ? w : tex.width, tex.height);
                 GUI.Label(rect, txt, style);
                 GL.PopMatrix();
                 tex.ReadPixels(new Rect(0, 0, tex.width, tex.height), 0, 0);
@@ -396,12 +396,13 @@ public class UnityImagePainter : IAbstImagePainter
     {
         var pos = position; var txt = text; var col = (color ?? new AColor(0, 0, 0)).ToUnityColor();
         var fnt = font; var fs = fontSize; var w = width; var h = height; var align = alignment; var st = style;
+        var fi = _fontManager.GetFontInfo(fnt ?? string.Empty, fs);
         _drawActions.Add((
             () =>
             {
                 if (!AutoResize) return null;
                 float textW = w >= 0 ? w : _fontManager.MeasureTextWidth(txt, fnt ?? string.Empty, fs);
-                int textH = h >= 0 ? h : _fontManager.GetFontInfo(fnt ?? string.Empty, fs).Height;
+                int textH = h >= 0 ? h : fi.FontHeight - fi.TopIndentation;
                 return EnsureCapacity((int)(pos.X + textW), (int)(pos.Y + textH));
             },
             tex =>
@@ -424,7 +425,7 @@ public class UnityImagePainter : IAbstImagePainter
                     AbstTextAlignment.Right => TextAnchor.MiddleRight,
                     _ => TextAnchor.UpperLeft
                 };
-                var rect = new Rect(pos.X, pos.Y, w >= 0 ? w : tex.width, h >= 0 ? h : tex.height);
+                var rect = new Rect(pos.X, pos.Y - fi.TopIndentation, w >= 0 ? w : tex.width, h >= 0 ? h : tex.height);
                 GUI.Label(rect, txt, gstyle);
                 GL.PopMatrix();
                 tex.ReadPixels(new Rect(0, 0, tex.width, tex.height), 0, 0);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Styles/UnityFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Styles/UnityFontManager.cs
@@ -62,8 +62,9 @@ namespace AbstUI.LUnity.Styles;
                 (_loadedFonts.TryGetValue((fontName, AbstFontStyle.Regular), out var f) ? f : _defaultFont);
         font.RequestCharactersInTexture(" ", fontSize, FontStyle.Normal);
         font.GetCharacterInfo(' ', out var info, fontSize);
-        int height = Mathf.CeilToInt(info.glyphHeight);
-        int top = Mathf.CeilToInt(info.glyphHeight - info.maxY);
-        return new FontInfo(height, top);
+        int glyphHeight = Mathf.CeilToInt(info.glyphHeight);
+        int lineHeight = Mathf.CeilToInt(font.lineHeight * (fontSize / (float)font.fontSize));
+        int lineGap = Math.Max(0, lineHeight - glyphHeight);
+        return new FontInfo(glyphHeight, lineGap);
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Graphics/SDLImagePainter.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Graphics/SDLImagePainter.cs
@@ -334,6 +334,7 @@ namespace AbstUI.SDL2.Components.Graphics
             if (font == null) return;
             var fnt = font.FontHandle;
             if (fnt == nint.Zero) { font.Release(); return; }
+            var fi = _fontManager.GetFontInfo(fntName ?? string.Empty, fs);
 
             string RenderLine(string line)
             {
@@ -347,7 +348,7 @@ namespace AbstUI.SDL2.Components.Graphics
 
             string[] lines = txt.Split('\n');
             int maxW = 0;
-            int totalH = 0;
+            int totalH = -fi.TopIndentation;
             foreach (var ln in lines)
             {
                 var line = RenderLine(ln);
@@ -380,7 +381,7 @@ namespace AbstUI.SDL2.Components.Graphics
                         surfaces.Add((s, sur.w, sur.h));
                     }
 
-                    int y = (int)pos.Y;
+                    int y = (int)pos.Y - fi.TopIndentation;
                     int boxW = w >= 0 ? w : Math.Max(0, Width - (int)pos.X);
 
                     foreach (var (s, tw, th) in surfaces)
@@ -443,7 +444,7 @@ namespace AbstUI.SDL2.Components.Graphics
                             if (calcH < 0) calcH = fs;
                         }
                     }
-                    return EnsureCapacity((int)pos.X + calcW, (int)pos.Y + calcH);
+                    return EnsureCapacity((int)pos.X + calcW, (int)pos.Y + calcH - fi.TopIndentation);
                 },
                 () =>
                 {
@@ -467,7 +468,7 @@ namespace AbstUI.SDL2.Components.Graphics
                                     break;
                             }
                         }
-                        SDL.SDL_Rect dst = new SDL.SDL_Rect { x = startX, y = (int)pos.Y, w = sur.w, h = sur.h };
+                        SDL.SDL_Rect dst = new SDL.SDL_Rect { x = startX, y = (int)pos.Y - fi.TopIndentation, w = sur.w, h = sur.h };
                         SDL.SDL_RenderCopy(Renderer, tex, nint.Zero, ref dst);
                         SDL.SDL_DestroyTexture(tex);
                     }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputText.cs
@@ -370,7 +370,10 @@ namespace AbstUI.SDL2.Components.Inputs
 
             int ascent = SDL_ttf.TTF_FontAscent(_font.FontHandle);
             int descent = SDL_ttf.TTF_FontDescent(_font.FontHandle);
-            int lineHeight = SDL_ttf.TTF_FontHeight(_font.FontHandle) - (_multiLine ? 1 : 0);
+            int lineSkip = SDL_ttf.TTF_FontLineSkip(_font.FontHandle);
+            int fontHeight = SDL_ttf.TTF_FontHeight(_font.FontHandle);
+            int lineGap = lineSkip - fontHeight;
+            int lineHeight = fontHeight;
             var span = CollectionsMarshal.AsSpan(_codepoints);
             int innerX = (int)X + 4;
             int innerY = (int)Y + 2;
@@ -388,11 +391,11 @@ namespace AbstUI.SDL2.Components.Inputs
             int firstLineY;
             if (_multiLine)
             {
-                firstLineY = innerY - _scrollY;
+                firstLineY = innerY - _scrollY - lineGap;
             }
             else
             {
-                int baseline = (int)Y + ((int)Height + ascent + descent) / 2;
+                int baseline = (int)Y + ((int)Height + ascent + descent) / 2 - lineGap;
                 firstLineY = baseline - ascent - _scrollY;
             }
 
@@ -469,7 +472,10 @@ namespace AbstUI.SDL2.Components.Inputs
             GetCaretPixel(out int caretX, out int caretY);
             int innerWidth = (int)Width - 8;
             int innerHeight = (int)Height - 4;
-            int lineHeight = SDL_ttf.TTF_FontHeight(_font.FontHandle) - (_multiLine ? 1 : 0);
+            int lineSkip = SDL_ttf.TTF_FontLineSkip(_font.FontHandle);
+            int fontHeight = SDL_ttf.TTF_FontHeight(_font.FontHandle);
+            int lineGap = lineSkip - fontHeight;
+            int lineHeight = fontHeight;
             if (caretX - _scrollX > innerWidth)
                 _scrollX = caretX - innerWidth;
             else if (caretX - _scrollX < 0)
@@ -514,10 +520,13 @@ namespace AbstUI.SDL2.Components.Inputs
         {
             if (_atlas == null || _font == null) return _caret;
             var span = CollectionsMarshal.AsSpan(_codepoints);
-            int lineHeight = SDL_ttf.TTF_FontHeight(_font.FontHandle) - (_multiLine ? 1 : 0);
+            int lineSkip = SDL_ttf.TTF_FontLineSkip(_font.FontHandle);
+            int fontHeight = SDL_ttf.TTF_FontHeight(_font.FontHandle);
+            int lineGap = lineSkip - fontHeight;
+            int lineHeight = fontHeight;
             if (px <= 0 && py <= 0 && span.Length == 0) return 0;
 
-            int lineIndex = py / lineHeight;
+            int lineIndex = (py + lineGap) / lineHeight;
             if (lineIndex < 0) lineIndex = 0;
             int currentLine = 0;
             int index = 0;
@@ -551,7 +560,10 @@ namespace AbstUI.SDL2.Components.Inputs
             y = 0;
             if (_atlas == null || _font == null) return;
             var span = CollectionsMarshal.AsSpan(_codepoints);
-            int lineHeight = SDL_ttf.TTF_FontHeight(_font.FontHandle) - (_multiLine ? 1 : 0);
+            int lineSkip = SDL_ttf.TTF_FontLineSkip(_font.FontHandle);
+            int fontHeight = SDL_ttf.TTF_FontHeight(_font.FontHandle);
+            int lineGap = lineSkip - fontHeight;
+            int lineHeight = fontHeight;
             int lineStart = 0;
             int line = 0;
             for (int i = 0; i < _caret; i++)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Styles/SdlFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Styles/SdlFontManager.cs
@@ -81,9 +81,10 @@ public class SdlFontManager : IAbstFontManager
         var user = new object();
         var font = GetTyped(user, string.IsNullOrEmpty(fontName) ? null : fontName, fontSize);
         int height = SDL_ttf.TTF_FontHeight(font.FontHandle);
-        int ascent = SDL_ttf.TTF_FontAscent(font.FontHandle);
+        int lineSkip = SDL_ttf.TTF_FontLineSkip(font.FontHandle);
         font.Release();
-        return new FontInfo(height, height - ascent);
+        int lineGap = lineSkip - height;
+        return new FontInfo(height, lineGap);
     }
 
     // SDL Fonts


### PR DESCRIPTION
## Summary
- eliminate leading line gap in Blazor image painter
- compute line gap from font metrics in SDL, Unity, and Godot font managers
- adjust image painters and SDL input text to offset first line correctly

## Testing
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/AbstUI.GfxVisualTest.SDL2.csproj` *(fails: type or namespace name 'AbstTextAlignment' could not be found)*
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/AbstUI.GfxVisualTest.LUnity.csproj` *(fails: 'UnityTexture2D' does not implement inherited abstract member)*


------
https://chatgpt.com/codex/tasks/task_e_68b93085b69883329644f5717e18f53e