### PR TITLE
Fix transition target rect rendering in Godot and SDL2

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Primitives/ARect.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Primitives/ARect.cs
@@ -66,6 +66,22 @@
             return new ARect(Left + dx, Top + dy, Right - dx, Bottom - dy);
         }
 
+        public ARect Clamp(int width, int height)
+        {
+#if NET48
+            int x = (int)MathCompat.Clamp(Left, 0, width);
+            int y = (int)MathCompat.Clamp(Top, 0, height);
+            int w = (int)MathCompat.Clamp(Width, 0, width - x);
+            int h = (int)MathCompat.Clamp(Height, 0, height - y);
+#else
+            int x = (int)Math.Clamp(Left, 0, width);
+            int y = (int)Math.Clamp(Top, 0, height);
+            int w = (int)Math.Clamp(Width, 0, width - x);
+            int h = (int)Math.Clamp(Height, 0, height - y);
+#endif
+            return New(x, y, w, h);
+        }
+
         public override string ToString() =>
             $"Rect({Left}, {Top}, {Right}, {Bottom})";
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Tools/APixel.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Tools/APixel.cs
@@ -1,4 +1,5 @@
 using System;
+using AbstUI.Primitives;
 
 namespace AbstUI.Tools;
 
@@ -25,5 +26,50 @@ public static class APixel
             argbPixels[idx + 2] = b;
             argbPixels[idx + 3] = a;
         });
+    }
+
+    /// <summary>
+    /// Copies a rectangular region of pixels from <paramref name="src"/> to <paramref name="dest"/>.
+    /// </summary>
+    public static void CopyRectPixels(byte[] src, byte[] dest, int width, ARect rect)
+    {
+        int x = (int)rect.Left;
+        int y = (int)rect.Top;
+        int w = (int)rect.Width;
+        int h = (int)rect.Height;
+        for (int row = 0; row < h; row++)
+        {
+            int srcIdx = ((y + row) * width + x) * 4;
+            Buffer.BlockCopy(src, srcIdx, dest, srcIdx, w * 4);
+        }
+    }
+
+    /// <summary>
+    /// Computes the smallest rectangle that contains all differing pixels between two buffers.
+    /// </summary>
+    public static ARect ComputeDifferenceRect(int width, int height, byte[] from, byte[] to)
+    {
+        int minX = width;
+        int minY = height;
+        int maxX = -1;
+        int maxY = -1;
+        for (int y = 0; y < height; y++)
+        {
+            int rowIndex = y * width * 4;
+            for (int x = 0; x < width; x++)
+            {
+                int idx = rowIndex + x * 4;
+                if (from[idx] != to[idx] || from[idx + 1] != to[idx + 1] || from[idx + 2] != to[idx + 2] || from[idx + 3] != to[idx + 3])
+                {
+                    if (x < minX) minX = x;
+                    if (y < minY) minY = y;
+                    if (x > maxX) maxX = x;
+                    if (y > maxY) maxY = y;
+                }
+            }
+        }
+        if (maxX < minX || maxY < minY)
+            return ARect.New(0, 0, width, height);
+        return ARect.New(minX, minY, maxX - minX + 1, maxY - minY + 1);
     }
 }

--- a/src/LingoEngine.SDL2/Stages/SdlStage.cs
+++ b/src/LingoEngine.SDL2/Stages/SdlStage.cs
@@ -33,7 +33,7 @@ public class SdlStage : ILingoFrameworkStage, IDisposable
         _rootContext = rootContext;
         _clock = clock;
         _factory = factory;
-       
+
     }
 
     internal LingoSdlRootContext RootContext => _rootContext;
@@ -69,7 +69,7 @@ public class SdlStage : ILingoFrameworkStage, IDisposable
     }
 
     public void Dispose()
-    { 
+    {
         _movies.Clear();
         if (_spritesTexture != nint.Zero)
             SDL.SDL_DestroyTexture(_spritesTexture);
@@ -85,11 +85,11 @@ public class SdlStage : ILingoFrameworkStage, IDisposable
     }
     public IAbstTexture2D GetScreenshot()
     {
-        var texture = new SdlTexture2D(_spritesTexture, _stage.Width, _stage.Height, "StageShot_"+_activeMovie!.CurrentFrame, _factory.RootContext.Renderer);
+        var texture = new SdlTexture2D(_spritesTexture, _stage.Width, _stage.Height, "StageShot_" + _activeMovie!.CurrentFrame, _factory.RootContext.Renderer);
         var clone = (SdlTexture2D)texture.Clone();
-//#if DEBUG
-//        clone.DebugWriteToDiskInc(_factory.RootContext.Renderer);
-//#endif
+        //#if DEBUG
+        //        clone.DebugWriteToDiskInc(_factory.RootContext.Renderer);
+        //#endif
         return clone;
     }
 
@@ -97,7 +97,7 @@ public class SdlStage : ILingoFrameworkStage, IDisposable
     public void ShowTransition(IAbstTexture2D startTexture)
     {
         _startFrame?.Dispose();
-        _startFrame = (SdlTexture2D)startTexture.Clone(); 
+        _startFrame = (SdlTexture2D)startTexture.Clone();
         _isTransitioning = true;
     }
 
@@ -117,7 +117,7 @@ public class SdlStage : ILingoFrameworkStage, IDisposable
         _transitionFrame = null;
         _startFrame?.Dispose();
         _startFrame = null;
-       
+
 #if DEBUG
         SdlTexture2D.ResetDebuggerInc();
 #endif
@@ -168,14 +168,15 @@ public class SdlStage : ILingoFrameworkStage, IDisposable
         }
         if (_transitionFrame != null)
         {
-            var dst = new SDL.SDL_Rect
+            var src = new SDL.SDL_Rect
             {
                 x = (int)_transitionRect.Left,
                 y = (int)_transitionRect.Top,
                 w = (int)_transitionRect.Width,
                 h = (int)_transitionRect.Height
             };
-            SDL.SDL_RenderCopy(context.Renderer, _transitionFrame.Handle, IntPtr.Zero, ref dst);
+            var dst = src;
+            SDL.SDL_RenderCopy(context.Renderer, _transitionFrame.Handle, ref src, ref dst);
         }
     }
 
@@ -200,5 +201,5 @@ public class SdlStage : ILingoFrameworkStage, IDisposable
         return tex;
     }
 
-   
+
 }


### PR DESCRIPTION
## Summary
- add dedicated start sprite so Godot transitions keep the original frame and overlay the animated region
- crop and position overlay sprite using target rect for proper partial-frame transitions
- centralize pixel rectangle helpers in `APixel` and move clamping logic into `ARect`

## Testing
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/Transitions/LingoTransitionPlayer.cs`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI/Tools/APixel.cs WillMoveToOwnRepo/AbstUI/src/AbstUI/Primitives/ARect.cs`
- `dotnet test Test/LingoEngine.Tests/LingoEngine.Tests.csproj` *(fails: type-parameter constraints mismatch in DummyCast methods)*
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj` *(fails: Markdown renderer expectation differences)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9ffa013083328cf7af3dd0399a4a