### PR TITLE
Fix baseline and width handling in AbstMarkdownRenderer

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/Docs/Fonts.md
+++ b/WillMoveToOwnRepo/AbstUI/Docs/Fonts.md
@@ -32,7 +32,7 @@ Each font manager maintains a default font used when no name is provided. This d
 
 All font managers expose methods to measure text width and obtain basic metrics:
 
-- `MeasureTextWidth(string text, string fontName, int fontSize)`
-- `GetFontInfo(string fontName, int fontSize)`
+- `MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)`
+- `GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)`
 
 These APIs respect the previously added fonts and their styles, enabling consistent text layout across backends.

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstMarkdownRendererTests.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstMarkdownRendererTests.cs
@@ -11,9 +11,15 @@ public class AbstMarkdownRendererTests
     private class TestFontManager : IAbstFontManager
     {
         private readonly int _topIndent;
+        private readonly Dictionary<string, int> _topIndents;
+        private readonly Dictionary<string, int> _extraHeights;
 
-        public TestFontManager(int topIndent = 0)
-            => _topIndent = topIndent;
+        public TestFontManager(int topIndent = 0, Dictionary<string, int>? topIndents = null, Dictionary<string, int>? extraHeights = null)
+        {
+            _topIndent = topIndent;
+            _topIndents = topIndents ?? new();
+            _extraHeights = extraHeights ?? new();
+        }
 
         public IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular) => this;
         public void LoadAll() { }
@@ -21,13 +27,19 @@ public class AbstMarkdownRendererTests
         public T GetDefaultFont<T>() where T : class => null!;
         public void SetDefaultFont<T>(T font) where T : class { }
         public IEnumerable<string> GetAllNames() => System.Array.Empty<string>();
-        public float MeasureTextWidth(string text, string fontName, int fontSize) => text.Length * fontSize;
-        public FontInfo GetFontInfo(string fontName, int fontSize) => new(fontSize, _topIndent);
+        public float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular) => text.Length * fontSize;
+        public FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
+        {
+            int ascent = _topIndents.TryGetValue(fontName, out var ti) ? ti : _topIndent;
+            int extra = _extraHeights.TryGetValue(fontName, out var h) ? h : 0;
+            return new(fontSize + extra, ascent);
+        }
     }
 
     private class RecordingPainter : IAbstImagePainter
     {
         public List<APoint> TextPositions { get; } = new();
+        public List<int> FontSizes { get; } = new();
 
         public int Height { get; set; }
         public int Width { get; set; }
@@ -43,9 +55,15 @@ public class AbstMarkdownRendererTests
         public void DrawArc(APoint center, float radius, float startDeg, float endDeg, int segments, AColor color, float width = 1) { }
         public void DrawPolygon(IReadOnlyList<APoint> points, AColor color, bool filled = true, float width = 1) { }
         public void DrawText(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, AbstTextAlignment alignment = AbstTextAlignment.Left, AbstFontStyle style = AbstFontStyle.Regular)
-            => TextPositions.Add(position);
+        {
+            TextPositions.Add(position);
+            FontSizes.Add(fontSize);
+        }
         public void DrawSingleLine(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, int height = -1, AbstTextAlignment alignment = AbstTextAlignment.Left, AbstFontStyle style = AbstFontStyle.Regular)
-            => TextPositions.Add(position);
+        {
+            TextPositions.Add(position);
+            FontSizes.Add(fontSize);
+        }
         public void DrawPicture(byte[] data, int width, int height, APoint position, APixelFormat format) { }
         public void DrawPicture(IAbstTexture2D texture, int width, int height, APoint position) { }
         public IAbstTexture2D GetTexture(string? name = null) => null!;
@@ -53,8 +71,8 @@ public class AbstMarkdownRendererTests
         public void Dispose() { }
     }
 
-    private static AbstMarkdownRenderer CreateRenderer(int topIndent = 0)
-        => new(new TestFontManager(topIndent));
+    private static AbstMarkdownRenderer CreateRenderer(int topIndent = 0, Dictionary<string, int>? topIndents = null, Dictionary<string, int>? extraHeights = null)
+        => new(new TestFontManager(topIndent, topIndents, extraHeights));
 
     private static AbstTextStyle CreateDefaultStyle()
         => new() { Name = "default", Font = "Arial", FontSize = 12, Color = AColors.Black };
@@ -157,7 +175,7 @@ public class AbstMarkdownRendererTests
         Assert.Equal(3, painter.TextPositions.Count);
         int lineHeight = style.FontSize;
         Assert.Equal(start.Y - 4, painter.TextPositions[0].Y);
-        Assert.Equal(start.Y + lineHeight, painter.TextPositions[1].Y);
+        Assert.Equal(start.Y + lineHeight - 4, painter.TextPositions[1].Y);
     }
 
     [Fact]
@@ -193,6 +211,77 @@ public class AbstMarkdownRendererTests
 
         Assert.Equal(2, painter.TextPositions.Count);
         Assert.Equal(start.Y - 4, painter.TextPositions[0].Y);
