### PR TITLE
feat: add ZIndex support to AbstUI SDL

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.SDLTest/ZIndexEventOrderTests.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.SDLTest/ZIndexEventOrderTests.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using AbstUI.SDL2.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace AbstUI.SDLTest;
+
+public class ZIndexEventOrderTests
+{
+    [Fact]
+    public void Activate_SortsByZIndex()
+    {
+        var focus = new SdlFocusManager();
+        var container = new AbstSDLComponentContainer(focus);
+
+        var low = new AbstSDLComponentContext(container);
+        low.SetZIndex(0);
+        var high = new AbstSDLComponentContext(container);
+        high.SetZIndex(10);
+
+        var field = typeof(AbstSDLComponentContainer)
+            .GetField("_activeComponents", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var list = (List<AbstSDLComponentContext>)field.GetValue(container)!;
+
+        list.Should().ContainInOrder(low, high);
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj
@@ -31,6 +31,7 @@
 
         <ItemGroup>
                 <InternalsVisibleTo Include="AbstUI.GfxVisualTest.SDL2" />
+                <InternalsVisibleTo Include="AbstUI.SDLTest" />
         </ItemGroup>
 
 	<ItemGroup>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Base/AbstSdlComponent.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Base/AbstSdlComponent.cs
@@ -64,6 +64,12 @@ public abstract class AbstSdlComponent : IAbstSDLComponent, IDisposable
         }
     }
 
+    public virtual int ZIndex
+    {
+        get => ComponentContext.ZIndex;
+        set => ComponentContext.SetZIndex(value);
+    }
+
     private bool _visibility = true;
     public virtual bool Visibility
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Core/AbstSDLComponentContainer.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Core/AbstSDLComponentContainer.cs
@@ -24,18 +24,13 @@ public class AbstSDLComponentContainer
     public void Activate(AbstSDLComponentContext context)
     {
         _activeComponents.Remove(context);
-        if (context.AlwaysOnTop)
-        {
-            _activeComponents.Add(context);
-        }
+        int idx = _activeComponents.FindIndex(c =>
+            (c.AlwaysOnTop && !context.AlwaysOnTop) ||
+            (c.AlwaysOnTop == context.AlwaysOnTop && c.ZIndex > context.ZIndex));
+        if (idx >= 0)
+            _activeComponents.Insert(idx, context);
         else
-        {
-            int idx = _activeComponents.FindIndex(c => c.AlwaysOnTop);
-            if (idx >= 0)
-                _activeComponents.Insert(idx, context);
-            else
-                _activeComponents.Add(context);
-        }
+            _activeComponents.Add(context);
     }
 
     public void Deactivate(AbstSDLComponentContext context) => _activeComponents.Remove(context);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Core/AbstSDLComponentContext.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Core/AbstSDLComponentContext.cs
@@ -28,6 +28,7 @@ public class AbstSDLComponentContext : IDisposable
     public bool FlipH { get; set; }
     public bool FlipV { get; set; }
     public bool AlwaysOnTop { get; set; }
+    public int ZIndex { get; private set; }
     public SDL.SDL_BlendMode BlendMode { get; set; } = SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND;
 
     internal AbstSDLComponentContext(
@@ -40,6 +41,12 @@ public class AbstSDLComponentContext : IDisposable
         VisualParent = parent;
         Component = component;
         _container.Register(this);
+    }
+
+    public void SetZIndex(int zIndex)
+    {
+        ZIndex = zIndex;
+        _container.Activate(this);
     }
 
     internal void SetParents(AbstSDLComponentContext? logicalParent, AbstSDLComponentContext? visualParent = null)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/AbstNodeBase.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/AbstNodeBase.cs
@@ -20,6 +20,7 @@ namespace AbstUI.Components
 
         public virtual float Width { get => _framework.Width; set => _framework.Width = value; }
         public virtual float Height { get => _framework.Height; set => _framework.Height = value; }
+        public virtual int ZIndex { get => _framework.ZIndex; set => _framework.ZIndex = value; }
 
         #region Styling
         /// <summary>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/IAbstFrameworkNode.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/IAbstFrameworkNode.cs
@@ -12,6 +12,7 @@ namespace AbstUI.Components
 
         /// <summary>Margin around the node.</summary>
         AMargin Margin { get; set; }
+        int ZIndex { get; set; }
         object FrameworkNode { get; }
     }
     /// <summary>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/IAbstNode.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/IAbstNode.cs
@@ -12,6 +12,7 @@ namespace AbstUI.Components
         float Width { get; set; }
         float Height { get; set; }
         AMargin Margin { get; set; }
+        int ZIndex { get; set; }
         T Framework<T>() where T : IAbstFrameworkNode;
         IAbstFrameworkNode FrameworkObj { get; set; }
     }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Windowing/AbstWindow.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Windowing/AbstWindow.cs
@@ -51,6 +51,7 @@ public class AbstWindow<TFrameworkWindow> : IAbstWindow, IDisposable, IAbstKeyEv
     public bool Visibility { get => IsOpen; set { } }
     float IAbstNode.Width { get => Width; set => Width = (int)value; }
     float IAbstNode.Height { get => Height; set => Height = (int)value; }
+    public int ZIndex { get => _framework.ZIndex; set => _framework.ZIndex = value; }
     public AMargin Margin { get; set; } = new AMargin();
 
     protected IAbstNode? _content;


### PR DESCRIPTION
## Summary
- allow UI nodes to specify a ZIndex
- order SDL components by ZIndex so top-most handles events first
- expose internals for SDL tests and add ZIndex ordering test

## Testing
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj -v minimal` *(fails: AbstMarkdownRendererTests)*
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.SDLTest/AbstUI.SDLTest.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68c0db6946108332a0984747b25e578d