### PR TITLE
Propagate redraw from SDL inputs

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlScrollViewer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlScrollViewer.cs
@@ -17,12 +17,90 @@ namespace AbstUI.SDL2.Components.Containers
         {
         }
 
-        public AMargin Margin { get; set; } = AMargin.Zero;
-        public float ScrollHorizontal { get; set; }
-        public float ScrollVertical { get; set; }
-        public bool ClipContents { get; set; } = true;
-        public AbstScrollbarMode ScrollbarModeH { get; set; } = AbstScrollbarMode.Auto;
-        public AbstScrollbarMode ScrollbarModeV { get; set; } = AbstScrollbarMode.Auto;
+        private AMargin _margin = AMargin.Zero;
+        public AMargin Margin
+        {
+            get => _margin;
+            set
+            {
+                if (!_margin.Equals(value))
+                {
+                    _margin = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private float _scrollHorizontal;
+        public float ScrollHorizontal
+        {
+            get => _scrollHorizontal;
+            set
+            {
+                if (Math.Abs(_scrollHorizontal - value) > float.Epsilon)
+                {
+                    _scrollHorizontal = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private float _scrollVertical;
+        public float ScrollVertical
+        {
+            get => _scrollVertical;
+            set
+            {
+                if (Math.Abs(_scrollVertical - value) > float.Epsilon)
+                {
+                    _scrollVertical = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private bool _clipContents = true;
+        public bool ClipContents
+        {
+            get => _clipContents;
+            set
+            {
+                if (_clipContents != value)
+                {
+                    _clipContents = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private AbstScrollbarMode _scrollbarModeH = AbstScrollbarMode.Auto;
+        public AbstScrollbarMode ScrollbarModeH
+        {
+            get => _scrollbarModeH;
+            set
+            {
+                if (_scrollbarModeH != value)
+                {
+                    _scrollbarModeH = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private AbstScrollbarMode _scrollbarModeV = AbstScrollbarMode.Auto;
+        public AbstScrollbarMode ScrollbarModeV
+        {
+            get => _scrollbarModeV;
+            set
+            {
+                if (_scrollbarModeV != value)
+                {
+                    _scrollbarModeV = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
         protected float ContentWidth { get; set; }
         protected float ContentHeight { get; set; }
 
@@ -46,10 +124,61 @@ namespace AbstUI.SDL2.Components.Containers
         private float _dragRatioH;
         private float _dragRatioV;
 
-        public AColor Color_Handle { get; set; } = AColor.FromRGBA(100, 100, 100);
-        public AColor Color_Bars_Bg { get; set; } = AColor.FromRGBA(255, 255, 255, 0);
-        public AColor Color_ScollBorder { get; set; } = AColor.FromRGBA(255, 255, 255, 0);
-        public AColor BackgroundColor { get; set; } = AColor.FromRGBA(255, 255, 255, 0);
+        private AColor _colorHandle = AColor.FromRGBA(100, 100, 100);
+        public AColor Color_Handle
+        {
+            get => _colorHandle;
+            set
+            {
+                if (!_colorHandle.Equals(value))
+                {
+                    _colorHandle = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private AColor _colorBarsBg = AColor.FromRGBA(255, 255, 255, 0);
+        public AColor Color_Bars_Bg
+        {
+            get => _colorBarsBg;
+            set
+            {
+                if (!_colorBarsBg.Equals(value))
+                {
+                    _colorBarsBg = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private AColor _colorScollBorder = AColor.FromRGBA(255, 255, 255, 0);
+        public AColor Color_ScollBorder
+        {
+            get => _colorScollBorder;
+            set
+            {
+                if (!_colorScollBorder.Equals(value))
+                {
+                    _colorScollBorder = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
+
+        private AColor _backgroundColor = AColor.FromRGBA(255, 255, 255, 0);
+        public AColor BackgroundColor
+        {
+            get => _backgroundColor;
+            set
+            {
+                if (!_backgroundColor.Equals(value))
+                {
+                    _backgroundColor = value;
+                    ComponentContext.QueueRedraw(this);
+                }
+            }
+        }
         protected abstract void RenderContent(AbstSDLRenderContext context);
 
         protected virtual void HandleContentEvent(AbstSDLEvent e)
@@ -87,7 +216,7 @@ namespace AbstUI.SDL2.Components.Containers
 
             bool needRender = _texture == nint.Zero || _texW != w || _texH != h ||
                                _lastScrollH != ScrollHorizontal || _lastScrollV != ScrollVertical;
-            //if (needRender)
+            if (needRender)
             {
                 if (_texture != nint.Zero)
                     SDL.SDL_DestroyTexture(_texture);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputNumber.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputNumber.cs
@@ -142,6 +142,8 @@ internal class AbstSdlInputNumber<TValue> : AbstSdlComponent, IAbstFrameworkInpu
                 return;
             }
         }
+        if (e.StopPropagation)
+            ComponentContext.QueueRedraw(this);
     }
 
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputText.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputText.cs
@@ -48,6 +48,7 @@ namespace AbstUI.SDL2.Components.Inputs
                 _selectionStart = -1;
                 ValueChanged?.Invoke();
                 AdjustScroll();
+                ComponentContext.QueueRedraw(this);
             }
         }
         public virtual int MaxLength { get; set; }
@@ -65,7 +66,7 @@ namespace AbstUI.SDL2.Components.Inputs
         public bool HasFocus => _focused;
 
 
-        
+
         public event Action? ValueChanged;
         public AbstSdlInputText(AbstSdlComponentFactory factory, bool multiLine) : base(factory)
         {
@@ -201,7 +202,7 @@ namespace AbstUI.SDL2.Components.Inputs
 
             SDL.SDL_RenderSetClipRect(renderer, nint.Zero);
 
-            return AbstSDLRenderResult.RequireRender();
+            return _focused ? AbstSDLRenderResult.RequireRender() : default;
         }
 
 
@@ -281,6 +282,9 @@ namespace AbstUI.SDL2.Components.Inputs
                     HandleKeyDown(e, ev);
                     break;
             }
+
+            if (e.StopPropagation)
+                ComponentContext.QueueRedraw(this);
         }
 
         private void HandleKeyDown(AbstSDLEvent e, SDL.SDL_Event ev)
@@ -454,7 +458,7 @@ namespace AbstUI.SDL2.Components.Inputs
 
         protected virtual bool IsAllowedText(string text) => TextValidate(text);
 
-       
+
         protected virtual void AdjustScroll()
         {
             if (_atlas == null || _font == null) return;
@@ -662,6 +666,7 @@ namespace AbstUI.SDL2.Components.Inputs
                 _blinkStart = SDL.SDL_GetTicks();
             else
                 _selectionStart = -1;
+            ComponentContext.QueueRedraw(this);
         }
 
         public void SetCaretPosition(int position)
@@ -669,6 +674,7 @@ namespace AbstUI.SDL2.Components.Inputs
             _caret = Math.Clamp(position, 0, _codepoints.Count);
             _selectionStart = -1;
             AdjustScroll();
+            ComponentContext.QueueRedraw(this);
         }
 
         public void SetSelection(int start, int end)
@@ -678,6 +684,7 @@ namespace AbstUI.SDL2.Components.Inputs
             if (_selectionStart == _caret)
                 _selectionStart = -1;
             AdjustScroll();
+            ComponentContext.QueueRedraw(this);
         }
 
         public void SetSelection(Range range)
@@ -685,6 +692,6 @@ namespace AbstUI.SDL2.Components.Inputs
             SetSelection(range.Start.GetOffset(_codepoints.Count), range.End.GetOffset(_codepoints.Count));
         }
 
-       
+
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlSpinBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlSpinBox.cs
@@ -50,6 +50,7 @@ internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IFramew
     public AbstSdlSpinBox(AbstSdlComponentFactory factory) : base(factory)
     {
         _number = new AbstSdlInputNumber<float>(factory);
+        _number.ComponentContext.SetParents(ComponentContext);
         _number.ValueChanged += () => ValueChanged?.Invoke();
         Width = 50;
         Height = 20;
@@ -89,11 +90,14 @@ internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IFramew
                 var dir = e.ComponentTop > Height / 2 ? -1 : 1;
                 Value += Step * dir;
                 e.StopPropagation = true;
+                ComponentContext.QueueRedraw(this);
                 return;
             }
         }
 
         _number.HandleEvent(e);
+        if (e.StopPropagation)
+            ComponentContext.QueueRedraw(this);
     }
 
     private SDL.SDL_Rect GetUpRect() => new SDL.SDL_Rect
@@ -121,7 +125,7 @@ internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IFramew
         _number.Y = Y;
         _number.Width = Width - ButtonWidth;
         _number.Height = Height;
-        _number.Render(context);
+        var result = _number.Render(context);
 
         var renderer = context.Renderer;
         var up = GetUpRect();
@@ -138,7 +142,7 @@ internal class AbstSdlSpinBox : AbstSdlComponent, IAbstFrameworkSpinBox, IFramew
         SDL.SDL_RenderDrawLine(renderer, down.x + 3, down.y + 3, down.x + down.w / 2, down.y + down.h - 3);
         SDL.SDL_RenderDrawLine(renderer, down.x + down.w - 3, down.y + 3, down.x + down.w / 2, down.y + down.h - 3);
 
-        return AbstSDLRenderResult.RequireRender();
+        return result;
     }
 
     public override void Dispose()

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Menus/AbstSdlMenuItem.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Menus/AbstSdlMenuItem.cs
@@ -25,6 +25,6 @@ namespace AbstUI.SDL2.Components.Menus
         public void Invoke() => Activated?.Invoke();
         public override void Dispose() => base.Dispose();
 
-        public override AbstSDLRenderResult Render(AbstSDLRenderContext context) => AbstSDLRenderResult.RequireRender();
+        public override AbstSDLRenderResult Render(AbstSDLRenderContext context) => default;
     }
 }


### PR DESCRIPTION
## Summary
- queue redraw when text input state changes instead of redrawing every frame
- forward redraw requests from numeric and spin box inputs and reuse child render results
- avoid unnecessary render requests from unimplemented menu items

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputText.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlSpinBox.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Inputs/AbstSdlInputNumber.cs WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Menus/AbstSdlMenuItem.cs --verbosity diagnostic`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj` *(fails: 'AbstMarkdownRendererTests.RecordingPainter' does not implement interface member 'IAbstImagePainter.Name')*

------
https://chatgpt.com/codex/tasks/task_e_68b964b4510083329e320a52d2f1fadc