-        Assert.Equal(start.Y + style.LineHeight, painter.TextPositions[1].Y);
+        Assert.Equal(start.Y + style.LineHeight - 4, painter.TextPositions[1].Y);
+    }
+
+    [Fact]
+    public void SlowRender_HandlesInlineFontSizeChanges()
+    {
+        var renderer = CreateRenderer();
+        renderer.SetText("{{FONT-SIZE:14}}Enter your {{FONT-SIZE:18}}Name", new[] { CreateDefaultStyle() });
+        Assert.False(renderer.DoFastRendering);
+
+        var painter = new RecordingPainter();
+        renderer.Render(painter, new APoint(0, 0));
+
+        Assert.Equal(2, painter.TextPositions.Count);
+        Assert.Equal(0, painter.TextPositions[0].X);
+        Assert.Equal(14, painter.FontSizes[0]);
+        // width of "Enter your " (11 characters) at size 14 -> 154
+        Assert.Equal(154, painter.TextPositions[1].X);
+        Assert.Equal(18, painter.FontSizes[1]);
+    }
+
+    [Fact]
+    public void SlowRender_AlignsSegments_WithDifferentTopIndentations()
+    {
+        var topIndents = new Dictionary<string, int>
+        {
+            ["A"] = 4,
+            ["B"] = 10
+        };
+        var renderer = CreateRenderer(topIndents: topIndents);
+        var style = new AbstTextStyle { Name = "default", Font = "A", FontSize = 12 };
+        renderer.SetText("Hello {{FONT-FAMILY:B}}g{{FONT-FAMILY:A}}!", new[] { style });
+        Assert.False(renderer.DoFastRendering);
+
+        var painter = new RecordingPainter();
+        renderer.Render(painter, new APoint(0, 20));
+
+        Assert.Equal(3, painter.TextPositions.Count);
+        Assert.Equal(16, painter.TextPositions[0].Y);
+        Assert.Equal(10, painter.TextPositions[1].Y);
+        Assert.Equal(16, painter.TextPositions[2].Y);
+    }
+
+    [Fact]
+    public void SlowRender_RespectsFontHeight_ForLineAdvance()
+    {
+        var renderer = CreateRenderer(extraHeights: new() { ["Arial"] = 4 });
+        renderer.SetText("Line1#\nLine2", new[] { CreateDefaultStyle() });
+        Assert.False(renderer.DoFastRendering);
+
+        var painter = new RecordingPainter();
+        renderer.Render(painter, new APoint(0, 0));
+
+        Assert.Equal(2, painter.TextPositions.Count);
+        Assert.Equal(0, painter.TextPositions[0].Y);
+        Assert.Equal(16, painter.TextPositions[1].Y);
+    }
+
+    [Fact]
+    public void SlowRender_SkipsEmptyLines()
+    {
+        var renderer = CreateRenderer(topIndent: 4);
+        var style = CreateDefaultStyle();
+        renderer.SetText("Line1#\n\nLine3", new[] { style });
+        Assert.False(renderer.DoFastRendering);
+
+        var painter = new RecordingPainter();
+        renderer.Render(painter, new APoint(0, 20));
+
+        Assert.Equal(2, painter.TextPositions.Count);
+        Assert.Equal(16, painter.TextPositions[0].Y);
+        Assert.Equal(40, painter.TextPositions[1].Y);
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Styles/AbstBlazorFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Styles/AbstBlazorFontManager.cs
@@ -4,30 +4,30 @@ using System.Linq;
 
 namespace AbstUI.Blazor.Styles;
 
-    public class AbstBlazorFontManager : IAbstFontManager
-    {
-        private readonly List<(string Name, AbstFontStyle Style, string File)> _fontsToLoad = new();
-        private readonly Dictionary<(string Name, AbstFontStyle Style), string> _loadedFonts = new();
-        private string _defaultFont = "sans-serif";
+public class AbstBlazorFontManager : IAbstFontManager
+{
+    private readonly List<(string Name, AbstFontStyle Style, string File)> _fontsToLoad = new();
+    private readonly Dictionary<(string Name, AbstFontStyle Style), string> _loadedFonts = new();
+    private string _defaultFont = "sans-serif";
 
     public event Action? FontsChanged;
 
-      public IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular)
-      {
-          _fontsToLoad.Add((name, style, pathAndName));
-          return this;
-      }
+    public IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular)
+    {
+        _fontsToLoad.Add((name, style, pathAndName));
+        return this;
+    }
 
     public void LoadAll()
     {
-          foreach (var font in _fontsToLoad)
-              _loadedFonts[(font.Name, font.Style)] = font.File;
+        foreach (var font in _fontsToLoad)
+            _loadedFonts[(font.Name, font.Style)] = font.File;
         _fontsToLoad.Clear();
         FontsChanged?.Invoke();
     }
 
-      public T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class
-          => _loadedFonts.TryGetValue((name, style), out var font) ? font as T : null;
+    public T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class
+        => _loadedFonts.TryGetValue((name, style), out var font) ? font as T : null;
 
     public T GetDefaultFont<T>() where T : class
         => (_defaultFont as T)!;
@@ -35,11 +35,11 @@ namespace AbstUI.Blazor.Styles;
     public void SetDefaultFont<T>(T font) where T : class
         => _defaultFont = font?.ToString() ?? string.Empty;
 
-      public IEnumerable<string> GetAllNames() => _loadedFonts.Keys.Select(k => k.Name).Distinct();
+    public IEnumerable<string> GetAllNames() => _loadedFonts.Keys.Select(k => k.Name).Distinct();
 
-    public float MeasureTextWidth(string text, string fontName, int fontSize)
+    public float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
         => text.Length * fontSize * 0.6f;
 
-    public FontInfo GetFontInfo(string fontName, int fontSize)
-        => new(fontSize, 0);
+    public FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
+        => new(fontSize, fontSize);
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/GodotImagePainterToTexture.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/GodotImagePainterToTexture.cs
@@ -428,7 +428,6 @@ namespace AbstUI.LGodot.Components.Graphics
                     var height = font.GetHeight();
                     var lineYOffset = height - asc;
 
-                    var isFirstLine = true;
                     foreach (var raw in lines)
                     {
                         var line = TrimToWidth(raw, boxW, ts, rids, fs);   // <= see helper below
@@ -441,7 +440,7 @@ namespace AbstUI.LGodot.Components.Graphics
                         float lineW = lineSize.X;
                         var ascent = ts.FontGetAscent(fr, fs);
                         var descent = ts.FontGetDescent(fr, fs);
-                        var baseline = isFirstLine ? y + ascent - descent + 2 : y + ascent; //+2 is a FIX for some fonts
+                        var baseline = y + ascent;
 
                         // per-line horizontal alignment
                         float xOff = 0f;
@@ -494,7 +493,6 @@ namespace AbstUI.LGodot.Components.Graphics
 
                         ts.FreeRid(shaped);
                         y += (int)MathF.Ceiling((float)(ascent + descent));  // advance to next line
-                        isFirstLine = false;
 
                     }
                 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Styles/AbstGodotFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Styles/AbstGodotFontManager.cs
@@ -49,20 +49,22 @@ namespace AbstUI.LGodot.Styles
 
         public IEnumerable<string> GetAllNames() => _loadedFonts.Keys.Select(k => k.Name).Distinct();
 
-        public float MeasureTextWidth(string text, string fontName, int fontSize)
+        public float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
         {
-            var font = string.IsNullOrEmpty(fontName) ? _defaultStyle :
-                (_loadedFonts.TryGetValue((fontName, AbstFontStyle.Regular), out var f) ? f : _defaultStyle);
+            var font = string.IsNullOrEmpty(fontName)
+                ? _defaultStyle
+                : (_loadedFonts.TryGetValue((fontName, style), out var f) ? f : _defaultStyle);
             return font.GetStringSize(text, HorizontalAlignment.Left, -1, fontSize).X;
         }
 
-        public FontInfo GetFontInfo(string fontName, int fontSize)
+        public FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
         {
-            var font = string.IsNullOrEmpty(fontName) ? _defaultStyle :
-                (_loadedFonts.TryGetValue((fontName, AbstFontStyle.Regular), out var f) ? f : _defaultStyle);
+            var font = string.IsNullOrEmpty(fontName)
+                ? _defaultStyle
+                : (_loadedFonts.TryGetValue((fontName, style), out var f) ? f : _defaultStyle);
             int height = (int)font.GetHeight(fontSize);
             int ascent = (int)font.GetAscent(fontSize);
-            return new FontInfo(height, height - ascent);
+            return new FontInfo(height, ascent);
         }
 
         public Dictionary<long, Image> GetAtlasCache(string fontName, int fontSize)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Styles/UnityFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Styles/UnityFontManager.cs
@@ -7,33 +7,33 @@ namespace AbstUI.LUnity.Styles;
 /// <summary>
 /// Basic font manager that loads Unity <see cref="Font"/> assets and exposes them to the engine.
 /// </summary>
-    internal class UnityFontManager : IAbstFontManager
-    {
-        private readonly List<(string Name, AbstFontStyle Style, string FileName)> _fontsToLoad = new();
-        private readonly Dictionary<(string Name, AbstFontStyle Style), Font> _loadedFonts = new();
+internal class UnityFontManager : IAbstFontManager
+{
+    private readonly List<(string Name, AbstFontStyle Style, string FileName)> _fontsToLoad = new();
+    private readonly Dictionary<(string Name, AbstFontStyle Style), Font> _loadedFonts = new();
 
-        public IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular)
-        {
-            _fontsToLoad.Add((name, style, pathAndName));
-            return this;
-        }
+    public IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular)
+    {
+        _fontsToLoad.Add((name, style, pathAndName));
+        return this;
+    }
 
     public void LoadAll()
     {
-            foreach (var font in _fontsToLoad)
-            {
+        foreach (var font in _fontsToLoad)
+        {
             // Try loading from Resources first; fall back to built-in Tahoma
 
             var loaded = UnityEngine.Resources.Load<Font>(font.FileName) ?? UnityEngine.Resources.GetBuiltinResource<Font>("Tahoma.ttf");
-                _loadedFonts[(font.Name, font.Style)] = loaded;
-            }
+            _loadedFonts[(font.Name, font.Style)] = loaded;
+        }
         _fontsToLoad.Clear();
     }
 
-        public T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class
-            => _loadedFonts.TryGetValue((name, style), out var f) ? f as T : null;
+    public T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class
+        => _loadedFonts.TryGetValue((name, style), out var f) ? f as T : null;
 
-        public Font GetTyped(string name, AbstFontStyle style = AbstFontStyle.Regular) => _loadedFonts[(name, style)];
+    public Font GetTyped(string name, AbstFontStyle style = AbstFontStyle.Regular) => _loadedFonts[(name, style)];
 
     private Font _defaultFont = UnityEngine.Resources.GetBuiltinResource<Font>("Tahoma.ttf");
 
@@ -41,30 +41,36 @@ namespace AbstUI.LUnity.Styles;
 
     public void SetDefaultFont<T>(T font) where T : class => _defaultFont = (font as Font)!;
 
-        public IEnumerable<string> GetAllNames() => _loadedFonts.Keys.Select(k => k.Name).Distinct();
+    public IEnumerable<string> GetAllNames() => _loadedFonts.Keys.Select(k => k.Name).Distinct();
 
-    public float MeasureTextWidth(string text, string fontName, int fontSize)
+    public float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
     {
-            var font = string.IsNullOrEmpty(fontName) ? _defaultFont :
-                (_loadedFonts.TryGetValue((fontName, AbstFontStyle.Regular), out var f) ? f : _defaultFont);
-        font.RequestCharactersInTexture(text, fontSize, FontStyle.Normal);
+        var font = string.IsNullOrEmpty(fontName) ? _defaultFont :
+            (_loadedFonts.TryGetValue((fontName, style), out var f) ? f : _defaultFont);
+        var unityStyle = FontStyle.Normal;
+        if ((style & AbstFontStyle.Bold) != 0) unityStyle |= FontStyle.Bold;
+        if ((style & AbstFontStyle.Italic) != 0) unityStyle |= FontStyle.Italic;
+        font.RequestCharactersInTexture(text, fontSize, unityStyle);
         float width = 0f;
         foreach (var ch in text)
         {
-            if (font.GetCharacterInfo(ch, out var info, fontSize))
+            if (font.GetCharacterInfo(ch, out var info, fontSize, unityStyle))
                 width += info.advance;
         }
         return width;
     }
 
-    public FontInfo GetFontInfo(string fontName, int fontSize)
+    public FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
     {
-            var font = string.IsNullOrEmpty(fontName) ? _defaultFont :
-                (_loadedFonts.TryGetValue((fontName, AbstFontStyle.Regular), out var f) ? f : _defaultFont);
-        font.RequestCharactersInTexture(" ", fontSize, FontStyle.Normal);
-        font.GetCharacterInfo(' ', out var info, fontSize);
+        var font = string.IsNullOrEmpty(fontName) ? _defaultFont :
+            (_loadedFonts.TryGetValue((fontName, style), out var f) ? f : _defaultFont);
+        var unityStyle = FontStyle.Normal;
+        if ((style & AbstFontStyle.Bold) != 0) unityStyle |= FontStyle.Bold;
+        if ((style & AbstFontStyle.Italic) != 0) unityStyle |= FontStyle.Italic;
+        font.RequestCharactersInTexture(" ", fontSize, unityStyle);
+        font.GetCharacterInfo(' ', out var info, fontSize, unityStyle);
         int height = Mathf.CeilToInt(info.glyphHeight);
-        int top = Mathf.CeilToInt(info.glyphHeight - info.maxY);
+        int top = Mathf.CeilToInt(info.maxY);
         return new FontInfo(height, top);
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Styles/SdlFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Styles/SdlFontManager.cs
@@ -17,76 +17,76 @@ public interface IAbstSdlFont
 }
 public class SdlFontManager : IAbstFontManager
 {
-      private readonly List<(string Name, AbstFontStyle Style, string FileName)> _fontsToLoad = new();
-      private readonly Dictionary<(string Name, AbstFontStyle Style), AbstSdlFont> _loadedFonts = new();
-      public IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular)
-      {
-          _fontsToLoad.Add((name, style, pathAndName));
-          return this;
-      }
+    private readonly List<(string Name, AbstFontStyle Style, string FileName)> _fontsToLoad = new();
+    private readonly Dictionary<(string Name, AbstFontStyle Style), AbstSdlFont> _loadedFonts = new();
+    public IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular)
+    {
+        _fontsToLoad.Add((name, style, pathAndName));
+        return this;
+    }
     public void LoadAll()
     {
-          if (_loadedFonts.Count == 0)
-          {
-              var tahoma = Path.Combine(AppContext.BaseDirectory, "Fonts", "Tahoma.ttf");
-              _loadedFonts.Add(("default", AbstFontStyle.Regular), new AbstSdlFont(this, "Tahoma", tahoma));
-              _loadedFonts.Add(("default", AbstFontStyle.Italic), new AbstSdlFont(this, "Tahoma", tahoma));
-              _loadedFonts.Add(("default", AbstFontStyle.Bold), new AbstSdlFont(this, "Tahoma", tahoma));
-              _loadedFonts.Add(("default", AbstFontStyle.BoldItalic), new AbstSdlFont(this, "Tahoma", tahoma));
-              _loadedFonts.Add(("Tahoma", AbstFontStyle.Regular), new AbstSdlFont(this, "Tahoma", tahoma));
-          }
+        if (_loadedFonts.Count == 0)
+        {
+            var tahoma = Path.Combine(AppContext.BaseDirectory, "Fonts", "Tahoma.ttf");
+            _loadedFonts.Add(("default", AbstFontStyle.Regular), new AbstSdlFont(this, "Tahoma", tahoma));
+            _loadedFonts.Add(("default", AbstFontStyle.Italic), new AbstSdlFont(this, "Tahoma", tahoma));
+            _loadedFonts.Add(("default", AbstFontStyle.Bold), new AbstSdlFont(this, "Tahoma", tahoma));
+            _loadedFonts.Add(("default", AbstFontStyle.BoldItalic), new AbstSdlFont(this, "Tahoma", tahoma));
+            _loadedFonts.Add(("Tahoma", AbstFontStyle.Regular), new AbstSdlFont(this, "Tahoma", tahoma));
+        }
 
-          foreach (var font in _fontsToLoad)
-          {
-              var path = Path.IsPathRooted(font.FileName)
-                  ? font.FileName
-                  : Path.Combine(AppContext.BaseDirectory, font.FileName.Replace("\\", "/"));
-              _loadedFonts[(font.Name, font.Style)] = new AbstSdlFont(this, font.Name, path);
-          }
+        foreach (var font in _fontsToLoad)
+        {
+            var path = Path.IsPathRooted(font.FileName)
+                ? font.FileName
+                : Path.Combine(AppContext.BaseDirectory, font.FileName.Replace("\\", "/"));
+            _loadedFonts[(font.Name, font.Style)] = new AbstSdlFont(this, font.Name, path);
+        }
 
         _fontsToLoad.Clear();
         InitFonts();
 
     }
