### PR TITLE
feat(blazor): add root panel and implement missing features

### DIFF
--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Blazor/App.razor
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Blazor/App.razor
@@ -1,4 +1,5 @@
-﻿<Router AppAssembly="@typeof(App).Assembly">
+﻿<LingoBlazorRoot />
+<Router AppAssembly="@typeof(App).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
         <FocusOnNavigate RouteData="@routeData" Selector="h1" />

--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Blazor/_Imports.razor
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Blazor/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using LingoEngine.Demo.TetriGrounds.Blazor
 @using LingoEngine.Demo.TetriGrounds.Blazor.Layout
+@using LingoEngine.Blazor.Movies

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIScriptResolver.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIScriptResolver.cs
@@ -33,6 +33,9 @@ public class AbstUIScriptResolver : IAsyncDisposable
     public async ValueTask CanvasAddToBody(ElementReference canvas)
         => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.addCanvasToBody", canvas);
 
+    public async ValueTask CanvasAddToElement(ElementReference element, ElementReference canvas)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.addCanvasToElement", element, canvas);
+
     public async ValueTask CanvasSetVisible(ElementReference canvas, bool visible)
         => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.setCanvasVisible", canvas, visible);
 
@@ -75,7 +78,7 @@ public class AbstUIScriptResolver : IAsyncDisposable
     public async ValueTask SetCursor(string cursor)
         => await (await GetModuleAsync()).InvokeVoidAsync("AbstUIKey.setCursor", cursor);
     public async ValueTask<ScrollData> GetScrollPosition(string elementRef)
-        => await (await GetModuleAsync()).InvokeAsync< ScrollData>("AbstScrollContainer.getScrollPosition", elementRef);
+        => await (await GetModuleAsync()).InvokeAsync<ScrollData>("AbstScrollContainer.getScrollPosition", elementRef);
 
     public async ValueTask ShowBootstrapModal(string id)
         => await (await GetModuleAsync()).InvokeVoidAsync("AbstUIWindow.showBootstrapModal", id);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
@@ -16,6 +16,12 @@ export class abstCanvas {
         document.body.appendChild(canvas);
     }
 
+    static addCanvasToElement(element, canvas) {
+        if (element && canvas) {
+            element.appendChild(canvas);
+        }
+    }
+
     static setCanvasVisible(canvas, visible) {
         canvas.style.display = visible ? 'block' : 'none';
     }

--- a/src/LingoEngine.Blazor/BlazorSetup.cs
+++ b/src/LingoEngine.Blazor/BlazorSetup.cs
@@ -4,6 +4,7 @@ using AbstUI.Core;
 using LingoEngine.Core;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Setup;
+using LingoEngine.Blazor.Movies;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LingoEngine.Blazor;
@@ -15,6 +16,7 @@ public static class BlazorSetup
         LingoEngineGlobal.RunFramework = AbstEngineRunFramework.Blazor;
         reg.ServicesMain(s => s
                 .AddSingleton<ILingoFrameworkFactory, BlazorFactory>()
+                .AddSingleton<LingoBlazorRootPanel>()
                 .WithAbstUIBlazor(windowRegistrations)
             )
             .WithFrameworkFactory(setup)

--- a/src/LingoEngine.Blazor/Movies/LingoBlazorMovie.cs
+++ b/src/LingoEngine.Blazor/Movies/LingoBlazorMovie.cs
@@ -28,19 +28,21 @@ public class LingoBlazorMovie : ILingoFrameworkMovie, IDisposable
     private readonly AbstUIScriptResolver _scripts;
     private readonly int _width;
     private readonly int _height;
+    private readonly LingoBlazorRootPanel _rootPanel;
     private ElementReference _canvas;
     private IJSObjectReference? _ctx;
 
-    public LingoBlazorMovie(LingoBlazorStage stage, LingoMovie movie, Action<LingoBlazorMovie> remove, AbstUIScriptResolver scripts)
+    public LingoBlazorMovie(LingoBlazorStage stage, LingoMovie movie, Action<LingoBlazorMovie> remove, AbstUIScriptResolver scripts, LingoBlazorRootPanel rootPanel)
     {
         _stage = stage;
         _movie = movie;
         _remove = remove;
         _scripts = scripts;
+        _rootPanel = rootPanel;
         _width = stage.LingoStage.Width;
         _height = stage.LingoStage.Height;
         _canvas = _scripts.CanvasCreateCanvas(_width, _height).GetAwaiter().GetResult();
-        _scripts.CanvasAddToBody(_canvas).GetAwaiter().GetResult();
+        _scripts.CanvasAddToElement(_rootPanel.Root, _canvas).GetAwaiter().GetResult();
         _ctx = _scripts.CanvasGetContext(_canvas, true).GetAwaiter().GetResult();
         _scripts.CanvasSetVisible(_canvas, false).GetAwaiter().GetResult();
     }

