### PR TITLE
Improve SDL2 circle fill using scanlines

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Graphics/SDLImagePainter.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Graphics/SDLImagePainter.cs
@@ -228,20 +228,22 @@ namespace AbstUI.SDL2.Components.Graphics
                 () =>
                 {
                     SDL.SDL_SetRenderDrawColor(Renderer, c.R, c.G, c.B, c.A);
-                    int segs = (int)(rad * 6);
-                    double step = Math.PI * 2 / segs;
-                    float prevX = ctr.X + rad;
-                    float prevY = ctr.Y;
-                    for (int i = 1; i <= segs; i++)
+                    int r = (int)MathF.Ceiling(rad);
+                    for (int dy = -r; dy <= r; dy++)
                     {
-                        double angle = step * i;
-                        float x = ctr.X + (float)(rad * Math.Cos(angle));
-                        float y = ctr.Y + (float)(rad * Math.Sin(angle));
-                        SDL.SDL_RenderDrawLineF(Renderer, prevX, prevY, x, y);
+                        float dyf = dy;
+                        if (MathF.Abs(dyf) > rad) continue;
+                        float y = ctr.Y + dyf;
+                        float dx = (float)MathF.Sqrt(MathF.Max(0, rad * rad - dyf * dyf));
                         if (f)
-                            SDL.SDL_RenderDrawLineF(Renderer, ctr.X, ctr.Y, x, y);
-                        prevX = x;
-                        prevY = y;
+                        {
+                            SDL.SDL_RenderDrawLineF(Renderer, ctr.X - dx, y, ctr.X + dx, y);
+                        }
+                        else
+                        {
+                            SDL.SDL_RenderDrawPointF(Renderer, ctr.X - dx, y);
+                            SDL.SDL_RenderDrawPointF(Renderer, ctr.X + dx, y);
+                        }
                     }
                 }
             ));


### PR DESCRIPTION
## Summary
- Improve `SDLImagePainter.DrawCircle` to render filled circles using horizontal scanlines for smooth coverage

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --include Components/Graphics/SDLImagePainter.cs --verbosity minimal`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.SDLTest/AbstUI.SDLTest.csproj` *(fails: IMG_SavePNG couldn't open C:/temp/director/SDL_h.png)*
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj` *(fails: Assert.Equal() Failure: Expected 16 Actual 20)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1986aa2c8332962289de12f5894e