### PR TITLE
Add Godot wrapper for markdown text editor

### DIFF
--- a/src/Director/LingoEngine.Director.Core/DirectorSetup.cs
+++ b/src/Director/LingoEngine.Director.Core/DirectorSetup.cs
@@ -61,7 +61,7 @@ namespace LingoEngine.Director.Core
                     .AddSingleton<DirectorBinaryViewerWindow>()
                     .AddSingleton<DirectorBinaryViewerWindowV2>()
                     .AddSingleton<DirectorStageWindow>()
-                    .AddSingleton<DirectorTextEditWindow>()
+                    .AddSingleton<DirectorTextEditWindowV2>()
                     .AddSingleton<DirectorBitmapEditWindow>()
                     .AddSingleton<DirectorImportExportWindow>()
                     .AddSingleton<DirStageManager>()

--- a/src/Director/LingoEngine.Director.Core/Texts/DirectorTextEditWindowV2.cs
+++ b/src/Director/LingoEngine.Director.Core/Texts/DirectorTextEditWindowV2.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+using AbstUI.Components.Containers;
+using AbstUI.Components.Graphics;
+using AbstUI.Components.Inputs;
+using AbstUI.Primitives;
+using AbstUI.Texts;
+using AbstUI.Styles;
+using AbstUI.Windowing;
+using LingoEngine.Director.Core.UI;
+using LingoEngine.Director.Core.Windowing;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Texts;
+
+namespace LingoEngine.Director.Core.Texts
+{
+    public class DirectorTextEditWindowV2 : DirectorWindow<IDirFrameworkTextEditWindow>
+    {
+        private readonly AbstInputText _markdownInput;
+        private readonly AbstGfxCanvas _previewCanvas;
+        private readonly AbstMarkdownRenderer _renderer;
+        private readonly AbstWrapPanel _rootPanel;
+        private CancellationTokenSource? _renderCts;
+        private IAbstTexture2D? _previewTexture;
+        private SynchronizationContext? _uiContext;
+        private ILingoMemberTextBase? _member;
+
+        public TextEditIconBar IconBar { get; }
+        public AbstTextStyle CurrentStyle => IconBar.CurrentStyle;
+        public AbstWrapPanel RootPanel => _rootPanel;
+
+        public DirectorTextEditWindowV2(ILingoFrameworkFactory factory, IServiceProvider serviceProvider) : base(serviceProvider, DirectorMenuCodes.TextEditWindow)
+        {
+            IconBar = new TextEditIconBar(factory);
+            var fontManager = factory.ComponentFactory.GetRequiredService<IAbstFontManager>();
+            _renderer = new AbstMarkdownRenderer(fontManager);
+            IconBar.SetFonts(fontManager.GetAllNames());
+            _rootPanel = factory.CreateWrapPanel(AOrientation.Vertical, "TextEditWindowV2Root");
+            _rootPanel.AddItem(IconBar.Panel);
+
+            var columns = factory.CreateWrapPanel(AOrientation.Horizontal, "TextEditWindowV2Columns");
+            _rootPanel.AddItem(columns);
+
+            _markdownInput = factory.CreateInputText("MarkdownInput", onChange: OnTextChanged, multiLine: true);
+            _markdownInput.Width = 400;
+            _markdownInput.Height = 400;
+            columns.AddItem(_markdownInput);
+
+            _previewCanvas = factory.CreateGfxCanvas("MarkdownPreview", 400, 400);
+            _previewCanvas.Width = 400;
+            _previewCanvas.Height = 400;
+            columns.AddItem(_previewCanvas);
+
+            IconBar.BoldChanged += v =>
+            {
+                if (v)
+                {
+                    InsertAroundSelection("**", "**");
+                    IconBar.SetBold(false);
+                }
+            };
+            IconBar.ItalicChanged += v =>
+            {
+                if (v)
+                {
+                    InsertAroundSelection("*", "*");
+                    IconBar.SetItalic(false);
+                }
+            };
+            IconBar.UnderlineChanged += v =>
+            {
+                if (v)
+                {
+                    InsertAroundSelection("__", "__");
+                    IconBar.SetUnderline(false);
+                }
+            };
+            IconBar.AlignmentChanged += a =>
+            {
+                var style = EnsureParagraphStyle();
+                style.Alignment = a;
+                SyncMemberText();
+                ScheduleRender(_markdownInput.Text);
+            };
+            IconBar.FontSizeChanged += v =>
+            {
+                var style = EnsureParagraphStyle();
+                style.FontSize = v;
+                SyncMemberText();
+                ScheduleRender(_markdownInput.Text);
+            };
+            IconBar.FontChanged += n =>
+            {
+                if (string.IsNullOrEmpty(n)) return;
+                var style = EnsureParagraphStyle();
+                style.Font = n;
+                SyncMemberText();
+                ScheduleRender(_markdownInput.Text);
+            };
+            IconBar.ColorChanged += c =>
+            {
+                if (_markdownInput.HasSelection)
+                {
+                    var styleName = IconBar.CreateStyle(s => s.Color = c);
+                    InsertAroundSelection($"{{{{STYLE:{styleName}}}}}", "{{/STYLE}}");
+                }
+                else
+                {
+                    var style = EnsureParagraphStyle();
+                    style.Color = c;
+                    SyncMemberText();
+                    ScheduleRender(_markdownInput.Text);
+                }
+            };
+
+            Width = 820;
+            Height = 480;
+            MinimumWidth = 400;
+            MinimumHeight = 460;
+            X = 1000;
+            Y = 700;
+        }
+
+        protected override void OnInit(IAbstFrameworkWindow frameworkWindow)
+        {
+            base.OnInit(frameworkWindow);
+            _uiContext = SynchronizationContext.Current;
+            Content = _rootPanel;
+        }
+
+        protected override void OnDispose()
+        {
+            _renderCts?.Cancel();
+            _renderCts?.Dispose();
+            _previewTexture?.Dispose();
+            base.OnDispose();
+        }
+
+        protected override void OnResizing(bool firstLoad, int width, int height)
+        {
+            base.OnResizing(firstLoad, width, height);
+            IconBar.OnResizing(width, height);
+            _rootPanel.Width = width;
+            _rootPanel.Height = height;
+            var contentHeight = height - IconBar.Panel.Height;
+            _markdownInput.Width = width / 2;
+            _markdownInput.Height = contentHeight;
+            _previewCanvas.Width = width / 2;
+            _previewCanvas.Height = contentHeight;
+        }
+
+        public void SetMemberValues(ILingoMemberTextBase textMember)
+        {
+            _member = textMember;
+            _markdownInput.Text = textMember.Text;
+            IconBar.SetMemberValues(textMember);
+            RenderMarkdown(_markdownInput.Text);
+        }
+
+        private void OnTextChanged(string text)
+        {
+            if (_member != null)
+                _member.Text = text;
+            ScheduleRender(text);
+        }
+
+        private void SyncMemberText()
+        {
+            if (_member != null)
+                _member.Text = _markdownInput.Text;
+        }
+
+        private void ScheduleRender(string text)
+        {
+            _renderCts?.Cancel();
+            var cts = new CancellationTokenSource();
+            _renderCts = cts;
+            Task.Delay(250, cts.Token).ContinueWith(t =>
+            {
+                if (!t.IsCanceled)
+                {
+                    if (_uiContext != null)
+                        _uiContext.Post(_ => RenderMarkdown(text), null);
+                    else
+                        RenderMarkdown(text);
+                }
+            }, TaskScheduler.Default);
+        }
+
+        private void RenderMarkdown(string text)
+        {
+            _previewTexture?.Dispose();
+            using var painter = _factory.ComponentFactory.CreateImagePainterToTexture((int)_previewCanvas.Width, (int)_previewCanvas.Height);
+            painter.AutoResize = true;
+            _renderer.Reset();
+            _renderer.SetText(text, IconBar.Styles);
+            _renderer.Render(painter, new APoint(0, 0));
+            _previewTexture = painter.GetTexture("MarkdownPreview");
+            _previewCanvas.Clear(AColors.White);
+            if (_previewTexture != null)
+                _previewCanvas.DrawPicture(_previewTexture, _previewTexture.Width, _previewTexture.Height, new APoint(0, 0));
+        }
+
+        private AbstTextStyle EnsureParagraphStyle()
+        {
+            int caret = _markdownInput.GetCaretPosition();
+            var text = _markdownInput.Text;
+            int lineStart = text.LastIndexOf('\n', Math.Max(0, caret - 1)) + 1;
+            int lineEnd = text.IndexOf('\n', caret);
+            if (lineEnd < 0) lineEnd = text.Length;
+
+            var segment = text.Substring(lineStart, lineEnd - lineStart);
+            var paraMatch = Regex.Match(segment, "^\\{\\{PARA:([^}]+)\\}\\}");
+            string styleName;
+            bool inserted = false;
+            if (paraMatch.Success)
+            {
+                styleName = paraMatch.Groups[1].Value;
+            }
+            else
+            {
+                styleName = IconBar.CreateStyle();
+                string tag = $"{{{{PARA:{styleName}}}}}";
+                text = text.Insert(lineStart, tag);
+                _markdownInput.Text = text;
+                _markdownInput.SetCaretPosition(caret + tag.Length);
+                SyncMemberText();
+                inserted = true;
+            }
+
+            var style = IconBar.EnsureStyle(styleName);
+            if (inserted)
+                ScheduleRender(_markdownInput.Text);
+            return style;
+        }
+
+        private void InsertAroundSelection(string prefix, string suffix)
+        {
+            var text = _markdownInput.Text;
+            int end = _markdownInput.GetCaretPosition();
+            if (_markdownInput.HasSelection)
+            {
+                _markdownInput.DeleteSelection();
+                int start = _markdownInput.GetCaretPosition();
+                var selected = text.Substring(start, end - start);
+                _markdownInput.InsertText(prefix + selected + suffix);
+                _markdownInput.SetCaretPosition(start + prefix.Length + selected.Length + suffix.Length);
+            }
+            else
+            {
+                _markdownInput.InsertText(prefix + suffix);
+                _markdownInput.SetCaretPosition(end + prefix.Length);
+            }
+            SyncMemberText();
+            ScheduleRender(_markdownInput.Text);
+        }
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Texts/TextEditIconBar.cs
+++ b/src/Director/LingoEngine.Director.Core/Texts/TextEditIconBar.cs
@@ -74,6 +74,12 @@ public class TextEditIconBar
     /// <summary>Currently selected font name.</summary>
     public string SelectedFont => _fontsCombo.SelectedValue ?? string.Empty;
 
+    /// <summary>Enumerates all defined text styles.</summary>
+    public IEnumerable<AbstTextStyle> Styles => _styles.Values;
+
+    /// <summary>Returns the style at the current caret position.</summary>
+    public AbstTextStyle CurrentStyle => _currentStyle;
+
     public TextEditIconBar(ILingoFrameworkFactory factory)
     {
         const int actionBarHeight = 22;
@@ -341,6 +347,50 @@ public class TextEditIconBar
     {
         Panel.Width = x;
     }
+
+    /// <summary>
+    /// Ensure a style with the given name exists. If missing, a new style
+    /// is created from the current toolbar values and added to the list.
+    /// </summary>
+    public AbstTextStyle EnsureStyle(string name)
+    {
+        if (!_styles.TryGetValue(name, out var style))
+        {
+            style = new AbstTextStyle
+            {
+                Name = name,
+                FontSize = _currentStyle.FontSize,
+                Font = _currentStyle.Font,
+                Color = _currentStyle.Color,
+                Alignment = _currentStyle.Alignment,
+                Bold = _currentStyle.Bold,
+                Italic = _currentStyle.Italic,
+                Underline = _currentStyle.Underline,
+                LineHeight = _currentStyle.LineHeight,
+                MarginLeft = _currentStyle.MarginLeft,
+                MarginRight = _currentStyle.MarginRight
+            };
+            _styles.Add(name, style);
+            RefreshStylesCombo();
+        }
+        return style;
+    }
+
+    /// <summary>
+    /// Create a new style based on the current settings and return its name.
+    /// An optional configure action allows adjusting the new style.
+    /// </summary>
+    public string CreateStyle(Action<AbstTextStyle>? configure = null)
+    {
+        string newName = GenerateStyleName();
+        var style = EnsureStyle(newName);
+        configure?.Invoke(style);
+        return newName;
+    }
+
+    /// <summary>Try to get a style by name.</summary>
+    public bool TryGetStyle(string name, out AbstTextStyle style)
+        => _styles.TryGetValue(name, out style);
 
     private void ApplyStyle(string name)
     {

--- a/src/Director/LingoEngine.Director.Core/Windowing/DirectorWindowRegistrator.cs
+++ b/src/Director/LingoEngine.Director.Core/Windowing/DirectorWindowRegistrator.cs
@@ -25,10 +25,10 @@ namespace LingoEngine.Director.Core.Windowing
                 .AddSingletonWindow<DirectorBinaryViewerWindow>(DirectorMenuCodes.BinaryViewerWindow)
                 .AddSingletonWindow<DirectorBinaryViewerWindowV2>(DirectorMenuCodes.BinaryViewerWindowV2)
                 .AddSingletonWindow<DirectorStageWindow>(DirectorMenuCodes.StageWindow, s => s.CreateShortCut(DirectorMenuCodes.StageWindow, "Ctrl+1", sc => new ExecuteShortCutCommand(sc)))
-                .AddSingletonWindow<DirectorTextEditWindow>(DirectorMenuCodes.TextEditWindow, s => s.CreateShortCut(DirectorMenuCodes.TextEditWindow, "Ctrl+T", sc => new ExecuteShortCutCommand(sc)))
+                .AddSingletonWindow<DirectorTextEditWindowV2>(DirectorMenuCodes.TextEditWindow, s => s.CreateShortCut(DirectorMenuCodes.TextEditWindow, "Ctrl+T", sc => new ExecuteShortCutCommand(sc)))
                 .AddSingletonWindow<DirectorBitmapEditWindow>(DirectorMenuCodes.PictureEditWindow, s => s.CreateShortCut(DirectorMenuCodes.PictureEditWindow, "Ctrl+5", sc => new ExecuteShortCutCommand(sc)))
                 .AddSingletonWindow<DirectorImportExportWindow>(DirectorMenuCodes.ImportExportWindow)
-               // .Register<DirectorMainMenu>(DirectorMenuCodes.MainMenu)
+                // .Register<DirectorMainMenu>(DirectorMenuCodes.MainMenu)
                 ;
 
             return registrator;

--- a/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
+++ b/src/Director/LingoEngine.Director.LGodot/DirGodotSetup.cs
@@ -18,6 +18,7 @@ using LingoEngine.Director.Core.Projects;
 using LingoEngine.Director.Core.Scores;
 using LingoEngine.Director.Core.Stages;
 using LingoEngine.Director.Core.Tools;
+using LingoEngine.Director.Core.Texts;
 using LingoEngine.Director.Core.UI;
 using LingoEngine.Director.LGodot.Casts;
 using LingoEngine.Director.LGodot.FileSystems;
@@ -46,7 +47,7 @@ namespace LingoEngine.Director.LGodot
         {
             LingoEngineGlobal.IsRunningDirector = true;
             engineRegistration
-                .WithLingoGodotEngine(rootNode, true,null, windowRegistrations)
+                .WithLingoGodotEngine(rootNode, true, null, windowRegistrations)
                 .WithDirectorEngine(directorSettingsConfig)
                 .ServicesMain(s =>
                 {
@@ -62,7 +63,7 @@ namespace LingoEngine.Director.LGodot
                     .AddSingleton<DirGodotBinaryViewerWindowV2>()
                     .AddSingleton<DirGodotImportExportWindow>()
                     .AddSingleton<DirGodotPropertyInspector>()
-                    .AddSingleton<DirGodotTextableMemberWindow>()
+                    .AddSingleton<DirGodotTextableMemberWindowV2>()
                     .AddSingleton<DirGodotPictureMemberEditorWindow>()
                     .AddSingleton<DirGodotMainMenu>()
                     .AddSingleton<IDirFilePicker, GodotFilePicker>()
@@ -71,7 +72,7 @@ namespace LingoEngine.Director.LGodot
 
                     .AddTransient<DirCodeHighlichter>()
                     .AddTransient<DirGodotCodeHighlighter>()
-                    
+
                     //.AddSingleton<AbstGodotFrameworkFactory>()
                     .AddSingleton<IDirectorIconManager>(p =>
                     {
@@ -91,9 +92,10 @@ namespace LingoEngine.Director.LGodot
                     s.AddTransient<IDirFrameworkBinaryViewerWindow>(p => p.GetRequiredService<DirGodotBinaryViewerWindow>());
                     s.AddTransient<IDirFrameworkBinaryViewerWindowV2>(p => p.GetRequiredService<DirGodotBinaryViewerWindowV2>());
                     s.AddTransient<IDirFrameworkPropertyInspectorWindow>(p => p.GetRequiredService<DirGodotPropertyInspector>());
+                    s.AddTransient<IDirFrameworkTextEditWindow>(p => p.GetRequiredService<DirGodotTextableMemberWindowV2>());
                     s.AddTransient<IDirFrameworkBitmapEditWindow>(p => p.GetRequiredService<DirGodotPictureMemberEditorWindow>());
                     s.AddTransient<IDirFrameworkImportExportWindow>(p => p.GetRequiredService<DirGodotImportExportWindow>());
-                    
+
 
 
                 })
@@ -112,8 +114,8 @@ namespace LingoEngine.Director.LGodot
                            .Register(AbstGodotThemeElementType.PopupWindow, styles.GetPopupWindowTheme());
                     p.GetRequiredService<IAbstComponentFactory>()
                         .DiscoverInAssembly(typeof(DirGodotSetup).Assembly)
-                        //.Register<IAbstDialog<>, IAbstGodotDialog<LingoCodeImporterPopup>>()
-                        // .Register<DirCodeHighlichter,DirGodotCodeHighlighter>()
+                    //.Register<IAbstDialog<>, IAbstGodotDialog<LingoCodeImporterPopup>>()
+                    // .Register<DirCodeHighlichter,DirGodotCodeHighlighter>()
                     ;
                     new LingoGodotDirectorRoot(p.GetRequiredService<LingoPlayer>(), p, p.GetRequiredService<LingoProjectSettings>());
                 });

--- a/src/Director/LingoEngine.Director.LGodot/Texts/TextableMemberWindowV2.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Texts/TextableMemberWindowV2.cs
@@ -1,0 +1,38 @@
+using System;
+using AbstEngine.Director.LGodot;
+using AbstUI.FrameworkCommunication;
+using LingoEngine.Director.Core.Events;
+using LingoEngine.Director.Core.Texts;
+using LingoEngine.Director.Core.Tools;
+using LingoEngine.Members;
+using LingoEngine.Texts;
+
+namespace LingoEngine.Director.LGodot.Casts
+{
+    internal partial class DirGodotTextableMemberWindowV2 : BaseGodotWindow, IHasMemberSelectedEvent, IDirFrameworkTextEditWindow, IFrameworkFor<DirectorTextEditWindowV2>
+    {
+        private readonly IDirectorEventMediator _mediator;
+        private readonly DirectorTextEditWindowV2 _editor;
+
+        public DirGodotTextableMemberWindowV2(IDirectorEventMediator mediator, DirectorTextEditWindowV2 editor, IServiceProvider serviceProvider)
+            : base("Edit Text", serviceProvider)
+        {
+            _mediator = mediator;
+            _editor = editor;
+            _mediator.Subscribe(this);
+            Init(editor);
+        }
+
+        public void MemberSelected(ILingoMember member)
+        {
+            if (member is ILingoMemberTextBase textMember)
+                _editor.SetMemberValues(textMember);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _mediator.Unsubscribe(this);
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Director/LingoEngine.Director.LGodot/UI/LingoGodotDirectorRoot.cs
+++ b/src/Director/LingoEngine.Director.LGodot/UI/LingoGodotDirectorRoot.cs
@@ -33,7 +33,7 @@ namespace LingoEngine.Director.LGodot.UI
         private readonly DirGodotBinaryViewerWindow _binaryViewer;
         private readonly DirGodotBinaryViewerWindowV2 _binaryViewerV2;
         private readonly DirGodotImportExportWindow _importExportWindow;
-        private readonly DirGodotTextableMemberWindow _textWindow;
+        private readonly DirGodotTextableMemberWindowV2 _textWindow;
         private readonly DirGodotPictureMemberEditorWindow _picture;
         private List<BaseGodotWindow> _windows = new List<BaseGodotWindow>();
 


### PR DESCRIPTION
## Summary
- support paragraph-level styles by inserting `{{PARA:styleId}}` tags and storing formatting in the toolbar's style list
- expose style management helpers on `TextEditIconBar` to create and retrieve styles

## Testing
- `dotnet format src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj --include src/Director/LingoEngine.Director.Core/Texts/DirectorTextEditWindowV2.cs src/Director/LingoEngine.Director.Core/Texts/TextEditIconBar.cs --verbosity diagnostic`
- `dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bb41b83c588332b65c1b9b45bdd313