--- a/src/LingoEngine.Blazor/Movies/LingoBlazorRoot.razor
+++ b/src/LingoEngine.Blazor/Movies/LingoBlazorRoot.razor
@@ -1,0 +1,16 @@
+@using Microsoft.AspNetCore.Components
+@inject LingoEngine.Blazor.Movies.LingoBlazorRootPanel RootPanel
+
+<div @ref="_root"></div>
+
+@code {
+    private ElementReference _root;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            RootPanel.SetRoot(_root);
+        }
+    }
+}

--- a/src/LingoEngine.Blazor/Movies/LingoBlazorRootPanel.cs
+++ b/src/LingoEngine.Blazor/Movies/LingoBlazorRootPanel.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Components;
+
+namespace LingoEngine.Blazor.Movies;
+
+/// <summary>
+/// Holds a reference to the root DOM element where Lingo movies
+/// should insert their canvases.
+/// </summary>
+public class LingoBlazorRootPanel
+{
+    private ElementReference _root;
+
+    /// <summary>
+    /// Gets the root element reference.
+    /// </summary>
+    public ElementReference Root => _root;
+
+    /// <summary>
+    /// Updates the root element reference. Called by the root component
+    /// once it has been rendered.
+    /// </summary>
+    /// <param name="element">The element that should host movie canvases.</param>
+    public void SetRoot(ElementReference element) => _root = element;
+}
+

--- a/src/LingoEngine.Blazor/Scripts/LingoBlazorMemberScript.cs
+++ b/src/LingoEngine.Blazor/Scripts/LingoBlazorMemberScript.cs
@@ -1,0 +1,20 @@
+using LingoEngine.Scripts;
+using LingoEngine.Sprites;
+
+namespace LingoEngine.Blazor.Scripts;
+
+/// <summary>
+/// Minimal script member implementation for the Blazor backend.
+/// </summary>
+public class LingoBlazorMemberScript : ILingoFrameworkMemberScript
+{
+    public bool IsLoaded => true;
+    public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
+    public void CopyToClipboard() { }
+    public void Erase() { }
+    public void ImportFileInto() { }
+    public void PasteClipboardInto() { }
+    public void Preload() { }
+    public void Unload() { }
+    public bool IsPixelTransparent(int x, int y) => false;
+}

--- a/src/LingoEngine.Blazor/Sounds/LingoBlazorSound.cs
+++ b/src/LingoEngine.Blazor/Sounds/LingoBlazorSound.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using LingoEngine.Sounds;
+
+namespace LingoEngine.Blazor.Sounds;
+
+/// <summary>
+/// Minimal sound implementation for the Blazor backend.
+/// Provides no real audio playback but keeps track of settings.
+/// </summary>
+public class LingoBlazorSound : ILingoFrameworkSound
+{
+    private readonly List<LingoSoundDevice> _devices = new();
+    private LingoSound _sound = null!;
+
+    public List<LingoSoundDevice> SoundDeviceList => _devices;
+    public int SoundLevel { get; set; }
+    public bool SoundEnable { get; set; } = true;
+
+    internal void Init(LingoSound sound) => _sound = sound;
+
+    public void Beep() { }
+}

--- a/src/LingoEngine.Blazor/Sounds/LingoBlazorSoundChannel.cs
+++ b/src/LingoEngine.Blazor/Sounds/LingoBlazorSoundChannel.cs
@@ -1,0 +1,42 @@
+using LingoEngine.Sounds;
+
+namespace LingoEngine.Blazor.Sounds;
+
+/// <summary>
+/// Placeholder sound channel for the Blazor backend.
+/// Implements the required interface without real audio output.
+/// </summary>
+public class LingoBlazorSoundChannel : ILingoFrameworkSoundChannel
+{
+    private LingoSoundChannel _channel = null!;
+
+    public LingoBlazorSoundChannel(int number)
+    {
+        ChannelNumber = number;
+    }
+
+    public int ChannelNumber { get; }
+    public int SampleRate => 44100;
+    public int Volume { get; set; }
+    public int Pan { get; set; }
+    public float CurrentTime { get; set; }
+    public bool IsPlaying { get; private set; }
+    public int ChannelCount => 2;
+    public int SampleCount => 0;
+    public float ElapsedTime => CurrentTime;
+    public float StartTime { get; set; }
+    public float EndTime { get; set; }
+
+    internal void Init(LingoSoundChannel channel) => _channel = channel;
+
+    public void Pause() => IsPlaying = !IsPlaying;
+    public void PlayFile(string stringFilePath) => IsPlaying = true;
+    public void PlayNow(LingoMemberSound member) => IsPlaying = true;
+    public void Repeat() { }
+    public void Rewind() => CurrentTime = 0;
+    public void Stop()
+    {
+        IsPlaying = false;
+        CurrentTime = 0;
+    }
+}

