### PR TITLE
Optimize SDL redraw to avoid unnecessary renders

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlScrollViewer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlScrollViewer.cs
@@ -17,12 +17,90 @@ namespace AbstUI.SDL2.Components.Containers
         {
         }
 
-        public AMargin Margin { get; set; } = AMargin.Zero;
-        public float ScrollHorizontal { get; set; }
-        public float ScrollVertical { get; set; }
-        public bool ClipContents { get; set; } = true;
-        public AbstScrollbarMode ScrollbarModeH { get; set; } = AbstScrollbarMode.Auto;
-        public AbstScrollbarMode ScrollbarModeV { get; set; } = AbstScrollbarMode.Auto;
+        private AMargin _margin = AMargin.Zero;
+        public AMargin Margin
+        {
+            get => _margin;
+            set
+            {
+                if (!_margin.Equals(value))
+                {
+                    _margin = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private float _scrollHorizontal;
+        public float ScrollHorizontal
+        {
+            get => _scrollHorizontal;
+            set
+            {
+                if (Math.Abs(_scrollHorizontal - value) > float.Epsilon)
+                {
+                    _scrollHorizontal = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private float _scrollVertical;
+        public float ScrollVertical
+        {
+            get => _scrollVertical;
+            set
+            {
+                if (Math.Abs(_scrollVertical - value) > float.Epsilon)
+                {
+                    _scrollVertical = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private bool _clipContents = true;
+        public bool ClipContents
+        {
+            get => _clipContents;
+            set
+            {
+                if (_clipContents != value)
+                {
+                    _clipContents = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private AbstScrollbarMode _scrollbarModeH = AbstScrollbarMode.Auto;
+        public AbstScrollbarMode ScrollbarModeH
+        {
+            get => _scrollbarModeH;
+            set
+            {
+                if (_scrollbarModeH != value)
+                {
+                    _scrollbarModeH = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private AbstScrollbarMode _scrollbarModeV = AbstScrollbarMode.Auto;
+        public AbstScrollbarMode ScrollbarModeV
+        {
+            get => _scrollbarModeV;
+            set
+            {
+                if (_scrollbarModeV != value)
+                {
+                    _scrollbarModeV = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
         protected float ContentWidth { get; set; }
         protected float ContentHeight { get; set; }
 
@@ -46,10 +124,61 @@ namespace AbstUI.SDL2.Components.Containers
         private float _dragRatioH;
         private float _dragRatioV;
 
-        public AColor Color_Handle { get; set; } = AColor.FromRGBA(100, 100, 100);
-        public AColor Color_Bars_Bg { get; set; } = AColor.FromRGBA(255, 255, 255, 0);
-        public AColor Color_ScollBorder { get; set; } = AColor.FromRGBA(255, 255, 255, 0);
-        public AColor BackgroundColor { get; set; } = AColor.FromRGBA(255, 255, 255, 0);
+        private AColor _colorHandle = AColor.FromRGBA(100, 100, 100);
+        public AColor Color_Handle
+        {
+            get => _colorHandle;
+            set
+            {
+                if (!_colorHandle.Equals(value))
+                {
+                    _colorHandle = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private AColor _colorBarsBg = AColor.FromRGBA(255, 255, 255, 0);
+        public AColor Color_Bars_Bg
+        {
+            get => _colorBarsBg;
+            set
+            {
+                if (!_colorBarsBg.Equals(value))
+                {
+                    _colorBarsBg = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private AColor _colorScollBorder = AColor.FromRGBA(255, 255, 255, 0);
+        public AColor Color_ScollBorder
+        {
+            get => _colorScollBorder;
+            set
+            {
+                if (!_colorScollBorder.Equals(value))
+                {
+                    _colorScollBorder = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private AColor _backgroundColor = AColor.FromRGBA(255, 255, 255, 0);
+        public AColor BackgroundColor
+        {
+            get => _backgroundColor;
+            set
+            {
+                if (!_backgroundColor.Equals(value))
+                {
+                    _backgroundColor = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
         protected abstract void RenderContent(AbstSDLRenderContext context);
 
         protected virtual void HandleContentEvent(AbstSDLEvent e)
@@ -87,7 +216,7 @@ namespace AbstUI.SDL2.Components.Containers
 
             bool needRender = _texture == nint.Zero || _texW != w || _texH != h ||
                                _lastScrollH != ScrollHorizontal || _lastScrollV != ScrollVertical;
-            //if (needRender)
+            if (needRender)
             {
                 if (_texture != nint.Zero)
                     SDL.SDL_DestroyTexture(_texture);


### PR DESCRIPTION
## Summary
- restore SDL render result implicit operator to request a redraw when returning a texture
- queue redraws in SDL scroll viewer whenever public properties change

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Core/AbstSDLRenderResult.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlScrollViewer.cs --verbosity diagnostic`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj` *(fails: 'AbstMarkdownRendererTests.RecordingPainter' does not implement interface member 'IAbstImagePainter.Name')*

------
https://chatgpt.com/codex/tasks/task_e_68b964b4510083329e320a52d2f1fadc