### PR TITLE
Implement Blazor texture helpers

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Bitmaps/AbstBlazorTexture2D.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Bitmaps/AbstBlazorTexture2D.cs
@@ -3,6 +3,7 @@ using Microsoft.JSInterop;
 using AbstUI.Blazor;
 using AbstUI.Bitmaps;
 using AbstUI.Primitives;
+using AbstUI.Tools;
 
 namespace AbstUI.Blazor.Bitmaps;
 
@@ -51,21 +52,55 @@ public class AbstBlazorTexture2D : AbstBaseTexture2D<ElementReference>
 
     public override byte[] GetPixels()
     {
-        throw new NotImplementedException();
+        var scripts = new AbstUIScriptResolver(_jsRuntime);
+        try
+        {
+            return GetPixelDataAsync(scripts).GetAwaiter().GetResult();
+        }
+        finally
+        {
+            scripts.DisposeAsync().GetAwaiter().GetResult();
+        }
     }
 
     public override void SetARGBPixels(byte[] argbPixels)
     {
-        throw new NotImplementedException();
+        if (argbPixels == null || argbPixels.Length != Width * Height * 4)
+            throw new ArgumentException("Expected ARGB8888 buffer with Width*Height*4 bytes.", nameof(argbPixels));
+
+        Tools.APixel.ToRGBA(argbPixels);
+        SetRGBAPixels(argbPixels);
     }
 
     public override void SetRGBAPixels(byte[] rgbaPixels)
     {
-        throw new NotImplementedException();
+        if (rgbaPixels == null || rgbaPixels.Length != Width * Height * 4)
+            throw new ArgumentException("Expected RGBA8888 buffer with Width*Height*4 bytes.", nameof(rgbaPixels));
+
+        var scripts = new AbstUIScriptResolver(_jsRuntime);
+        try
+        {
+            var ctx = scripts.CanvasGetContext(Canvas, false).GetAwaiter().GetResult();
+            scripts.CanvasDrawPictureData(ctx, rgbaPixels, Width, Height, 0, 0).GetAwaiter().GetResult();
+        }
+        finally
+        {
+            scripts.DisposeAsync().GetAwaiter().GetResult();
+        }
     }
 
     public override IAbstTexture2D Clone()
     {
-        throw new NotImplementedException();
+        var scripts = new AbstUIScriptResolver(_jsRuntime);
+        try
+        {
+            var data = GetPixelDataAsync(scripts).GetAwaiter().GetResult();
+            return CreateFromPixelDataAsync(_jsRuntime, scripts, data, Width, Height, Name + "_Clone")
+                .GetAwaiter().GetResult();
+        }
+        finally
+        {
+            scripts.DisposeAsync().GetAwaiter().GetResult();
+        }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Graphics/AbstBlazorGfxCanvasComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Graphics/AbstBlazorGfxCanvasComponent.cs
@@ -1,4 +1,7 @@
 using AbstUI.Components.Graphics;
+using AbstUI.Bitmaps;
+using AbstUI.Blazor;
+using AbstUI.Blazor.Bitmaps;
 using AbstUI.FrameworkCommunication;
 using AbstUI.Primitives;
 using AbstUI.Styles;
@@ -125,16 +128,15 @@ public class AbstBlazorGfxCanvasComponent : AbstBlazorComponentModelBase, IAbstF
             int width = -1, int height = -1, AbstTextAlignment alignment = AbstTextAlignment.Left,
             AbstFontStyle style = AbstFontStyle.Regular)
     {
-        //var col = ToCss(color ?? AColors.Black);
-        //var align = alignment switch
-        //{
-        //    AbstTextAlignment.Center => "center",
-        //    AbstTextAlignment.Right => "right",
-        //    _ => "left"
-        //};
-        //_drawActions.Add(ctx => _module!.InvokeVoidAsync("abstCanvas.drawText", ctx, position.X, position.Y, text, font, col, fontSize, align));
-        //MarkDirty();
-        throw new NotImplementedException();
+        var col = ToCss(color ?? AColors.Black);
+        var align = alignment switch
+        {
+            AbstTextAlignment.Center => "center",
+            AbstTextAlignment.Right => "right",
+            _ => "left"
+        };
+        _drawActions.Add(ctx => _module!.InvokeVoidAsync("abstCanvas.drawText", ctx, position.X, position.Y, text, font, col, fontSize, align));
+        MarkDirty();
     }
     public void DrawPicture(byte[] data, int width, int height, APoint position, APixelFormat format)
     {
@@ -158,6 +160,19 @@ public class AbstBlazorGfxCanvasComponent : AbstBlazorComponentModelBase, IAbstF
 
     public IAbstTexture2D GetTexture(string? name = null)
     {
-        throw new NotImplementedException();
+        if (_context == null)
+            throw new InvalidOperationException("Canvas context not initialized.");
+
+        var scripts = new AbstUIScriptResolver(_js);
+        try
+        {
+            var data = scripts.CanvasGetImageData(_context, (int)Width, (int)Height).GetAwaiter().GetResult();
+            return AbstBlazorTexture2D.CreateFromPixelDataAsync(_js, scripts, data, (int)Width, (int)Height, name ?? string.Empty)
+                .GetAwaiter().GetResult();
+        }
+        finally
+        {
+            scripts.DisposeAsync().GetAwaiter().GetResult();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement pixel access and cloning in Blazor textures
- add drawing and texture extraction helpers for Blazor canvas component

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj` *(fails: Assert.Equal() Failure: Values differ)*

------
https://chatgpt.com/codex/tasks/task_e_68c065e4eb108332b1e89d7a877deb0e