### PR TITLE
Add custom transition rectangles and change detection

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Scores/Transitions/DirScoreTransitionGridChannel.cs
+++ b/src/Director/LingoEngine.Director.Core/Scores/Transitions/DirScoreTransitionGridChannel.cs
@@ -50,6 +50,14 @@ internal partial class DirScoreTransitionGridChannel : DirScoreChannel<ILingoSpr
         }
     }
 
+    public int RectX { get; set; }
+
+    public int RectY { get; set; }
+
+    public int RectWidth { get; set; }
+
+    public int RectHeight { get; set; }
+
     public DirScoreTransitionGridChannel(IDirScoreManager scoreManager, ILingoTransitionLibrary transitionLibrary)
         : base(LingoTransitionSprite.SpriteNumOffset + 1, scoreManager)
     {
@@ -99,6 +107,7 @@ internal partial class DirScoreTransitionGridChannel : DirScoreChannel<ILingoSpr
     {
         settings.Duration = Duration;
         settings.Smoothness = Smoothness;
+        settings.Rect = ARect.New(RectX, RectY, RectWidth, RectHeight);
     }
 
     private void ShowDialog(LingoTransitionFrameSettings settings, Action okAction)
@@ -134,10 +143,10 @@ internal partial class DirScoreTransitionGridChannel : DirScoreChannel<ILingoSpr
         categoryList.Height = 200;
 
         panel.SetLabelAt("TransitionLabel", 140, 10, "Transitions:");
-        
+
         transitionList.Height = 200;
 
-       
+
 
         panel.SetLabelAt("DurationLabel", 10, 230, "Duration (secs):");
         _durationSlider = panel.SetSliderAt(this, "DurationSlider", 100, 230, 190, AOrientation.Horizontal, s => s.Duration, 1f, 30f, 0.1f);
@@ -151,12 +160,29 @@ internal partial class DirScoreTransitionGridChannel : DirScoreChannel<ILingoSpr
         var affectsOptions = new[]
         {
             new KeyValuePair<string, string>(LingoTransitionAffects.EntireStage.ToString(), "Entire Stage"),
-            new KeyValuePair<string, string>(LingoTransitionAffects.ChangingAreaOnly.ToString(), "Changing Area Only")
+            new KeyValuePair<string, string>(LingoTransitionAffects.ChangingAreaOnly.ToString(), "Changing Area Only"),
+            new KeyValuePair<string, string>(LingoTransitionAffects.Custom.ToString(), "Custom")
         };
+        var xLabel = panel.SetLabelAt("RectXLabel", 240, 275, "X:");
+        var xInput = panel.SetInputNumberAt(this, "RectX", 240, 290, 40, s => s.RectX, 0, null);
+        var yLabel = panel.SetLabelAt("RectYLabel", 285, 275, "Y:");
+        var yInput = panel.SetInputNumberAt(this, "RectY", 285, 290, 40, s => s.RectY, 0, null);
+        var wLabel = panel.SetLabelAt("RectWLabel", 330, 275, "W:");
+        var wInput = panel.SetInputNumberAt(this, "RectWidth", 330, 290, 40, s => s.RectWidth, 1, null);
+        var hLabel = panel.SetLabelAt("RectHLabel", 375, 275, "H:");
+        var hInput = panel.SetInputNumberAt(this, "RectHeight", 375, 290, 40, s => s.RectHeight, 1, null);
+        void ToggleRectInputs(bool visible)
+        {
+            xLabel.Visible = xInput.Visible = yLabel.Visible = yInput.Visible = wLabel.Visible = wInput.Visible = hLabel.Visible = hInput.Visible = visible;
+        }
+        ToggleRectInputs(settings.Affects == LingoTransitionAffects.Custom);
         panel.SetComboBoxAt(affectsOptions, "AffectsCombo", 70, 290, 160, settings.Affects.ToString(), key =>
         {
             if (Enum.TryParse<LingoTransitionAffects>(key, out var affects))
+            {
                 settings.Affects = affects;
+                ToggleRectInputs(affects == LingoTransitionAffects.Custom);
+            }
         });
 
         panel.AddPopupButtons(okAction, CloseDialog);
@@ -164,9 +190,13 @@ internal partial class DirScoreTransitionGridChannel : DirScoreChannel<ILingoSpr
         _dialog = _showConfirmDialog?.Invoke("Frame Properties: Transition", (IAbstFrameworkPanel)panel.FrameworkObj);
         Smoothness = settings.Smoothness;
         Duration = settings.Duration;
-        
+        RectX = (int)settings.Rect.Left;
+        RectY = (int)settings.Rect.Top;
+        RectWidth = (int)settings.Rect.Width;
+        RectHeight = (int)settings.Rect.Height;
+
     }
