### PR TITLE
Handle paragraph tags in markdown renderer

### DIFF
--- a/Test/LingoEngine.Tests/LingoEngine.Tests.csproj
+++ b/Test/LingoEngine.Tests/LingoEngine.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="FluentAssertions" Version="8.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LingoEngine\LingoEngine.csproj" />

--- a/Test/LingoEngine.Tests/RtfToMarkdownTests.cs
+++ b/Test/LingoEngine.Tests/RtfToMarkdownTests.cs
@@ -6,6 +6,7 @@ using AbstUI.Primitives;
 using AbstUI.Styles;
 using AbstUI.Texts;
 using LingoEngine.Tools;
+using FluentAssertions;
 using Xunit;
 namespace LingoEngine.Tests;
 public class RtfToMarkdownTests
@@ -17,18 +18,18 @@ public class RtfToMarkdownTests
 
         var data = RtfToMarkdown.Convert(rtf);
 
-        Assert.Equal("{{PARA:0}}plain**bold***italic*__underline__", data.Markdown);
-        Assert.Equal(new[]
+        data.Markdown.Should().Be("{{PARA:0}}plain**bold***italic*__underline__");
+        data.Segments.Select(s => (s.Bold, s.Italic, s.Underline)).Should().Equal(new[]
         {
             (false, false, false),
             (true, false, false),
             (false, true, false),
             (false, false, true)
-        }, data.Segments.Select(s => (s.Bold, s.Italic, s.Underline)));
-        Assert.True(data.Styles.ContainsKey("0"));
-        Assert.Equal("Arial", data.Styles["0"].Font);
-        Assert.Equal(12, data.Styles["0"].FontSize);
-        Assert.Equal("#000000", data.Styles["0"].Color.ToHex());
+        });
+        data.Styles.Should().ContainKey("0");
+        data.Styles["0"].Font.Should().Be("Arial");
+        data.Styles["0"].FontSize.Should().Be(12);
+        data.Styles["0"].Color.ToHex().Should().Be("#000000");
     }
 
     [Fact]
@@ -39,15 +40,15 @@ public class RtfToMarkdownTests
         var data = RtfToMarkdown.Convert(rtf);
 
         var expected = "{{PARA:0}}line1\n{{PARA:0}}{{COLOR:#0000FF}}*line2*";
-        Assert.Equal(expected, data.Markdown);
-        Assert.Equal(new[]
+        data.Markdown.Should().Be(expected);
+        data.Segments.Select(s => (s.Bold, s.Italic, s.Underline)).Should().Equal(new[]
         {
             (false, false, false),
             (false, true, false)
-        }, data.Segments.Select(s => (s.Bold, s.Italic, s.Underline)));
-        Assert.True(data.Segments[0].IsParagraph);
-        Assert.False(data.Segments[1].IsParagraph);
-        Assert.Equal("line1\nline2", data.PlainText);
+        });
+        data.Segments[0].IsParagraph.Should().BeTrue();
+        data.Segments[1].IsParagraph.Should().BeFalse();
+        data.PlainText.Should().Be("line1\nline2");
     }
 
     [Fact]
@@ -57,9 +58,9 @@ public class RtfToMarkdownTests
 
         var data = RtfToMarkdown.Convert(rtf);
 
-        Assert.Equal("{{PARA:0}}right", data.Markdown);
-        Assert.Single(data.Segments);
-        Assert.Equal(AbstTextAlignment.Right, data.Styles["0"].Alignment);
+        data.Markdown.Should().Be("{{PARA:0}}right");
+        data.Segments.Should().HaveCount(1);
+        data.Styles["0"].Alignment.Should().Be(AbstTextAlignment.Right);
     }
 
     [Fact]
@@ -69,9 +70,9 @@ public class RtfToMarkdownTests
 
         var data = RtfToMarkdown.Convert(rtf);
 
