### PR TITLE
Compose sprites as DOM elements in Blazor

### DIFF
--- a/src/LingoEngine.Blazor/BlazorFactory.cs
+++ b/src/LingoEngine.Blazor/BlazorFactory.cs
@@ -72,7 +72,9 @@ public class BlazorFactory : ILingoFrameworkFactory, IDisposable
     {
         var js = _services.GetRequiredService<IJSRuntime>();
         var scripts = _services.GetRequiredService<AbstUIScriptResolver>();
+        var root = _services.GetRequiredService<LingoBlazorRootPanel>();
         var impl = new LingoBlazorStage((LingoClock)lingoPlayer.Clock, js, scripts);
+        root.Stage = impl;
         var stage = new LingoStage(impl);
         impl.Init(stage);
         _disposables.Add(impl);

--- a/src/LingoEngine.Blazor/Movies/LingoBlazorMovieView.razor
+++ b/src/LingoEngine.Blazor/Movies/LingoBlazorMovieView.razor
@@ -1,0 +1,26 @@
+@using LingoEngine.Blazor.Movies
+@using LingoEngine.Blazor.Sprites
+@implements IDisposable
+
+<div style="position:relative;width:@(Movie.WidthPx)px;height:@(Movie.HeightPx)px;">
+    @foreach (var s in Movie.VisibleSprites)
+    {
+        <LingoBlazorSprite Sprite="s" />
+    }
+</div>
+
+@code {
+    [Parameter] public LingoBlazorMovie Movie { get; set; } = default!;
+
+    protected override void OnInitialized()
+    {
+        Movie.Changed += OnChanged;
+    }
+
+    private void OnChanged() => InvokeAsync(StateHasChanged);
+
+    public void Dispose()
+    {
+        Movie.Changed -= OnChanged;
+    }
+}

--- a/src/LingoEngine.Blazor/Movies/LingoBlazorRoot.razor
+++ b/src/LingoEngine.Blazor/Movies/LingoBlazorRoot.razor
@@ -1,16 +1,11 @@
-@using Microsoft.AspNetCore.Components
-@inject LingoEngine.Blazor.Movies.LingoBlazorRootPanel RootPanel
+@using AbstUI.Blazor.Components.Containers
+@using LingoEngine.Blazor.Movies
+@using LingoEngine.Blazor.Stages
+@inject LingoBlazorRootPanel RootPanel
 
-<div @ref="_root"></div>
-
-@code {
-    private ElementReference _root;
-
-    protected override void OnAfterRender(bool firstRender)
+<AbstBlazorPanel Component="RootPanel.Component">
+    @if (RootPanel.Stage is not null)
     {
-        if (firstRender)
-        {
-            RootPanel.SetRoot(_root);
-        }
+        <LingoBlazorStageView Stage="RootPanel.Stage" />
     }
-}
+</AbstBlazorPanel>

--- a/src/LingoEngine.Blazor/Movies/LingoBlazorRootPanel.cs
+++ b/src/LingoEngine.Blazor/Movies/LingoBlazorRootPanel.cs
@@ -1,25 +1,19 @@
-using Microsoft.AspNetCore.Components;
+using AbstUI.Components;
+using LingoEngine.Blazor.Stages;
+using AbstUI.Blazor.Components.Containers;
 
 namespace LingoEngine.Blazor.Movies;
 
 /// <summary>
-/// Holds a reference to the root DOM element where Lingo movies
-/// should insert their canvases.
+/// Holds the root AbstUI panel used to compose the Blazor stage.
 /// </summary>
 public class LingoBlazorRootPanel
 {
-    private ElementReference _root;
+    public AbstBlazorPanelComponent Component { get; }
+    public LingoBlazorStage? Stage { get; set; }
 
-    /// <summary>
-    /// Gets the root element reference.
-    /// </summary>
-    public ElementReference Root => _root;
-
-    /// <summary>
-    /// Updates the root element reference. Called by the root component
-    /// once it has been rendered.
-    /// </summary>
-    /// <param name="element">The element that should host movie canvases.</param>
-    public void SetRoot(ElementReference element) => _root = element;
+    public LingoBlazorRootPanel(IAbstComponentFactory factory)
+    {
+        Component = factory.CreatePanel("LingoRoot").Framework<AbstBlazorPanelComponent>();
+    }
 }
-

--- a/src/LingoEngine.Blazor/Sprites/LingoBlazorSprite.razor
+++ b/src/LingoEngine.Blazor/Sprites/LingoBlazorSprite.razor
@@ -1,0 +1,45 @@
+@implements IDisposable
+@using AbstUI.Blazor
+@using LingoEngine.Blazor.Sprites
+@using AbstUI.Blazor.Bitmaps
+@inject AbstUIScriptResolver Scripts
+
+<div @ref="_host" style="@BuildStyle()"></div>
+
+@code {
+    [Parameter] public LingoBlazorSprite2D Sprite { get; set; } = default!;
+    private ElementReference _host;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        Sprite.Changed += OnSpriteChanged;
+    }
+
+    private void OnSpriteChanged() => InvokeAsync(StateHasChanged);
+
+    private string BuildStyle()
+    {
+        var drawW = Sprite.DesiredWidth > 0 ? Sprite.DesiredWidth : Sprite.Width;
+        var drawH = Sprite.DesiredHeight > 0 ? Sprite.DesiredHeight : Sprite.Height;
+        var x = Sprite.X - Sprite.RegPoint.X;
+        var y = Sprite.Y - Sprite.RegPoint.Y;
+        var scaleX = Sprite.FlipH ? -1 : 1;
+        var scaleY = Sprite.FlipV ? -1 : 1;
+        var transform = $"translate({Sprite.RegPoint.X}px,{Sprite.RegPoint.Y}px) rotate({Sprite.Rotation}deg) scale({scaleX},{scaleY}) translate(-{Sprite.RegPoint.X}px,-{Sprite.RegPoint.Y}px)";
+        var style = $"position:absolute;left:{x}px;top:{y}px;width:{drawW}px;height:{drawH}px;z-index:{Sprite.ZIndex};opacity:{Sprite.Blend};transform:{transform};";
+        if (!Sprite.Visibility) style += "display:none;";
+        return style;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (Sprite.Texture is AbstBlazorTexture2D tex)
+            await Scripts.CanvasAddToElement(_host, tex.Canvas);
+    }
+
+    public void Dispose()
+    {
+        Sprite.Changed -= OnSpriteChanged;
+    }
+}

