### PR TITLE
Refactor bitmap selection handling

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
@@ -34,6 +34,7 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
         _registry = registry;
         _mapper.Map<AbstBlazorWrapPanelComponent, AbstBlazorWrapPanel>();
         _mapper.Map<AbstBlazorPanelComponent, AbstBlazorPanel>();
+        _mapper.Map<AbstBlazorZoomBoxComponent, AbstBlazorPanel>();
         _mapper.Map<AbstBlazorTabContainerComponent, AbstBlazorTabContainer>();
         _mapper.Map<AbstBlazorScrollContainerComponent, AbstBlazorScrollContainer>();
         _mapper.Map<AbstBlazorButtonComponent, AbstBlazorButton>();
@@ -93,6 +94,16 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
         InitComponent(panel);
         panel.Name = name;
         return panel;
+    }
+
+    public AbstZoomBox CreateZoomBox(string name)
+    {
+        var box = new AbstZoomBox();
+        var impl = new AbstBlazorZoomBoxComponent(_registry, _mapper);
+        box.Init(impl);
+        InitComponent(box);
+        box.Name = name;
+        return box;
     }
     public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y)
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIBlazorSetup.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIBlazorSetup.cs
@@ -28,6 +28,7 @@ public static class AbstUIBlazorSetup
             .AddSingleton<AbstBlazorComponentMapper>()
             .AddSingleton<AbstBlazorComponentContainer>()
             .AddTransient<AbstBlazorWrapPanelComponent>()