--- a/src/LingoEngine.Blazor/Texts/LingoBlazorMemberField.cs
+++ b/src/LingoEngine.Blazor/Texts/LingoBlazorMemberField.cs
@@ -1,4 +1,5 @@
 using AbstUI.Blazor;
+using AbstUI.Styles;
 using LingoEngine.Texts;
 using LingoEngine.Texts.FrameworkCommunication;
 using Microsoft.JSInterop;
@@ -10,6 +11,7 @@ namespace LingoEngine.Blazor.Texts;
 /// </summary>
 public class LingoBlazorMemberField : LingoBlazorMemberTextBase<LingoMemberField>, ILingoFrameworkMemberField
 {
-    public LingoBlazorMemberField(IJSRuntime js, AbstUIScriptResolver scripts) : base(js, scripts) { }
+    public LingoBlazorMemberField(IJSRuntime js, AbstUIScriptResolver scripts, IAbstFontManager fontManager)
+        : base(js, scripts, fontManager) { }
 }
 

--- a/src/LingoEngine.Blazor/Texts/LingoBlazorMemberText.cs
+++ b/src/LingoEngine.Blazor/Texts/LingoBlazorMemberText.cs
@@ -1,4 +1,5 @@
 using AbstUI.Blazor;
+using AbstUI.Styles;
 using LingoEngine.Texts;
 using LingoEngine.Texts.FrameworkCommunication;
 using Microsoft.JSInterop;
@@ -10,6 +11,7 @@ namespace LingoEngine.Blazor.Texts;
 /// </summary>
 public class LingoBlazorMemberText : LingoBlazorMemberTextBase<LingoMemberText>, ILingoFrameworkMemberText
 {
-    public LingoBlazorMemberText(IJSRuntime js, AbstUIScriptResolver scripts) : base(js, scripts) { }
+    public LingoBlazorMemberText(IJSRuntime js, AbstUIScriptResolver scripts, IAbstFontManager fontManager)
+        : base(js, scripts, fontManager) { }
 }
 

--- a/src/LingoEngine.Blazor/Texts/LingoBlazorMemberTextBase.cs
+++ b/src/LingoEngine.Blazor/Texts/LingoBlazorMemberTextBase.cs
@@ -25,6 +25,7 @@ public abstract class LingoBlazorMemberTextBase<TText> : ILingoFrameworkMemberTe
     protected TText _lingoMemberText = default!;
     private readonly IJSRuntime _js;
     private readonly AbstUIScriptResolver _scripts;
+    private readonly IAbstFontManager _fontManager;
     private AbstBlazorTexture2D? _texture;
     private bool _dirty;
 
@@ -40,10 +41,11 @@ public abstract class LingoBlazorMemberTextBase<TText> : ILingoFrameworkMemberTe
     private int _width;
     private int _height;
 
-    public LingoBlazorMemberTextBase(IJSRuntime js, AbstUIScriptResolver scripts)
+    public LingoBlazorMemberTextBase(IJSRuntime js, AbstUIScriptResolver scripts, IAbstFontManager fontManager)
     {
         _js = js;
         _scripts = scripts;
+        _fontManager = fontManager;
     }
 
     internal void Init(TText member) => _lingoMemberText = member;
@@ -184,7 +186,7 @@ public abstract class LingoBlazorMemberTextBase<TText> : ILingoFrameworkMemberTe
     }
     public IAbstTexture2D? TextureLingo => _texture;
 
-    public IAbstFontManager FontManager => throw new NotImplementedException();
+    public IAbstFontManager FontManager => _fontManager;
 
     public void Copy(string text) => _js.InvokeVoidAsync("navigator.clipboard.writeText", text).AsTask().GetAwaiter().GetResult();
 


### PR DESCRIPTION
## Summary
- add injectable `LingoBlazorRootPanel` and root component to host movie canvases
- implement missing Blazor factory members and stub sound support
- expose font manager in text members and allow adding canvas to arbitrary element

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj -c Release`
- `dotnet build src/LingoEngine.Blazor/LingoEngine.Blazor.csproj -c Release`
- `dotnet build Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Blazor/LingoEngine.Demo.TetriGrounds.Blazor.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68c0701f65408332a4e9f43d9ebc7f00