-      public T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class
-          => _loadedFonts.TryGetValue((name, style), out var f) ? f as T : null;
-      public ISdlFontLoadedByUser GetTyped(object fontUser, string? name, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
-      {
-          if (string.IsNullOrEmpty(name)) return _loadedFonts[("default", style)].Get(fontUser, fontSize);
-          if(_loadedFonts.ContainsKey((name, style)) == false)
+    public T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class
+        => _loadedFonts.TryGetValue((name, style), out var f) ? f as T : null;
+    public ISdlFontLoadedByUser GetTyped(object fontUser, string? name, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
+    {
+        if (string.IsNullOrEmpty(name)) return _loadedFonts[("default", style)].Get(fontUser, fontSize);
+        if (_loadedFonts.ContainsKey((name, style)) == false)
             return _loadedFonts[("default", style)].Get(fontUser, fontSize);
         return _loadedFonts[(name, style)].Get(fontUser, fontSize);
-      }
+    }
 
-      public T GetDefaultFont<T>() where T : class
-          => _loadedFonts.TryGetValue(("default", AbstFontStyle.Regular), out var f) ? (f as T)! : throw new KeyNotFoundException("Default font not found");
+    public T GetDefaultFont<T>() where T : class
+        => _loadedFonts.TryGetValue(("default", AbstFontStyle.Regular), out var f) ? (f as T)! : throw new KeyNotFoundException("Default font not found");
 
     public void SetDefaultFont<T>(T font) where T : class
     {
         if (font is not IAbstSdlFont sdlFont)
             throw new ArgumentException("Font must be of type IAbstSdlFont", nameof(font));
-          _loadedFonts[("default", AbstFontStyle.Regular)] = (AbstSdlFont)sdlFont;
+        _loadedFonts[("default", AbstFontStyle.Regular)] = (AbstSdlFont)sdlFont;
     }
 
-      public IEnumerable<string> GetAllNames() => _loadedFonts.Keys.Select(k => k.Name).Distinct();
+    public IEnumerable<string> GetAllNames() => _loadedFonts.Keys.Select(k => k.Name).Distinct();
 
-    public float MeasureTextWidth(string text, string fontName, int fontSize)
+    public float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
     {
         var user = new object();
-        var font = GetTyped(user, string.IsNullOrEmpty(fontName) ? null : fontName, fontSize);
+        var font = GetTyped(user, string.IsNullOrEmpty(fontName) ? null : fontName, fontSize, style);
         SDL_ttf.TTF_SizeUTF8(font.FontHandle, text, out int w, out _);
         font.Release();
         return w;
     }
 
-    public FontInfo GetFontInfo(string fontName, int fontSize)
+    public FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
     {
         var user = new object();
-        var font = GetTyped(user, string.IsNullOrEmpty(fontName) ? null : fontName, fontSize);
+        var font = GetTyped(user, string.IsNullOrEmpty(fontName) ? null : fontName, fontSize, style);
         int height = SDL_ttf.TTF_FontHeight(font.FontHandle);
         int ascent = SDL_ttf.TTF_FontAscent(font.FontHandle);
         font.Release();
-        return new FontInfo(height, height - ascent);
+        return new FontInfo(height, ascent);
     }
 
     // SDL Fonts

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/IAbstFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/IAbstFontManager.cs
@@ -9,8 +9,8 @@
         void SetDefaultFont<T>(T font) where T : class;
         IEnumerable<string> GetAllNames();
 
-        float MeasureTextWidth(string text, string fontName, int fontSize);
-        FontInfo GetFontInfo(string fontName, int fontSize);
+        float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular);
+        FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular);
     }
 
     public readonly record struct FontInfo(int FontHeight, int TopIndentation);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Linq;
 using AbstUI.Components.Graphics;
 using AbstUI.Primitives;
 using AbstUI.Styles;
