### PR TITLE
Handle whitespace and control symbols in RTF to Markdown conversion

### DIFF
--- a/Test/LingoEngine.Tests/RtfToMarkdownTests.cs
+++ b/Test/LingoEngine.Tests/RtfToMarkdownTests.cs
@@ -159,5 +159,95 @@ public class RtfToMarkdownTests
         Assert.Equal("GAME OVER", data.PlainText);
         Assert.Equal(28, data.Styles["0"].MarginRight);
     }
-}
 
+
+    [Fact]
+    public void Convert_HandlesActionKeyInstructions()
+    {
+        var rtf = @"{\rtf1\ansi\deff0 {\fonttbl{\f0\fswiss Arial;}{\f1\fnil Tahoma *;}}{\colortbl\red0\green0\blue0;\red102\green102\blue102;\red255\green0 \blue0;\red153\green153\blue153;\red187\green187\blue187;\red0\green0\blue224;\red224\green0\blue0;\red224\green0\blue224;}{\stylesheet
+{\s0\fs24 Normal Text;}}\pard \f0\fs24{\pard \i\f1\cf3\expnd4\sl240 Actionkey}{\pard \b\i\f1\cf3\expnd4\sl240  = }{\pard \b\i\f1\cf4\expnd4\sl240 Space}{\pard \b\i\f1\cf3\expnd4\sl240\par
+}{\pard \i\f1\cf3\expnd4\sl240 Press }{\pard \b\i\f1\cf4\expnd4\sl240 P}{\pard \b\i\f1\cf3\expnd4\sl240  }{\pard \i\f1\cf3\expnd4
+\sl240 for Pause}{\pard \b\i\f1\cf3\expnd4\sl240\par
+}{\pard \i\f1\cf3\expnd4\sl240 Press }{\pard \b\i\f1\cf4\expnd4\sl240 S }{\pard \i\f1\cf3\expnd4\sl240 to stop}{\pard \b\i\f1\cf3
+\expnd4\sl240\par
+}{\pard \i\f1\cf3\expnd4\sl240 Press }{\pard \b\i\f1\cf4\expnd4\sl240 ESC}{\pard \b\i\f1\cf3\expnd4\sl240  }{\pard \i\f1\cf3\expnd4
+\sl240 to Quit}}";
+
+        var data = RtfToMarkdown.Convert(rtf);
+
+        Assert.Contains("Actionkey = Space", data.PlainText);
+        Assert.Contains("Press P", data.PlainText);
+        Assert.Contains("for Pause", data.PlainText);
+        Assert.Contains("Press S", data.PlainText);
+        Assert.Contains("to stop", data.PlainText);
+        Assert.Contains("Press ESC", data.PlainText);
+        Assert.Contains("to Quit", data.PlainText);
+    }
+
+    [Fact]
+    public void Convert_HandlesConstructionKitRtf()
+    {
+        var rtf = @"{\rtf1\ansi\deff0 {\fonttbl{\f0\fswiss Arial;}{\f1\fnil Tahoma *;}{\f2\fnil Bikly *;}{\f3\fnil Earth *;}{\f4\fnil Bikly;}{\f5\fnil Arcade *;}
+}{\colortbl\red0\green0\blue0;\red255\green0\blue0;\red170\green170\blue170;\red255\green255\blue255;\red0\green0\blue224;\red224
+\green0\blue0;\red224\green0\blue224;}{\stylesheet{\s0\fs24 Normal Text;}}\pard \f0\fs24{\pard \b\i\f5\fs36\cf3\sl380 Construction Kit}
+}";
+
+        var data = RtfToMarkdown.Convert(rtf);
+
+        Assert.Equal("Construction Kit", data.PlainText);
+    }
+
+    [Fact]
+    public void Convert_HandlesColonEscapes()
+    {
+        var rtf = @"{\rtf1\ansi\deff0 {\fonttbl{\f0\fswiss Arial;}{\f1\fmodern Courier;}}{\colortbl\red0\green0\blue0;\red128\green128\blue128;}{\stylesheet
+{\s0\fs24 Normal Text;}}\pard \f0\fs24{\f1\cf1 ..................................................\:\:Multi BALLS\:\:....................................................
+\par
+..................................................\:\:Black Balls\:\:....................................................}{\pard 
+\plain\f1\fs24\par
+ }{\pard \f1\cf1 ....................................................\:\:Expand\:\:........................................................
+\par
+...................................................\:\:XTRA Balls\:\:.....................................................}{\pard 
+\plain\f1\fs24\par
+}{\pard \f1\cf1 ...................................................\:\:Slow Down\:\:.......................................................}
+{\pard \plain\f1\fs24\par
+}{\pard \f1\cf1 .....................................................\:\:Shoot\:\:...........................................................}
+{\pard \plain\f1\fs24\par
+}{\pard \f1\cf1 ....................................................\:\:Speed Up\:\:......................................................}
+{\pard \plain\f1\fs24\par
+}{\pard \f1\cf1 ......................................................\:\:Magnetic\:\:...................................................}
+{\pard \plain\f1\fs24\par
+}{\pard \f1\cf1 ......................................................\:\:Live\:\:..........................................................}
+{\pard \plain\f1\fs24\par
+}{\pard \f1\cf1 ......................................................\:\:Gates\:\:..........................................................}
+}";
+
+        var data = RtfToMarkdown.Convert(rtf);
+
+        Assert.Contains("::Multi BALLS::", data.PlainText);
+        Assert.Contains("::Black Balls::", data.PlainText);
+        Assert.DoesNotContain("\\", data.PlainText);
+    }
+
+    [Fact]
+    public void Convert_PreservesLeadingTab()
+    {
+        var rtf = "{\\rtf1\\ansi{\\fonttbl{\\f0 Arial;}}{\\colortbl;\\red0\\green0\\blue0;}{\\f0\\fs24\\cf1\\tabAfter}}";
+
+        var data = RtfToMarkdown.Convert(rtf);
+
+        Assert.Equal("\tAfter", data.PlainText);
+    }
+
+    [Fact]
+    public void Convert_ParsesLineHeight()
+    {
+        var rtf = "{\\rtf1\\ansi{\\fonttbl{\\f0 Arial;}}{\\colortbl;\\red0\\green0\\blue0;}\\pard{\\f0\\fs24\\cf1\\sl360 line}}";
+
+        var data = RtfToMarkdown.Convert(rtf);
+
+        Assert.Equal("line", data.PlainText);
+        Assert.Equal(18, data.Segments[0].LineHeight);
+    }
+
+}

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstMarkdownRendererTests.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstMarkdownRendererTests.cs
@@ -33,6 +33,7 @@ public class AbstMarkdownRendererTests
         public int Width { get; set; }
         public bool Pixilated { get; set; }
         public bool AutoResize { get; set; }