-    private void PopulateTransitions(LingoTransitionFrameSettings settings, AbstItemList transitionList,string? category)
+    private void PopulateTransitions(LingoTransitionFrameSettings settings, AbstItemList transitionList, string? category)
     {
         var filtered = _transitions
             .Where(t => category == "All" || t.Category == category)

--- a/src/LingoEngine/Transitions/LingoTransitionFrameSettings.cs
+++ b/src/LingoEngine/Transitions/LingoTransitionFrameSettings.cs
@@ -1,14 +1,17 @@
-﻿namespace LingoEngine.Transitions
+using AbstUI.Primitives;
+
+namespace LingoEngine.Transitions;
+
+public class LingoTransitionFrameSettings
 {
-    public class LingoTransitionFrameSettings
-    {
-        public int TransitionId { get; set; }
-        public string TransitionName { get; set; } = "";
-        /// <summary>
-        /// Duration in Seconds from 0 to 30 seconds
-        /// </summary>
-        public float Duration { get; set; }
-        public float Smoothness { get; set; }
-        public LingoTransitionAffects Affects { get; set; } = LingoTransitionAffects.ChangingAreaOnly;
-    }
+    public int TransitionId { get; set; }
+    public string TransitionName { get; set; } = "";
+    /// <summary>
+    /// Duration in Seconds from 0 to 30 seconds
+    /// </summary>
+    public float Duration { get; set; }
+    public float Smoothness { get; set; }
+    public LingoTransitionAffects Affects { get; set; } = LingoTransitionAffects.ChangingAreaOnly;
+    public ARect Rect { get; set; }
 }
+

--- a/src/LingoEngine/Transitions/LingoTransitionMember.cs
+++ b/src/LingoEngine/Transitions/LingoTransitionMember.cs
@@ -1,52 +1,55 @@
-﻿using AbstUI.Primitives;
+using AbstUI.Primitives;
 using LingoEngine.Casts;
 using LingoEngine.Members;
 using LingoEngine.Sprites;
 
-namespace LingoEngine.Transitions
+namespace LingoEngine.Transitions;
+
+public enum LingoTransitionAffects
 {
-    public enum LingoTransitionAffects
+    EntireStage,
+    ChangingAreaOnly,
+    Custom
+}
+
+public class LingoTransitionMember : LingoMember
+{
+    public int TransitionId { get; set; }
+    public string TransitionName { get; set; } = "";
+    /// <summary>
+    /// Duration in Seconds from 0 to 30 seconds
+    /// </summary>
+    public float Duration { get; set; }
+    public float Smoothness { get; set; }
+    public LingoTransitionAffects Affects { get; set; } = LingoTransitionAffects.ChangingAreaOnly;
+    public ARect Rect { get; set; }
+
+    public LingoTransitionMember(LingoCast cast, int numberInCast, string name = "", string fileName = "", APoint regPoint = default)
+        : base(new LingoTransitionMemberFW(), LingoMemberType.Transition, cast, numberInCast, name, fileName, regPoint)
     {
-        EntireStage,
-        ChangingAreaOnly
     }
-    public class LingoTransitionMember : LingoMember
+
+    public void SetSettings(LingoTransitionFrameSettings settings)
     {
-        public int TransitionId { get; set; }
-        public string TransitionName { get; set; } = "";
-        /// <summary>
-        /// Duration in Seconds from 0 to 30 seconds
-        /// </summary>
-        public float Duration { get; set; }
-        public float Smoothness { get; set; }
-        public LingoTransitionAffects Affects { get; set; } = LingoTransitionAffects.ChangingAreaOnly;
+        TransitionId = settings.TransitionId;
+        Affects = settings.Affects;
+        Duration = settings.Duration;
+        Smoothness = settings.Smoothness;
+        TransitionName = settings.TransitionName;
+        Rect = settings.Rect;
+    }
 
-
-
-        public LingoTransitionMember(LingoCast cast, int numberInCast, string name = "", string fileName = "", APoint regPoint = default) : base(new LingoTransitionMemberFW(), LingoMemberType.Transition, cast, numberInCast, name, fileName, regPoint)
+    public LingoTransitionFrameSettings GetSettings()
+    {
+        return new LingoTransitionFrameSettings
         {
-        }
-
-        public void SetSettings(LingoTransitionFrameSettings settings)
-        {
-            TransitionId = settings.TransitionId;
-            Affects = settings.Affects;
-            TransitionId = settings.TransitionId;
-            Duration = settings.Duration;
-            Smoothness = settings.Smoothness;
-            TransitionName = settings.TransitionName;
-        }
-
-        public LingoTransitionFrameSettings GetSettings()
-        {
-            return new LingoTransitionFrameSettings
-            {
-                Affects = Affects,
-                TransitionId = TransitionId,
-                Duration = Duration,
-                Smoothness = Smoothness,
-                TransitionName = TransitionName,
-            };
-        }
+            Affects = Affects,
+            TransitionId = TransitionId,
+            Duration = Duration,
+            Smoothness = Smoothness,
+            TransitionName = TransitionName,
+            Rect = Rect,
+        };
     }
 }
