### PR TITLE
refactor image painter base

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Graphics/SDLImagePainter.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Graphics/SDLImagePainter.cs
@@ -1,4 +1,4 @@
-﻿using AbstUI.Components.Graphics;
+using AbstUI.Components.Graphics;
 using AbstUI.Primitives;
 using AbstUI.SDL2.Bitmaps;
 using AbstUI.SDL2.SDLL;
@@ -7,606 +7,471 @@ using AbstUI.Styles;
 using AbstUI.Texts;
 using System.Runtime.InteropServices;
 
-namespace AbstUI.SDL2.Components.Graphics
+namespace AbstUI.SDL2.Components.Graphics;
+
+public class SDLImagePainter : AbstImagePainter<nint>
 {
-    public class SDLImagePainter : IAbstImagePainter
+    private readonly SdlFontManager _fontManager;
+    private nint _texture;
+    private nint _prevTarget;
+
+    public SDLImagePainter(IAbstFontManager fontManager, int width, int height, nint renderer)
+        : base(width, height, GetMaxTexSize(renderer).W, GetMaxTexSize(renderer).H)
     {
-        private readonly SdlFontManager _fontManager;
-        private nint _texture;
-        private readonly List<(Func<APoint?> GetTotalSize, Action DrawAction)> _drawActions = new();
-        private AColor? _clearColor;
-        protected bool _dirty;
-        private readonly int _maxWidth;
-        private readonly int _maxHeight;
-        private int _width;
-        private int _height;
+        _fontManager = (SdlFontManager)fontManager;
+        Renderer = renderer;
+        _texture = SDL.SDL_CreateTexture(renderer, SDL.SDL_PIXELFORMAT_RGBA8888,
+            (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, Width, Height);
+    }
 
-        public nint Renderer { get; }
+    public nint Renderer { get; }
+    protected override nint Target => _texture;
+    public nint Texture => _texture;
 
-        public int Width
+    public static (int W, int H) GetMaxTexSize(nint renderer)
+    {
+        SDL.SDL_GetRendererInfo(renderer, out var info);
+        return ((int)info.max_texture_width, (int)info.max_texture_height);
+    }
+
+    public override void Dispose()
+    {
+        if (_texture != nint.Zero)
         {
-            get => _width;
-            set
+            SDL.SDL_DestroyTexture(_texture);
+            _texture = nint.Zero;
+        }
+    }
+
+    protected override void BeginRender(AColor clearColor)
+    {
+        _prevTarget = SDL.SDL_GetRenderTarget(Renderer);
+        SDL.SDL_SetRenderTarget(Renderer, _texture);
+        SDL.SDL_SetRenderDrawColor(Renderer, clearColor.R, clearColor.G, clearColor.B, clearColor.A);
+        SDL.SDL_RenderClear(Renderer);
+    }
+
+    protected override void EndRender()
+    {
+        SDL.SDL_SetRenderTarget(Renderer, _prevTarget);
+    }
+
+    protected override void ResizeTexture(int width, int height)
+    {
+        if (_texture != nint.Zero)
+            SDL.SDL_DestroyTexture(_texture);
+        _texture = SDL.SDL_CreateTexture(Renderer, SDL.SDL_PIXELFORMAT_RGBA8888,
+            (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, width, height);
+    }
+
+    public override void SetPixel(APoint point, AColor color)
+    {
+        var p = point;
+        var c = color;
+        var resizePos = new APoint((int)p.X, (int)p.Y);
+        _drawActions.Add(new DrawAction(AutoResizeWidth || AutoResizeHeight, resizePos, new APoint(1, 1), _ =>
+        {
+            SDL.SDL_SetRenderDrawColor(Renderer, c.R, c.G, c.B, 255);
+            SDL.SDL_RenderDrawPointF(Renderer, p.X, p.Y);
+        }));
+        MarkDirty();
+    }
+
+    public override void DrawLine(APoint start, APoint end, AColor color, float width = 1)
+    {
+        var s = start;
+        var e = end;
+        var c = color;
+        int maxX = (int)MathF.Ceiling(MathF.Max(s.X, e.X)) + 1;
+        int maxY = (int)MathF.Ceiling(MathF.Max(s.Y, e.Y)) + 1;
+        _drawActions.Add(new DrawAction(AutoResizeWidth || AutoResizeHeight, new APoint(0, 0), new APoint(maxX, maxY), _ =>
+        {
+            SDL.SDL_SetRenderDrawColor(Renderer, c.R, c.G, c.B, 255);
+            SDL.SDL_RenderDrawLineF(Renderer, s.X, s.Y, e.X, e.Y);
+        }));
+        MarkDirty();
+    }
+
+    public override void DrawRect(ARect rect, AColor color, bool filled = true, float width = 1)
+    {
+        var r = rect;
+        var c = color;
+        var f = filled;
+        var resizePos = new APoint((int)r.Left, (int)r.Top);
+        var size = new APoint((int)r.Width, (int)r.Height);
+        _drawActions.Add(new DrawAction(AutoResizeWidth || AutoResizeHeight, resizePos, size, _ =>
+        {
+            var rct = new SDL.SDL_Rect
             {
-                if (_width == value)
-                    return;
-                _width = value;
-                MarkDirty();
-            }
-        }
+                x = (int)r.Left,
+                y = (int)r.Top,
+                w = (int)r.Width,
+                h = (int)r.Height
+            };
+            SDL.SDL_SetRenderDrawColor(Renderer, c.R, c.G, c.B, c.A);
+            if (f)
+                SDL.SDL_RenderFillRect(Renderer, ref rct);
+            else
+                SDL.SDL_RenderDrawRect(Renderer, ref rct);
+        }));
+        MarkDirty();
+    }
 
-        public int Height
+    public override void DrawCircle(APoint center, float radius, AColor color, bool filled = true, float width = 1)
+    {
+        var ctr = center;
+        var rad = radius;
+        var c = color;
+        var f = filled;
+        int r = (int)MathF.Ceiling(rad);
+        var resizePos = new APoint((int)ctr.X - r, (int)ctr.Y - r);
+        var size = new APoint(r * 2 + 1, r * 2 + 1);
+        _drawActions.Add(new DrawAction(AutoResizeWidth || AutoResizeHeight, resizePos, size, _ =>
         {
-            get => _height;
-            set
+            SDL.SDL_SetRenderDrawColor(Renderer, c.R, c.G, c.B, c.A);
+            for (int dy = -r; dy <= r; dy++)
             {
-                if (_height == value)
-                    return;
-                _height = value;
-                MarkDirty();
+                float dyf = dy;
+                if (MathF.Abs(dyf) > rad) continue;
+                float y = ctr.Y + dyf;
+                float dx = (float)MathF.Sqrt(MathF.Max(0, rad * rad - dyf * dyf));
+                if (f)
+                {
+                    SDL.SDL_RenderDrawLineF(Renderer, ctr.X - dx, y, ctr.X + dx, y);
+                }
+                else
+                {
+                    SDL.SDL_RenderDrawPointF(Renderer, ctr.X - dx, y);
+                    SDL.SDL_RenderDrawPointF(Renderer, ctr.X + dx, y);
+                }
             }
-        }
+        }));
+        MarkDirty();
+    }
 
