### PR TITLE
Enhance Blazor media and sound playback

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIScriptResolver.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIScriptResolver.cs
@@ -75,6 +75,54 @@ public class AbstUIScriptResolver : IAsyncDisposable
     public async ValueTask CanvasSetGlobalAlpha(IJSObjectReference ctx, double alpha)
         => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.setGlobalAlpha", ctx, alpha);
 
+    public async ValueTask<IJSObjectReference> MediaCreateVideo(string id, string url, DotNetObjectReference<object> dotNetHelper)
+        => await (await GetModuleAsync()).InvokeAsync<IJSObjectReference>("abstMedia.createVideo", id, url, dotNetHelper);
+
+    public async ValueTask MediaPlayVideo(IJSObjectReference video)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstMedia.playVideo", video);
+
+    public async ValueTask MediaPauseVideo(IJSObjectReference video)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstMedia.pauseVideo", video);
+
+    public async ValueTask MediaStopVideo(IJSObjectReference video)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstMedia.stopVideo", video);
+
+    public async ValueTask MediaSeekVideo(IJSObjectReference video, double seconds)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstMedia.seekVideo", video, seconds);
+
+    public async ValueTask<double> MediaGetDuration(IJSObjectReference video)
+        => await (await GetModuleAsync()).InvokeAsync<double>("abstMedia.getDuration", video);
+
+    public async ValueTask<double> MediaGetCurrentTime(IJSObjectReference video)
+        => await (await GetModuleAsync()).InvokeAsync<double>("abstMedia.getCurrentTime", video);
+
+    public async ValueTask<IJSObjectReference> AudioCreate(string id, DotNetObjectReference<object> dotNetHelper)
+        => await (await GetModuleAsync()).InvokeAsync<IJSObjectReference>("abstMedia.createAudio", id, dotNetHelper);
+
+    public async ValueTask AudioPlay(IJSObjectReference audio, string url)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstMedia.playAudio", audio, url);
+
+    public async ValueTask AudioPause(IJSObjectReference audio)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstMedia.pauseAudio", audio);
+
+    public async ValueTask AudioStop(IJSObjectReference audio)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstMedia.stopAudio", audio);
+
+    public async ValueTask AudioResume(IJSObjectReference audio)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstMedia.resumeAudio", audio);
+
+    public async ValueTask AudioSeek(IJSObjectReference audio, double seconds)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstMedia.seekAudio", audio, seconds);
+
+    public async ValueTask<double> AudioGetCurrentTime(IJSObjectReference audio)
+        => await (await GetModuleAsync()).InvokeAsync<double>("abstMedia.getCurrentTimeAudio", audio);
+
+    public async ValueTask AudioSetVolume(IJSObjectReference audio, double volume)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstMedia.setVolumeAudio", audio, volume);
+
+    public async ValueTask MediaBeep()
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstMedia.beep");
+
     public async ValueTask SetCursor(string cursor)
         => await (await GetModuleAsync()).InvokeVoidAsync("AbstUIKey.setCursor", cursor);
     public async ValueTask<ScrollData> GetScrollPosition(string elementRef)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
@@ -219,3 +219,43 @@ export class AbstUIWindow {
         toast.show();
     }
 }
+
+export class abstMedia {
+    static createVideo(id, url, dotNetHelper) {
+        const video = document.createElement('video');
+        video.id = id;
+        video.src = url;
+        video.addEventListener('ended', () => dotNetHelper.invokeMethodAsync('OnVideoEnded'));
+        video.load();
+        return video;
+    }
+    static playVideo(video) { video.play(); }
+    static pauseVideo(video) { video.pause(); }
+    static stopVideo(video) { video.pause(); video.currentTime = 0; }
+    static seekVideo(video, seconds) { video.currentTime = seconds; }
+    static getDuration(video) { return isNaN(video.duration) ? 0 : video.duration * 1000.0; }
+    static getCurrentTime(video) { return video.currentTime * 1000.0; }
+
+    static createAudio(id, dotNetHelper) {
+        const audio = new Audio();
+        audio.id = id;
+        audio.addEventListener('ended', () => dotNetHelper.invokeMethodAsync('OnSoundEnded'));
+        return audio;
+    }
+    static playAudio(audio, url) { audio.src = url; audio.play(); }
+    static pauseAudio(audio) { audio.pause(); }
+    static stopAudio(audio) { audio.pause(); audio.currentTime = 0; }
+    static resumeAudio(audio) { audio.play(); }
+    static seekAudio(audio, seconds) { audio.currentTime = seconds; }
+    static getCurrentTimeAudio(audio) { return audio.currentTime * 1000.0; }
+    static setVolumeAudio(audio, volume) { audio.volume = volume; }
+    static beep() {
+        const ctx = new (window.AudioContext || window.webkitAudioContext)();
+        const osc = ctx.createOscillator();
+        osc.type = 'square';
+        osc.frequency.value = 440;
+        osc.connect(ctx.destination);
+        osc.start();
+        osc.stop(ctx.currentTime + 0.2);
+    }
+}