--- a/src/LingoEngine.Blazor/Sprites/LingoBlazorSprite2D.cs
+++ b/src/LingoEngine.Blazor/Sprites/LingoBlazorSprite2D.cs
@@ -34,6 +34,14 @@ public class LingoBlazorSprite2D : ILingoFrameworkSprite, ILingoFrameworkSpriteV
     internal bool IsDirty { get; set; } = true;
     internal bool IsDirtyMember { get; set; } = true;
 
+    public event Action? Changed;
+
+    private void MakeDirty()
+    {
+        IsDirty = true;
+        Changed?.Invoke();
+    }
+
     public LingoBlazorSprite2D(LingoSprite2D sprite,
         Action<LingoBlazorSprite2D> show,
         Action<LingoBlazorSprite2D> hide,
@@ -58,41 +66,41 @@ public class LingoBlazorSprite2D : ILingoFrameworkSprite, ILingoFrameworkSpriteV
         {
             _visible = value;
             if (value) _show(this); else _hide(this);
-            IsDirty = true;
+            MakeDirty();
         }
     }
     private bool _visible;
 
     private float _blend = 1f;
-    public float Blend { get => _blend; set { _blend = value; IsDirty = true; } }
+    public float Blend { get => _blend; set { _blend = value; MakeDirty(); } }
     private float _x;
-    public float X { get => _x; set { _x = value; IsDirty = true; } }
+    public float X { get => _x; set { _x = value; MakeDirty(); } }
     private float _y;
-    public float Y { get => _y; set { _y = value; IsDirty = true; } }
+    public float Y { get => _y; set { _y = value; MakeDirty(); } }
     public float Width { get; private set; }
     public float Height { get; private set; }
     private string _name = string.Empty;
-    public string Name { get => _name; set { _name = value; IsDirty = true; } }
+    public string Name { get => _name; set { _name = value; MakeDirty(); } }
     private APoint _regPoint;