-        Assert.Equal("{{PARA:0}}center", data.Markdown);
-        Assert.Single(data.Segments);
-        Assert.Equal(AbstTextAlignment.Center, data.Styles["0"].Alignment);
+        data.Markdown.Should().Be("{{PARA:0}}center");
+        data.Segments.Should().HaveCount(1);
+        data.Styles["0"].Alignment.Should().Be(AbstTextAlignment.Center);
     }
 
     [Fact]
@@ -81,13 +82,13 @@ public class RtfToMarkdownTests
 
         var data = RtfToMarkdown.Convert(rtf);
 
-        Assert.Single(data.Segments);
-        Assert.Equal("{{PARA:0}}margin", data.Markdown);
-        Assert.Equal(10, data.Styles["0"].MarginLeft);
-        Assert.Equal(20, data.Styles["0"].MarginRight);
-        Assert.False(data.Segments[0].Bold);
-        Assert.False(data.Segments[0].Italic);
-        Assert.False(data.Segments[0].Underline);
+        data.Segments.Should().HaveCount(1);
+        data.Markdown.Should().Be("{{PARA:0}}margin");
+        data.Styles["0"].MarginLeft.Should().Be(10);
+        data.Styles["0"].MarginRight.Should().Be(20);
+        data.Segments[0].Bold.Should().BeFalse();
+        data.Segments[0].Italic.Should().BeFalse();
+        data.Segments[0].Underline.Should().BeFalse();
     }
 
     [Fact]
@@ -97,13 +98,13 @@ public class RtfToMarkdownTests
 
         var data = RtfToMarkdown.Convert(rtf);
 
-        Assert.Equal("{{PARA:1}}{{FONT-FAMILY:Arial}}{{FONT-SIZE:12}}{{ALIGN:left}}text1{{STYLE:2}}text2{{/STYLE}}", data.Markdown);
-        Assert.Equal(1, data.Segments[0].StyleId);
-        Assert.Equal(2, data.Segments[1].StyleId);
-        Assert.True(data.Styles.ContainsKey("1"));
-        Assert.True(data.Styles["1"].Bold);
-        Assert.True(data.Styles.ContainsKey("2"));
-        Assert.True(data.Styles["2"].Italic);
+        data.Markdown.Should().Be("{{PARA:1}}{{FONT-FAMILY:Arial}}{{FONT-SIZE:12}}{{ALIGN:left}}text1{{STYLE:2}}text2{{/STYLE}}");
+        data.Segments[0].StyleId.Should().Be(1);
+        data.Segments[1].StyleId.Should().Be(2);
+        data.Styles.Should().ContainKey("1");
+        data.Styles["1"].Bold.Should().BeTrue();
+        data.Styles.Should().ContainKey("2");
+        data.Styles["2"].Italic.Should().BeTrue();
     }
 
     [Fact]
@@ -113,12 +114,12 @@ public class RtfToMarkdownTests
 
         var data = RtfToMarkdown.Convert(rtf);
 
-        Assert.Equal("{{PARA:1}}{{ALIGN:left}}text", data.Markdown);
-        Assert.Equal(1, data.Segments[0].StyleId);
-        Assert.True(data.Styles.ContainsKey("1"));
-        Assert.Equal("Arial", data.Styles["1"].Font);
-        Assert.Equal(12, data.Styles["1"].FontSize);
-        Assert.Equal("#FF0000", data.Styles["1"].Color.ToHex());
+        data.Markdown.Should().Be("{{PARA:1}}{{ALIGN:left}}text");
+        data.Segments[0].StyleId.Should().Be(1);
+        data.Styles.Should().ContainKey("1");
+        data.Styles["1"].Font.Should().Be("Arial");
+        data.Styles["1"].FontSize.Should().Be(12);
+        data.Styles["1"].Color.ToHex().Should().Be("#FF0000");
     }
 
     [Fact]
@@ -131,9 +132,9 @@ public class RtfToMarkdownTests
         var data = RtfToMarkdown.Convert(rtf);
 
         var expected = "{{PARA:0}}**HI-SCORES**";