+            .AddTransient<AbstBlazorZoomBoxComponent>()
             .AddTransient<AbstBlazorPanelComponent>()
             .AddTransient<AbstBlazorTabContainerComponent>()
             .AddTransient<AbstBlazorTabItemComponent>()

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorZoomBoxComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorZoomBoxComponent.cs
@@ -1,0 +1,84 @@
+using AbstUI.Components;
+using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
+
+namespace AbstUI.Blazor.Components.Containers;
+
+public class AbstBlazorZoomBoxComponent : AbstBlazorComponentModelBase, IAbstFrameworkZoomBox, IFrameworkFor<AbstZoomBox>, IAbstBlazorRegistryAware
+{
+    private AbstBlazorComponentContainer _registry;
+    private readonly AbstBlazorComponentContainer _childContainer;
+    private IAbstFrameworkLayoutNode? _content;
+    private float _scaleH = 1f;
+    private float _scaleV = 1f;
+
+    public AbstBlazorZoomBoxComponent(AbstBlazorComponentContainer registry, AbstBlazorComponentMapper mapper)
+    {
+        _registry = registry;
+        _childContainer = new AbstBlazorComponentContainer(mapper);
+    }
+
+    public void AttachRegistry(AbstBlazorComponentContainer registry)
+    {
+        if (!ReferenceEquals(_registry, registry))
+        {
+            _registry = registry;
+            if (_content != null)
+            {
+                if (_content is IAbstBlazorRegistryAware aware)
+                    aware.AttachRegistry(_registry);
+                _registry.Register(_content);
+            }
+        }
+    }
+
+    public AbstBlazorComponentContainer ChildContainer => _childContainer;
+
+    public IAbstFrameworkLayoutNode? Content
+    {
+        get => _content;
+        set
+        {
+            if (_content == value)
+                return;
+            if (_content != null)
+            {
+                _childContainer.Unregister(_content);
+                _registry.Unregister(_content);
+            }
+            _content = value;
+            if (_content != null)
+            {
+                if (_content is IAbstBlazorRegistryAware aware)
+                    aware.AttachRegistry(_registry);
+                _registry.Register(_content);
+                _childContainer.Register(_content);
+            }
+            RaiseChanged();
+        }
+    }
+
+    public float ScaleH
+    {
+        get => _scaleH;
+        set
+        {
+            if (_scaleH == value)
+                return;
+            _scaleH = value;
+            RaiseChanged();
+        }
+    }
+
+    public float ScaleV
+    {
+        get => _scaleV;
+        set
+        {
+            if (_scaleV == value)
+                return;
+            _scaleV = value;
+            RaiseChanged();
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstImGuiComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstImGuiComponentFactory.cs
@@ -61,6 +61,16 @@ namespace AbstUI.ImGui
             return panel;
         }
 
+        public AbstZoomBox CreateZoomBox(string name)
+        {
+            var box = new AbstZoomBox();
+            var impl = new AbstImGuiZoomBox(this);
+            box.Init(impl);
+            InitComponent(box);
+            box.Name = name;
+            return box;
+        }
+
         public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y)
         {
             if (content is IAbstLayoutNode)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiZoomBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiZoomBox.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Components;
+using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
+
+namespace AbstUI.ImGui.Components
+{
+    internal class AbstImGuiZoomBox : AbstImGuiPanel, IAbstFrameworkZoomBox, IFrameworkFor<AbstZoomBox>, IDisposable
+    {
+        private IAbstFrameworkLayoutNode? _content;
+        private float _scaleH = 1f;
+        private float _scaleV = 1f;
+
+        public AbstImGuiZoomBox(AbstImGuiComponentFactory factory) : base(factory)
+        {
+        }
+
+        public IAbstFrameworkLayoutNode? Content
+        {
+            get => _content;
+            set
+            {
+                if (_content != null)
+                    base.RemoveItem(_content);
+                _content = value;
+                if (_content != null)
+                    base.AddItem(_content);
+            }
+        }
+
+        public new void AddItem(IAbstFrameworkLayoutNode child)
+            => throw new NotSupportedException("Use Content property");
+
+        public new void RemoveItem(IAbstFrameworkLayoutNode child)
+        {
+            if (_content == child)
+                Content = null;
+        }
+
+        public new void RemoveAll() => Content = null;
+
+        public new IEnumerable<IAbstFrameworkLayoutNode> GetItems()
+        {
+            if (_content != null)
+                yield return _content;
+        }
+
+        public float ScaleH
+        {
+            get => _scaleH;
+            set => _scaleH = value;
+        }
+
+        public float ScaleV
+        {
+            get => _scaleV;
+            set => _scaleV = value;
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Containers/AbstGodotZoomBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Containers/AbstGodotZoomBox.cs
@@ -1,0 +1,95 @@
+using System;
+using AbstUI.Components;
+using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
+using AbstUI.Primitives;
+using Godot;
+
+namespace AbstUI.LGodot.Components
+{
+    /// <summary>
+    /// Godot implementation of <see cref="AbstZoomBox"/> hosting a single child.
+    /// </summary>
+    public partial class AbstGodotZoomBox : Control, IAbstFrameworkZoomBox, IFrameworkFor<AbstZoomBox>, IDisposable
+    {
+        private AMargin _margin = AMargin.Zero;
+        private IAbstFrameworkLayoutNode? _content;
+
+        public AbstGodotZoomBox(AbstZoomBox zoomBox)
+        {
+            MouseFilter = MouseFilterEnum.Ignore;
+            zoomBox.Init(this);
+            SizeFlagsVertical = SizeFlags.ExpandFill;
+        }
+
+        public float X { get => Position.X; set => Position = new Vector2(value, Position.Y); }
+        public float Y { get => Position.Y; set => Position = new Vector2(Position.X, value); }
+        public float Width { get => Size.X; set => Size = new Vector2(value, Size.Y); }
+        public float Height { get => Size.Y; set { Size = new Vector2(Size.X, value); CustomMinimumSize = new Vector2(Size.X, value); } }
+        public bool Visibility { get => Visible; set => Visible = value; }
+        string IAbstFrameworkNode.Name { get => Name; set => Name = value; }
+
+        public AMargin Margin
+        {
+            get => _margin;
+            set
+            {
+                _margin = value;
+                ApplyMargin();
+            }
+        }
+
+        public object FrameworkNode => this;
+
+        public IAbstFrameworkLayoutNode? Content
+        {
+            get => _content;
+            set
+            {
+                if (_content != null && _content.FrameworkNode is Node oldNode)
+                    RemoveChild(oldNode);
+                _content = value;
+                if (_content != null && _content.FrameworkNode is Node node)
+                {
+                    AddChild(node);
+                    if (node is Control control)
+                    {
+                        control.AnchorLeft = 0;
+                        control.AnchorTop = 0;
+                        control.AnchorRight = 0;
+                        control.AnchorBottom = 0;
+                        control.Position = new Vector2(_content.X, _content.Y);
+                    }
+                }
+            }
+        }
+
+        float IAbstFrameworkZoomBox.ScaleH
+        {
+            get => Scale.X;
+            set => Scale = new Vector2(value, Scale.Y);
+        }
+
+        float IAbstFrameworkZoomBox.ScaleV
+        {
+            get => Scale.Y;
+            set => Scale = new Vector2(Scale.X, value);
+        }
+
+        private void ApplyMargin()
+        {
+            AddThemeConstantOverride("margin_left", (int)_margin.Left);
+            AddThemeConstantOverride("margin_right", (int)_margin.Right);
+            AddThemeConstantOverride("margin_top", (int)_margin.Top);
+            AddThemeConstantOverride("margin_bottom", (int)_margin.Bottom);
+        }
+
+        public new void Dispose()
+        {
+            if (_content != null && _content.FrameworkNode is Node node)
+                RemoveChild(node);
+            base.Dispose();
+            QueueFree();
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/GodotComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/GodotComponentFactory.cs
@@ -31,7 +31,7 @@ namespace AbstUI.LGodot.Components
            => new GodotImagePainter((AbstGodotFontManager)FontManager, width, height);
         public IAbstImagePainter CreateImagePainterToTexture(int width = 0, int height = 0)
            => new GodotImagePainterToTexture((AbstGodotFontManager)FontManager, width, height);
-           
+
         public AbstGfxCanvas CreateGfxCanvas(string name, int width, int height)
         {
             var canvas = new AbstGfxCanvas();
@@ -60,6 +60,15 @@ namespace AbstUI.LGodot.Components
             InitComponent(panel);
             panel.Name = name;
             return panel;
+        }
+
+        public AbstZoomBox CreateZoomBox(string name)
+        {
+            var box = new AbstZoomBox();
+            var impl = new AbstGodotZoomBox(box);
+            InitComponent(box);
+            box.Name = name;
+            return box;
         }
 
         public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/AbstUnityComponentFactory.cs
@@ -68,6 +68,16 @@ public class AbstUnityComponentFactory : AbstComponentFactoryBase, IAbstComponen
         return panel;
     }
 
+    public AbstZoomBox CreateZoomBox(string name)
+    {
+        var box = new AbstZoomBox();
+        var impl = new AbstUnityZoomBox();
+        box.Init(impl);
+        InitComponent(box);
+        box.Name = name;
+        return box;
+    }
+
     public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y)
     {
         var wrapper = new AbstLayoutWrapper(content);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Containers/AbstUnityZoomBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Containers/AbstUnityZoomBox.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Components;
+using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
+
+namespace AbstUI.LUnity.Components.Containers
+{
+    /// <summary>Unity implementation of <see cref="AbstZoomBox"/>.</summary>
+    public class AbstUnityZoomBox : AbstUnityPanel, IAbstFrameworkZoomBox, IFrameworkFor<AbstZoomBox>
+    {
+        private IAbstFrameworkLayoutNode? _content;
+        private float _scaleH = 1f;
+        private float _scaleV = 1f;
+
+        public AbstUnityZoomBox() : base()
+        {
+        }
+
+        public IAbstFrameworkLayoutNode? Content
+        {
+            get => _content;
+            set
+            {
+                if (_content != null)
+                    base.RemoveItem(_content);
+                _content = value;
+                if (_content != null)
+                    base.AddItem(_content);
+            }
+        }
+
+        public new void AddItem(IAbstFrameworkLayoutNode child)
+            => throw new NotSupportedException("Use Content property");
+
+        public new void RemoveItem(IAbstFrameworkLayoutNode child)
+        {
+            if (_content == child)
+                Content = null;
+        }
+
+        public new void RemoveAll() => Content = null;
+
+        public new IEnumerable<IAbstFrameworkLayoutNode> GetItems()
+        {
+            if (_content != null)
+                yield return _content;
+        }
+
+        public float ScaleH
+        {
+            get => _scaleH;
+            set => _scaleH = value;
+        }
+
+        public float ScaleV
+        {
+            get => _scaleV;
+            set => _scaleV = value;
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/AbstSdlComponentFactory.cs
@@ -50,9 +50,9 @@ namespace AbstUI.SDL2.Components
             => new(_rootContext.Renderer, origin, FontManagerTyped, parent);
 
         public IAbstImagePainter CreateImagePainter(int width = 0, int height = 0)
-            =>  new SDLImagePainter(FontManager,width,height, RootContext.Renderer);
+            => new SDLImagePainter(FontManager, width, height, RootContext.Renderer);
         public IAbstImagePainter CreateImagePainterToTexture(int width = 0, int height = 0)
-            =>  new SDLImagePainter(FontManager,width,height, RootContext.Renderer);
+            => new SDLImagePainter(FontManager, width, height, RootContext.Renderer);
 
         public AbstGfxCanvas CreateGfxCanvas(string name, int width, int height)
         {
@@ -85,6 +85,16 @@ namespace AbstUI.SDL2.Components
             InitComponent(panel);
             panel.Name = name;
             return panel;
+        }
+
+        public AbstZoomBox CreateZoomBox(string name)
+        {
+            var box = new AbstZoomBox();
+            var impl = new AbstSdlZoomBox(this);
+            box.Init(impl);
+            InitComponent(box);
+            box.Name = name;
+            return box;
         }
 
         public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlZoomBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlZoomBox.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Components;
+using AbstUI.Components.Containers;
+using AbstUI.FrameworkCommunication;
+using AbstUI.SDL2.Components.Base;
+using AbstUI.SDL2.Core;
+using AbstUI.SDL2.Events;
+using AbstUI.SDL2.SDLL;
+
+namespace AbstUI.SDL2.Components.Containers
+{
+    /// <summary>
+    /// SDL implementation of <see cref="AbstZoomBox"/> using a single child panel.
+    /// </summary>
+    public class AbstSdlZoomBox : AbstSdlPanel, IAbstFrameworkZoomBox, IFrameworkFor<AbstZoomBox>
+    {
+        private IAbstFrameworkLayoutNode? _content;
+        private float _scaleH = 1f;
+        private float _scaleV = 1f;
+
+        public AbstSdlZoomBox(AbstSdlComponentFactory factory) : base(factory)
+        {
+        }
+
+        public IAbstFrameworkLayoutNode? Content
+        {
+            get => _content;
+            set
+            {
+                if (_content != null)
+                    base.RemoveItem(_content);
+                _content = value;
+                if (_content != null)
+                    base.AddItem(_content);
+            }
+        }
+
+        public new void AddItem(IAbstFrameworkLayoutNode child)
+            => throw new NotSupportedException("Use Content property");
+
+        public new void RemoveItem(IAbstFrameworkLayoutNode child)
+        {
+            if (_content == child)
+                Content = null;
+        }
+
+        public new void RemoveAll() => Content = null;
+
+        public new IEnumerable<IAbstFrameworkLayoutNode> GetItems()
+        {
+            if (_content != null)
+                yield return _content;
+        }
+
+        public float ScaleH
+        {
+            get => _scaleH;
+            set => _scaleH = value;
+        }
+
+        public float ScaleV
+        {
+            get => _scaleV;
+            set => _scaleV = value;
+        }
+
+        public override AbstSDLRenderResult Render(AbstSDLRenderContext context)
+        {
+            SDL.SDL_RenderGetScale(context.Renderer, out var oldSX, out var oldSY);
+            SDL.SDL_RenderSetScale(context.Renderer, _scaleH, _scaleV);
+            var result = base.Render(context);
+            SDL.SDL_RenderSetScale(context.Renderer, oldSX, oldSY);
+            return result;
+        }
+
+        public override void HandleEvent(AbstSDLEvent e)
+        {
+            if (_content?.FrameworkNode is AbstSdlComponent comp && comp is IHandleSdlEvent handler)
+            {
+                var oriX = e.OffsetX;
+                var oriY = e.OffsetY;
+                e.OffsetX = (oriX - _content.X) / _scaleH;
+                e.OffsetY = (oriY - _content.Y) / _scaleV;
+                e.CalulateIsInside(comp.Width, comp.Height);
+                if (handler.CanHandleEvent(e))
+                    handler.HandleEvent(e);
+                e.OffsetX = oriX;
+                e.OffsetY = oriY;
+            }
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Containers/AbstZoomBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Containers/AbstZoomBox.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace AbstUI.Components.Containers
+{
+    /// <summary>
+    /// Container that hosts a single child and allows panning and scaling it.
+    /// </summary>
+    public class AbstZoomBox : AbstNodeLayoutBase<IAbstFrameworkZoomBox>
+    {
+        private IAbstLayoutNode? _content;
+
+        /// <summary>Child displayed inside the zoom box.</summary>
+        public IAbstLayoutNode? Content
+        {
+            get => _content;
+            set
+            {
+                _content = value;
+                _framework.Content = _content?.Framework<IAbstFrameworkLayoutNode>();
+            }
+        }
+
+        /// <summary>Horizontal offset applied to the content.</summary>
+        public float OffsetX
+        {
+            get => _content?.X ?? 0f;
+            set { if (_content != null) _content.X = value; }
+        }
+
+        /// <summary>Vertical offset applied to the content.</summary>
+        public float OffsetY
+        {
+            get => _content?.Y ?? 0f;
+            set { if (_content != null) _content.Y = value; }
+        }
+
+        /// <summary>Horizontal zoom scale applied to the content. Scaling behavior is framework‑dependent.</summary>
+        public float ScaleH
+        {
+            get => _framework.ScaleH;
+            set => _framework.ScaleH = value;
+        }
+
+        /// <summary>Vertical zoom scale applied to the content. Scaling behavior is framework‑dependent.</summary>
+        public float ScaleV
+        {
+            get => _framework.ScaleV;
+            set => _framework.ScaleV = value;
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Containers/IAbstFrameworkZoomBox.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Containers/IAbstFrameworkZoomBox.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace AbstUI.Components.Containers
+{
+    /// <summary>
+    /// Framework-specific implementation for <see cref="AbstZoomBox"/> hosting a single child.
+    /// </summary>
+    public interface IAbstFrameworkZoomBox : IAbstFrameworkLayoutNode
+    {
+        /// <summary>Content displayed inside the zoom box.</summary>
+        IAbstFrameworkLayoutNode? Content { get; set; }
+
+        /// <summary>Horizontal zoom scale applied to the content.</summary>
+        float ScaleH { get; set; }
+
+        /// <summary>Vertical zoom scale applied to the content.</summary>
+        float ScaleV { get; set; }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/IAbstComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/IAbstComponentFactory.cs
@@ -18,6 +18,7 @@ namespace AbstUI.Components
         AbstGfxCanvas CreateGfxCanvas(string name, int width, int height);
         AbstWrapPanel CreateWrapPanel(AOrientation orientation, string name);
         AbstPanel CreatePanel(string name);
+        AbstZoomBox CreateZoomBox(string name);
         AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y);
         AbstTabContainer CreateTabContainer(string name);
         AbstTabItem CreateTabItem(string name, string title);
@@ -40,6 +41,6 @@ namespace AbstUI.Components
         AbstMenu CreateContextMenu(object window);
         AbstHorizontalLineSeparator CreateHorizontalLineSeparator(string name);
         AbstVerticalLineSeparator CreateVerticalLineSeparator(string name);
-        
+
     }
 }

--- a/src/Director/LingoEngine.Director.Core/Bitmaps/DirectorBitmapEditWindowV2.cs
+++ b/src/Director/LingoEngine.Director.Core/Bitmaps/DirectorBitmapEditWindowV2.cs
@@ -1,0 +1,278 @@
+using System;
+using LingoEngine.Director.Core.UI;
+using LingoEngine.FrameworkCommunication;
+using LingoEngine.Director.Core.Styles;
+using AbstUI.Components.Containers;
+using AbstUI.Components.Graphics;
+using AbstUI.Inputs;
+using AbstUI.Primitives;
+
+namespace LingoEngine.Director.Core.Bitmaps;
+
+public class DirectorBitmapEditWindowV2 : DirectorWindow<IDirFrameworkBitmapEditWindowV2>
+{
+    private readonly AbstZoomBox _zoomBox;
+    private readonly AbstPanel _rootPanel;
+    private readonly AbstGfxCanvas _background;
+    private readonly PaintCanvasV2 _paintCanvas;
+    private readonly AbstGfxCanvas _selectionCanvas;
+    private readonly RegPointCanvas _regPointCanvas;
+    private readonly PicturePainterV2 _painter;
+    private readonly LingoBitmapSelection _selection = new();
+
+    private PainterToolType _selectedTool = PainterToolType.Pencil;
+    private AColor _currentColor = AColors.Black;
+    private int _brushSize = 1;
+    private bool _mouseDown;
+    private bool _panning;
+    private bool _spaceDown;
+    private APoint _selectionStart;
+    private APoint _lastMousePos;
+    private float _scale = 1f;
+    private bool _ctrlDown;
+    private bool _shiftDown;
+
+    private IAbstMouseSubscription? _mouseDownSub;
+    private IAbstMouseSubscription? _mouseMoveSub;
+    private IAbstMouseSubscription? _mouseUpSub;
+
+    public AbstPanel Panel => _rootPanel;
+    public AbstGfxCanvas Background => _background;
+    public AbstGfxCanvas PaintCanvas => _paintCanvas.Canvas;
+    public AbstGfxCanvas Selection => _selectionCanvas;
+
+    public DirectorBitmapEditWindowV2(IServiceProvider serviceProvider) : base(serviceProvider, DirectorMenuCodes.PictureEditWindow)
+    {
+        Width = 800;
+        Height = 500;
+        MinimumWidth = 200;
+        MinimumHeight = 150;
+        X = 20;
+        Y = 120;
+
+        _zoomBox = Factory.ComponentFactory.CreateZoomBox("BitmapEditZoomBox");
+        _rootPanel = Factory.ComponentFactory.CreatePanel("BitmapEditZoomContent");
+        _zoomBox.Content = _rootPanel;
+        _background = Factory.CreateGfxCanvas("BackgroundCanvas", 0, 0);
+        _paintCanvas = new PaintCanvasV2(Factory);
+        _selectionCanvas = Factory.CreateGfxCanvas("SelectionCanvas", 0, 0);
+        _regPointCanvas = new RegPointCanvas(Factory);
+        Func<int, int, IAbstTexture2D> texFactory = (w, h) =>
+        {
+            var p = Factory.ComponentFactory.CreateImagePainterToTexture(w, h);
+            p.Clear(AColors.Transparent);
+            var t = p.GetTexture();
+            p.Dispose();
+            return t;
+        };
+        _painter = new PicturePainterV2(1, 1, texFactory);
+
+        _rootPanel.AddItem(_background);
+        _rootPanel.AddItem(_paintCanvas.Canvas);
+        _rootPanel.AddItem(_selectionCanvas);
+        _rootPanel.AddItem(_regPointCanvas.Canvas);
+
+        Content = _zoomBox;
+
+        _mouseDownSub = MouseT.OnMouseDown(OnMouseDown);
+        _mouseMoveSub = MouseT.OnMouseMove(OnMouseMove);
+        _mouseUpSub = MouseT.OnMouseUp(OnMouseUp);
+    }
+
+    public void SelectTool(PainterToolType tool) => _selectedTool = tool;
+
+    public void SetColor(AColor color) => _currentColor = color;
+
+    public void SetBrushSize(int size) => _brushSize = size;
+
+    private void OnMouseDown(AbstMouseEvent e)
+    {
+        _mouseDown = true;
+        if (_spaceDown)
+        {
+            _panning = true;
+            _lastMousePos = new APoint(e.MouseH, e.MouseV);
+            return;
+        }
+
+        var point = GetPixel(e);
+        switch (_selectedTool)
+        {
+            case PainterToolType.Pencil:
+                _painter.PaintPixel(point, _currentColor);
+                _paintCanvas.Draw(_painter, _scale);
+                DrawSelectionOverlay();
+                break;
+            case PainterToolType.PaintBrush:
+                _painter.PaintBrush(point, _currentColor, _brushSize);
+                _paintCanvas.Draw(_painter, _scale);
+                DrawSelectionOverlay();
+                break;
+            case PainterToolType.Eraser:
+                _painter.EraseBrush(point, _brushSize);
+                _paintCanvas.Draw(_painter, _scale);
+                DrawSelectionOverlay();
+                break;
+            case PainterToolType.SelectRectangle:
+                _selection.BeginRectSelection();
+                _selectionStart = point;
+                _selection.UpdateRectSelection(_selectionStart, point);
+                DrawSelectionOverlay();
+                break;
+            case PainterToolType.SelectLasso:
+                _selection.BeginLassoSelection(point);
+                DrawSelectionOverlay();
+                break;
+        }
+    }
+
+    private void OnMouseMove(AbstMouseEvent e)
+    {
+        if (!_mouseDown)
+            return;
+
+        if (_panning)
+        {
+            var pos = new APoint(e.MouseH, e.MouseV);
+            var delta = pos - _lastMousePos;
+            _zoomBox.OffsetX += delta.X;
+            _zoomBox.OffsetY += delta.Y;
+            _lastMousePos = pos;
+            return;
+        }
+
+        var point = GetPixel(e);
+        switch (_selectedTool)
+        {
+            case PainterToolType.Pencil:
+                _painter.PaintPixel(point, _currentColor);
+                _paintCanvas.Draw(_painter, _scale);
+                DrawSelectionOverlay();
+                break;
+            case PainterToolType.PaintBrush:
+                _painter.PaintBrush(point, _currentColor, _brushSize);
+                _paintCanvas.Draw(_painter, _scale);
+                DrawSelectionOverlay();
+                break;
+            case PainterToolType.Eraser:
+                _painter.EraseBrush(point, _brushSize);
+                _paintCanvas.Draw(_painter, _scale);
+                DrawSelectionOverlay();
+                break;
+            case PainterToolType.SelectRectangle:
+                _selection.UpdateRectSelection(_selectionStart, point);
+                DrawSelectionOverlay();
+                break;
+            case PainterToolType.SelectLasso:
+                _selection.AddLassoPoint((int)point.X, (int)point.Y);
+                DrawSelectionOverlay();
+                break;
+        }
+    }
+
+    private void OnMouseUp(AbstMouseEvent e)
+    {
+        if (!_mouseDown)
+            return;
+
+        if (_panning)
+        {
+            _panning = false;
+            _mouseDown = false;
+            return;
+        }
+
+        var point = GetPixel(e);
+        switch (_selectedTool)
+        {
+            case PainterToolType.SelectRectangle:
+                _selection.UpdateRectSelection(_selectionStart, point);
+                if (_selection.DragRect.HasValue)
+                    _selection.ApplySelection(_selection.DragRect.Value, ctrl: _ctrlDown, shift: _shiftDown);
+                _selection.EndRectSelection();
+                DrawSelectionOverlay();
+                break;
+            case PainterToolType.SelectLasso:
+                _selection.AddLassoPoint((int)point.X, (int)point.Y);
+                var points = _selection.EndLassoSelection();
+                _selection.ApplySelection(points, ctrl: _ctrlDown, shift: _shiftDown);
+                DrawSelectionOverlay();
+                break;
+        }
+        _mouseDown = false;
+    }
+
+    private APoint GetPixel(AbstMouseEvent e)
+        => new((int)(e.MouseH / _scale), (int)(e.MouseV / _scale));
+
+    protected override void OnRaiseKeyDown(AbstKeyEvent key)
+    {
+        _ctrlDown = key.ControlDown;
+        _shiftDown = key.ShiftDown;
+        if (key.KeyPressed(AbstUIKeyType.SPACE))
+            _spaceDown = true;
+    }
+
+    protected override void OnRaiseKeyUp(AbstKeyEvent key)
+    {
+        _ctrlDown = key.ControlDown;
+        _shiftDown = key.ShiftDown;
+        if (key.KeyPressed(AbstUIKeyType.SPACE))
+            _spaceDown = false;
+    }
+
+    private void DrawSelectionOverlay()
+    {
+        _selectionCanvas.Width = _painter.Width * _scale;
+        _selectionCanvas.Height = _painter.Height * _scale;
+        _selectionCanvas.Clear(AColors.Transparent);
+        _selection.Prepare((int)_selectionCanvas.Width, (int)_selectionCanvas.Height, _painter.Width, _painter.Height);
+
+        foreach (var px in _selection.SelectedPixels)
+        {
+            var pos = _selection.ToCanvas(px, _scale);
+            _selectionCanvas.DrawRect(ARect.New(pos.X, pos.Y, _scale, _scale), DirectorColors.BitmapSelectionFill, true);
+        }
+
+        if (_selection.IsDragSelecting && _selection.DragRect.HasValue)
+        {
+            var rect = _selection.ToCanvas(_selection.DragRect.Value, _scale);
+            _selectionCanvas.DrawRect(ARect.New(rect.Left, rect.Top, rect.Width, rect.Height), AColors.Cyan, false);
+        }
+        else if (_selection.IsLassoSelecting && _selection.LassoPoints.Count > 1)
+        {
+            for (int i = 0; i < _selection.LassoPoints.Count - 1; i++)
+            {
+                var p1 = _selection.ToCanvas(_selection.LassoPoints[i], _scale);
+                var p2 = _selection.ToCanvas(_selection.LassoPoints[i + 1], _scale);
+                _selectionCanvas.DrawLine(p1, p2, AColors.Cyan);
+            }
+        }
+    }
+
+    protected override void OnDispose()
+    {
+        _mouseDownSub?.Release();
+        _mouseMoveSub?.Release();
+        _mouseUpSub?.Release();
+        base.OnDispose();
+    }
+
+    protected override void OnResizing(bool firstLoad, int width, int height)
+    {
+        base.OnResizing(firstLoad, width, height);
+        _zoomBox.Width = width;
+        _zoomBox.Height = height;
+        _rootPanel.Width = width;
+        _rootPanel.Height = height;
+        _background.Width = width;
+        _background.Height = height;
+        _paintCanvas.Canvas.Width = width;
+        _paintCanvas.Canvas.Height = height;
+        _selectionCanvas.Width = width;
+        _selectionCanvas.Height = height;
+        _regPointCanvas.Canvas.Width = width;
+        _regPointCanvas.Canvas.Height = height;
+    }
+}
+

--- a/src/Director/LingoEngine.Director.Core/Bitmaps/IDirFrameworkBitmapEditWindowV2.cs
+++ b/src/Director/LingoEngine.Director.Core/Bitmaps/IDirFrameworkBitmapEditWindowV2.cs
@@ -1,0 +1,9 @@
+using AbstUI.Windowing;
+using LingoEngine.Director.Core.Windowing;
+
+namespace LingoEngine.Director.Core.Bitmaps;
+
+public interface IDirFrameworkBitmapEditWindowV2 : IAbstFrameworkWindow
+{
+}
+

--- a/src/Director/LingoEngine.Director.Core/Bitmaps/LingoBitmapSelection.cs
+++ b/src/Director/LingoEngine.Director.Core/Bitmaps/LingoBitmapSelection.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using AbstUI.Primitives;
-using AbstUI.Components.Graphics;
 
 namespace LingoEngine.Director.Core.Bitmaps;
 
@@ -23,9 +22,13 @@ public class LingoBitmapSelection
     private APoint _canvasHalf;
     private APoint _offset;
 
-    public void Prepare(AbstGfxCanvas canvas, int memberWidth, int memberHeight)
+    public LingoBitmapSelection()
     {
-        _canvasHalf = new APoint(canvas.Width / 2f, canvas.Height / 2f);
+    }
+
+    public void Prepare(int canvasWidth, int canvasHeight, int memberWidth, int memberHeight)
+    {
+        _canvasHalf = new APoint(canvasWidth / 2f, canvasHeight / 2f);
         var imageHalf = new APoint(memberWidth / 2f, memberHeight / 2f);
         _offset = _canvasHalf - imageHalf;
     }

--- a/src/Director/LingoEngine.Director.Core/Bitmaps/PaintCanvasV2.cs
+++ b/src/Director/LingoEngine.Director.Core/Bitmaps/PaintCanvasV2.cs
@@ -1,0 +1,42 @@
+using AbstUI.Components.Graphics;
+using AbstUI.Primitives;
+using LingoEngine.FrameworkCommunication;
+
+namespace LingoEngine.Director.Core.Bitmaps;
+
+public class PaintCanvasV2
+{
+    private readonly AbstGfxCanvas _canvas;
+    public AbstGfxCanvas Canvas => _canvas;
+
+    public PaintCanvasV2(ILingoFrameworkFactory factory)
+    {
+        _canvas = factory.CreateGfxCanvas("PaintCanvas", 0, 0);
+    }
+
+    public void Draw(PicturePainterV2 painter, float scale)
+    {
+        _canvas.Width = painter.Width * scale;
+        _canvas.Height = painter.Height * scale;
+        foreach (var (pos, texture) in painter.GetDirtyTiles())
+        {
+            var origin = painter.Offset + pos;
+            int size = (int)(painter.TileSize * scale);
+            var dest = new APoint(origin.X * scale, origin.Y * scale);
+            _canvas.DrawPicture(texture, size, size, dest);
+        }
+    }
+
+    public void DrawAll(PicturePainterV2 painter, float scale)
+    {
+        _canvas.Width = painter.Width * scale;
+        _canvas.Height = painter.Height * scale;
+        foreach (var (pos, texture) in painter.GetTiles())
+        {
+            var origin = painter.Offset + pos;
+            int size = (int)(painter.TileSize * scale);
+            var dest = new APoint(origin.X * scale, origin.Y * scale);
+            _canvas.DrawPicture(texture, size, size, dest);
+        }
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Bitmaps/PicturePainterV2.cs
+++ b/src/Director/LingoEngine.Director.Core/Bitmaps/PicturePainterV2.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Primitives;
+
+namespace LingoEngine.Director.Core.Bitmaps;
+
+public class PicturePainterV2
+{
+    private class Tile
+    {
+        public readonly byte[] Pixels;
+        public readonly int Size;
+        public readonly IAbstTexture2D Texture;
+        public bool Dirty;
+
+        public Tile(int size, Func<int, int, IAbstTexture2D> createTexture)
+        {
+            Size = size;
+            Pixels = new byte[size * size * 4];
+            Texture = createTexture(size, size);
+            Dirty = true;
+        }
+
+        public void SetPixel(int x, int y, AColor color)
+        {
+            int idx = (y * Size + x) * 4;
+            Pixels[idx] = color.A;
+            Pixels[idx + 1] = color.R;
+            Pixels[idx + 2] = color.G;
+            Pixels[idx + 3] = color.B;
+            Dirty = true;
+        }
+
+        public void RenderToTexture()
+        {
+            Texture.SetARGBPixels(Pixels);
+            Dirty = false;
+        }
+    }
+
+    private Tile[,] _tiles;
+    private readonly int _tileSize;
+    private readonly Func<int, int, IAbstTexture2D> _createTexture;
+    private APoint _offset;
+
+    public APoint Offset => _offset;
+    public int Width => _tiles.GetLength(0) * _tileSize;
+    public int Height => _tiles.GetLength(1) * _tileSize;
+    public int TileSize => _tileSize;
+
+    public PicturePainterV2(int width, int height, Func<int, int, IAbstTexture2D> createTexture, int tileSize = 128)
+    {
+        _tileSize = tileSize;
+        _createTexture = createTexture;
+        int tilesX = (width + tileSize - 1) / tileSize;
+        int tilesY = (height + tileSize - 1) / tileSize;
+        _tiles = new Tile[tilesX, tilesY];
+        for (int y = 0; y < tilesY; y++)
+            for (int x = 0; x < tilesX; x++)
+                _tiles[x, y] = new Tile(tileSize, createTexture);
+        _offset = new APoint(0, 0);
+    }
+
+    public void PaintPixel(APoint point, AColor color)
+    {
+        var p = point;
+        EnsureCapacity(ref p);
+        int tileX = (int)p.X / _tileSize;
+        int tileY = (int)p.Y / _tileSize;
+        int localX = (int)p.X % _tileSize;
+        int localY = (int)p.Y % _tileSize;
+        var tile = _tiles[tileX, tileY];
+        tile.SetPixel(localX, localY, color);
+    }
+
+    public void ErasePixel(APoint point) => PaintPixel(point, AColor.Transparent());
+
+    public void PaintBrush(APoint center, AColor color, int size)
+    {
+        int radius = System.Math.Max(0, size / 2);
+        var c = center;
+        EnsureCapacityForBrush(ref c, radius);
+        for (int y = -radius; y <= radius; y++)
+            for (int x = -radius; x <= radius; x++)
+                if (x * x + y * y <= radius * radius)
+                {
+                    int px = (int)c.X + x;
+                    int py = (int)c.Y + y;
+                    int tileX = px / _tileSize;
+                    int tileY = py / _tileSize;
+                    int localX = px % _tileSize;
+                    int localY = py % _tileSize;
+                    var tile = _tiles[tileX, tileY];
+                    tile.SetPixel(localX, localY, color);
+                }
+    }
+
+    public void EraseBrush(APoint center, int size) => PaintBrush(center, AColor.Transparent(), size);
+
+    private void EnsureCapacityForBrush(ref APoint center, int radius)
+    {
+        var bottomRight = center + new APoint(radius, radius);
+        var topLeft = center - new APoint(radius, radius);
+
+        int leftPad = System.Math.Max(0, (int)-topLeft.X);
+        int topPad = System.Math.Max(0, (int)-topLeft.Y);
+        int rightPad = System.Math.Max(0, (int)(bottomRight.X - (Width - 1)));
+        int bottomPad = System.Math.Max(0, (int)(bottomRight.Y - (Height - 1)));
+
+        int leftTiles = (leftPad + _tileSize - 1) / _tileSize;
+        int topTiles = (topPad + _tileSize - 1) / _tileSize;
+        int rightTiles = (rightPad + _tileSize - 1) / _tileSize;
+        int bottomTiles = (bottomPad + _tileSize - 1) / _tileSize;
+
+        ExpandTiles(leftTiles, topTiles, rightTiles, bottomTiles);
+        center += new APoint(leftTiles * _tileSize, topTiles * _tileSize);
+    }
+
+    private void EnsureCapacity(ref APoint point)
+    {
+        int leftPad = System.Math.Max(0, (int)-point.X);
+        int topPad = System.Math.Max(0, (int)-point.Y);
+        int rightPad = System.Math.Max(0, (int)(point.X - (Width - 1)));
+        int bottomPad = System.Math.Max(0, (int)(point.Y - (Height - 1)));
+
+        int leftTiles = (leftPad + _tileSize - 1) / _tileSize;
+        int topTiles = (topPad + _tileSize - 1) / _tileSize;
+        int rightTiles = (rightPad + _tileSize - 1) / _tileSize;
+        int bottomTiles = (bottomPad + _tileSize - 1) / _tileSize;
+
+        ExpandTiles(leftTiles, topTiles, rightTiles, bottomTiles);
+        point += new APoint(leftTiles * _tileSize, topTiles * _tileSize);
+    }
+
+    private void ExpandTiles(int left, int top, int right, int bottom)
+    {
+        if (left == 0 && top == 0 && right == 0 && bottom == 0)
+            return;
+
+        int oldW = _tiles.GetLength(0);
+        int oldH = _tiles.GetLength(1);
+        int newW = oldW + left + right;
+        int newH = oldH + top + bottom;
+        var newTiles = new Tile[newW, newH];
+
+        for (int y = 0; y < oldH; y++)
+            for (int x = 0; x < oldW; x++)
+                newTiles[x + left, y + top] = _tiles[x, y];
+
+        for (int y = 0; y < newH; y++)
+            for (int x = 0; x < newW; x++)
+            {
+                if (newTiles[x, y] == null)
+                    newTiles[x, y] = new Tile(_tileSize, _createTexture);
+                else
+                    newTiles[x, y].Dirty = true;
+            }
+
+        _tiles = newTiles;
+        _offset += new APoint(left * _tileSize, top * _tileSize);
+    }
+
+    public IEnumerable<(APoint Position, IAbstTexture2D Texture)> GetTiles()
+    {
+        int tilesX = _tiles.GetLength(0);
+        int tilesY = _tiles.GetLength(1);
+        for (int y = 0; y < tilesY; y++)
+            for (int x = 0; x < tilesX; x++)
+            {
+                var tile = _tiles[x, y];
+                if (tile.Dirty)
+                    tile.RenderToTexture();
+                yield return (new APoint(x * _tileSize, y * _tileSize), tile.Texture);
+            }
+    }
+
+    public IEnumerable<(APoint Position, IAbstTexture2D Texture)> GetDirtyTiles()
+    {
+        int tilesX = _tiles.GetLength(0);
+        int tilesY = _tiles.GetLength(1);
+        for (int y = 0; y < tilesY; y++)
+            for (int x = 0; x < tilesX; x++)
+            {
+                var tile = _tiles[x, y];
+                if (!tile.Dirty) continue;
+                tile.RenderToTexture();
+                yield return (new APoint(x * _tileSize, y * _tileSize), tile.Texture);
+            }
+    }
+
+    public void SetState(AColor[,] pixels, APoint offset)
+    {
+        int width = pixels.GetLength(0);
+        int height = pixels.GetLength(1);
+        int tilesX = (width + _tileSize - 1) / _tileSize;
+        int tilesY = (height + _tileSize - 1) / _tileSize;
+        _tiles = new Tile[tilesX, tilesY];
+        for (int ty = 0; ty < tilesY; ty++)
+            for (int tx = 0; tx < tilesX; tx++)
+            {
+                var tile = new Tile(_tileSize, _createTexture);
+                for (int y = 0; y < _tileSize; y++)
+                    for (int x = 0; x < _tileSize; x++)
+                    {
+                        int ix = tx * _tileSize + x;
+                        int iy = ty * _tileSize + y;
+                        if (ix < width && iy < height)
+                            tile.SetPixel(x, y, pixels[ix, iy]);
+                    }
+                _tiles[tx, ty] = tile;
+            }
+        _offset = offset;
+    }
+}

--- a/src/Director/LingoEngine.Director.Core/Bitmaps/SelectionCanvas.cs
+++ b/src/Director/LingoEngine.Director.Core/Bitmaps/SelectionCanvas.cs
@@ -22,7 +22,7 @@ public class SelectionCanvas
         _canvas.Width = member.Width * scale;
         _canvas.Height = member.Height * scale;
         _canvas.Clear(AColors.Transparent);
-        selection.Prepare(_canvas, member.Width, member.Height);
+        selection.Prepare((int)_canvas.Width, (int)_canvas.Height, member.Width, member.Height);
         var color = DirectorColors.BitmapSelectionFill;
 
         foreach (var px in selection.SelectedPixels)

--- a/src/Director/LingoEngine.Director.LGodot/Bitmaps/DirGodotPictureMemberEditorWindow.cs
+++ b/src/Director/LingoEngine.Director.LGodot/Bitmaps/DirGodotPictureMemberEditorWindow.cs
@@ -59,7 +59,7 @@ internal partial class DirGodotPictureMemberEditorWindow : BaseGodotWindow, IHas
     private PicturePainter? _painter;
     private readonly PaintToolbar _paintToolbar;
     private int _brushSize = 1;
-    private readonly LingoBitmapSelection _selection = new();
+    private LingoBitmapSelection _selection = new();
     private Vector2I _selectStart;
     private Vector2 _lastMousePos;
 
@@ -83,7 +83,7 @@ internal partial class DirGodotPictureMemberEditorWindow : BaseGodotWindow, IHas
         _historyManager = historyManager;
         _mediator.Subscribe(this);
         Init(directorPictureEditWindow);
-        
+
 
         _navBar = new MemberNavigationBar<LingoMemberBitmap>(_mediator, _player, _iconManager, factory, NavigationBarHeight);
         AddChild(_navBar.Panel.Framework<AbstGodotWrapPanel>());
@@ -406,6 +406,7 @@ internal partial class DirGodotPictureMemberEditorWindow : BaseGodotWindow, IHas
         selNode.OffsetTop = -h / 2f;
         selNode.OffsetRight = w / 2f;
         selNode.OffsetBottom = h / 2f;
+        _selection = new LingoBitmapSelection();
     }
 
     private void RedrawRegPointCanvas()


### PR DESCRIPTION
## Summary
- split zoom scaling into independent horizontal and vertical factors for framework abstraction and component
- update SDL zoom box to use SDL_RenderSetScale and forward mouse events to its content
- adjust Godot, Blazor, Unity, ImGui zoom boxes to implement the new scale properties

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Containers/AbstZoomBox.cs WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Containers/IAbstFrameworkZoomBox.cs --verbosity diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Containers/AbstSdlZoomBox.cs --verbosity diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Containers/AbstGodotZoomBox.cs --verbosity diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Components/Containers/AbstUnityZoomBox.cs --verbosity diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorZoomBoxComponent.cs --verbosity diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Components/AbstImGuiZoomBox.cs --verbosity diagnostic`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj --no-restore`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --no-restore`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj --no-restore`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/AbstUI.LUnity.csproj --no-restore`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --no-restore`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj --no-restore` *(fails: missing references)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc1cbbc6c83328ff029ee61b972cd