### PR TITLE
Add SDL and Godot key code mapping

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.LGodotTest/GodotKeyCodeMapTests.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.LGodotTest/GodotKeyCodeMapTests.cs
@@ -1,0 +1,22 @@
+using AbstUI.LGodot.Inputs;
+using Godot;
+using Xunit;
+
+namespace AbstUI.LGodotTest;
+
+public class GodotKeyCodeMapTests
+{
+    [Fact]
+    public void MapsLettersToLingoCodes()
+    {
+        var code = GodotKeyCodeMap.ToLingo(Key.A);
+        Assert.Equal(0, code);
+        Assert.Equal(Key.A, GodotKeyCodeMap.ToGodot(0));
+    }
+
+    [Fact]
+    public void MapsFunctionKey()
+    {
+        Assert.Equal(122, GodotKeyCodeMap.ToLingo(Key.F1));
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.SDLTest/SdlKeyCodeMapTests.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.SDLTest/SdlKeyCodeMapTests.cs
@@ -1,0 +1,22 @@
+using AbstUI.SDL2.Inputs;
+using AbstUI.SDL2.SDLL;
+using Xunit;
+
+namespace AbstUI.SDLTest;
+
+public class SdlKeyCodeMapTests
+{
+    [Fact]
+    public void MapsLettersToLingoCodes()
+    {
+        var code = SdlKeyCodeMap.ToLingo(SDL.SDL_Keycode.SDLK_a);
+        Assert.Equal(0, code);
+        Assert.Equal(SDL.SDL_Keycode.SDLK_a, SdlKeyCodeMap.ToSDL(0));
+    }
+
+    [Fact]
+    public void MapsFunctionKey()
+    {
+        Assert.Equal(122, SdlKeyCodeMap.ToLingo(SDL.SDL_Keycode.SDLK_F1));
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Inputs/AbstGodotKey.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Inputs/AbstGodotKey.cs
@@ -31,14 +31,14 @@ public partial class AbstGodotKey : Node, IAbstFrameworkKey, IFrameworkFor<AbstK
             {
                 if (!_pressed.Contains(k.Keycode))
                     _pressed.Add(k.Keycode);
-                _lastCode = (int)k.Keycode;
+                _lastCode = GodotKeyCodeMap.ToLingo(k.Keycode);
                 _lastKey = k.KeyLabel.ToString();
                 _lingoKey.Value.DoKeyDown();
             }
             else
             {
                 _pressed.Remove(k.Keycode);
-                _lastCode = (int)k.Keycode;
+                _lastCode = GodotKeyCodeMap.ToLingo(k.Keycode);
                 _lastKey = k.KeyLabel.ToString();
                 _lingoKey.Value.DoKeyUp();
             }
@@ -61,10 +61,10 @@ public partial class AbstGodotKey : Node, IAbstFrameworkKey, IFrameworkFor<AbstK
     };
 
     public bool KeyPressed(char key)
-        => _pressed.Contains((Key)char.ToUpperInvariant(key));
+        => _pressed.Contains(GodotKeyCodeMap.ToGodot(char.IsLetter(key) ? char.ToUpperInvariant(key) : key));
 
     public bool KeyPressed(int keyCode)
-        => _pressed.Contains((Key)keyCode);
+        => _pressed.Contains(GodotKeyCodeMap.ToGodot(keyCode));
 
     public string Key => _lastKey;
     public int KeyCode => _lastCode;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Inputs/GodotKeyCodeMap.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Inputs/GodotKeyCodeMap.cs
@@ -1,0 +1,149 @@
+using System.Collections.Generic;
+using Godot;
+
+namespace AbstUI.LGodot.Inputs;
+
+public static class GodotKeyCodeMap
+{
+    private static readonly Dictionary<Key, int> Mac = new()
+    {
+        // Editing / Navigation
+        { Key.Enter, 36 },
+        { Key.Escape, 53 },
+        { Key.Tab, 48 },
+        { Key.Space, 49 },
+        { Key.Backspace, 51 },
+        { Key.Delete, 117 },
+        { Key.Home, 115 },
+        { Key.End, 119 },
+        { Key.Pageup, 116 },
+        { Key.Pagedown, 121 },
+        { Key.Left, 123 },
+        { Key.Right, 124 },
+        { Key.Down, 125 },
+        { Key.Up, 126 },
+        { Key.Help, 114 },
+        { Key.Clear, 71 },
+        { Key.KpEnter, 76 },
+        // Modifiers
+        { Key.Shift, 56 },
+        { Key.Ctrl, 59 },
+        { Key.Alt, 58 },
+        { Key.Meta, 55 },
+        { Key.Capslock, 57 },
+        // Function Keys
+        { Key.F1, 122 },
+        { Key.F2, 120 },
+        { Key.F3, 99 },
+        { Key.F4, 118 },
+        { Key.F5, 96 },
+        { Key.F6, 97 },
+        { Key.F7, 98 },
+        { Key.F8, 100 },
+        { Key.F9, 101 },
+        { Key.F10, 109 },
+        { Key.F11, 103 },
+        { Key.F12, 111 },
+        // Letters
+        { Key.A, 0 },
+        { Key.B, 11 },
+        { Key.C, 8 },
+        { Key.D, 2 },
+        { Key.E, 14 },
+        { Key.F, 3 },
+        { Key.G, 5 },
+        { Key.H, 4 },
+        { Key.I, 34 },
+        { Key.J, 38 },
+        { Key.K, 40 },
+        { Key.L, 37 },
+        { Key.M, 46 },
+        { Key.N, 45 },
+        { Key.O, 31 },
+        { Key.P, 35 },
+        { Key.Q, 12 },
+        { Key.R, 15 },
+        { Key.S, 1 },
+        { Key.T, 17 },
+        { Key.U, 32 },
+        { Key.V, 9 },
+        { Key.W, 13 },
+        { Key.X, 7 },
+        { Key.Y, 16 },
+        { Key.Z, 6 },
+        // Numbers & Symbols
+        { Key.Key1, 18 },
+        { Key.Key2, 19 },
+        { Key.Key3, 20 },
+        { Key.Key4, 21 },
+        { Key.Key5, 23 },
+        { Key.Key6, 22 },
+        { Key.Key7, 26 },
+        { Key.Key8, 28 },
+        { Key.Key9, 25 },
+        { Key.Key0, 29 },
+        { Key.Minus, 27 },
+        { Key.Equal, 24 },
+        { Key.Quoteleft, 50 },
+        { Key.Bracketleft, 33 },
+        { Key.Bracketright, 30 },
+        { Key.Backslash, 42 },
+        { Key.Semicolon, 41 },
+        { Key.Apostrophe, 39 },
+        { Key.Comma, 43 },
+        { Key.Period, 47 },
+        { Key.Slash, 44 },
+        // Numpad
+        { Key.Kp0, 82 },
+        { Key.Kp1, 83 },
+        { Key.Kp2, 84 },
+        { Key.Kp3, 85 },
+        { Key.Kp4, 86 },
+        { Key.Kp5, 87 },
+        { Key.Kp6, 88 },
+        { Key.Kp7, 89 },
+        { Key.Kp8, 91 },
+        { Key.Kp9, 92 },
+        { Key.KpPeriod, 65 },
+        { Key.KpDivide, 75 },
+        { Key.KpMultiply, 67 },
+        { Key.KpSubtract, 78 },
+        { Key.KpAdd, 69 },
+    };
+
+    private static Dictionary<int, Key> BuildReverse(Dictionary<Key, int> source)
+    {
+        var dict = new Dictionary<int, Key>();
+        foreach (var kv in source)
+            if (!dict.ContainsKey(kv.Value))
+                dict[kv.Value] = kv.Key;
+        return dict;
+    }
+
+    private static readonly Dictionary<int, Key> MacReverse = BuildReverse(Mac);
+
+    public static int ToLingo(Key key)
+    {
+        if (Mac.TryGetValue(key, out var code))
+            return code;
+        int val = (int)key;
+        if (val >= 'a' && val <= 'z')
+            return val - 32;
+        if (val >= 'A' && val <= 'Z')
+            return val;
+        if (val >= '0' && val <= '9')
+            return val;
+        return val;
+    }
+
+    public static Key ToGodot(int lingoCode)
+    {
+        if (MacReverse.TryGetValue(lingoCode, out var key))
+            return key;
+        if (lingoCode >= 65 && lingoCode <= 90)
+            return (Key)lingoCode;
+        if (lingoCode >= 48 && lingoCode <= 57)
+            return (Key)lingoCode;
+        return (Key)lingoCode;
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Inputs/SdlKey.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Inputs/SdlKey.cs
@@ -4,6 +4,7 @@ using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Inputs;
 
+
 public class SdlKey : IAbstFrameworkKey, IFrameworkFor<AbstKey>
 {
     private readonly HashSet<SDL.SDL_Keycode> _keys = new();
@@ -18,14 +19,14 @@ public class SdlKey : IAbstFrameworkKey, IFrameworkFor<AbstKey>
         if (e.type == SDL.SDL_EventType.SDL_KEYDOWN && e.key.repeat == 0)
         {
             _keys.Add(e.key.keysym.sym);
-            _lastCode = (int)e.key.keysym.sym;
+            _lastCode = SdlKeyCodeMap.ToLingo(e.key.keysym.sym);
             _lastKey = SDL.SDL_GetKeyName(e.key.keysym.sym);
             _lingoKey?.DoKeyDown();
         }
         else if (e.type == SDL.SDL_EventType.SDL_KEYUP)
         {
             _keys.Remove(e.key.keysym.sym);
-            _lastCode = (int)e.key.keysym.sym;
+            _lastCode = SdlKeyCodeMap.ToLingo(e.key.keysym.sym);
             _lastKey = SDL.SDL_GetKeyName(e.key.keysym.sym);
             _lingoKey?.DoKeyUp();
         }
@@ -46,9 +47,13 @@ public class SdlKey : IAbstFrameworkKey, IFrameworkFor<AbstKey>
         _ => false
     };
 
-    public bool KeyPressed(char key) => _keys.Contains((SDL.SDL_Keycode)char.ToUpperInvariant(key));
+    public bool KeyPressed(char key)
+    {
+        int lingoCode = char.IsLetter(key) ? char.ToUpperInvariant(key) : key;
+        return _keys.Contains(SdlKeyCodeMap.ToSDL(lingoCode));
+    }
 
-    public bool KeyPressed(int keyCode) => _keys.Contains((SDL.SDL_Keycode)keyCode);
+    public bool KeyPressed(int keyCode) => _keys.Contains(SdlKeyCodeMap.ToSDL(keyCode));
 
     public string Key => _lastKey;
     public int KeyCode => _lastCode;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Inputs/SdlKeyCodeMap.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Inputs/SdlKeyCodeMap.cs
@@ -1,0 +1,151 @@
+using System.Collections.Generic;
+using AbstUI.SDL2.SDLL;
+
+namespace AbstUI.SDL2.Inputs;
+
+public static class SdlKeyCodeMap
+{
+    private static readonly Dictionary<SDL.SDL_Keycode, int> Mac = new()
+    {
+        // Editing / Navigation
+        { SDL.SDL_Keycode.SDLK_RETURN, 36 },
+        { SDL.SDL_Keycode.SDLK_ESCAPE, 53 },
+        { SDL.SDL_Keycode.SDLK_TAB, 48 },
+        { SDL.SDL_Keycode.SDLK_SPACE, 49 },
+        { SDL.SDL_Keycode.SDLK_BACKSPACE, 51 },
+        { SDL.SDL_Keycode.SDLK_DELETE, 117 },
+        { SDL.SDL_Keycode.SDLK_HOME, 115 },
+        { SDL.SDL_Keycode.SDLK_END, 119 },
+        { SDL.SDL_Keycode.SDLK_PAGEUP, 116 },
+        { SDL.SDL_Keycode.SDLK_PAGEDOWN, 121 },
+        { SDL.SDL_Keycode.SDLK_LEFT, 123 },
+        { SDL.SDL_Keycode.SDLK_RIGHT, 124 },
+        { SDL.SDL_Keycode.SDLK_DOWN, 125 },
+        { SDL.SDL_Keycode.SDLK_UP, 126 },
+        { SDL.SDL_Keycode.SDLK_HELP, 114 },
+        { SDL.SDL_Keycode.SDLK_CLEAR, 71 },
+        { SDL.SDL_Keycode.SDLK_KP_ENTER, 76 },
+        // Modifiers
+        { SDL.SDL_Keycode.SDLK_LSHIFT, 56 },
+        { SDL.SDL_Keycode.SDLK_RSHIFT, 56 },
+        { SDL.SDL_Keycode.SDLK_LCTRL, 59 },
+        { SDL.SDL_Keycode.SDLK_RCTRL, 59 },
+        { SDL.SDL_Keycode.SDLK_LALT, 58 },
+        { SDL.SDL_Keycode.SDLK_RALT, 58 },
+        { SDL.SDL_Keycode.SDLK_LGUI, 55 },
+        { SDL.SDL_Keycode.SDLK_RGUI, 54 },
+        { SDL.SDL_Keycode.SDLK_CAPSLOCK, 57 },
+        // Function Keys
+        { SDL.SDL_Keycode.SDLK_F1, 122 },
+        { SDL.SDL_Keycode.SDLK_F2, 120 },
+        { SDL.SDL_Keycode.SDLK_F3, 99 },
+        { SDL.SDL_Keycode.SDLK_F4, 118 },
+        { SDL.SDL_Keycode.SDLK_F5, 96 },
+        { SDL.SDL_Keycode.SDLK_F6, 97 },
+        { SDL.SDL_Keycode.SDLK_F7, 98 },
+        { SDL.SDL_Keycode.SDLK_F8, 100 },
+        { SDL.SDL_Keycode.SDLK_F9, 101 },
+        { SDL.SDL_Keycode.SDLK_F10, 109 },
+        { SDL.SDL_Keycode.SDLK_F11, 103 },
+        { SDL.SDL_Keycode.SDLK_F12, 111 },
+        // Letters
+        { SDL.SDL_Keycode.SDLK_a, 0 },
+        { SDL.SDL_Keycode.SDLK_b, 11 },
+        { SDL.SDL_Keycode.SDLK_c, 8 },
+        { SDL.SDL_Keycode.SDLK_d, 2 },
+        { SDL.SDL_Keycode.SDLK_e, 14 },
+        { SDL.SDL_Keycode.SDLK_f, 3 },
+        { SDL.SDL_Keycode.SDLK_g, 5 },
+        { SDL.SDL_Keycode.SDLK_h, 4 },
+        { SDL.SDL_Keycode.SDLK_i, 34 },
+        { SDL.SDL_Keycode.SDLK_j, 38 },
+        { SDL.SDL_Keycode.SDLK_k, 40 },
+        { SDL.SDL_Keycode.SDLK_l, 37 },
+        { SDL.SDL_Keycode.SDLK_m, 46 },
+        { SDL.SDL_Keycode.SDLK_n, 45 },
+        { SDL.SDL_Keycode.SDLK_o, 31 },
+        { SDL.SDL_Keycode.SDLK_p, 35 },
+        { SDL.SDL_Keycode.SDLK_q, 12 },
+        { SDL.SDL_Keycode.SDLK_r, 15 },
+        { SDL.SDL_Keycode.SDLK_s, 1 },
+        { SDL.SDL_Keycode.SDLK_t, 17 },
+        { SDL.SDL_Keycode.SDLK_u, 32 },
+        { SDL.SDL_Keycode.SDLK_v, 9 },
+        { SDL.SDL_Keycode.SDLK_w, 13 },
+        { SDL.SDL_Keycode.SDLK_x, 7 },
+        { SDL.SDL_Keycode.SDLK_y, 16 },
+        { SDL.SDL_Keycode.SDLK_z, 6 },
+        // Numbers & Symbols
+        { SDL.SDL_Keycode.SDLK_1, 18 },
+        { SDL.SDL_Keycode.SDLK_2, 19 },
+        { SDL.SDL_Keycode.SDLK_3, 20 },
+        { SDL.SDL_Keycode.SDLK_4, 21 },
+        { SDL.SDL_Keycode.SDLK_5, 23 },
+        { SDL.SDL_Keycode.SDLK_6, 22 },
+        { SDL.SDL_Keycode.SDLK_7, 26 },
+        { SDL.SDL_Keycode.SDLK_8, 28 },
+        { SDL.SDL_Keycode.SDLK_9, 25 },
+        { SDL.SDL_Keycode.SDLK_0, 29 },
+        { SDL.SDL_Keycode.SDLK_MINUS, 27 },
+        { SDL.SDL_Keycode.SDLK_EQUALS, 24 },
+        { SDL.SDL_Keycode.SDLK_BACKQUOTE, 50 },
+        { SDL.SDL_Keycode.SDLK_LEFTBRACKET, 33 },
+        { SDL.SDL_Keycode.SDLK_RIGHTBRACKET, 30 },
+        { SDL.SDL_Keycode.SDLK_BACKSLASH, 42 },
+        { SDL.SDL_Keycode.SDLK_SEMICOLON, 41 },
+        { SDL.SDL_Keycode.SDLK_QUOTE, 39 },
+        { SDL.SDL_Keycode.SDLK_COMMA, 43 },
+        { SDL.SDL_Keycode.SDLK_PERIOD, 47 },
+        { SDL.SDL_Keycode.SDLK_SLASH, 44 },
+        // Numpad
+        { SDL.SDL_Keycode.SDLK_KP_0, 82 },
+        { SDL.SDL_Keycode.SDLK_KP_1, 83 },
+        { SDL.SDL_Keycode.SDLK_KP_2, 84 },
+        { SDL.SDL_Keycode.SDLK_KP_3, 85 },
+        { SDL.SDL_Keycode.SDLK_KP_4, 86 },
+        { SDL.SDL_Keycode.SDLK_KP_5, 87 },
+        { SDL.SDL_Keycode.SDLK_KP_6, 88 },
+        { SDL.SDL_Keycode.SDLK_KP_7, 89 },
+        { SDL.SDL_Keycode.SDLK_KP_8, 91 },
+        { SDL.SDL_Keycode.SDLK_KP_9, 92 },
+        { SDL.SDL_Keycode.SDLK_KP_PERIOD, 65 },
+        { SDL.SDL_Keycode.SDLK_KP_DIVIDE, 75 },
+        { SDL.SDL_Keycode.SDLK_KP_MULTIPLY, 67 },
+        { SDL.SDL_Keycode.SDLK_KP_MINUS, 78 },
+        { SDL.SDL_Keycode.SDLK_KP_PLUS, 69 },
+    };
+
+    private static Dictionary<int, SDL.SDL_Keycode> BuildReverse(Dictionary<SDL.SDL_Keycode, int> source)
+    {
+        var dict = new Dictionary<int, SDL.SDL_Keycode>();
+        foreach (var kv in source)
+            if (!dict.ContainsKey(kv.Value))
+                dict[kv.Value] = kv.Key;
+        return dict;
+    }
+
+    private static readonly Dictionary<int, SDL.SDL_Keycode> MacReverse = BuildReverse(Mac);
+
+    public static int ToLingo(SDL.SDL_Keycode key)
+    {
+        if (Mac.TryGetValue(key, out var code))
+            return code;
+        int val = (int)key;
+        if (val >= 'a' && val <= 'z')
+            return val - 32;
+        if (val >= '0' && val <= '9')
+            return val;
+        return val;
+    }
+
+    public static SDL.SDL_Keycode ToSDL(int lingoCode)
+    {
+        if (MacReverse.TryGetValue(lingoCode, out var key))
+            return key;
+        if (lingoCode >= 65 && lingoCode <= 90)
+            return (SDL.SDL_Keycode)(lingoCode + 32);
+        if (lingoCode >= 48 && lingoCode <= 57)
+            return (SDL.SDL_Keycode)lingoCode;
+        return (SDL.SDL_Keycode)lingoCode;
+    }
+}


### PR DESCRIPTION
## Summary
- map SDL key codes to macOS hardware codes and apply the same mapping on all platforms
- map Godot key codes to the same macOS hardware codes for cross-platform consistency
- update SDL and Godot unit tests to assert the unified key codes

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Inputs/SdlKeyCodeMap.cs -v diag`
- `dotnet format WillMoveToOwnRepo/AbstUI/Test/AbstUI.SDLTest/AbstUI.SDLTest.csproj --include WillMoveToOwnRepo/AbstUI/Test/AbstUI.SDLTest/SdlKeyCodeMapTests.cs -v diag`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Inputs/GodotKeyCodeMap.cs -v diag`
- `dotnet format WillMoveToOwnRepo/AbstUI/Test/AbstUI.LGodotTest/AbstUI.LGodotTest.csproj --include WillMoveToOwnRepo/AbstUI/Test/AbstUI.LGodotTest/GodotKeyCodeMapTests.cs -v diag`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.SDLTest/AbstUI.SDLTest.csproj`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.LGodotTest/AbstUI.LGodotTest.csproj` *(fails: Test host process crashed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0256bb2d0833291e06779d9959edc