-    public APoint RegPoint { get => _regPoint; set { _regPoint = value; IsDirty = true; } }
+    public APoint RegPoint { get => _regPoint; set { _regPoint = value; MakeDirty(); } }
     private float _desiredHeight;
-    public float DesiredHeight { get => _desiredHeight; set { _desiredHeight = value; IsDirty = true; } }
+    public float DesiredHeight { get => _desiredHeight; set { _desiredHeight = value; MakeDirty(); } }
     private float _desiredWidth;
-    public float DesiredWidth { get => _desiredWidth; set { _desiredWidth = value; IsDirty = true; } }
+    public float DesiredWidth { get => _desiredWidth; set { _desiredWidth = value; MakeDirty(); } }
     private int _zIndex;
-    public int ZIndex { get => _zIndex; set { _zIndex = value; IsDirty = true; } }
+    public int ZIndex { get => _zIndex; set { _zIndex = value; MakeDirty(); } }
     private float _rotation;
-    public float Rotation { get => _rotation; set { _rotation = value; IsDirty = true; } }
+    public float Rotation { get => _rotation; set { _rotation = value; MakeDirty(); } }
     private float _skew;
-    public float Skew { get => _skew; set { _skew = value; IsDirty = true; } }
+    public float Skew { get => _skew; set { _skew = value; MakeDirty(); } }
     private bool _flipH;
-    public bool FlipH { get => _flipH; set { _flipH = value; IsDirty = true; } }
+    public bool FlipH { get => _flipH; set { _flipH = value; MakeDirty(); } }
     private bool _flipV;
-    public bool FlipV { get => _flipV; set { _flipV = value; IsDirty = true; } }
+    public bool FlipV { get => _flipV; set { _flipV = value; MakeDirty(); } }
     private bool _directToStage;
-    public bool DirectToStage { get => _directToStage; set { _directToStage = value; IsDirty = true; } }
+    public bool DirectToStage { get => _directToStage; set { _directToStage = value; MakeDirty(); } }
     private int _ink;
-    public int Ink { get => _ink; set { _ink = value; IsDirty = true; } }
+    public int Ink { get => _ink; set { _ink = value; MakeDirty(); } }
 
     public void MemberChanged()
     {
@@ -119,6 +127,7 @@ public class LingoBlazorSprite2D : ILingoFrameworkSprite, ILingoFrameworkSpriteV
                 _mediaStatus = blazorMedia.MediaStatus;
             }
             IsDirtyMember = true;
+            MakeDirty();
         }
     }
 
@@ -138,6 +147,7 @@ public class LingoBlazorSprite2D : ILingoFrameworkSprite, ILingoFrameworkSpriteV
         }
         _lingoSprite.FWTextureHasChanged(texture);
         IsDirtyMember = true;
+        MakeDirty();
     }
 
     /// <inheritdoc/>

--- a/src/LingoEngine.Blazor/Stages/LingoBlazorStageView.razor
+++ b/src/LingoEngine.Blazor/Stages/LingoBlazorStageView.razor
@@ -1,0 +1,24 @@
+@using LingoEngine.Blazor.Stages
+@using LingoEngine.Blazor.Movies
+@implements IDisposable
+
+@if (Stage.ActiveMovie is not null)
+{
+    <LingoBlazorMovieView Movie="Stage.ActiveMovie" />
+}
+
+@code {
+    [Parameter] public LingoBlazorStage Stage { get; set; } = default!;
+
+    protected override void OnInitialized()
+    {
+        Stage.Changed += OnChanged;
+    }
+
+    private void OnChanged() => InvokeAsync(StateHasChanged);
+
+    public void Dispose()
+    {
+        Stage.Changed -= OnChanged;
+    }
+}


### PR DESCRIPTION
## Summary
- Render each sprite into its own absolutely positioned canvas and use z-index
- Expose movie and stage as AbstUI components for DOM composition
- Wrap Blazor stage in a root AbstUI panel to host movie content
- Centralize sprite dirty-state notifications in a helper method

## Testing
- `dotnet format src/LingoEngine.Blazor/LingoEngine.Blazor.csproj --include src/LingoEngine.Blazor/Sprites/LingoBlazorSprite2D.cs -v diagnostic`
- `dotnet build src/LingoEngine.Blazor/LingoEngine.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c0df8aecb48332ba712cb14f7e9834