-        Assert.Equal(expected, data.Markdown);
-        Assert.Equal("HI-SCORES", data.PlainText);
-        Assert.Equal(AbstTextAlignment.Right, data.Styles["0"].Alignment);
+        data.Markdown.Should().Be(expected);
+        data.PlainText.Should().Be("HI-SCORES");
+        data.Styles["0"].Alignment.Should().Be(AbstTextAlignment.Right);
     }
 
     [Fact]
@@ -146,9 +147,9 @@ public class RtfToMarkdownTests
         var data = RtfToMarkdown.Convert(rtf);
 
         var expected = "{{PARA:0}}**1**";
-        Assert.Equal(expected, data.Markdown);
-        Assert.Equal("1", data.PlainText);
-        Assert.Equal(AbstTextAlignment.Right, data.Styles["0"].Alignment);
+        data.Markdown.Should().Be(expected);
+        data.PlainText.Should().Be("1");
+        data.Styles["0"].Alignment.Should().Be(AbstTextAlignment.Right);
     }
 
     [Fact]
@@ -160,9 +161,9 @@ public class RtfToMarkdownTests
         var data = RtfToMarkdown.Convert(rtf);
 
         var expected = "{{PARA:0}}**GAME OVER**";
-        Assert.Equal(expected, data.Markdown);
-        Assert.Equal("GAME OVER", data.PlainText);
-        Assert.Equal(28, data.Styles["0"].MarginRight);
+        data.Markdown.Should().Be(expected);
+        data.PlainText.Should().Be("GAME OVER");
+        data.Styles["0"].MarginRight.Should().Be(28);
     }
 
 
@@ -180,13 +181,13 @@ public class RtfToMarkdownTests
 
         var data = RtfToMarkdown.Convert(rtf);
 
-        Assert.Contains("Actionkey = Space", data.PlainText);
-        Assert.Contains("Press P", data.PlainText);
-        Assert.Contains("for Pause", data.PlainText);
-        Assert.Contains("Press S", data.PlainText);
-        Assert.Contains("to stop", data.PlainText);
-        Assert.Contains("Press ESC", data.PlainText);
-        Assert.Contains("to Quit", data.PlainText);
+        data.PlainText.Should().Contain("Actionkey = Space");
+        data.PlainText.Should().Contain("Press P");
+        data.PlainText.Should().Contain("for Pause");
+        data.PlainText.Should().Contain("Press S");
+        data.PlainText.Should().Contain("to stop");
+        data.PlainText.Should().Contain("Press ESC");
+        data.PlainText.Should().Contain("to Quit");
     }
 
     [Fact]
@@ -199,7 +200,7 @@ public class RtfToMarkdownTests
 
         var data = RtfToMarkdown.Convert(rtf);
 
-        Assert.Equal("Construction Kit", data.PlainText);
+        data.PlainText.Should().Be("Construction Kit");
     }
 
     [Fact]
@@ -245,18 +246,18 @@ public class RtfToMarkdownTests
                      + ".........................................................::Live::..................................."
                      + ".............................................................................::Gates::.............."
                      + "............................................";
-        Assert.Equal(expected, data.Markdown);
+        data.Markdown.Should().Be(expected);
 
-        Assert.Single(data.Styles);
-        Assert.All(data.Segments, s => Assert.Equal(0, s.StyleId));
+        data.Styles.Should().HaveCount(1);
+        data.Segments.Should().AllSatisfy(s => s.StyleId.Should().Be(0));
         var style = data.Styles["0"];
