### PR TITLE
Add GodotTestHost for LGodot tests

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.LGodotTest/AbstUI.LGodotTest.csproj
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.LGodotTest/AbstUI.LGodotTest.csproj
@@ -7,15 +7,26 @@
 		<LangVersion>12</LangVersion>
 		<Platforms>AnyCPU;x64;x86</Platforms>
 	</PropertyGroup>
-	<ItemGroup>
-	  <Content Include="Media\Fonts\8PinMatrix.ttf" />
-	  <Content Include="Media\Fonts\arcade.ttf" />
-	  <Content Include="Media\Fonts\bikly.ttf" />
-	  <Content Include="Media\Fonts\earth.ttf" />
-	  <Content Include="Media\Fonts\Tahoma.ttf" />
-	</ItemGroup>
+        <ItemGroup>
+          <Content Include="Media\Fonts\8PinMatrix.ttf">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          </Content>
+          <Content Include="Media\Fonts\arcade.ttf">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          </Content>
+          <Content Include="Media\Fonts\bikly.ttf">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          </Content>
+          <Content Include="Media\Fonts\earth.ttf">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          </Content>
+          <Content Include="Media\Fonts\Tahoma.ttf">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          </Content>
+        </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="8.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.LGodotTest/GodotImagePainterBaselineTests.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.LGodotTest/GodotImagePainterBaselineTests.cs
@@ -1,7 +1,7 @@
-using System.IO;
 using AbstUI.Primitives;
 using AbstUI.LGodot.Bitmaps;
 using AbstUI.LGodot.Components.Graphics;
+using FluentAssertions;
 using AbstUI.LGodot.Styles;
 using AbstUI.Tests.Common;
 
@@ -12,24 +12,31 @@ public class GodotImagePainterBaselineTests
     [Fact]
     public void DescenderGlyphExtendsBelowBaseline()
     {
-        var fm = new AbstGodotFontManager();
-        using var painter = new GodotImagePainterToTexture(fm, 64, 64);
+        GodotTestHost.Run(fontManager =>
+        {
+            using var painter = new GodotImagePainterToTexture(fontManager, 64, 64);
+            painter.AutoResize = true;
 
-        painter.DrawText(new APoint(0, 0), "h", fontSize: 32);
-        var hTex = (AbstGodotTexture2D)painter.GetTexture("h");
-        var hPixels = hTex.GetPixels();
-        int topH = GraphicsPixelHelper.FindTopOpaqueRow(hPixels, hTex.Width, hTex.Height);
-        int bottomH = GraphicsPixelHelper.FindBottomOpaqueRow(hPixels, hTex.Width, hTex.Height);
+            painter.Name = "h";
+            painter.DrawRect(ARect.New(0, 0, 80, 30), AColors.Red);
+            painter.DrawText(new APoint(0, 0), "halooo", "Tahoma", AColors.Black, 32);
+            painter.Render();
+            var hTex = (AbstGodotTexture2D)painter.GetTexture("h");
+            var hPixels = hTex.GetPixels();
+            int topH = GraphicsPixelHelper.FindTopOpaqueRow(hPixels, hTex.Width, hTex.Height);
+            int bottomH = GraphicsPixelHelper.FindBottomOpaqueRow(hPixels, hTex.Width, hTex.Height);
 
-        painter.Clear(new AColor(0, 0, 0, 0));
-        painter.DrawText(new APoint(0, 0), "p", fontSize: 32);
-        var pTex = (AbstGodotTexture2D)painter.GetTexture("p");
-        var pPixels = pTex.GetPixels();
-        int topP = GraphicsPixelHelper.FindTopOpaqueRow(pPixels, pTex.Width, pTex.Height);
-        int bottomP = GraphicsPixelHelper.FindBottomOpaqueRow(pPixels, pTex.Width, pTex.Height);
+            painter.Name = "p";
+            painter.Clear(new AColor(0, 0, 0, 0));
+            painter.DrawText(new APoint(0, 0), "p", "Tahoma", AColors.Black, 32);
+            painter.Render();
+            var pTex = (AbstGodotTexture2D)painter.GetTexture("p");
+            var pPixels = pTex.GetPixels();
+            int topP = GraphicsPixelHelper.FindTopOpaqueRow(pPixels, pTex.Width, pTex.Height);
+            int bottomP = GraphicsPixelHelper.FindBottomOpaqueRow(pPixels, pTex.Width, pTex.Height);
 
-        
-        Assert.Equal(topH, topP);
-        Assert.True(bottomP >= bottomH);
+            topH.Should().Be(topP);
+            bottomP.Should().BeGreaterThanOrEqualTo(bottomH);
+        });
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.LGodotTest/GodotTestHost.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.LGodotTest/GodotTestHost.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using AbstUI.LGodot.Styles;
+
+namespace AbstUI.LGodotTest;
+
+public static class GodotTestHost
+{
+    public static void Run(Action<AbstGodotFontManager> test)
+    {
+        var fontManager = new AbstGodotFontManager();
+        fontManager
+            .AddFont("Arcade", Path.Combine("Media", "Fonts", "arcade.ttf"))
+            .AddFont("Bikly", Path.Combine("Media", "Fonts", "bikly.ttf"))
+            .AddFont("8Pin Matrix", Path.Combine("Media", "Fonts", "8PinMatrix.ttf"))
+            .AddFont("Earth", Path.Combine("Media", "Fonts", "earth.ttf"))
+            .AddFont("Tahoma", Path.Combine("Media", "Fonts", "Tahoma.ttf"));
+        fontManager.LoadAll();
+        test(fontManager);
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable `GodotTestHost` with predefined fonts
- update baseline test to use new host and FluentAssertions
- ensure font assets are copied and add FluentAssertions dependency

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/Test/AbstUI.LGodotTest/AbstUI.LGodotTest.csproj`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.LGodotTest/AbstUI.LGodotTest.csproj` *(fails: Test host process crashed)*

------
https://chatgpt.com/codex/tasks/task_e_68bac80fcbbc833296c5022da578851f