+

--- a/src/LingoEngine/Transitions/LingoTransitionPlayer.cs
+++ b/src/LingoEngine/Transitions/LingoTransitionPlayer.cs
@@ -16,6 +16,9 @@ public sealed class LingoTransitionPlayer : ILingoTransitionPlayer, IDisposable
     private IAbstTexture2D? _current;
     private byte[]? _fromPixels;
     private byte[]? _toPixels;
+    private byte[]? _targetPixels;
+    private ARect _targetRect;
+    private bool _computeDiffRect;
     private LingoBaseTransition? _transition;
     private int _tick;
     private int _duration;
@@ -37,7 +40,7 @@ public sealed class LingoTransitionPlayer : ILingoTransitionPlayer, IDisposable
         _from?.Dispose();
         _to?.Dispose();
         _from = _to = _current = null;
-        _fromPixels = _toPixels = null;
+        _fromPixels = _toPixels = _targetPixels = null;
         _waitingForToFrame = false;
         _isPlaying = false;
 
@@ -47,6 +50,17 @@ public sealed class LingoTransitionPlayer : ILingoTransitionPlayer, IDisposable
 
         _from = _stage.GetScreenshot();
         _fromPixels = _from.GetPixels();
+
+        var affects = sprite.Member?.Affects ?? LingoTransitionAffects.EntireStage;
+        _computeDiffRect = affects == LingoTransitionAffects.ChangingAreaOnly;
+        if (affects == LingoTransitionAffects.Custom)
+        {
+            _targetRect = ClampRect(sprite.Member!.Rect, _from.Width, _from.Height);
+        }
+        else
+        {
+            _targetRect = ARect.New(0, 0, _from.Width, _from.Height);
+        }
 
         // make a copy we can mutate
         _current = _from.Clone();
@@ -61,18 +75,84 @@ public sealed class LingoTransitionPlayer : ILingoTransitionPlayer, IDisposable
         _isCapturingToFrame = false;
         return true;
     }
-   
+
     private void CaptureToFrame(IAbstTexture2D texture2D)
     {
         if (!_waitingForToFrame)
             return;
-        //_to = _stage.GetScreenshot();
         _to = texture2D;
         _toPixels = _to.GetPixels();
+        if (_computeDiffRect)
+        {
+            _targetRect = ComputeDiffRect(_from!.Width, _from.Height, _fromPixels!, _toPixels);
+            if (_targetRect.Width <= 0 || _targetRect.Height <= 0)
+                _targetRect = ARect.New(0, 0, _from.Width, _from.Height);
+        }
+        _targetPixels = PrepareTargetPixels();
         _waitingForToFrame = false;
         _isPlaying = true;
     }