@@ -24,16 +25,7 @@ namespace AbstUI.Texts
 
         private string _markdown = string.Empty;
 
-        private string _fontFamily = "Arial";
-        private int _fontSize = 12;
-        private AbstTextAlignment _alignment = AbstTextAlignment.Left;
-        private AColor _color = AColors.Black;
-        private int _lineHeight;
-        private int _marginLeft;
-        private int _marginRight;
-        private bool _styleBold;
-        private bool _styleItalic;
-        private bool _styleUnderline;
+        private readonly AbstTextStyle _currentStyle = new() { Font = "Arial", FontSize = 12, Color = AColors.Black, Alignment = AbstTextAlignment.Left };
         private readonly Stack<AbstTextStyle> _styleStack = new();
 
         private Dictionary<string, AbstTextStyle> _styles = new();
@@ -91,15 +83,13 @@ namespace AbstUI.Texts
 
             var lines = _markdown.Split('\n');
             var pos = start;
-            var firstLine = true;
 
             foreach (var rawLine in lines)
             {
                 var line = rawLine.TrimEnd('\r');
                 ApplyLeadingStyle(ref line);
-                ProcessTags(ref line);
-                if (_fontSize <= 0)
-                    _fontSize = 12;
+                if (_currentStyle.FontSize <= 0)
+                    _currentStyle.FontSize = 12;
 
                 // determine header level
                 int headerLevel = 0;
@@ -107,7 +97,7 @@ namespace AbstUI.Texts
                     headerLevel++;
                 var content = headerLevel > 0 ? line.Substring(headerLevel).TrimStart() : line;
 
-                int usedFontSize = headerLevel > 0 ? 32 - (headerLevel - 1) * 4 : _fontSize;
+                int usedFontSize = headerLevel > 0 ? 32 - (headerLevel - 1) * 4 : _currentStyle.FontSize;
                 bool headerBold = headerLevel > 0;
 
                 if (content.StartsWith("!["))
@@ -124,28 +114,38 @@ namespace AbstUI.Texts
                     }
                 }
 