-        Assert.Equal("Courier", style.Font);
-        Assert.Equal(12, style.FontSize);
-        Assert.Equal("#808080", style.Color.ToHex());
-        Assert.Equal(AbstTextAlignment.Left, style.Alignment);
-        Assert.Contains("::Multi BALLS::", data.PlainText);
-        Assert.Contains("::Black Balls::", data.PlainText);
-        Assert.DoesNotContain("\\", data.PlainText);
+        style.Font.Should().Be("Courier");
+        style.FontSize.Should().Be(12);
+        style.Color.ToHex().Should().Be("#808080");
+        style.Alignment.Should().Be(AbstTextAlignment.Left);
+        data.PlainText.Should().Contain("::Multi BALLS::");
+        data.PlainText.Should().Contain("::Black Balls::");
+        data.PlainText.Should().NotContain("\\");
     }
 
     [Fact]
@@ -266,7 +267,7 @@ public class RtfToMarkdownTests
 
         var data = RtfToMarkdown.Convert(rtf);
 
-        Assert.Equal("\tAfter", data.PlainText);
+        data.PlainText.Should().Be("\tAfter");
     }
 
     [Fact]
@@ -276,8 +277,8 @@ public class RtfToMarkdownTests
 
         var data = RtfToMarkdown.Convert(rtf);
 
-        Assert.Equal("line", data.PlainText);
-        Assert.Equal(18, data.Segments[0].LineHeight);
+        data.PlainText.Should().Be("line");
+        data.Segments[0].LineHeight.Should().Be(18);
     }
 
     [Fact]
@@ -288,13 +289,13 @@ public class RtfToMarkdownTests
         var data = RtfToMarkdown.Convert(rtf);
 
         var expected = "{{PARA:1}}New **Highscore!!!**\n{{PARA}}{{FONT-SIZE:14}}Enter your {{FONT-SIZE:18}}Name";
-        Assert.Equal(expected, data.Markdown);
+        data.Markdown.Should().Be(expected);
 
         var style = data.Styles["1"];
-        Assert.Equal("Earth", style.Font);
-        Assert.Equal(18, style.FontSize);
-        Assert.Equal("#FF0000", style.Color.ToHex());
-        Assert.Equal(AbstTextAlignment.Center, style.Alignment);
+        style.Font.Should().Be("Earth");
+        style.FontSize.Should().Be(18);
+        style.Color.ToHex().Should().Be("#FF0000");
+        style.Alignment.Should().Be(AbstTextAlignment.Center);
     }
 
     [Fact]
@@ -312,8 +313,8 @@ public class RtfToMarkdownTests
         renderer.Render(painter, new APoint(0, 0));
 
         var expected = "{{PARA:1}}New **Highscore!!!**\n{{PARA}}{{FONT-SIZE:14}}Enter your {{FONT-SIZE:18}}Name";
-        Assert.Equal(expected, data.Markdown);
-        Assert.True(painter.Height >= 18);
+        data.Markdown.Should().Be(expected);
+        painter.Height.Should().BeGreaterThanOrEqualTo(18);
     }
 
     [Fact]
@@ -323,7 +324,7 @@ public class RtfToMarkdownTests
 
         var data = RtfToMarkdown.Convert(rtf);
 
-        Assert.Equal("© 2005 by Emmanuel The Creator\n", data.PlainText);
+        data.PlainText.Should().Be("© 2005 by Emmanuel The Creator\n");
     }
 
     [Fact]
@@ -334,14 +335,14 @@ public class RtfToMarkdownTests
         var data = RtfToMarkdown.Convert(rtf);
 
         var expected = "{{PARA:0}}nele\n{{PARA:0}}nele\n{{PARA:0}}Michael\n{{PARA:0}}Michael\n{{PARA:0}}nele\n{{PARA:0}}nele\n{{PARA:0}}Manu\n{{PARA:0}}Michael\n{{PARA:0}}Michael\n{{PARA:0}}Laura\n{{PARA:0}}";
