### PR TITLE
Add C++ DirectorClient using SignalR

### DIFF
--- a/src/Director/cpp/DirectorClient/DirectorClient.cpp
+++ b/src/Director/cpp/DirectorClient/DirectorClient.cpp
@@ -1,0 +1,161 @@
+#include "DirectorClient.h"
+
+void DirectorClient::Connect(const std::string& hubUrl, const HelloDto& hello)
+{
+    auto connection = signalr::hub_connection_builder::create(hubUrl).build();
+    connection.start().get();
+    connection.invoke<void>("SessionHello", hello).get();
+    _connection = std::make_shared<signalr::hub_connection>(std::move(connection));
+}
+
+void DirectorClient::Disconnect()
+{
+    if (_connection)
+    {
+        _connection->stop().get();
+        _connection.reset();
+    }
+}
+
+void DirectorClient::StreamFrames(std::function<void(const StageFrameDto&)> handler)
+{
+    if (_connection)
+    {
+        _connection->on("StreamFrames", [handler](const StageFrameDto& dto)
+        {
+            handler(dto);
+        });
+    }
+}
+
+void DirectorClient::StreamDeltas(std::function<void(const SpriteDeltaDto&)> handler)
+{
+    if (_connection)
+    {
+        _connection->on("StreamDeltas", [handler](const SpriteDeltaDto& dto)
+        {
+            handler(dto);
+        });
+    }
+}
+
+void DirectorClient::StreamKeyframes(std::function<void(const KeyframeDto&)> handler)
+{
+    if (_connection)
+    {
+        _connection->on("StreamKeyframes", [handler](const KeyframeDto& dto)
+        {
+            handler(dto);
+        });
+    }
+}
+
+void DirectorClient::StreamFilmLoops(std::function<void(const FilmLoopDto&)> handler)
+{
+    if (_connection)
+    {
+        _connection->on("StreamFilmLoops", [handler](const FilmLoopDto& dto)
+        {
+            handler(dto);
+        });
+    }
+}
+
+void DirectorClient::StreamSounds(std::function<void(const SoundEventDto&)> handler)
+{
+    if (_connection)
+    {
+        _connection->on("StreamSounds", [handler](const SoundEventDto& dto)
+        {
+            handler(dto);
+        });
+    }
+}
+
+void DirectorClient::StreamTempos(std::function<void(const TempoDto&)> handler)
+{
+    if (_connection)
+    {
+        _connection->on("StreamTempos", [handler](const TempoDto& dto)
+        {
+            handler(dto);
+        });
+    }
+}
+
+void DirectorClient::StreamColorPalettes(std::function<void(const ColorPaletteDto&)> handler)
+{
+    if (_connection)
+    {
+        _connection->on("StreamColorPalettes", [handler](const ColorPaletteDto& dto)
+        {
+            handler(dto);
+        });
+    }
+}
+
+void DirectorClient::StreamFrameScripts(std::function<void(const FrameScriptDto&)> handler)
+{
+    if (_connection)
+    {
+        _connection->on("StreamFrameScripts", [handler](const FrameScriptDto& dto)
+        {
+            handler(dto);
+        });
+    }
+}
+
+void DirectorClient::StreamTransitions(std::function<void(const TransitionDto&)> handler)
+{
+    if (_connection)
+    {
+        _connection->on("StreamTransitions", [handler](const TransitionDto& dto)
+        {
+            handler(dto);
+        });
+    }
+}
+
+void DirectorClient::StreamMemberProperties(std::function<void(const MemberPropertyDto&)> handler)
+{
+    if (_connection)
+    {
+        _connection->on("StreamMemberProperties", [handler](const MemberPropertyDto& dto)
+        {
+            handler(dto);
+        });
+    }
+}
+
+void DirectorClient::StreamTextStyles(std::function<void(const TextStyleDto&)> handler)
+{
+    if (_connection)
+    {
+        _connection->on("StreamTextStyles", [handler](const TextStyleDto& dto)
+        {
+            handler(dto);
+        });
+    }
+}
+
+MovieStateDto DirectorClient::GetMovieSnapshot()
+{
+    return _connection->invoke<MovieStateDto>("GetMovieSnapshot").get();
+}
+
+void DirectorClient::SendCommand(const DebugCommandDto& cmd)
+{
+    if (_connection)
+    {
+        _connection->invoke<void>("SendCommand", cmd).get();
+    }
+}
+
+void DirectorClient::SendHeartbeat()
+{
+    if (_connection)
+    {
+        _connection->invoke<void>("Heartbeat").get();
+    }
+}
+