-                var plain = StripFormatting(content);
-                float lineWidth = EstimateWidth(plain, usedFontSize);
-                float lineX = pos.X;
-                if (_alignment == AbstTextAlignment.Center)
-                    lineX -= lineWidth / 2f;
-                else if (_alignment == AbstTextAlignment.Right)
-                    lineX -= lineWidth;
-                lineX += _marginLeft;
-                if (_alignment == AbstTextAlignment.Right)
-                    lineX -= _marginRight;
-                else if (_alignment == AbstTextAlignment.Center)
-                    lineX -= _marginRight / 2f;
+                var segments = ParseInlineSegments(content, usedFontSize, headerBold || _currentStyle.Bold, _currentStyle.Italic, _currentStyle.Underline, out float lineWidth);
 
-                bool bold = headerBold || _styleBold;
-                bool italic = _styleItalic;
-                bool underline = _styleUnderline;
+                if (segments.Count > 0)
+                {
+                    float lineX = pos.X;
+                    if (_currentStyle.Alignment == AbstTextAlignment.Center)
+                        lineX -= lineWidth / 2f;
+                    else if (_currentStyle.Alignment == AbstTextAlignment.Right)
+                        lineX -= lineWidth;
+                    lineX += _currentStyle.MarginLeft;
+                    if (_currentStyle.Alignment == AbstTextAlignment.Right)
+                        lineX -= _currentStyle.MarginRight;
+                    else if (_currentStyle.Alignment == AbstTextAlignment.Center)
+                        lineX -= _currentStyle.MarginRight / 2f;
 
-                var fontInfo = _fontManager.GetFontInfo(_fontFamily, usedFontSize);
-                RenderInlineText(content, new APoint(lineX, pos.Y - (firstLine ? fontInfo.TopIndentation : 0)), usedFontSize, bold, italic, underline);
-                int advance = _lineHeight > 0 ? _lineHeight : usedFontSize;
-                pos.Offset(0, advance);
-                firstLine = false;
+                    var firstSeg = segments[0];
+                    var firstStyle = AbstFontStyle.Regular;
+                    if (firstSeg.Bold) firstStyle |= AbstFontStyle.Bold;
+                    if (firstSeg.Italic) firstStyle |= AbstFontStyle.Italic;
+                    var fontInfo = _fontManager.GetFontInfo(firstSeg.FontFamily, firstSeg.FontSize, firstStyle);
+                    RenderSegments(segments, new APoint(lineX, pos.Y - fontInfo.TopIndentation));
+
+                    int lineHeight = _currentStyle.LineHeight > 0
+                        ? _currentStyle.LineHeight
+                        : segments.Max(s => _fontManager.GetFontInfo(s.FontFamily, s.FontSize, (s.Bold ? AbstFontStyle.Bold : AbstFontStyle.Regular) | (s.Italic ? AbstFontStyle.Italic : AbstFontStyle.Regular)).FontHeight);
+                    pos.Offset(0, lineHeight);
+                }
+                else
+                {
+                    int lineHeight = _currentStyle.LineHeight > 0 ? _currentStyle.LineHeight : usedFontSize;
+                    pos.Offset(0, lineHeight);
+                }
             }
         }
 