-    
+
+    private byte[] PrepareTargetPixels()
+    {
+        if (_fromPixels == null || _toPixels == null)
+            return _toPixels ?? _fromPixels ?? Array.Empty<byte>();
+
+        var width = _from!.Width;
+        var rect = ClampRect(_targetRect, width, _from.Height);
+        var result = (byte[])_fromPixels.Clone();
+        CopyRectPixels(_toPixels, result, width, rect);
+        return result;
+    }
+
+    private static void CopyRectPixels(byte[] src, byte[] dest, int width, ARect rect)
+    {
+        int x = (int)rect.Left;
+        int y = (int)rect.Top;
+        int w = (int)rect.Width;
+        int h = (int)rect.Height;
+        for (int row = 0; row < h; row++)
+        {
+            int srcIdx = ((y + row) * width + x) * 4;
+            Buffer.BlockCopy(src, srcIdx, dest, srcIdx, w * 4);
+        }
+    }
+
+    private static ARect ComputeDiffRect(int width, int height, byte[] from, byte[] to)
+    {
+        int minX = width;
+        int minY = height;
+        int maxX = -1;
+        int maxY = -1;
+        for (int y = 0; y < height; y++)
+        {
+            int rowIndex = y * width * 4;
+            for (int x = 0; x < width; x++)
+            {
+                int idx = rowIndex + x * 4;
+                if (from[idx] != to[idx] || from[idx + 1] != to[idx + 1] || from[idx + 2] != to[idx + 2] || from[idx + 3] != to[idx + 3])
+                {
+                    if (x < minX) minX = x;
+                    if (y < minY) minY = y;
+                    if (x > maxX) maxX = x;
+                    if (y > maxY) maxY = y;
+                }
+            }
+        }
+        if (maxX < minX || maxY < minY)
+            return ARect.New(0, 0, width, height);
+        return ARect.New(minX, minY, maxX - minX + 1, maxY - minY + 1);
+    }
+
+    private static ARect ClampRect(ARect rect, int width, int height)
+    {
+        int x = (int)Math.Clamp(rect.Left, 0, width);
+        int y = (int)Math.Clamp(rect.Top, 0, height);
+        int w = (int)Math.Clamp(rect.Width, 0, width - x);
+        int h = (int)Math.Clamp(rect.Height, 0, height - y);
+        return ARect.New(x, y, w, h);
+    }
+
     public void Tick()
     {
         if (_toPixels == null)
@@ -82,12 +162,12 @@ public sealed class LingoTransitionPlayer : ILingoTransitionPlayer, IDisposable
             _stage.RequestNextFrameScreenshot(CaptureToFrame);
             return;
         }
-        if (!_isPlaying || _fromPixels == null || _toPixels == null || _from == null || _transition == null)
+        if (!_isPlaying || _fromPixels == null || _targetPixels == null || _from == null || _transition == null)
             return;
         _tick++;
         float progress = (float)_tick / _duration;
         if (progress >= 1f) progress = 1f;
-        var blended = _transition.StepFrame(_from.Width, _from.Height, _fromPixels, _toPixels, progress);
+        var blended = _transition.StepFrame(_from.Width, _from.Height, _fromPixels, _targetPixels, progress);
         _current!.SetRGBAPixels(blended);
         _stage.UpdateTransitionFrame(_current, ARect.New(0, 0, _from.Width, _from.Height));
         if (progress >= 1f)
@@ -97,8 +177,10 @@ public sealed class LingoTransitionPlayer : ILingoTransitionPlayer, IDisposable
             _to?.Dispose();
             _current?.Dispose();
             _current = _from = _to = null;
-            _fromPixels = _toPixels = null;
+            _fromPixels = _toPixels = _targetPixels = null;
             _transition = null;
+            _computeDiffRect = false;
+            _targetRect = ARect.New(0, 0, 0, 0);
             _isPlaying = false;
         }
     }

--- a/src/LingoEngine/Transitions/LingoTransitionPlayer.cs
+++ b/src/LingoEngine/Transitions/LingoTransitionPlayer.cs
@@ -146,10 +146,10 @@ public sealed class LingoTransitionPlayer : ILingoTransitionPlayer, IDisposable
 
     private static ARect ClampRect(ARect rect, int width, int height)
     {
-        int x = (int)Math.Clamp(rect.Left, 0, width);
-        int y = (int)Math.Clamp(rect.Top, 0, height);
-        int w = (int)Math.Clamp(rect.Width, 0, width - x);
-        int h = (int)Math.Clamp(rect.Height, 0, height - y);
+        int x = (int)MathCompat.Clamp(rect.Left, 0, width);
+        int y = (int)MathCompat.Clamp(rect.Top, 0, height);
+        int w = (int)MathCompat.Clamp(rect.Width, 0, width - x);
+        int h = (int)MathCompat.Clamp(rect.Height, 0, height - y);
         return ARect.New(x, y, w, h);
     }
 


### PR DESCRIPTION
## Summary
- store transition rectangles as ARect instead of four separate ints
- bind Director transition dialog inputs to channel and persist rectangle using ARect.New
- apply custom rectangle during transitions using the member's Rect

## Testing
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/Transitions/LingoTransitionFrameSettings.cs --include src/LingoEngine/Transitions/LingoTransitionMember.cs --include src/LingoEngine/Transitions/LingoTransitionPlayer.cs`
- `dotnet format src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj --include src/Director/LingoEngine.Director.Core/Scores/Transitions/DirScoreTransitionGridChannel.cs`
- `dotnet test Test/LingoEngine.Tests/LingoEngine.Tests.csproj` *(fails: ImportInCastFromCsvFile_CreatesMarkdownWhenReadingRtf)*

------
https://chatgpt.com/codex/tasks/task_e_68be52b71e988332be39fe4e34919d23