--- a/src/Director/cpp/DirectorClient/DirectorClient.h
+++ b/src/Director/cpp/DirectorClient/DirectorClient.h
@@ -1,0 +1,181 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <variant>
+#include <functional>
+#include <memory>
+
+#include <signalrclient/hub_connection.h>
+#include <signalrclient/hub_connection_builder.h>
+#include <nlohmann/json.hpp>
+
+// Data Transfer Objects ------------------------------------------------------
+
+struct HelloDto {
+    std::string ProjectId;
+    std::string ClientId;
+    std::string Version;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(HelloDto, ProjectId, ClientId, Version);
+
+struct StageFrameDto {
+    int Width;
+    int Height;
+    long long FrameId;
+    std::string TimestampUtc;
+    std::vector<uint8_t> Argb32;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(StageFrameDto, Width, Height, FrameId, TimestampUtc, Argb32);
+
+struct SpriteDeltaDto {
+    int Frame;
+    int SpriteNum;
+    int Z;
+    int MemberId;
+    int LocH;
+    int LocV;
+    int Width;
+    int Height;
+    int Rotation;
+    int Skew;
+    int Blend;
+    int Ink;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(SpriteDeltaDto, Frame, SpriteNum, Z, MemberId, LocH, LocV, Width, Height, Rotation, Skew, Blend, Ink);
+
+struct KeyframeDto {
+    int Frame;
+    int SpriteNum;
+    std::string Prop;
+    std::string Value;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(KeyframeDto, Frame, SpriteNum, Prop, Value);
+
+struct FilmLoopDto {
+    std::string Name;
+    int StartFrame;
+    int EndFrame;
+    bool IsPlaying;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(FilmLoopDto, Name, StartFrame, EndFrame, IsPlaying);
+
+struct SoundEventDto {
+    int Frame;
+    std::string SoundName;
+    bool IsPlaying;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(SoundEventDto, Frame, SoundName, IsPlaying);
+
+struct TempoDto {
+    int Frame;
+    int Tempo;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(TempoDto, Frame, Tempo);
+
+struct ColorPaletteDto {
+    int Frame;
+    std::vector<uint8_t> Argb32;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ColorPaletteDto, Frame, Argb32);
+
+struct FrameScriptDto {
+    int Frame;
+    std::string Script;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(FrameScriptDto, Frame, Script);
+
+struct TransitionDto {
+    int Frame;
+    std::string Type;
+    int Duration;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(TransitionDto, Frame, Type, Duration);
+
+struct MemberPropertyDto {
+    std::string MemberName;
+    std::string Prop;
+    std::string Value;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(MemberPropertyDto, MemberName, Prop, Value);
+
+struct TextStyleDto {
+    std::string MemberName;
+    int Start;
+    int End;
+    std::string Style;
+    std::string Value;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(TextStyleDto, MemberName, Start, End, Style, Value);
+
+struct MovieStateDto {
+    int Frame;
+    int Tempo;
+    bool IsPlaying;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(MovieStateDto, Frame, Tempo, IsPlaying);
+
+// Debug command hierarchy -----------------------------------------------------
+
+struct SetSpritePropCmd {
+    int SpriteNum;
+    std::string Prop;
+    std::string Value;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(SetSpritePropCmd, SpriteNum, Prop, Value);
+
+struct SetMemberPropCmd {
+    std::string MemberName;
+    std::string Prop;
+    std::string Value;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(SetMemberPropCmd, MemberName, Prop, Value);
+
+struct GoToFrameCmd {
+    int Frame;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GoToFrameCmd, Frame);
+
+struct PauseCmd {};
+inline void to_json(nlohmann::json& j, const PauseCmd&) { j = nlohmann::json::object(); }
+inline void from_json(const nlohmann::json&, PauseCmd&) {}
+
+struct ResumeCmd {};
+inline void to_json(nlohmann::json& j, const ResumeCmd&) { j = nlohmann::json::object(); }
+inline void from_json(const nlohmann::json&, ResumeCmd&) {}
+
+struct DebugCommandDto {
+    std::variant<SetSpritePropCmd, SetMemberPropCmd, GoToFrameCmd, PauseCmd, ResumeCmd> Command;
+};
+inline void to_json(nlohmann::json& j, const DebugCommandDto& cmd)
+{
+    std::visit([&j](const auto& v) { j = v; }, cmd.Command);
+}
+
+// DirectorClient --------------------------------------------------------------
+
+class DirectorClient {
+public:
+    void Connect(const std::string& hubUrl, const HelloDto& hello);
+    void Disconnect();
+
+    void StreamFrames(std::function<void(const StageFrameDto&)> handler);
+    void StreamDeltas(std::function<void(const SpriteDeltaDto&)> handler);
+    void StreamKeyframes(std::function<void(const KeyframeDto&)> handler);
+    void StreamFilmLoops(std::function<void(const FilmLoopDto&)> handler);
+    void StreamSounds(std::function<void(const SoundEventDto&)> handler);
+    void StreamTempos(std::function<void(const TempoDto&)> handler);
+    void StreamColorPalettes(std::function<void(const ColorPaletteDto&)> handler);
+    void StreamFrameScripts(std::function<void(const FrameScriptDto&)> handler);
+    void StreamTransitions(std::function<void(const TransitionDto&)> handler);
+    void StreamMemberProperties(std::function<void(const MemberPropertyDto&)> handler);
+    void StreamTextStyles(std::function<void(const TextStyleDto&)> handler);
+
+    MovieStateDto GetMovieSnapshot();
+    void SendCommand(const DebugCommandDto& cmd);
+    void SendHeartbeat();
+
+private:
+    std::shared_ptr<signalr::hub_connection> _connection;
+};
+

--- a/src/Director/cpp/DirectorClient/README.md
+++ b/src/Director/cpp/DirectorClient/README.md
@@ -1,0 +1,22 @@
+# C++ DirectorClient
+
+This folder contains a C++ implementation of the `DirectorClient` using the Microsoft SignalR client and `nlohmann::json`.
+
+## Build
+
+Install dependencies using vcpkg:
+
+```bash
+vcpkg install microsoft-signalr nlohmann-json
+```
+
+Compile the example:
+
+```bash
+g++ -std=c++17 DirectorClient.cpp example.cpp \
+    -I$VCPKG_ROOT/installed/x64-linux/include \
+    -L$VCPKG_ROOT/installed/x64-linux/lib \
+    -lsignalrclient -lcpprest -lssl -lcrypto -pthread
+```
+
+The example connects to a Director hub, registers a frame stream handler, sends a heartbeat, and disconnects.

--- a/src/Director/cpp/DirectorClient/example.cpp
+++ b/src/Director/cpp/DirectorClient/example.cpp
@@ -1,0 +1,21 @@
+#include "DirectorClient.h"
+#include <iostream>
+
+int main()
+{
+    DirectorClient client;
+    HelloDto hello{ "demo-project", "client-1", "1.0" };
+
+    client.Connect("http://localhost:5000/directorHub", hello);
+
+    client.StreamFrames([](const StageFrameDto& frame)
+    {
+        std::cout << "Received frame " << frame.FrameId << std::endl;
+    });
+
+    client.SendHeartbeat();
+
+    client.Disconnect();
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- Implement C++ DirectorClient with SignalR hub connection and DTOs
- Add example usage and build instructions for vcpkg
- Move C++ DirectorClient files to src/Director/cpp/DirectorClient

## Testing
- `dotnet build src/Director/LingoEngine.Director.Client/LingoEngine.Director.Client.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bfdb7ac0e883328540ee63f3693268