### PR TITLE
Fix case translation and Windows newline trimming

### DIFF
--- a/src/LingoEngine.Lingo.Core/CSharpWriter.cs
+++ b/src/LingoEngine.Lingo.Core/CSharpWriter.cs
@@ -308,6 +308,7 @@ public partial class CSharpWriter : ILingoAstVisitor
             AppendLine(":");
             Indent();
             label.Block?.Accept(this);
+            AppendLine("break;");
             Unindent();
             label = label.NextLabel;
         }
@@ -316,6 +317,7 @@ public partial class CSharpWriter : ILingoAstVisitor
             AppendLine("default:");
             Indent();
             node.Otherwise.Accept(this);
+            AppendLine("break;");
             Unindent();
         }
         Unindent();
@@ -712,6 +714,8 @@ public partial class CSharpWriter : ILingoAstVisitor
         {
             if (_sb.Length - startLen >= 2 && _sb[^2] == ';')
                 _sb.Length -= 2;
+            else if (_sb.Length - startLen >= 3 && _sb[^2] == '\r' && _sb[^3] == ';')
+                _sb.Length -= 3;
             _atLineStart = false;
         }
         else if (_sb.Length - startLen >= 1 && _sb[^1] == ';')

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
@@ -94,6 +94,7 @@ namespace LingoEngine.Lingo.Core.Tokenizer
                 case LingoTokenType.Next:
                 case LingoTokenType.Repeat:
                 case LingoTokenType.Return:
+                case LingoTokenType.Case:
                     return ParseKeywordStatement();
                 default:
                     AdvanceToken();
@@ -259,6 +260,9 @@ namespace LingoEngine.Lingo.Core.Tokenizer
                         retValue = ParseExpression();
                     }
                     return new LingoReturnStmtNode(retValue);
+
+                case LingoTokenType.Case:
+                    return ParseCaseStatement();
 
                 default:
                     return new LingoDatumNode(new LingoDatum(keywordToken.Lexeme));
@@ -972,8 +976,51 @@ namespace LingoEngine.Lingo.Core.Tokenizer
             }
         }
 
-    }
+        private LingoCaseLabelNode ParseCaseLabel()
+        {
+            var value = ParseExpression();
+            Expect(LingoTokenType.Colon);
+            var block = new LingoBlockNode();
+            block.Children.Add(ParseStatement());
+            return new LingoCaseLabelNode { Value = value, Block = block };
+        }
 
+        private LingoNode ParseCaseStatement()
+        {
+            var value = ParseExpression();
+            Expect(LingoTokenType.Of);
+            var first = ParseCaseLabel();
+            var current = first;
+            while (_currentToken.Type != LingoTokenType.End &&
+                   _currentToken.Type != LingoTokenType.Otherwise &&
+                   _currentToken.Type != LingoTokenType.Eof)
+            {
+                var nextLabel = ParseCaseLabel();
+                current.NextLabel = nextLabel;
+                current = nextLabel;
+            }
+
+            LingoOtherwiseNode? otherwise = null;
+            if (_currentToken.Type == LingoTokenType.Otherwise)
+            {
+                AdvanceToken();
+                if (_currentToken.Type == LingoTokenType.Colon)
+                    AdvanceToken();
+                var block = new LingoBlockNode();
+                while (_currentToken.Type != LingoTokenType.End &&
+                       _currentToken.Type != LingoTokenType.Eof)
+                {
+                    block.Children.Add(ParseStatement());
+                }
+                otherwise = new LingoOtherwiseNode { Block = block };
+            }
+
+            Expect(LingoTokenType.End);
+            Expect(LingoTokenType.Case);
+            return new LingoCaseStmtNode { Value = value, FirstLabel = first, Otherwise = otherwise };
+        }
+
+    }
 
 
 }

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoTokenizer.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoTokenizer.cs
@@ -66,7 +66,9 @@ namespace LingoEngine.Lingo.Core.Tokenizer
         Handler,
         Until,
         Forever,
-        Times
+        Times,
+        Case,
+        Otherwise
     }
     /// <summary>
     /// Represents a token in the Lingo source code.
@@ -136,7 +138,9 @@ namespace LingoEngine.Lingo.Core.Tokenizer
                 { "not", LingoTokenType.Not },
                 { "loop", LingoTokenType.Repeat },
                 { "forever", LingoTokenType.Forever },
-                { "times", LingoTokenType.Times }
+                { "times", LingoTokenType.Times },
+                { "case", LingoTokenType.Case },
+                { "otherwise", LingoTokenType.Otherwise }
             };
 
         public LingoTokenizer(string source)


### PR DESCRIPTION
## Summary
- parse `case` statements and handle `otherwise`
- test translation for switch cases and single-line `if` with Windows newlines
- ensure destroy handler `if` block emits valid C# without stray semicolons

## Testing
- `dotnet format Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj --verify-no-changes --verbosity diagnostic`
- `dotnet format src/LingoEngine.Lingo.Core/LingoEngine.Lingo.Core.csproj --verify-no-changes --verbosity diagnostic`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b9b6f59f148332b6729b71e237d375