### PR TITLE
Add optional stylesheet embedding in RTF Markdown conversion

### DIFF
--- a/Test/LingoEngine.Tests/AbstMarkdownRendererTests.cs
+++ b/Test/LingoEngine.Tests/AbstMarkdownRendererTests.cs
@@ -66,4 +66,17 @@ public class AbstMarkdownRendererTests
         data.Markdown.Should().Be(expected);
         painter.Height.Should().BeGreaterThanOrEqualTo(18);
     }
+
+    [Fact]
+    public void Render_ParsesEmbeddedStyleSheet()
+    {
+        var rtf = "{\\rtf1\\ansi{\\fonttbl{\\f0 Arial;}}{\\colortbl;\\red0\\green0\\blue0;}{\\f0\\fs40\\cf1 big}}";
+        var data = RtfToMarkdown.Convert(rtf, includeStyleSheet: true);
+        var fontManager = new TestFontManager();
+        var renderer = new AbstMarkdownRenderer(fontManager);
+        var painter = new RecordingPainter { AutoResize = true };
+        renderer.SetText(data.Markdown);
+        renderer.Render(painter, new APoint(0, 0));
+        painter.FontSizes[0].Should().Be(20);
+    }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/MarkdownStyleSheetTTO.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Texts/MarkdownStyleSheetTTO.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace AbstUI.Texts;
+
+public class MarkdownStyleSheetTTO
+{
+    [JsonPropertyName("font-family")]
+    public string? FontFamily { get; set; }
+
+    [JsonPropertyName("font-size")]
+    public int? FontSize { get; set; }
+
+    [JsonPropertyName("color")]
+    public string? Color { get; set; }
+
+    [JsonPropertyName("text-align")]
+    public string? TextAlign { get; set; }
+
+    [JsonPropertyName("font-weight")]
+    public string? FontWeight { get; set; }
+
+    [JsonPropertyName("font-style")]
+    public string? FontStyle { get; set; }
+
+    [JsonPropertyName("text-decoration")]
+    public string? TextDecoration { get; set; }
+
+    [JsonPropertyName("line-height")]
+    public int? LineHeight { get; set; }
+
+    [JsonPropertyName("margin-left")]
+    public int? MarginLeft { get; set; }
+
+    [JsonPropertyName("margin-right")]
+    public int? MarginRight { get; set; }
+}

--- a/src/LingoEngine/Tools/RtfToMarkdown.cs
+++ b/src/LingoEngine/Tools/RtfToMarkdown.cs
@@ -3,6 +3,8 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Linq;
 using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using AbstUI.Primitives;
 using AbstUI.Texts;
 
@@ -16,7 +18,7 @@ namespace LingoEngine.Tools
         /// Converts an RTF string into the custom AbstMarkdown format used by <see cref="AbstMarkdownRenderer"/>.
         /// Returns the Markdown string along with the style segments and stylesheet definitions used to build it.
         /// </summary>
-        public static AbstMarkdownData Convert(string rtfContent)
+        public static AbstMarkdownData Convert(string rtfContent, bool includeStyleSheet = false)
         {
             var fontEntries = ParseFontTable(rtfContent);
             var colorEntries = ParseColorTable(rtfContent, out int colorOffset);
@@ -32,7 +34,7 @@ namespace LingoEngine.Tools
                     var style = new AbstTextStyle
                     {
                         Name = "0",
-                        Font = seg.FontName ??"",
+                        Font = seg.FontName ?? "",
                         FontSize = seg.Size,
                         Color = seg.Color ?? AColors.Black,
                         Alignment = seg.Alignment,
@@ -199,6 +201,43 @@ namespace LingoEngine.Tools
             var styles = styleMap.ToDictionary(kv => kv.Key, kv => kv.Value.Style);
             var markdown = Regex.Replace(sb.ToString(), @"\n{2,}", "\n");
             markdown = Regex.Replace(markdown, @"\n\s+", "\n");
+
+            if (includeStyleSheet)
+            {
+                var sheet = styles.ToDictionary(kv => kv.Key, kv =>
+                {
+                    var s = kv.Value;
+                    var tto = new MarkdownStyleSheetTTO();
+                    if (!string.IsNullOrEmpty(s.Font))
+                        tto.FontFamily = s.Font;
+                    if (s.FontSize > 0)
+                        tto.FontSize = s.FontSize;
+                    var hex = s.Color.ToHex();
+                    if (!string.Equals(hex, "#000000", StringComparison.OrdinalIgnoreCase))
+                        tto.Color = hex;
+                    if (s.Alignment != AbstTextAlignment.Left)
+                        tto.TextAlign = s.Alignment.ToString().ToLowerInvariant();
+                    if (s.Bold)
+                        tto.FontWeight = "bold";
+                    if (s.Italic)
+                        tto.FontStyle = "italic";
+                    if (s.Underline)
+                        tto.TextDecoration = "underline";
+                    if (s.LineHeight > 0)
+                        tto.LineHeight = s.LineHeight;
+                    if (s.MarginLeft != 0)
+                        tto.MarginLeft = s.MarginLeft;
+                    if (s.MarginRight != 0)
+                        tto.MarginRight = s.MarginRight;
+                    return tto;
+                });
+                var json = JsonSerializer.Serialize(sheet, new JsonSerializerOptions
+                {
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                });
+                markdown = $"{{{{STYLE-SHEET:{json}}}}}" + markdown;
+            }
+
             var plainTextRaw = string.Concat(segments.Select(s => s.Text));
             var plainText = Regex.Replace(plainTextRaw, @"\n{2,}", "\n");
             plainText = Regex.Replace(plainText, @"\n\s+", "\n");


### PR DESCRIPTION
## Summary
- Rename embedded stylesheet tag to STYLE-SHEET and omit default values when serializing
- Make MarkdownStyleSheetTTO properties nullable and adjust renderer parsing
- Restore original fast rendering baseline

## Testing
- `dotnet test Test/LingoEngine.Tests/LingoEngine.Tests.csproj`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj` *(fails: AbstMarkdownRendererTests)*

------
https://chatgpt.com/codex/tasks/task_e_68bb182c0ed4833292751c55b7b8af7e