### PR TITLE
Optimize SDL redraw to avoid unnecessary renders

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlScrollViewer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlScrollViewer.cs
@@ -87,7 +87,7 @@ namespace AbstUI.SDL2.Components.Containers
 
             bool needRender = _texture == nint.Zero || _texW != w || _texH != h ||
                                _lastScrollH != ScrollHorizontal || _lastScrollV != ScrollVertical;
-            //if (needRender)
+            if (needRender)
             {
                 if (_texture != nint.Zero)
                     SDL.SDL_DestroyTexture(_texture);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Core/AbstSDLRenderResult.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Core/AbstSDLRenderResult.cs
@@ -12,7 +12,7 @@ public struct AbstSDLRenderResult
     };
 
     public static implicit operator AbstSDLRenderResult(nint texture)
-       => new AbstSDLRenderResult { Texture = texture, DoRender = texture != nint.Zero };
+       => new AbstSDLRenderResult { Texture = texture, DoRender = false };
 
     public static explicit operator nint(AbstSDLRenderResult r) => r.Texture;
 }


### PR DESCRIPTION
## Summary
- stop implicit SDL render result from always requesting redraws
- only rebuild scroll viewer textures when size or scroll position changes

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Core/AbstSDLRenderResult.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlScrollViewer.cs --verify-no-changes --verbosity diagnostic`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj` *(fails: 'AbstMarkdownRendererTests.RecordingPainter' does not implement interface member 'IAbstImagePainter.Name')*


------
https://chatgpt.com/codex/tasks/task_e_68b964b4510083329e320a52d2f1fadc