-        Assert.Equal(expected, data.Markdown);
-        Assert.Single(data.Styles);
-        Assert.True(data.Segments.All(s => s.StyleId == 0));
-        Assert.True(data.Segments.All(s => s.IsParagraph));
-        var style = data.Styles["0"];
-        Assert.Equal("Tahoma", style.Font);
-        Assert.Equal(12, style.FontSize);
-        Assert.Equal("#999999", style.Color.ToHex());
-        Assert.Equal(AbstTextAlignment.Right, style.Alignment);
+        data.Markdown.Should().Be(expected);
+        data.Styles.Should().HaveCount(1);
+        data.Segments.Should().OnlyContain(s => s.StyleId == 0);
+        data.Segments.Should().OnlyContain(s => s.IsParagraph);
+        var style2 = data.Styles["0"];
+        style2.Font.Should().Be("Tahoma");
+        style2.FontSize.Should().Be(12);
+        style2.Color.ToHex().Should().Be("#999999");
+        style2.Alignment.Should().Be(AbstTextAlignment.Right);
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/Docs/MarkDownRenderer.md
+++ b/WillMoveToOwnRepo/AbstUI/Docs/MarkDownRenderer.md
@@ -20,10 +20,15 @@ Custom tags are wrapped in double braces to avoid clashing with standard Markdow
 - `{{ALIGN:left|center|right|justify}}` – set text alignment
 - `{{COLOR:#RRGGBB}}` – set text color
 - `{{STYLE:name}}` and `{{/STYLE}}` – push and pop a named style supplied by the host application
+- `{{PARA:id}}` – start a new paragraph using the style with identifier `id`; `{{PARA}}` starts a new paragraph without changing style
 
 Example:
 
 ```
+{{PARA:0}}First paragraph
+{{PARA:1}}Second paragraph using style 1
+{{PARA}}Third paragraph keeps the current style
+
 {{FONT-FAMILY:Arial}}
 {{FONT-SIZE:18}}
 # Heading

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs
@@ -81,7 +81,8 @@ namespace AbstUI.Texts
                 return;
             }
 
-            var lines = _markdown.Split('\n');
+            var markdown = Regex.Replace(_markdown, @"\n(?=\{\{PARA(?::\d+)?\}\})", string.Empty);
+            var lines = markdown.Split('\n');
             var pos = start;
 
             foreach (var rawLine in lines)
@@ -232,7 +233,19 @@ namespace AbstUI.Texts
             while (true)
             {
                 var trimmed = line.TrimStart();
-                if (trimmed.StartsWith("{{STYLE:", StringComparison.Ordinal))
+                if (trimmed.StartsWith("{{PARA", StringComparison.Ordinal))
+                {
+                    int start = line.IndexOf("{{PARA", StringComparison.Ordinal);
+                    int end = line.IndexOf("}}", start + 6, StringComparison.Ordinal);
+                    if (end == -1)
+                        break;
+                    var idPart = line.Substring(start + 6, end - (start + 6)).TrimStart(':').Trim();
+                    _styleStack.Clear();
+                    if (idPart.Length > 0 && _styles.TryGetValue(idPart, out var paraStyle))
+                        ApplyStyle(paraStyle);
+                    line = line.Remove(start, end - start + 2);
+                }
+                else if (trimmed.StartsWith("{{STYLE:", StringComparison.Ordinal))
                 {
                     int start = line.IndexOf("{{STYLE:", StringComparison.Ordinal);
                     int end = line.IndexOf("}}", start + 8, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary
- support `{{PARA:id}}` tags in `AbstMarkdownRenderer` and ignore preceding line breaks
- document paragraph tags and examples in Markdown renderer docs
- convert `RtfToMarkdownTests` to FluentAssertions and add package reference

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/AbstMarkdownRenderer.cs --verbosity diagnostic`
- `dotnet format Test/LingoEngine.Tests/LingoEngine.Tests.csproj --include Test/LingoEngine.Tests/RtfToMarkdownTests.cs Test/LingoEngine.Tests/LingoEngine.Tests.csproj --verbosity diagnostic`
- `dotnet test Test/LingoEngine.Tests/LingoEngine.Tests.csproj`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ba8c1c52248332a79e948cd7e14bdf