@@ -156,8 +156,11 @@ namespace AbstUI.Texts
             var pos = start;
             var fontSize = style.FontSize;
             if (fontSize <= 0) fontSize = 12;
-            var fontInfo = _fontManager.GetFontInfo(style.Font, fontSize);
-            int lineHeight = style.LineHeight > 0 ? style.LineHeight : fontSize;
+            var baseStyle = AbstFontStyle.Regular;
+            if (style.Bold) baseStyle |= AbstFontStyle.Bold;
+            if (style.Italic) baseStyle |= AbstFontStyle.Italic;
+            var fontInfo = _fontManager.GetFontInfo(style.Font, fontSize, baseStyle);
+            int lineHeight = style.LineHeight > 0 ? style.LineHeight : fontInfo.FontHeight;
             bool firstLine = true;
 
             // 1) measure max width of all lines
@@ -167,7 +170,12 @@ namespace AbstUI.Texts
             foreach (var raw in lines)
             {
                 var line = raw.TrimEnd('\r');
-                var lineWidth = EstimateWidth(line, fontSize);
+                var fontStyleForWidth = AbstFontStyle.Regular;
+                if (style.Bold)
+                    fontStyleForWidth |= AbstFontStyle.Bold;
+                if (style.Italic)
+                    fontStyleForWidth |= AbstFontStyle.Italic;
+                var lineWidth = EstimateWidth(line, style.Font, fontSize, fontStyleForWidth);
                 lineWidths.Add(lineWidth);
                 fullWidth = MathF.Max(fullWidth, lineWidth);
             }
@@ -213,18 +221,7 @@ namespace AbstUI.Texts
         }
 
         private void ApplyStyle(AbstTextStyle style)
-        {
-            _fontSize = style.FontSize;
-            _fontFamily = style.Font;
-            _color = style.Color;
-            _alignment = style.Alignment;
-            _styleBold = style.Bold;
-            _styleItalic = style.Italic;
-            _styleUnderline = style.Underline;
-            _lineHeight = style.LineHeight;
-            _marginLeft = style.MarginLeft;
-            _marginRight = style.MarginRight;
-        }
+            => _currentStyle.CopyFrom(style);
 
         private void ApplyLeadingStyle(ref string line)
         {
@@ -238,19 +235,7 @@ namespace AbstUI.Texts
                     if (end == -1)
                         break;
                     var name = line.Substring(start + 8, end - (start + 8)).Trim();
-                    _styleStack.Push(new AbstTextStyle
-                    {
-                        FontSize = _fontSize,
-                        Font = _fontFamily,
-                        Color = _color,
-                        Alignment = _alignment,
-                        Bold = _styleBold,
-                        Italic = _styleItalic,
-                        Underline = _styleUnderline,
-                        LineHeight = _lineHeight,
-                        MarginLeft = _marginLeft,
-                        MarginRight = _marginRight
-                    });
+                    _styleStack.Push(_currentStyle.Clone());
                     if (_styles.TryGetValue(name, out var style))
                         ApplyStyle(style);
                     line = line.Remove(start, end - start + 2);
@@ -270,172 +255,8 @@ namespace AbstUI.Texts
             }
         }
 
