### PR TITLE
Bind Blazor inputs to document events

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/Pages/Home.razor
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/Pages/Home.razor
@@ -2,6 +2,7 @@
 @using AbstUI.Blazor
 @using AbstUI.Blazor.Components
 @using AbstUI.Blazor.Components.Containers
+@using AbstUI.Blazor.Components.Inputs
 @using AbstUI.Components
 @using AbstUI.Components.Containers
 @using LingoEngine.SDL2.GfxVisualTest
@@ -12,7 +13,9 @@
 <PageTitle>Home</PageTitle>
 
 <CascadingValue Value="ComponentContainer">
-    <AbstBlazorScrollContainer Component="_rootComponent" />
+    <AbstInputComponent>
+        <AbstBlazorScrollContainer Component="_rootComponent" />
+    </AbstInputComponent>
 </CascadingValue>
 
 @code {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstInputComponent.razor
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Components/Inputs/AbstInputComponent.razor
@@ -1,11 +1,8 @@
-@inherits AbstBlazorComponentBase
-<div tabindex="0" style="@BuildStyle()"
-     @onmousemove="Mouse.MouseMove"
-     @onmousedown="Mouse.MouseDown"
-     @onmouseup="Mouse.MouseUp"
-     @onwheel="Mouse.Wheel"
-     @onkeydown="Key.KeyDown"
-     @onkeyup="Key.KeyUp">
+<div @onmousemove:document="Mouse.MouseMove"
+     @onmousedown:document="Mouse.MouseDown"
+     @onmouseup:document="Mouse.MouseUp"
+     @onwheel:document="Mouse.Wheel"
+     @onkeydown:document="Key.KeyDown"
+     @onkeyup:document="Key.KeyUp">
     @ChildContent
 </div>
-


### PR DESCRIPTION
## Summary
- Route browser mouse and keyboard events through `AbstInputComponent`
- Use `AbstInputComponent` in Blazor visual test to capture input events

## Testing
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj` (fails: AbstMarkdownRendererTests)
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/AbstUI.GfxVisualTest.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c06785d9d483329ff978c401b1d127