-        public bool Pixilated { get; set; }
-        public bool AutoResizeWidth { get; set; } = false;
-        public bool AutoResizeHeight { get; set; } = true;
-        public nint Texture => _texture;
-        public string Name { get; set; } = "";
-
-        public SDLImagePainter(IAbstFontManager fontManager, int width, int height, nint renderer)
+    public override void DrawArc(APoint center, float radius, float startDeg, float endDeg, int segments, AColor color, float width = 1)
+    {
+        var ctr = center;
+        var rad = radius;
+        var sd = startDeg;
+        var ed = endDeg;
+        var segs = segments;
+        var c = color;
+        int r = (int)MathF.Ceiling(rad);
+        var resizePos = new APoint((int)ctr.X - r, (int)ctr.Y - r);
+        var size = new APoint(r * 2 + 1, r * 2 + 1);
+        _drawActions.Add(new DrawAction(AutoResizeWidth || AutoResizeHeight, resizePos, size, _ =>
         {
-            _fontManager = (SdlFontManager)fontManager;
-            (_maxWidth, _maxHeight) = GetMaxTexSize(renderer);
-            // if running tests, this is 0
-            if (_maxWidth == 0) _maxWidth = 2048;
-            if (_maxHeight == 0) _maxHeight = 2048;
-            _width = width > 0 ? Math.Min(width, _maxWidth) : 10;
-            _height = height > 0 ? Math.Min(height, _maxHeight) : 10;
-
-            _texture = SDL.SDL_CreateTexture(renderer, SDL.SDL_PIXELFORMAT_RGBA8888,
-                (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, _width, _height);
-            _dirty = true;
-            Renderer = renderer;
-        }
-
-        public void Resize(int width, int height)
-        {
-            width = Math.Min(width, _maxWidth);
-            height = Math.Min(height, _maxHeight);
-            if (Width == width && Height == height)
-                return;
-            _width = width;
-            _height = height;
-            MarkDirty();
-        }
-
-        /// <summary>
-        /// Query once at startup
-        /// </summary>
-        public static (int W, int H) GetMaxTexSize(nint renderer)
-        {
-            SDL.SDL_GetRendererInfo(renderer, out var info);
-            return ((int)info.max_texture_width, (int)info.max_texture_height);
-        }
-        public void Dispose()
-        {
-            if (_texture != nint.Zero)
+            SDL.SDL_SetRenderDrawColor(Renderer, c.R, c.G, c.B, c.A);
+            float startRad = MathF.PI * sd / 180f;
+            float endRad = MathF.PI * ed / 180f;
+            float step = (endRad - startRad) / segs;
+            float prevX = ctr.X + rad * MathF.Cos(startRad);
+            float prevY = ctr.Y + rad * MathF.Sin(startRad);
+            for (int i = 1; i <= segs; i++)
             {
-                SDL.SDL_DestroyTexture(_texture);
-                _texture = nint.Zero;
+                double ang = startRad + i * step;
+                float x = ctr.X + (float)(rad * Math.Cos(ang));
+                float y = ctr.Y + (float)(rad * Math.Sin(ang));
+                SDL.SDL_RenderDrawLineF(Renderer, prevX, prevY, x, y);
+                prevX = x;
+                prevY = y;
             }
-        }
+        }));
+        MarkDirty();
+    }
 