-        private void ProcessTags(ref string line)
-        {
-            int index = 0;
-            while (true)
-            {
-                int start = line.IndexOf("{{", index, StringComparison.Ordinal);
-                if (start == -1)
-                    break;
-                int end = line.IndexOf("}}", start + 2, StringComparison.Ordinal);
-                if (end == -1)
-                    break;
-
-                string tag = line.Substring(start + 2, end - start - 2);
-                if (tag.StartsWith("STYLE", StringComparison.OrdinalIgnoreCase))
-                {
-                    index = end + 2;
-                    continue;
-                }
-                ApplyTag(tag);
-                line = line.Remove(start, end - start + 2);
-            }
-        }
-
-        private void ApplyTag(string tag)
-        {
-            if (tag.StartsWith("FONT-SIZE:", StringComparison.OrdinalIgnoreCase))
-            {
-                if (int.TryParse(tag.Substring(10), out var size))
-                    _fontSize = size;
-            }
-            else if (tag.StartsWith("FONT-FAMILY:", StringComparison.OrdinalIgnoreCase))
-            {
-                _fontFamily = tag.Substring(12);
-            }
-            else if (tag.StartsWith("ALIGN:", StringComparison.OrdinalIgnoreCase))
-            {
-                var val = tag.Substring(6).Trim().ToLowerInvariant();
-                _alignment = val switch
-                {
-                    "center" => AbstTextAlignment.Center,
-                    "right" => AbstTextAlignment.Right,
-                    "justify" or "justified" => AbstTextAlignment.Justified,
-                    _ => AbstTextAlignment.Left,
-                };
-            }
-            else if (tag.StartsWith("COLOR:", StringComparison.OrdinalIgnoreCase))
-            {
-                try
-                {
-                    _color = AColor.FromHex(tag.Substring(6).Trim());
-                }
-                catch
-                {
-                    // ignore invalid color
-                }
-            }
-        }
-
-        private void RenderInlineText(string content, APoint pos, int fontSize, bool initialBold, bool initialItalic, bool initialUnderline)
-        {
-            int i = 0;
-            bool bold = initialBold;
-            bool italic = initialItalic;
-            bool underline = initialUnderline;
-            var sb = new StringBuilder();
-            float currentX = pos.X;
-
-            void Flush()
-            {
-                if (sb.Length == 0)
-                    return;
-                string text = sb.ToString();
-                float width = EstimateWidth(text, fontSize);
-                var fontInfo = _fontManager.GetFontInfo(_fontFamily, fontSize);
-                var fontStyle = AbstFontStyle.Regular;
-                if (bold)
-                    fontStyle |= AbstFontStyle.Bold;
-                if (italic)
-                    fontStyle |= AbstFontStyle.Italic;
-                _canvas!.DrawSingleLine(new APoint(currentX, pos.Y), text, _fontFamily, _color, fontSize, (int)MathF.Ceiling(width), fontInfo.FontHeight, _alignment, fontStyle);
-                if (underline)
-                    _canvas!.DrawLine(new APoint(currentX, pos.Y + fontSize), new APoint(currentX + width, pos.Y + fontSize), _color, 1);
-                currentX += width;
-                sb.Clear();
-            }
-
-            while (i < content.Length)
-            {
-                if (content.IndexOf("{{STYLE:", i, StringComparison.Ordinal) == i)
-                {
-                    int end = content.IndexOf("}}", i + 8, StringComparison.Ordinal);
-                    if (end != -1)
-                    {
-                        Flush();
-                        var name = content.Substring(i + 8, end - (i + 8)).Trim();
-                        _styleStack.Push(new AbstTextStyle
-                        {
-                            FontSize = _fontSize,
-                            Font = _fontFamily,
-                            Color = _color,
-                            Alignment = _alignment,
-                            Bold = bold,
-                            Italic = italic,
-                            Underline = underline,
-                            LineHeight = _lineHeight,
-                            MarginLeft = _marginLeft,
-                            MarginRight = _marginRight
-                        });
-                        if (_styles.TryGetValue(name, out var style))
-                            ApplyStyle(style);
-                        bold = _styleBold;
-                        italic = _styleItalic;
-                        underline = _styleUnderline;
-                        i = end + 2;
-                        continue;
-                    }
-                }
-                if (content.IndexOf("{{STYLE}}", i, StringComparison.Ordinal) == i || content.IndexOf("{{/STYLE}}", i, StringComparison.Ordinal) == i)
-                {
-                    Flush();
-                    if (_styleStack.Count > 0)
-                        ApplyStyle(_styleStack.Pop());
-                    bold = _styleBold;
-                    italic = _styleItalic;
-                    underline = _styleUnderline;
-                    i += content.IndexOf("{{STYLE}}", i, StringComparison.Ordinal) == i ? 9 : 10;
-                    continue;
-                }
-                if (content.IndexOf("**", i, StringComparison.Ordinal) == i)
-                {
-                    Flush();
-                    bold = !bold;
-                    i += 2;
-                    continue;
-                }
-                if (content.IndexOf("__", i, StringComparison.Ordinal) == i)
-                {
-                    Flush();
-                    underline = !underline;
-                    i += 2;
-                    continue;
-                }
-                if (content[i] == '*')
-                {
-                    Flush();
-                    italic = !italic;
-                    i++;
-                    continue;
-                }
-                sb.Append(content[i]);
-                i++;
-            }
-            Flush();
-        }
-
-        private float EstimateWidth(string text, int fontSize)
-        {
-            return _fontManager.MeasureTextWidth(text, _fontFamily, fontSize);
-        }
-
-        private static string StripFormatting(string text)
-        {
-            text = Regex.Replace(text, @"!\[[^\]]*\]\([^)]+\)", string.Empty);
-            text = text.Replace("**", string.Empty).Replace("*", string.Empty).Replace("__", string.Empty);
-            return text;
-        }
+        private float EstimateWidth(string text, string fontFamily, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
+            => _fontManager.MeasureTextWidth(text, fontFamily, fontSize, style);
 
         private static bool HasSpecialTags(string text)
             => text.IndexOf("{{", StringComparison.Ordinal) >= 0
@@ -455,6 +276,146 @@ namespace AbstUI.Texts
             int drawHeight = heightOverride ?? height;
             _canvas!.DrawPicture(data, drawWidth, drawHeight, position, format);
             return drawHeight;
+        }
+
+        private record TextSegment(string Text, string FontFamily, int FontSize, AColor Color, bool Bold, bool Italic, bool Underline);
+
+        private List<TextSegment> ParseInlineSegments(string content, int initialFontSize, bool initialBold, bool initialItalic, bool initialUnderline, out float totalWidth)
+        {
+            int i = 0;
+            var segments = new List<TextSegment>();
+            var sb = new StringBuilder();
+            float width = 0f;
+
+            var style = _currentStyle.Clone();
+            style.FontSize = initialFontSize;
+            style.Bold = initialBold;
+            style.Italic = initialItalic;
+            style.Underline = initialUnderline;
+
+            var localStack = new Stack<AbstTextStyle>(_styleStack.Select(s => s.Clone()).Reverse());
+
+            void Flush()
+            {
+                if (sb.Length == 0) return;
+                string text = sb.ToString();
+                var styleFlags = AbstFontStyle.Regular;
+                if (style.Bold) styleFlags |= AbstFontStyle.Bold;
+                if (style.Italic) styleFlags |= AbstFontStyle.Italic;
+                float segW = EstimateWidth(text, style.Font, style.FontSize, styleFlags);
+                width += segW;
+                segments.Add(new TextSegment(text, style.Font, style.FontSize, style.Color, style.Bold, style.Italic, style.Underline));
+                sb.Clear();
+            }
+
+            while (i < content.Length)
+            {
+                if (content.IndexOf("{{", i, StringComparison.Ordinal) == i)
+                {
+                    int end = content.IndexOf("}}", i + 2, StringComparison.Ordinal);
+                    if (end != -1)
+                    {
+                        Flush();
+                        string tag = content.Substring(i + 2, end - i - 2);
+                        if (tag.StartsWith("FONT-SIZE:", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (int.TryParse(tag.Substring(10), out var sz))
+                                style.FontSize = sz;
+                        }
+                        else if (tag.StartsWith("FONT-FAMILY:", StringComparison.OrdinalIgnoreCase))
+                        {
+                            style.Font = tag.Substring(12);
+                        }
+                        else if (tag.StartsWith("COLOR:", StringComparison.OrdinalIgnoreCase))
+                        {
+                            try { style.Color = AColor.FromHex(tag.Substring(6).Trim()); } catch { }
+                        }
+                        else if (tag.StartsWith("ALIGN:", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var val = tag.Substring(6).Trim().ToLowerInvariant();
+                            style.Alignment = val switch
+                            {
+                                "center" => AbstTextAlignment.Center,
+                                "right" => AbstTextAlignment.Right,
+                                "justify" or "justified" => AbstTextAlignment.Justified,
+                                _ => AbstTextAlignment.Left,
+                            };
+                        }
+                        else if (tag.StartsWith("STYLE:", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var name = tag.Substring(6).Trim();
+                            localStack.Push(style.Clone());
+                            if (_styles.TryGetValue(name, out var s))
+                                style.CopyFrom(s);
+                        }
+                        else if (tag.Equals("STYLE", StringComparison.OrdinalIgnoreCase) || tag.Equals("/STYLE", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (localStack.Count > 0)
+                                style.CopyFrom(localStack.Pop());
+                        }
+                        i = end + 2;
+                        continue;
+                    }
+                }
+                if (content.IndexOf("**", i, StringComparison.Ordinal) == i)
+                {
+                    Flush();
+                    style.Bold = !style.Bold;
+                    i += 2;
+                    continue;
+                }
+                if (content.IndexOf("__", i, StringComparison.Ordinal) == i)
+                {
+                    Flush();
+                    style.Underline = !style.Underline;
+                    i += 2;
+                    continue;
+                }
+                if (content[i] == '*')
+                {
+                    Flush();
+                    style.Italic = !style.Italic;
+                    i++;
+                    continue;
+                }
+                sb.Append(content[i]);
+                i++;
+            }
+            Flush();
+
+            _currentStyle.CopyFrom(style);
+
+            _styleStack.Clear();
+            foreach (var s in localStack.Reverse())
+                _styleStack.Push(s);
+
+            totalWidth = width;
+            return segments;
+        }
+
+        private void RenderSegments(List<TextSegment> segments, APoint topLeft)
+        {
+            float currentX = topLeft.X;
+            var firstInfo = _fontManager.GetFontInfo(segments[0].FontFamily, segments[0].FontSize);
+            float baselineY = topLeft.Y + firstInfo.TopIndentation;
+            foreach (var seg in segments)
+            {
+                var segStyle = AbstFontStyle.Regular;
+                if (seg.Bold) segStyle |= AbstFontStyle.Bold;
+                if (seg.Italic) segStyle |= AbstFontStyle.Italic;
+                float width = EstimateWidth(seg.Text, seg.FontFamily, seg.FontSize, segStyle);
+                var fontInfo = _fontManager.GetFontInfo(seg.FontFamily, seg.FontSize, segStyle);
+                float topY = baselineY - fontInfo.TopIndentation;
+                var fontStyle = AbstFontStyle.Regular;
+                if (seg.Bold)
+                    fontStyle |= AbstFontStyle.Bold;
+                if (seg.Italic)
+                    fontStyle |= AbstFontStyle.Italic;
+                _canvas!.DrawSingleLine(new APoint(currentX, topY), seg.Text, seg.FontFamily, seg.Color, seg.FontSize, (int)MathF.Ceiling(width), fontInfo.FontHeight, _currentStyle.Alignment, fontStyle);
+                if (seg.Underline)
+                    _canvas!.DrawLine(new APoint(currentX, topY + seg.FontSize), new APoint(currentX + width, topY + seg.FontSize), seg.Color, 1);
+                currentX += width;
+            }
         }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstTextStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstTextStyle.cs
@@ -5,10 +5,10 @@ namespace AbstUI.Texts;
 /// <summary>
 /// Represents a collection of style properties that can be applied to text.
 /// </summary>
-public class AbstTextStyle
+public class AbstTextStyle : IAbstTextStyle
 {
     public string Name { get; set; } = string.Empty;
-    public int FontSize { get; set; } 
+    public int FontSize { get; set; }
     public string Font { get; set; } = string.Empty;
     public AColor Color { get; set; } = AColors.Black;
     public AbstTextAlignment Alignment { get; set; } = AbstTextAlignment.Left;
@@ -18,4 +18,37 @@ public class AbstTextStyle
     public int LineHeight { get; set; }
     public int MarginLeft { get; set; }
     public int MarginRight { get; set; }
+
+    /// <summary>Creates a deep copy of this style.</summary>
+    public AbstTextStyle Clone()
+        => new()
+        {
+            Name = Name,
+            FontSize = FontSize,
+            Font = Font,
+            Color = Color,
+            Alignment = Alignment,
+            Bold = Bold,
+            Italic = Italic,
+            Underline = Underline,
+            LineHeight = LineHeight,
+            MarginLeft = MarginLeft,
+            MarginRight = MarginRight
+        };
+
+    /// <summary>Copies all style properties from another style instance.</summary>
+    public void CopyFrom(IAbstTextStyle style)
+    {
+        Name = style.Name;
+        FontSize = style.FontSize;
+        Font = style.Font;
+        Color = style.Color;
+        Alignment = style.Alignment;
+        Bold = style.Bold;
+        Italic = style.Italic;
+        Underline = style.Underline;
+        LineHeight = style.LineHeight;
+        MarginLeft = style.MarginLeft;
+        MarginRight = style.MarginRight;
+    }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/IAbstTextStyle.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/IAbstTextStyle.cs
@@ -1,0 +1,21 @@
+using AbstUI.Primitives;
+
+namespace AbstUI.Texts;
+
+/// <summary>
+/// Describes styling properties used by <see cref="AbstMarkdownRenderer"/> and related components.
+/// </summary>
+public interface IAbstTextStyle
+{
+    string Name { get; set; }
+    int FontSize { get; set; }
+    string Font { get; set; }
+    AColor Color { get; set; }
+    AbstTextAlignment Alignment { get; set; }
+    bool Bold { get; set; }
+    bool Italic { get; set; }
+    bool Underline { get; set; }
+    int LineHeight { get; set; }
+    int MarginLeft { get; set; }
+    int MarginRight { get; set; }
+}


### PR DESCRIPTION
## Summary
- extend `IAbstFontManager` to measure text with style and expose style-aware metrics
- compute line height from font metrics and measure widths with font style in `AbstMarkdownRenderer`
- align multi-line text correctly in `GodotImagePainterToTexture`
- adjust backend font managers and add tests for font height spacing

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs,WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/IAbstFontManager.cs --verbosity diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/GodotImagePainterToTexture.cs,WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Styles/AbstGodotFontManager.cs --verbosity diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Styles/SdlFontManager.cs --verbosity diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Styles/UnityFontManager.cs --verbosity diagnostic --no-restore`
- ⚠️ `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Styles/AbstBlazorFontManager.cs --verbosity diagnostic` (duplicate source files)
- `dotnet format WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj --include WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstMarkdownRendererTests.cs --verbosity diagnostic`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b981a836c48332b500b17785eed17e