--- a/src/LingoEngine.Blazor/BlazorFactory.cs
+++ b/src/LingoEngine.Blazor/BlazorFactory.cs
@@ -216,14 +216,16 @@ public class BlazorFactory : ILingoFrameworkFactory, IDisposable
     }
     public LingoSound CreateSound(ILingoCastLibsContainer castLibsContainer)
     {
-        var impl = new LingoBlazorSound();
+        var scripts = _services.GetRequiredService<AbstUIScriptResolver>();
+        var impl = new LingoBlazorSound(scripts);
         var sound = new LingoSound(impl, castLibsContainer, this);
         impl.Init(sound);
         return sound;
     }
     public LingoSoundChannel CreateSoundChannel(int number)
     {
-        var impl = new LingoBlazorSoundChannel(number);
+        var scripts = _services.GetRequiredService<AbstUIScriptResolver>();
+        var impl = new LingoBlazorSoundChannel(number, scripts);
         var channel = new LingoSoundChannel(impl, number);
         impl.Init(channel);
         return channel;

--- a/src/LingoEngine.Blazor/Medias/LingoBlazorMemberMedia.cs
+++ b/src/LingoEngine.Blazor/Medias/LingoBlazorMemberMedia.cs
@@ -1,7 +1,6 @@
 using LingoEngine.Medias;
 using LingoEngine.Members;
 using LingoEngine.Sprites;
-using System.IO;
 
 namespace LingoEngine.Blazor.Medias;
 
@@ -45,8 +44,7 @@ public class LingoBlazorMemberMedia : ILingoFrameworkMemberMedia
             return;
         if (!string.IsNullOrEmpty(_member.FileName))
         {
-            var fullPath = Path.GetFullPath(_member.FileName);
-            Url = new System.Uri(fullPath).AbsoluteUri;
+            Url = _member.FileName;
             MediaStatus = LingoMediaStatus.Opened;
         }
         IsLoaded = true;

--- a/src/LingoEngine.Blazor/Sounds/LingoBlazorMemberSound.cs
+++ b/src/LingoEngine.Blazor/Sounds/LingoBlazorMemberSound.cs
@@ -13,6 +13,7 @@ public class LingoBlazorMemberSound : ILingoFrameworkMemberSound, IDisposable
     private readonly HttpClient _httpClient;
     private LingoMemberSound _member = null!;
     private byte[]? _data;
+    internal string? Url { get; private set; }
 
     public bool Stereo { get; private set; }
     public double Length { get; private set; }
@@ -41,6 +42,7 @@ public class LingoBlazorMemberSound : ILingoFrameworkMemberSound, IDisposable
             return;
         if (!string.IsNullOrEmpty(_member.FileName))
         {
+            Url = _member.FileName;
             try
             {
                 _data = _httpClient.GetByteArrayAsync(_member.FileName).GetAwaiter().GetResult();

--- a/src/LingoEngine.Blazor/Sounds/LingoBlazorSound.cs
+++ b/src/LingoEngine.Blazor/Sounds/LingoBlazorSound.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using LingoEngine.Sounds;
+using AbstUI.Blazor;
 
 namespace LingoEngine.Blazor.Sounds;
 
@@ -11,12 +12,18 @@ public class LingoBlazorSound : ILingoFrameworkSound
 {
     private readonly List<LingoSoundDevice> _devices = new();
     private LingoSound _sound = null!;
+    private readonly AbstUIScriptResolver _scripts;
 
     public List<LingoSoundDevice> SoundDeviceList => _devices;
     public int SoundLevel { get; set; }
     public bool SoundEnable { get; set; } = true;
 
+    public LingoBlazorSound(AbstUIScriptResolver scripts)
+    {
+        _scripts = scripts;
+    }
+
     internal void Init(LingoSound sound) => _sound = sound;
 
-    public void Beep() { }
+    public void Beep() => _scripts.MediaBeep().GetAwaiter().GetResult();
 }

--- a/src/LingoEngine.Blazor/Sounds/LingoBlazorSoundChannel.cs
+++ b/src/LingoEngine.Blazor/Sounds/LingoBlazorSoundChannel.cs
@@ -1,4 +1,9 @@
+using System;
 using LingoEngine.Sounds;
+using LingoEngine.Members;
+using Microsoft.JSInterop;
+using AbstUI.Blazor;
+using LingoEngine.Blazor.Util;
 
 namespace LingoEngine.Blazor.Sounds;
 
@@ -6,37 +11,102 @@ namespace LingoEngine.Blazor.Sounds;
 /// Placeholder sound channel for the Blazor backend.
 /// Implements the required interface without real audio output.
 /// </summary>
-public class LingoBlazorSoundChannel : ILingoFrameworkSoundChannel
+public class LingoBlazorSoundChannel : ILingoFrameworkSoundChannel, IDisposable
 {
     private LingoSoundChannel _channel = null!;
+    private readonly AbstUIScriptResolver _scripts;
+    private IJSObjectReference? _audio;
+    private DotNetObjectReference<object>? _audioRef;
 
-    public LingoBlazorSoundChannel(int number)
+    public LingoBlazorSoundChannel(int number, AbstUIScriptResolver scripts)
     {
         ChannelNumber = number;
+        _scripts = scripts;
+        _audioRef = DotNetObjectReference.Create<object>(this);
+        var id = ElementIdGenerator.Create(number.ToString());
+        _audio = _scripts.AudioCreate(id, _audioRef).GetAwaiter().GetResult();
     }
 
     public int ChannelNumber { get; }
     public int SampleRate => 44100;
-    public int Volume { get; set; }
+    private int _volume;
+    public int Volume { get => _volume; set { _volume = value; _scripts.AudioSetVolume(_audio!, value / 255.0).GetAwaiter().GetResult(); } }
     public int Pan { get; set; }
-    public float CurrentTime { get; set; }
+    private float _currentTime;
+    public float CurrentTime
+    {
+        get => _currentTime;
+        set
+        {
+            _scripts.AudioSeek(_audio!, value);
+            _currentTime = value;
+        }
+    }
     public bool IsPlaying { get; private set; }
     public int ChannelCount => 2;
     public int SampleCount => 0;
-    public float ElapsedTime => CurrentTime;
+    public float ElapsedTime => _currentTime;
     public float StartTime { get; set; }
     public float EndTime { get; set; }
 
     internal void Init(LingoSoundChannel channel) => _channel = channel;
 
-    public void Pause() => IsPlaying = !IsPlaying;
-    public void PlayFile(string stringFilePath) => IsPlaying = true;
-    public void PlayNow(LingoMemberSound member) => IsPlaying = true;
-    public void Repeat() { }
-    public void Rewind() => CurrentTime = 0;
+    public void Pause()
+    {
+        if (!IsPlaying)
+        {
+            _scripts.AudioResume(_audio!).GetAwaiter().GetResult();
+            IsPlaying = true;
+        }
+        else
+        {
+            _scripts.AudioPause(_audio!).GetAwaiter().GetResult();
+            IsPlaying = false;
+        }
+    }
+    public void PlayFile(string stringFilePath)
+    {
+        _scripts.AudioPlay(_audio!, stringFilePath).GetAwaiter().GetResult();
+        IsPlaying = true;
+    }
+    public void PlayNow(LingoMemberSound member)
+    {
+        var url = member.Framework<LingoBlazorMemberSound>().Url;
+        if (url != null)
+        {
+            _scripts.AudioPlay(_audio!, url).GetAwaiter().GetResult();
+            IsPlaying = true;
+        }
+    }
+    public void Repeat()
+    {
+        _scripts.AudioSeek(_audio!, StartTime);
+        _scripts.AudioResume(_audio!).GetAwaiter().GetResult();
+        IsPlaying = true;
+    }
+    public void Rewind()
+    {
+        _scripts.AudioSeek(_audio!, 0);
+        _currentTime = 0;
+    }
     public void Stop()
     {
+        _scripts.AudioStop(_audio!).GetAwaiter().GetResult();
         IsPlaying = false;
-        CurrentTime = 0;
+        _currentTime = 0;
+    }
+
+    [JSInvokable]
+    public void OnSoundEnded()
+    {
+        IsPlaying = false;
+        _currentTime = 0;
+        _channel.SoundFinished();
+    }
+
+    public void Dispose()
+    {
+        _audio?.DisposeAsync().GetAwaiter().GetResult();
+        _audioRef?.Dispose();
     }
 }

--- a/src/LingoEngine.Blazor/Util/ElementIdGenerator.cs
+++ b/src/LingoEngine.Blazor/Util/ElementIdGenerator.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace LingoEngine.Blazor.Util;
+
+internal static class ElementIdGenerator
+{
+    public static string Create(string name)
+        => $"{Guid.NewGuid():N}_{name}";
+}
+


### PR DESCRIPTION
## Summary
- Handle video and audio in Blazor via new script helpers and interop
- Render video frames and sync media events on Blazor sprites
- Add basic HTML audio playback for Blazor sound channels
- Assign guid-based IDs to media elements with a reusable `ElementIdGenerator` to avoid DOM collisions
- Drive Blazor stage with a clock-based render loop and overlay transitions

## Testing
- `dotnet format src/LingoEngine.Blazor/LingoEngine.Blazor.csproj --include src/LingoEngine.Blazor/Sprites/LingoBlazorSprite2D.cs src/LingoEngine.Blazor/Sounds/LingoBlazorSoundChannel.cs src/LingoEngine.Blazor/Util/ElementIdGenerator.cs -v diagnostic`
- `dotnet build src/LingoEngine.Blazor/LingoEngine.Blazor.csproj`
- `dotnet format src/LingoEngine.Blazor/LingoEngine.Blazor.csproj --include src/LingoEngine.Blazor/Sprites/LingoBlazorSprite2D.cs src/LingoEngine.Blazor/Sounds/LingoBlazorSoundChannel.cs -v diagnostic`
- `dotnet build src/LingoEngine.Blazor/LingoEngine.Blazor.csproj`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIScriptResolver.cs -v diagnostic`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj` *(fails: Assert.Equal failures and ArgumentOutOfRangeException)*
- `dotnet format src/LingoEngine.Blazor/LingoEngine.Blazor.csproj --include src/LingoEngine.Blazor/Movies/LingoBlazorMovie.cs src/LingoEngine.Blazor/Sprites/LingoBlazorSprite2D.cs src/LingoEngine.Blazor/Medias/LingoBlazorMemberMedia.cs src/LingoEngine.Blazor/Sounds/LingoBlazorMemberSound.cs src/LingoEngine.Blazor/Sounds/LingoBlazorSoundChannel.cs src/LingoEngine.Blazor/Sounds/LingoBlazorSound.cs src/LingoEngine.Blazor/BlazorFactory.cs -v diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIScriptResolver.cs -v diagnostic`
- `dotnet build src/LingoEngine.Blazor/LingoEngine.Blazor.csproj`
- `dotnet format src/LingoEngine.Blazor/LingoEngine.Blazor.csproj --include src/LingoEngine.Blazor/Movies/LingoBlazorMovie.cs src/LingoEngine.Blazor/Texts/LingoBlazorMemberTextBase.cs -v diagnostic`
- `dotnet build src/LingoEngine.Blazor/LingoEngine.Blazor.csproj`
- `dotnet format src/LingoEngine.Blazor/LingoEngine.Blazor.csproj --include src/LingoEngine.Blazor/Stages/LingoBlazorStage.cs -v diagnostic`
- `dotnet build src/LingoEngine.Blazor/LingoEngine.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c084f07dac83329c4c35e53bf203d4