### PR TITLE
docs: update project list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,22 +39,40 @@ These instructions apply to the entire repository.
 | src/LingoEngine.Unity/LingoEngine.Unity.csproj | Unity engine integration layer |
 | src/LingoEngine.LGodot/LingoEngine.LGodot.csproj | Godot engine integration layer |
 | src/LingoEngine.3D.Core/LingoEngine.3D.Core.csproj | Core components for 3D features |
+| src/LingoEngine.Blazor/LingoEngine.Blazor.csproj | Blazor integration layer |
 | src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj | Editor tooling reminiscent of Macromedia Director |
+| src/Director/LingoEngine.Director.Contracts/LingoEngine.Director.Contracts.csproj | Shared contracts for Director tooling |
+| src/Director/LingoEngine.Director.Client/LingoEngine.Director.Client.csproj | Client library for Director tooling |
+| src/Director/LingoEngine.Director.Host/LingoEngine.Director.Host.csproj | SignalR host for Director tooling |
+| src/Director/LingoEngine.Director.SDL2/LingoEngine.Director.SDL2.csproj | SDL2 integration for Director tooling |
 | src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj | Godot integration for Director tooling |
 | Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/LingoEngine.Demo.TetriGrounds.Core.csproj | Shared code for the TetriGrounds demo |
 | Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.SDL2/LingoEngine.Demo.TetriGrounds.SDL2.csproj | SDL2-based TetriGrounds demo |
+| Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Blazor/LingoEngine.Demo.TetriGrounds.Blazor.csproj | Blazor-based TetriGrounds demo |
 | Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/LingoEngine.Demo.TetriGrounds.Godot.csproj | Godot-based TetriGrounds demo |
 | Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj | Tests for the Lingo scripting runtime |
 | Test/LingoEngine.Lingo.Tests/LingoEngine.Lingo.Tests.csproj | Tests for LingoEngine core features |
+| Test/LingoEngine.Tests/LingoEngine.Tests.csproj | Tests for additional LingoEngine features |
 | Test/LingoEngine.SDL2.GfxVisualTest/LingoEngine.SDL2.GfxVisualTest.csproj | Console app for manual SDL2 graphics checks |
 | WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj | Core abstractions for the AbstUI framework |
 | WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj | SDL2 backend for AbstUI |
 | WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj | Unity backend for AbstUI |
 | WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj | Godot backend for AbstUI |
 | WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj | ImGui backend for AbstUI |
+| WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj | Blazor backend for AbstUI |
+| WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2.FFmpeg/AbstUI.SDL2.FFmpeg.csproj | FFmpeg-based media playback for the SDL2 backend |
+| WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2.Vlc/AbstUI.SDL2.Vlc.csproj | LibVLC-based media playback for the SDL2 backend |
+| WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/AbstUI.SDL2RmlUi.csproj | SDL2 backend using RmlUi.NET |
 | WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest/AbstUI.GfxVisualTest.csproj | Shared graphics visual test utilities for AbstUI |
+| WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/AbstUI.GfxVisualTest.Blazor.csproj | Blazor visual test application for AbstUI |
+| WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LGodot/AbstUI.GfxVisualTest.LGodot.csproj | Godot visual test application for AbstUI |
+| WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LUnity/AbstUI.GfxVisualTest.LUnity.csproj | Unity visual test application for AbstUI |
 | WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.ImGui/AbstUI.GfxVisualTest.ImGui.csproj | ImGui visual test application for AbstUI |
 | WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/AbstUI.GfxVisualTest.SDL2.csproj | SDL2 visual test application for AbstUI |
+| WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests.Common/AbstUI.Tests.Common.csproj | Shared test utilities for AbstUI |
+| WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj | Tests for core AbstUI components |
+| WillMoveToOwnRepo/AbstUI/Test/AbstUI.SDLTest/AbstUI.SDLTest.csproj | Tests for the AbstUI SDL2 backend |
+| WillMoveToOwnRepo/AbstUI/Test/AbstUI.LGodotTest/AbstUI.LGodotTest.csproj | Tests for the AbstUI Godot backend |
 | WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/ProjectorRays.DotNet.csproj | Core ProjectorRays .NET library |
 | WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.Console/ProjectorRays.Console.csproj | Console showcase for ProjectorRays |
 | WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/ProjectorRays.DotNet.Test.csproj | Tests for ProjectorRays library |


### PR DESCRIPTION
## Summary
- document newly added LingoEngine, Director, demo, and AbstUI projects
- expand project table to cover AbstUI test projects

## Testing
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.LGodotTest/AbstUI.LGodotTest.csproj -v m` *(skipped: Requires Godot runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68bab746a8dc8332b6884be64a97f5a4