### PR TITLE
Fix RTF color indexing and baseline rendering

### DIFF
--- a/Test/LingoEngine.Tests/RtfToMarkdownTests.cs
+++ b/Test/LingoEngine.Tests/RtfToMarkdownTests.cs
@@ -250,4 +250,14 @@ public class RtfToMarkdownTests
         Assert.Equal(18, data.Segments[0].LineHeight);
     }
 
+    [Fact]
+    public void Convert_HandlesColorIndexWithoutLeadingSemicolon()
+    {
+        const string rtf = "{\\rtf1\\ansi\\deff0 {\\fonttbl{\\f0\\fswiss Arial;}{\\f1\\fnil Arcade *;}{\\f2\\fnil Earth *;}}{\\colortbl\\red0\\green0\\blue0;\\red255\\green0\\blue0;}{\\stylesheet{\\s0\\fs24 Normal Text;}}\\pard \\f0\\fs24{\\pard \\f2\\fs36\\cf1\\qc New }{\\pard \\b\\f2\\fs36\\cf1\\qc Highscore!!!}{\\pard \\f2\\fs36\\cf1\\qc\\par }{\\pard \\f2\\fs28\\cf1\\qc Enter your }{\\pard \\f2\\fs36\\cf1\\qc Name}}";
+
+        var data = RtfToMarkdown.Convert(rtf);
+
+        var expected = "{{FONT-FAMILY:Earth}}{{FONT-SIZE:18}}{{COLOR:#FF0000}}{{ALIGN:center}}New **Highscore!!!**\n{{FONT-SIZE:14}}Enter your {{FONT-SIZE:18}}Name";
+        Assert.Equal(expected, data.Markdown);
+    }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/GodotImagePainterToTexture.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/GodotImagePainterToTexture.cs
@@ -476,7 +476,7 @@ namespace AbstUI.LGodot.Components.Graphics
                             if (sw <= 0 || sh <= 0) continue;
 
                             int dx = (int)MathF.Floor((float)(pos.X + xOff + penX + offset.X - advance));
-                            int dy = (int)MathF.Floor((float)(baseline - offset.Y - sh));
+                            int dy = (int)MathF.Floor((float)(baseline - offset.Y));
 
                             for (int yy = 0; yy < sh; yy++)
                             {
@@ -601,7 +601,7 @@ namespace AbstUI.LGodot.Components.Graphics
 
                         int dx = (int)MathF.Floor((float)(pos.X + xOff + penX + offset.X - advance));
                         int baseline = (int)MathF.Floor((float)(pos.Y + ascent));
-                        int dy = (int)MathF.Floor(baseline - offset.Y - sh);
+                        int dy = (int)MathF.Floor(baseline - offset.Y);
 
                         for (int yy = 0; yy < sh; yy++)
                         {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
@@ -317,12 +317,6 @@ namespace AbstUI.Texts
                 width += segW;
                 segments.Add(new TextSegment(text, style.Font, style.FontSize, style.Color, style.Bold, style.Italic, style.Underline));
                 sb.Clear();
-                if (firstSegment)
-                {
-                    firstFontLocal = style.Font;
-                    firstSizeLocal = style.FontSize;
-                    firstSegment = false;
-                }
             }
 
             while (i < content.Length)


### PR DESCRIPTION
## Summary
- fix RTF color parsing and strip empty lines when converting to markdown
- ensure glyphs render on a common baseline in GodotImagePainterToTexture
- add regression test for color index handling

## Testing
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/Tools/RtfToMarkdown.cs Test/LingoEngine.Tests/RtfToMarkdownTests.cs`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Graphics/GodotImagePainterToTexture.cs`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs`
- `dotnet test Test/LingoEngine.Tests/LingoEngine.Tests.csproj`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b99e9fa7f4833288a7072f608fdea6