### PR TITLE
Refactor Blazor layout wrapper to use DynamicComponent

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstBlazorComponentFactory.cs
@@ -111,7 +111,8 @@ public class AbstBlazorComponentFactory : AbstComponentFactoryBase, IAbstCompone
             throw new InvalidOperationException($"Content {content.Name} already supports layout wrapping is unnecessary.");
 
         var wrapper = new AbstLayoutWrapper(content);
-        var impl = new AbstBlazorLayoutWrapperComponent(wrapper);
+        var impl = new AbstBlazorLayoutWrapperComponent(_registry, _mapper);
+        impl.SetContent((IAbstFrameworkNode)content.FrameworkObj);
         wrapper.Init(impl);
         InitComponent(wrapper);
         if (x.HasValue) wrapper.X = x.Value;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorLayoutWrapper.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorLayoutWrapper.razor
@@ -1,4 +1,14 @@
+@using Microsoft.AspNetCore.Components
+@using System.Collections.Generic
 @inherits AbstBlazorComponentBase
-<div id="@Name" style="@BuildWrapperStyle()">
-    @_component.ContentFragment
-</div>
+
+<CascadingValue Value="_component.ChildContainer">
+    <div id="@Name" style="@BuildWrapperStyle()">
+        @if (_component.ContentFrameworkNode is { } node)
+        {
+            var type = _component.ChildContainer.GetRazorComponentType(node);
+            var parameters = new Dictionary<string, object?> { ["Component"] = node };
+            <DynamicComponent Type="@type" Parameters="@parameters" />
+        }
+    </div>
+</CascadingValue>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorLayoutWrapperComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Containers/AbstBlazorLayoutWrapperComponent.cs
@@ -1,16 +1,57 @@
-using Microsoft.AspNetCore.Components;
+using System;
+using AbstUI.Components;
 using AbstUI.Components.Containers;
 using AbstUI.FrameworkCommunication;
+using AbstUI.Blazor;
 
 namespace AbstUI.Blazor.Components.Containers;
 
-public class AbstBlazorLayoutWrapperComponent : AbstBlazorComponentModelBase, IAbstFrameworkLayoutWrapper, IFrameworkFor<AbstLayoutWrapper>
+public class AbstBlazorLayoutWrapperComponent : AbstBlazorComponentModelBase, IAbstFrameworkLayoutWrapper, IFrameworkFor<AbstLayoutWrapper>, IAbstBlazorRegistryAware
 {
-    public RenderFragment? ContentFragment { get; }
+    private AbstBlazorComponentContainer _registry;
+    private readonly AbstBlazorComponentContainer _childContainer;
+    private IAbstFrameworkNode? _content;
 
-    public AbstBlazorLayoutWrapperComponent(AbstLayoutWrapper layoutWrapper)
+    public AbstBlazorLayoutWrapperComponent(AbstBlazorComponentContainer registry, AbstBlazorComponentMapper mapper)
     {
-        if (layoutWrapper.Content.FrameworkObj is AbstBlazorComponentBase component)
-            ContentFragment = component.RenderFragment;
+        _registry = registry;
+        _childContainer = new AbstBlazorComponentContainer(mapper);
+    }
+
+    internal IAbstFrameworkNode? ContentFrameworkNode => _content;
+
+    public AbstBlazorComponentContainer ChildContainer => _childContainer;
+
+    public void AttachRegistry(AbstBlazorComponentContainer registry)
+    {
+        if (ReferenceEquals(_registry, registry))
+            return;
+
+        _registry = registry;
+        if (_content != null)
+        {
+            if (_content is IAbstBlazorRegistryAware aware)
+                aware.AttachRegistry(_registry);
+            _registry.Register(_content);
+        }
+    }
+
+    internal void SetContent(IAbstFrameworkNode content)
+    {
+        _content = content;
+        if (_content is IAbstBlazorRegistryAware aware)
+            aware.AttachRegistry(_registry);
+        _registry.Register(_content);
+        _childContainer.Register(_content);
+    }
+
+    public override void Dispose()
+    {
+        if (_content != null)
+        {
+            _childContainer.Unregister(_content);
+            _registry.Unregister(_content);
+        }
+        base.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
- render layout wrapper content via DynamicComponent
- register wrapped content in Blazor component container

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --no-restore`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj` *(fails: Assert.Equal in AbstMarkdownRendererTests)*

------
https://chatgpt.com/codex/tasks/task_e_68c05afe0c2483328372d8cb61319a40