+        public string Name { get; set; } = string.Empty;
 
         public void Clear(AColor color) { }
         public void SetPixel(APoint point, AColor color) { }
@@ -118,7 +119,7 @@ public class AbstMarkdownRendererTests
         renderer.Render(painter, start);
 
         Assert.Equal(3, painter.TextPositions.Count);
-        int lineHeight = style.FontSize + 4;
+        int lineHeight = style.FontSize;
         Assert.Equal(start.Y - 4, painter.TextPositions[0].Y);
         Assert.Equal(start.Y + lineHeight, painter.TextPositions[1].Y);
     }
@@ -154,8 +155,44 @@ public class AbstMarkdownRendererTests
         renderer.Render(painter, start);
 
         Assert.Equal(3, painter.TextPositions.Count);
-        int lineHeight = style.FontSize + 4;
+        int lineHeight = style.FontSize;
         Assert.Equal(start.Y - 4, painter.TextPositions[0].Y);
         Assert.Equal(start.Y + lineHeight, painter.TextPositions[1].Y);
+    }
+
+    [Fact]
+    public void FastRender_UsesExplicitLineHeight()
+    {
+        var renderer = CreateRenderer(topIndent: 4);
+        var style = CreateDefaultStyle();
+        style.LineHeight = 20;
+        renderer.SetText("Line1\nLine2", new[] { style });
+        Assert.True(renderer.DoFastRendering);
+
+        var painter = new RecordingPainter();
+        var start = new APoint(0, 20);
+        renderer.Render(painter, start);
+
+        Assert.Equal(2, painter.TextPositions.Count);
+        Assert.Equal(start.Y - 4, painter.TextPositions[0].Y);
+        Assert.Equal(start.Y + style.LineHeight, painter.TextPositions[1].Y);
+    }
+
+    [Fact]
+    public void SlowRender_UsesExplicitLineHeight()
+    {
+        var renderer = CreateRenderer(topIndent: 4);
+        var style = CreateDefaultStyle();
+        style.LineHeight = 20;
+        renderer.SetText("Line1#\nLine2", new[] { style });
+        Assert.False(renderer.DoFastRendering);
+
+        var painter = new RecordingPainter();
+        var start = new APoint(0, 20);
+        renderer.Render(painter, start);
+
+        Assert.Equal(2, painter.TextPositions.Count);
+        Assert.Equal(start.Y - 4, painter.TextPositions[0].Y);
+        Assert.Equal(start.Y + style.LineHeight, painter.TextPositions[1].Y);
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMDSegment.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMDSegment.cs
@@ -12,6 +12,7 @@ public class AbstMDSegment
     public bool Bold { get; set; }
     public bool Italic { get; set; }
     public bool Underline { get; set; }
+    public int LineHeight { get; set; }
     public int MarginLeft { get; set; }
     public int MarginRight { get; set; }
     public int StyleId { get; set; } = -1;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
@@ -143,7 +143,7 @@ namespace AbstUI.Texts
 
                 var fontInfo = _fontManager.GetFontInfo(_fontFamily, usedFontSize);
                 RenderInlineText(content, new APoint(lineX, pos.Y - (firstLine ? fontInfo.TopIndentation : 0)), usedFontSize, bold, italic, underline);
-                int advance = _lineHeight > 0 ? _lineHeight : fontInfo.FontHeight + 4;
+                int advance = _lineHeight > 0 ? _lineHeight : usedFontSize;
                 pos.Offset(0, advance);
                 firstLine = false;
             }
@@ -157,7 +157,7 @@ namespace AbstUI.Texts
             var fontSize = style.FontSize;
             if (fontSize <= 0) fontSize = 12;
             var fontInfo = _fontManager.GetFontInfo(style.Font, fontSize);
-            int lineHeight = style.LineHeight > 0 ? style.LineHeight : fontInfo.FontHeight + 4;
+            int lineHeight = style.LineHeight > 0 ? style.LineHeight : fontSize;
             bool firstLine = true;
 
             // 1) measure max width of all lines


### PR DESCRIPTION
## Summary
- Preserve intended leading whitespace and tabs when converting RTF to markdown
- Strip miscellaneous control words and translate escaped symbols (like `\:`) into plain text
- Add regression tests covering provided RTF samples and tab preservation
- Parse line-height control words and capture them in markdown segments
- Respect `LineHeight` in `AbstMarkdownRenderer`, defaulting to font size when unspecified

## Testing
- `dotnet format --verify-no-changes LingoEngine.sln --include WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstMarkdownRendererTests.cs`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b95cf943e88332972ba37130fbeee7