### PR TITLE
Handle mismatched image formats and expose Control node in Godot image painter

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/AbstGodotGfxCanvas.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/AbstGodotGfxCanvas.cs
@@ -24,6 +24,7 @@ namespace AbstUI.LGodot.Components
             canvas.Init(this);
             Size = new Vector2(width, height);
             MouseFilter = MouseFilterEnum.Ignore;
+            AddChild(_painter.Control);
         }
 
         public bool Pixilated
@@ -87,7 +88,6 @@ namespace AbstUI.LGodot.Components
                 Size = new Vector2(_painter.Width, _painter.Height);
                 CustomMinimumSize = Size;
             }
-            DrawTexture(_painter.Texture, Vector2.Zero);
         }
 
         public void Clear(AColor color)


### PR DESCRIPTION
## Summary
- Convert source images to destination format before blitting in `GodotImagePainter`
- Expose a `Control` node for `GodotImagePainter` and attach it in `AbstGodotGfxCanvas`

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/GodotImagePainter.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/AbstGodotGfxCanvas.cs`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b951bc10a083329df785d6e7d1793b