-        public void Render()
+    public override void DrawPolygon(IReadOnlyList<APoint> points, AColor color, bool filled = true, float width = 1)
+    {
+        if (points.Count < 2) return;
+        var pts = new APoint[points.Count];
+        for (int i = 0; i < points.Count; i++)
+            pts[i] = points[i];
+        var c = color;
+        var f = filled;
+        int minX = int.MaxValue, maxX = int.MinValue;
+        int minY = int.MaxValue, maxY = int.MinValue;
+        foreach (var p in pts)
         {
-            if (!_dirty) return;
-
-            var newWidth = Width;
-            var newHeight = Height;
-            if (AutoResizeWidth || AutoResizeHeight)
+            if (p.X < minX) minX = (int)p.X;
+            if (p.X > maxX) maxX = (int)p.X;
+            if (p.Y < minY) minY = (int)p.Y;
+            if (p.Y > maxY) maxY = (int)p.Y;
+        }
+        var pos = new APoint(minX, minY);
+        var size = new APoint(maxX - minX + 1, maxY - minY + 1);
+        _drawActions.Add(new DrawAction(AutoResizeWidth || AutoResizeHeight, pos, size, _ =>
+        {
+            SDL.SDL_SetRenderDrawColor(Renderer, c.R, c.G, c.B, c.A);
+            for (int i = 0; i < pts.Length - 1; i++)
+                SDL.SDL_RenderDrawLineF(Renderer, pts[i].X, pts[i].Y, pts[i + 1].X, pts[i + 1].Y);
+            SDL.SDL_RenderDrawLineF(Renderer, pts[^1].X, pts[^1].Y, pts[0].X, pts[0].Y);
+            if (f)
             {
-                foreach (var a in _drawActions)
+                var p0 = pts[0];
+                for (int i = 1; i < pts.Length - 1; i++)
                 {
-                    var newSize = a.GetTotalSize();
-                    if (newSize != null)
-                    {
-                        if (AutoResizeWidth && newSize.Value.X > newWidth)
-                            newWidth = (int)MathF.Max(newWidth, newSize.Value.X);
-                        if (AutoResizeHeight && newSize.Value.Y > newHeight)
-                            newHeight = (int)MathF.Max(newHeight, newSize.Value.Y);
-                    }
+                    SDL.SDL_RenderDrawLineF(Renderer, p0.X, p0.Y, pts[i].X, pts[i].Y);
+                    SDL.SDL_RenderDrawLineF(Renderer, p0.X, p0.Y, pts[i + 1].X, pts[i + 1].Y);
                 }
             }
-            newWidth = Math.Min(newWidth, _maxWidth);
-            newHeight = Math.Min(newHeight, _maxHeight);
-            if (newWidth > Width || newHeight > Height)
+        }));
+        MarkDirty();
+    }
+
+    public override void DrawText(APoint position, string text, string? fontNamee = null, AColor? color = null, int fontSize = 12, int width = -1, AbstTextAlignment alignment = default, AbstFontStyle style = AbstFontStyle.Regular)
+    {
+        var pos = position;
+        var txt = text;
+        var fntName = fontNamee;
+        var col = color;
+        var fs = fontSize;
+        if (fs == 0) fs = 12;
+        var w = width;
+        var font = _fontManager.GetTyped(this, fntName ?? string.Empty, fs, style);
+        if (font == null) return;
+        var fnt = font.FontHandle;
+        if (fnt == nint.Zero) { font.Release(); return; }
+
+        string RenderLine(string line)
+        {
+            if (w >= 0)
             {
-                SDL.SDL_DestroyTexture(_texture);
-                var nw = AutoResizeWidth ? Math.Max(Width, newWidth) : Width;
-                var nh = AutoResizeHeight ? Math.Max(Height, newHeight) : Height;
-                var newTex = SDL.SDL_CreateTexture(Renderer, SDL.SDL_PIXELFORMAT_RGBA8888,
-                    (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, nw, nh);
-                _texture = newTex;
-                Width = nw;
-                Height = nh;
+                while (line.Length > 0 && SDL_ttf.TTF_SizeUTF8(fnt, line, out int tw, out _) == 0 && tw > w)
+                    line = line.Substring(0, line.Length - 1);
             }
-
-            var prev = SDL.SDL_GetRenderTarget(Renderer);
-            SDL.SDL_SetRenderTarget(Renderer, _texture);
-            var clear = _clearColor ?? AColor.FromRGBA(0, 0, 0, 0);
-            SDL.SDL_SetRenderDrawColor(Renderer, clear.R, clear.G, clear.B, clear.A);
-            SDL.SDL_RenderClear(Renderer);
-            foreach (var action in _drawActions)
-                action.DrawAction();
-            SDL.SDL_SetRenderTarget(Renderer, prev);
-            _dirty = false;
+            return line;
         }
 
-
-        protected void MarkDirty() => _dirty = true;
-
-        public void Clear(AColor color)
+        var rawLines = txt.Split('\n');
+        var lines = new string[rawLines.Length];
+        for (int i = 0; i < rawLines.Length; i++)
+            lines[i] = RenderLine(rawLines[i]);
+        int maxW = 0;
+        foreach (var line in lines)
         {
-            _drawActions.Clear();
-            _clearColor = color;
-            MarkDirty();
+            if (SDL_ttf.TTF_SizeUTF8(fnt, line, out int tw, out _) == 0 && tw > maxW)
+                maxW = tw;
         }
-
-        public void SetPixel(APoint point, AColor color)
+        int lineSkip = SDL_ttf.TTF_FontLineSkip(fnt);
+        int ascent = SDL_ttf.TTF_FontAscent(fnt);
+        int totalH = lines.Length * lineSkip;
+        int needW = (w >= 0) ? Math.Max(maxW, w) : maxW;
+        var resizePos = new APoint((int)pos.X, (int)pos.Y);
+        var size = new APoint(needW, totalH);
+        _drawActions.Add(new DrawAction(AutoResizeWidth || AutoResizeHeight, resizePos, size, _ =>
         {
-            var p = point;
-            var c = color;
-            _drawActions.Add((
-                () => (AutoResizeWidth || AutoResizeHeight) ? EnsureCapacity((int)p.X + 1, (int)p.Y + 1) : null,
-                () =>
-                {
-                    SDL.SDL_SetRenderDrawColor(Renderer, c.R, c.G, c.B, 255);
-                    SDL.SDL_RenderDrawPointF(Renderer, p.X, p.Y);
-                }
-            ));
-            MarkDirty();
-        }
+            SDL.SDL_Color c = new SDL.SDL_Color { r = col?.R ?? 0, g = col?.G ?? 0, b = col?.B ?? 0, a = 255 };
 
-        public void DrawLine(APoint start, APoint end, AColor color, float width = 1)
-        {
-            var s = start;
-            var e = end;
-            var c = color;
-            _drawActions.Add((
-                () =>
-                {
-                    if (!AutoResizeWidth && !AutoResizeHeight) return null;
-                    int maxX = (int)MathF.Ceiling(MathF.Max(s.X, e.X)) + 1;
-                    int maxY = (int)MathF.Ceiling(MathF.Max(s.Y, e.Y)) + 1;
-                    return EnsureCapacity(maxX, maxY);
-                },
-                () =>
-                {
-                    SDL.SDL_SetRenderDrawColor(Renderer, c.R, c.G, c.B, 255);
-                    SDL.SDL_RenderDrawLineF(Renderer, s.X, s.Y, e.X, e.Y);
-                }
-            ));
-            MarkDirty();
-        }
-
-        public void DrawRect(ARect rect, AColor color, bool filled = true, float width = 1)
-        {
-            var r = rect;
-            var c = color;
-            var f = filled;
-            _drawActions.Add((
-                () =>
-                {
-                    if (!AutoResizeWidth && !AutoResizeHeight) return null;
-                    int x = (int)r.Left, y = (int)r.Top, w = (int)r.Width, h = (int)r.Height;
-                    return EnsureCapacity(x + w, y + h);
-                },
-                () =>
-                {
-                    var rct = new SDL.SDL_Rect
-                    {
-                        x = (int)r.Left,
-                        y = (int)r.Top,
-                        w = (int)r.Width,
-                        h = (int)r.Height
-                    };
-                    SDL.SDL_SetRenderDrawColor(Renderer, c.R, c.G, c.B, c.A);
-                    if (f)
-                        SDL.SDL_RenderFillRect(Renderer, ref rct);
-                    else
-                        SDL.SDL_RenderDrawRect(Renderer, ref rct);
-                }
-            ));
-            MarkDirty();
-        }
-
-        public void DrawCircle(APoint center, float radius, AColor color, bool filled = true, float width = 1)
-        {
-            var ctr = center;
-            var rad = radius;
-            var c = color;
-            var f = filled;
-            _drawActions.Add((
-                () => (AutoResizeWidth || AutoResizeHeight) ? EnsureCapacity((int)ctr.X + (int)MathF.Ceiling(rad) + 1, (int)ctr.Y + (int)MathF.Ceiling(rad) + 1) : null,
-                () =>
-                {
-                    SDL.SDL_SetRenderDrawColor(Renderer, c.R, c.G, c.B, c.A);
-                    int r = (int)MathF.Ceiling(rad);
-                    for (int dy = -r; dy <= r; dy++)
-                    {
-                        float dyf = dy;
-                        if (MathF.Abs(dyf) > rad) continue;
-                        float y = ctr.Y + dyf;
-                        float dx = (float)MathF.Sqrt(MathF.Max(0, rad * rad - dyf * dyf));
-                        if (f)
-                        {
-                            SDL.SDL_RenderDrawLineF(Renderer, ctr.X - dx, y, ctr.X + dx, y);
-                        }
-                        else
-                        {
-                            SDL.SDL_RenderDrawPointF(Renderer, ctr.X - dx, y);
-                            SDL.SDL_RenderDrawPointF(Renderer, ctr.X + dx, y);
-                        }
-                    }
-                }
-            ));
-            MarkDirty();
-        }
-
-        public void DrawArc(APoint center, float radius, float startDeg, float endDeg, int segments, AColor color, float width = 1)
-        {
-            var ctr = center;
-            var rad = radius;
-            var sd = startDeg;
-            var ed = endDeg;
-            var segs = segments;
-            var c = color;
-            _drawActions.Add((
-                () =>
-                {
-                    if (!AutoResizeWidth && !AutoResizeHeight) return null;
-                    int cx = (int)ctr.X, cy = (int)ctr.Y, r = (int)MathF.Ceiling(rad);
-                    return EnsureCapacity(cx + r + 1, cy + r + 1);
-                },
-                () =>
-                {
-                    SDL.SDL_SetRenderDrawColor(Renderer, c.R, c.G, c.B, c.A);
-                    double startRad = sd * Math.PI / 180.0;
-                    double endRad = ed * Math.PI / 180.0;
-                    double step = (endRad - startRad) / segs;
-                    float prevX = ctr.X + (float)(rad * Math.Cos(startRad));
-                    float prevY = ctr.Y + (float)(rad * Math.Sin(startRad));
-                    for (int i = 1; i <= segs; i++)
-                    {
-                        double ang = startRad + i * step;
-                        float x = ctr.X + (float)(rad * Math.Cos(ang));
-                        float y = ctr.Y + (float)(rad * Math.Sin(ang));
-                        SDL.SDL_RenderDrawLineF(Renderer, prevX, prevY, x, y);
-                        prevX = x;
-                        prevY = y;
-                    }
-                }
-            ));
-            MarkDirty();
-        }
-
-        public void DrawPolygon(IReadOnlyList<APoint> points, AColor color, bool filled = true, float width = 1)
-        {
-            if (points.Count < 2) return;
-            var pts = new APoint[points.Count];
-            for (int i = 0; i < points.Count; i++)
-                pts[i] = points[i];
-            var c = color;
-            var f = filled;
-            _drawActions.Add((
-                () =>
-                {
-                    if (!AutoResizeWidth && !AutoResizeHeight) return null;
-                    int maxX = 0, maxY = 0;
-                    foreach (var p in pts)
-                    {
-                        if (p.X > maxX) maxX = (int)p.X;
-                        if (p.Y > maxY) maxY = (int)p.Y;
-                    }
-                    return EnsureCapacity(maxX + 1, maxY + 1);
-                },
-                () =>
-                {
-                    SDL.SDL_SetRenderDrawColor(Renderer, c.R, c.G, c.B, c.A);
-                    for (int i = 0; i < pts.Length - 1; i++)
-                        SDL.SDL_RenderDrawLineF(Renderer, pts[i].X, pts[i].Y, pts[i + 1].X, pts[i + 1].Y);
-                    SDL.SDL_RenderDrawLineF(Renderer, pts[^1].X, pts[^1].Y, pts[0].X, pts[0].Y);
-                    if (f)
-                    {
-                        var p0 = pts[0];
-                        for (int i = 1; i < pts.Length - 1; i++)
-                        {
-                            SDL.SDL_RenderDrawLineF(Renderer, p0.X, p0.Y, pts[i].X, pts[i].Y);
-                            SDL.SDL_RenderDrawLineF(Renderer, p0.X, p0.Y, pts[i + 1].X, pts[i + 1].Y);
-                        }
-                    }
-                }
-            ));
-            MarkDirty();
-        }
-
-        public void DrawText(APoint position, string text, string? fontNamee = null, AColor? color = null, int fontSize = 12, int width = -1, AbstTextAlignment alignment = default, AbstFontStyle style = AbstFontStyle.Regular)
-        {
-            var pos = position;
-            var txt = text;
-            var fntName = fontNamee;
-            var col = color;
-            var fs = fontSize;
-            if (fs == 0) fs = 12;
-            var w = width;
-            var font = _fontManager.GetTyped(this, fntName ?? string.Empty, fs, style);
-            if (font == null) return;
-            var fnt = font.FontHandle;
-            if (fnt == nint.Zero) { font.Release(); return; }
-
-            string RenderLine(string line)
-            {
-                if (w >= 0)
-                {
-                    while (line.Length > 0 && SDL_ttf.TTF_SizeUTF8(fnt, line, out int tw, out _) == 0 && tw > w)
-                        line = line.Substring(0, line.Length - 1);
-                }
-                return line;
-            }
-
-            var rawLines = txt.Split('\n');
-            var lines = new string[rawLines.Length];
-            for (int i = 0; i < rawLines.Length; i++)
-                lines[i] = RenderLine(rawLines[i]);
-            int maxW = 0;
+            List<(nint surf, int w, int h)> surfaces = new();
             foreach (var line in lines)
             {
-                if (SDL_ttf.TTF_SizeUTF8(fnt, line, out int tw, out _) == 0 && tw > maxW)
-                    maxW = tw;
+                nint s = SDL_ttf.TTF_RenderUTF8_Blended(fnt, line, c);
+                if (s == nint.Zero) continue;
+                var sur = SDL.PtrToStructure<SDL.SDL_Surface>(s);
+                surfaces.Add((s, sur.w, sur.h));
             }
-            int lineSkip = SDL_ttf.TTF_FontLineSkip(fnt);
-            int ascent = SDL_ttf.TTF_FontAscent(fnt);
-            int totalH = lines.Length * lineSkip;
+            //int y = (int)pos.Y - ascent;
+            int y = (int)pos.Y; // was: pos.Y - ascent
+            int boxW = w >= 0 ? w : Math.Max(0, Width - (int)pos.X);
 
-            _drawActions.Add((
-                () =>
-                {
-                    if (!AutoResizeWidth && !AutoResizeHeight) return null;
-                    int needW = (w >= 0) ? Math.Max(maxW, w) : maxW;
-                    return EnsureCapacity((int)(pos.X + needW), (int)(pos.Y + totalH));
-                },
-                () =>
-                {
-                    SDL.SDL_Color c = new SDL.SDL_Color { r = col?.R ?? 0, g = col?.G ?? 0, b = col?.B ?? 0, a = 255 };
-
-                    List<(nint surf, int w, int h)> surfaces = new();
-                    foreach (var line in lines)
-                    {
-                        nint s = SDL_ttf.TTF_RenderUTF8_Blended(fnt, line, c);
-                        if (s == nint.Zero) continue;
-                        var sur = SDL.PtrToStructure<SDL.SDL_Surface>(s);
-                        surfaces.Add((s, sur.w, sur.h));
-                    }
-                    //int y = (int)pos.Y - ascent;
-                    int y = (int)pos.Y;                     // was: pos.Y - ascent
-                    int boxW = w >= 0 ? w : Math.Max(0, Width - (int)pos.X);
-
-                    foreach (var (s, tw, th) in surfaces)
-                    {
-                        nint tex = SDL.SDL_CreateTextureFromSurface(Renderer, s);
-                        if (tex != nint.Zero)
-                        {
-                            int startX = (int)pos.X;
-                            if (boxW > 0)
-                            {
-                                switch (alignment)
-                                {
-                                    case AbstTextAlignment.Center: startX += Math.Max(0, (boxW - tw) / 2); break;
-                                    case AbstTextAlignment.Right: startX += Math.Max(0, boxW - tw); break;
-                                }
-                            }
-                            SDL.SDL_Rect dst = new SDL.SDL_Rect { x = startX, y = y, w = tw, h = th };
-                            SDL.SDL_RenderCopy(Renderer, tex, nint.Zero, ref dst);
-                            SDL.SDL_DestroyTexture(tex);
-                        }
-                        y += lineSkip;
-                    }
-                }
-            ));
-            font.Release();
-            MarkDirty();
-        }
-
-        public void DrawSingleLine(APoint position, string text, string? fontName = null, AColor? color = null, int fontSize = 12, int width = -1, int height = -1, AbstTextAlignment alignment = default, AbstFontStyle style = AbstFontStyle.Regular)
-        {
-            var pos = position;
-            var txt = text;
-            var fntName = fontName;
-            var col = color;
-            var fs = fontSize;
-            if (fs == 0) fs = 12;
-            var w = width;
-            var h = height;
-            var font = _fontManager.GetTyped(this, fntName ?? string.Empty, fs, style);
-            if (font == null) return;
-            var fnt = font.FontHandle;
-            if (fnt == nint.Zero) { font.Release(); return; }
-
-            int ascent = SDL_ttf.TTF_FontAscent(fnt);
-            int lineHeight = SDL_ttf.TTF_FontHeight(fnt);
-
-            _drawActions.Add((
-                () =>
-                {
-                    if (!AutoResizeWidth && !AutoResizeHeight) return null;
-                    int calcW = w;
-                    int calcH = h;
-                    if (SDL_ttf.TTF_SizeUTF8(fnt, txt, out int tw, out _) == 0)
-                    {
-                        calcW = (w >= 0) ? Math.Max(w, tw) : tw;
-                        calcH = (h >= 0) ? h : lineHeight;
-                    }
-                    else
-                    {
-                        if (calcW < 0) calcW = 0;
-                        if (calcH < 0) calcH = lineHeight;
-                    }
-                    //return EnsureCapacity((int)pos.X + calcW, (int)(pos.Y - ascent + calcH));
-                    return EnsureCapacity((int)pos.X + calcW, (int)pos.Y + calcH);
-                },
-                () =>
-                {
-                    SDL.SDL_Color c = new SDL.SDL_Color { r = col?.R ?? 0, g = col?.G ?? 0, b = col?.B ?? 0, a = 255 };
-                    nint s = SDL_ttf.TTF_RenderUTF8_Blended(fnt, txt, c);
-                    if (s == nint.Zero) return;
-                    var sur = SDL.PtrToStructure<SDL.SDL_Surface>(s);
-                    nint tex = SDL.SDL_CreateTextureFromSurface(Renderer, s);
-                    if (tex != nint.Zero)
-                    {
-                        int startX = (int)pos.X;
-                        if (w >= 0)
-                        {
-                            switch (alignment)
-                            {
-                                case AbstTextAlignment.Center:
-                                    startX += Math.Max(0, (w - sur.w) / 2);
-                                    break;
-                                case AbstTextAlignment.Right:
-                                    startX += Math.Max(0, w - sur.w);
-                                    break;
-                            }
-                        }
-                        //SDL.SDL_Rect dst = new SDL.SDL_Rect { x = startX, y = (int)pos.Y - ascent, w = sur.w, h = sur.h };
-                        SDL.SDL_Rect dst = new SDL.SDL_Rect { x = startX, y = (int)pos.Y, w = sur.w, h = sur.h };
-                        SDL.SDL_RenderCopy(Renderer, tex, nint.Zero, ref dst);
-                        SDL.SDL_DestroyTexture(tex);
-                    }
-                    SDL.SDL_FreeSurface(s);
-                }
-            ));
-            font.Release();
-            MarkDirty();
-        }
-        public void DrawPicture(byte[] data, int width, int height, APoint position, APixelFormat format)
-        {
-            var dat = data;
-            var w = width;
-            var h = height;
-            var pos = position;
-            var fmt = format;
-            _drawActions.Add((
-                () => (AutoResizeWidth || AutoResizeHeight) ? EnsureCapacity((int)pos.X + w, (int)pos.Y + h) : null,
-                () =>
-                {
-                    fmt.GetMasks(out uint rmask, out uint gmask, out uint bmask, out uint amask, out int bpp);
-                    var handle = GCHandle.Alloc(dat, GCHandleType.Pinned);
-                    nint surf = SDL.SDL_CreateRGBSurfaceFrom(handle.AddrOfPinnedObject(), w, h, bpp, w * (bpp / 8), rmask, gmask, bmask, amask);
-                    if (surf == nint.Zero) { handle.Free(); return; }
-                    nint tex = SDL.SDL_CreateTextureFromSurface(Renderer, surf);
-                    if (tex != nint.Zero)
-                    {
-                        SDL.SDL_Rect dst = new SDL.SDL_Rect { x = (int)pos.X, y = (int)pos.Y, w = w, h = h };
-                        SDL.SDL_RenderCopy(Renderer, tex, nint.Zero, ref dst);
-                        SDL.SDL_DestroyTexture(tex);
-                    }
-                    SDL.SDL_FreeSurface(surf);
-                    handle.Free();
-                }
-            ));
-            MarkDirty();
-        }
-        public void DrawPicture(IAbstTexture2D texture, int width, int height, APoint position)
-        {
-            var tex = texture;
-            var w = width;
-            var h = height;
-            var pos = position;
-            _drawActions.Add((
-                () =>
-                {
-                    if (!AutoResizeWidth && !AutoResizeHeight) return null;
-                    switch (tex)
-                    {
-                        case SdlImageTexture surface when surface.SurfaceId != nint.Zero:
-                            {
-                                int copyW = Math.Min(w, surface.Width);
-                                int copyH = Math.Min(h, surface.Height);
-                                return EnsureCapacity((int)pos.X + copyW, (int)pos.Y + copyH);
-                            }
-                        case SdlTexture2D img when img.Handle != nint.Zero:
-                            {
-                                int copyW = Math.Min(w, img.Width);
-                                int copyH = Math.Min(h, img.Height);
-                                return EnsureCapacity((int)pos.X + copyW, (int)pos.Y + copyH);
-                            }
-                        default:
-                            return null;
-                    }
-                },
-                () =>
-                {
-                    switch (tex)
-                    {
-                        case SdlImageTexture surface when surface.SurfaceId != nint.Zero:
-                            {
-                                nint sdlTex = SDL.SDL_CreateTextureFromSurface(Renderer, surface.SurfaceId);
-                                if (sdlTex != nint.Zero)
-                                {
-                                    SDL.SDL_Rect dst = new SDL.SDL_Rect
-                                    {
-                                        x = (int)pos.X,
-                                        y = (int)pos.Y,
-                                        w = w,
-                                        h = h
-                                    };
-                                    SDL.SDL_RenderCopy(Renderer, sdlTex, nint.Zero, ref dst);
-                                    SDL.SDL_DestroyTexture(sdlTex);
-                                }
-                                break;
-                            }
-                        case SdlTexture2D img when img.Handle != nint.Zero:
-                            {
-                                SDL.SDL_Rect dst = new SDL.SDL_Rect
-                                {
-                                    x = (int)pos.X,
-                                    y = (int)pos.Y,
-                                    w = w,
-                                    h = h
-                                };
-                                SDL.SDL_RenderCopy(Renderer, img.Handle, nint.Zero, ref dst);
-                                break;
-                            }
-                    }
-                }
-            ));
-            MarkDirty();
-        }
-
-        public IAbstTexture2D GetTexture(string? name = null)
-        {
-            Render();
-            var texture = new SdlTexture2D(_texture, Width, Height, name ?? $"Texture_{Width}x{Height}");
-            if (_texture != nint.Zero)
+            foreach (var (s, tw, th) in surfaces)
             {
-                //SdlTexture2D textureClone = (SdlTexture2D)texture.Clone(Renderer);
-                //texture.Dispose();
+                nint tex = SDL.SDL_CreateTextureFromSurface(Renderer, s);
+                if (tex != nint.Zero)
+                {
+                    int startX = (int)pos.X;
+                    if (boxW > 0)
+                    {
+                        switch (alignment)
+                        {
+                            case AbstTextAlignment.Center: startX += Math.Max(0, (boxW - tw) / 2); break;
+                            case AbstTextAlignment.Right: startX += Math.Max(0, boxW - tw); break;
+                        }
+                    }
+                    SDL.SDL_Rect dst = new SDL.SDL_Rect { x = startX, y = y, w = tw, h = th };
+                    SDL.SDL_RenderCopy(Renderer, tex, nint.Zero, ref dst);
+                    SDL.SDL_DestroyTexture(tex);
+                }
+                y += lineSkip;
+            }
+        }));
+        font.Release();
+        MarkDirty();
+    }
+
+    public override void DrawSingleLine(APoint position, string text, string? fontName = null, AColor? color = null, int fontSize = 12, int width = -1, int height = -1, AbstTextAlignment alignment = default, AbstFontStyle style = AbstFontStyle.Regular)
+    {
+        var pos = position;
+        var txt = text;
+        var fntName = fontName;
+        var col = color;
+        var fs = fontSize;
+        if (fs == 0) fs = 12;
+        var w = width;
+        var h = height;
+        var font = _fontManager.GetTyped(this, fntName ?? string.Empty, fs, style);
+        if (font == null) return;
+        var fnt = font.FontHandle;
+        if (fnt == nint.Zero) { font.Release(); return; }
+
+        int ascent = SDL_ttf.TTF_FontAscent(fnt);
+        int lineHeight = SDL_ttf.TTF_FontHeight(fnt);
+        int calcW = w;
+        int calcH = h;
+        if (SDL_ttf.TTF_SizeUTF8(fnt, txt, out int tw, out _) == 0)
+        {
+            calcW = (w >= 0) ? Math.Max(w, tw) : tw;
+            calcH = (h >= 0) ? h : lineHeight;
+        }
+        else
+        {
+            if (calcW < 0) calcW = 0;
+            if (calcH < 0) calcH = lineHeight;
+        }
+        //return EnsureCapacity((int)pos.X + calcW, (int)(pos.Y - ascent + calcH));
+        var resizePos = new APoint((int)pos.X, (int)pos.Y);
+        var size = new APoint(calcW, calcH);
+        _drawActions.Add(new DrawAction(AutoResizeWidth || AutoResizeHeight, resizePos, size, _ =>
+        {
+            SDL.SDL_Color c = new SDL.SDL_Color { r = col?.R ?? 0, g = col?.G ?? 0, b = col?.B ?? 0, a = 255 };
+            nint s = SDL_ttf.TTF_RenderUTF8_Blended(fnt, txt, c);
+            if (s == nint.Zero) return;
+            var sur = SDL.PtrToStructure<SDL.SDL_Surface>(s);
+            nint tex = SDL.SDL_CreateTextureFromSurface(Renderer, s);
+            if (tex != nint.Zero)
+            {
+                int startX = (int)pos.X;
+                if (w >= 0)
+                {
+                    switch (alignment)
+                    {
+                        case AbstTextAlignment.Center:
+                            startX += Math.Max(0, (w - sur.w) / 2);
+                            break;
+                        case AbstTextAlignment.Right:
+                            startX += Math.Max(0, w - sur.w);
+                            break;
+                    }
+                }
+                //SDL.SDL_Rect dst = new SDL.SDL_Rect { x = startX, y = (int)pos.Y - ascent, w = sur.w, h = sur.h };
+                SDL.SDL_Rect dst = new SDL.SDL_Rect { x = startX, y = (int)pos.Y, w = sur.w, h = sur.h };
+                SDL.SDL_RenderCopy(Renderer, tex, nint.Zero, ref dst);
+                SDL.SDL_DestroyTexture(tex);
+            }
+            SDL.SDL_FreeSurface(s);
+        }));
+        font.Release();
+        MarkDirty();
+    }
+
+    public override void DrawPicture(byte[] data, int width, int height, APoint position, APixelFormat format)
+    {
+        var dat = data;
+        var w = width;
+        var h = height;
+        var pos = position;
+        var fmt = format;
+        var resizePos = new APoint((int)pos.X, (int)pos.Y);
+        _drawActions.Add(new DrawAction(AutoResizeWidth || AutoResizeHeight, resizePos, new APoint(w, h), _ =>
+        {
+            fmt.GetMasks(out uint rmask, out uint gmask, out uint bmask, out uint amask, out int bpp);
+            var handle = GCHandle.Alloc(dat, GCHandleType.Pinned);
+            nint surf = SDL.SDL_CreateRGBSurfaceFrom(handle.AddrOfPinnedObject(), w, h, bpp, w * (bpp / 8), rmask, gmask, bmask, amask);
+            if (surf == nint.Zero) { handle.Free(); return; }
+            nint tex = SDL.SDL_CreateTextureFromSurface(Renderer, surf);
+            if (tex != nint.Zero)
+            {
+                SDL.SDL_Rect dst = new SDL.SDL_Rect { x = (int)pos.X, y = (int)pos.Y, w = w, h = h };
+                SDL.SDL_RenderCopy(Renderer, tex, nint.Zero, ref dst);
+                SDL.SDL_DestroyTexture(tex);
+            }
+            SDL.SDL_FreeSurface(surf);
+            handle.Free();
+        }));
+        MarkDirty();
+    }
+
+    public override void DrawPicture(IAbstTexture2D texture, int width, int height, APoint position)
+    {
+        var tex = texture;
+        var w = width;
+        var h = height;
+        var pos = position;
+        bool needResize = AutoResizeWidth || AutoResizeHeight;
+        int calcW = w;
+        int calcH = h;
+        if (needResize)
+        {
+            switch (tex)
+            {
+                case SdlImageTexture surface when surface.SurfaceId != nint.Zero:
+                    calcW = Math.Min(w, surface.Width);
+                    calcH = Math.Min(h, surface.Height);
+                    break;
+                case SdlTexture2D img when img.Handle != nint.Zero:
+                    calcW = Math.Min(w, img.Width);
+                    calcH = Math.Min(h, img.Height);
+                    break;
+                default:
+                    needResize = false;
+                    break;
+            }
+        }
+        var resizePos = new APoint((int)pos.X, (int)pos.Y);
+        var size = new APoint(calcW, calcH);
+        _drawActions.Add(new DrawAction(needResize, resizePos, size, _ =>
+        {
+            switch (tex)
+            {
+                case SdlImageTexture surface when surface.SurfaceId != nint.Zero:
+                    {
+                        nint sdlTex = SDL.SDL_CreateTextureFromSurface(Renderer, surface.SurfaceId);
+                        if (sdlTex != nint.Zero)
+                        {
+                            SDL.SDL_Rect dst = new SDL.SDL_Rect
+                            {
+                                x = (int)pos.X,
+                                y = (int)pos.Y,
+                                w = w,
+                                h = h
+                            };
+                            SDL.SDL_RenderCopy(Renderer, sdlTex, nint.Zero, ref dst);
+                            SDL.SDL_DestroyTexture(sdlTex);
+                        }
+                        break;
+                    }
+                case SdlTexture2D img when img.Handle != nint.Zero:
+                    {
+                        SDL.SDL_Rect dst = new SDL.SDL_Rect
+                        {
+                            x = (int)pos.X,
+                            y = (int)pos.Y,
+                            w = w,
+                            h = h
+                        };
+                        SDL.SDL_RenderCopy(Renderer, img.Handle, nint.Zero, ref dst);
+                        break;
+                    }
+            }
+        }));
+        MarkDirty();
+    }
+
+    public override IAbstTexture2D GetTexture(string? name = null)
+    {
+        Render();
+        var texture = new SdlTexture2D(_texture, Width, Height, name ?? $"Texture_{Width}x{Height}");
+        if (_texture != nint.Zero)
+        {
 #if DEBUG
-                texture.DebugWriteToDisk(Renderer);
+            texture.DebugWriteToDisk(Renderer);
 #endif
-            }
-            else
-            {
-                // image to big, ignore
-            }
-            return texture;
         }
-
-        private APoint? EnsureCapacity(int minW, int minH)
+        else
         {
-            int newW = Math.Max(Width, minW);
-            int newH = Math.Max(Height, minH);
-            if (newW == Width && newH == Height) return null;
-            return new APoint(newW, newH);
+            // image too big, ignore
         }
+        return texture;
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Graphics/AbstImagePainter.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Graphics/AbstImagePainter.cs
@@ -1,0 +1,129 @@
+using AbstUI.Primitives;
+using AbstUI.Styles;
+using AbstUI.Texts;
+
+namespace AbstUI.Components.Graphics;
+
+public abstract class AbstImagePainter<TTexture> : IAbstImagePainter
+{
+    public readonly record struct DrawAction(bool NeedResize, APoint Position, APoint Size, Action<TTexture> Execute);
+
+    protected readonly List<DrawAction> _drawActions = new();
+    private AColor? _clearColor;
+    protected bool _dirty;
+    protected readonly int _maxWidth;
+    protected readonly int _maxHeight;
+    private int _width;
+    private int _height;
+
+    protected AbstImagePainter(int width, int height, int maxWidth, int maxHeight)
+    {
+        _maxWidth = maxWidth == 0 ? 2048 : maxWidth;
+        _maxHeight = maxHeight == 0 ? 2048 : maxHeight;
+        _width = width > 0 ? Math.Min(width, _maxWidth) : 10;
+        _height = height > 0 ? Math.Min(height, _maxHeight) : 10;
+        _dirty = true;
+    }
+
+    public int Width
+    {
+        get => _width;
+        set
+        {
+            if (_width == value) return;
+            _width = value;
+            MarkDirty();
+        }
+    }
+
+    public int Height
+    {
+        get => _height;
+        set
+        {
+            if (_height == value) return;
+            _height = value;
+            MarkDirty();
+        }
+    }
+
+    public bool Pixilated { get; set; }
+    public bool AutoResizeWidth { get; set; } = false;
+    public bool AutoResizeHeight { get; set; } = true;
+    public string Name { get; set; } = string.Empty;
+
+    protected void MarkDirty() => _dirty = true;
+
+    public void Clear(AColor color)
+    {
+        _drawActions.Clear();
+        _clearColor = color;
+        MarkDirty();
+    }
+
+    public void Resize(int width, int height)
+    {
+        width = Math.Min(width, _maxWidth);
+        height = Math.Min(height, _maxHeight);
+        if (_width == width && _height == height) return;
+        _width = width;
+        _height = height;
+        MarkDirty();
+    }
+
+    public void Render()
+    {
+        if (!_dirty) return;
+
+        var newWidth = Width;
+        var newHeight = Height;
+        if (AutoResizeWidth || AutoResizeHeight)
+        {
+            foreach (var action in _drawActions)
+            {
+                if (!action.NeedResize) continue;
+                var candidateW = (int)MathF.Ceiling(action.Position.X + action.Size.X);
+                var candidateH = (int)MathF.Ceiling(action.Position.Y + action.Size.Y);
+                if (AutoResizeWidth && candidateW > newWidth)
+                    newWidth = candidateW;
+                if (AutoResizeHeight && candidateH > newHeight)
+                    newHeight = candidateH;
+            }
+        }
+
+        var targetWidth = AutoResizeWidth ? Math.Max(Width, newWidth) : Width;
+        var targetHeight = AutoResizeHeight ? Math.Max(Height, newHeight) : Height;
+        targetWidth = Math.Min(targetWidth, _maxWidth);
+        targetHeight = Math.Min(targetHeight, _maxHeight);
+        if (targetWidth != Width || targetHeight != Height)
+        {
+            ResizeTexture(targetWidth, targetHeight);
+            _width = targetWidth;
+            _height = targetHeight;
+        }
+
+        BeginRender(_clearColor ?? AColor.FromRGBA(0, 0, 0, 0));
+        foreach (var action in _drawActions)
+            action.Execute(Target);
+        EndRender();
+        _dirty = false;
+    }
+
+    protected abstract void BeginRender(AColor clearColor);
+    protected abstract void EndRender();
+    protected abstract void ResizeTexture(int width, int height);
+    protected abstract TTexture Target { get; }
+
+    public abstract void SetPixel(APoint point, AColor color);
+    public abstract void DrawLine(APoint start, APoint end, AColor color, float width = 1);
+    public abstract void DrawRect(ARect rect, AColor color, bool filled = true, float width = 1);
+    public abstract void DrawCircle(APoint center, float radius, AColor color, bool filled = true, float width = 1);
+    public abstract void DrawArc(APoint center, float radius, float startDeg, float endDeg, int segments, AColor color, float width = 1);
+    public abstract void DrawPolygon(IReadOnlyList<APoint> points, AColor color, bool filled = true, float width = 1);
+    public abstract void DrawPicture(byte[] data, int width, int height, APoint position, APixelFormat format);
+    public abstract void DrawPicture(IAbstTexture2D texture, int width, int height, APoint position);
+    public abstract void DrawText(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, AbstTextAlignment alignment = AbstTextAlignment.Left, AbstFontStyle style = AbstFontStyle.Regular);
+    public abstract void DrawSingleLine(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, int height = -1, AbstTextAlignment alignment = AbstTextAlignment.Left, AbstFontStyle style = AbstFontStyle.Regular);
+    public abstract IAbstTexture2D GetTexture(string? name = null);
+    public abstract void Dispose();
+}


### PR DESCRIPTION
## Summary
- extract generic `AbstImagePainter<TTexture>` with shared render logic
- refactor SDL image painter to inherit from base and use structured draw actions
- preserve original sizing by truncating resize bounds to integer coordinates

## Testing
- `dotnet format --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Graphics/SDLImagePainter.cs` *(failed: Restore operation failed)*
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj -v minimal` *(failed: Assert.Equal() Failure)*
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.SDLTest/AbstUI.SDLTest.csproj -v minimal` *(failed: IMG_SavePNG failed: Couldn't open C:/temp/director/SDL_h.png)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb4931360833297df65058d839ee7