### PR TITLE
Add DebugWithDirector configuration for TetriGrounds Godot and SDL

### DIFF
--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/LingoEngine.Demo.TetriGrounds.Godot.csproj
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/LingoEngine.Demo.TetriGrounds.Godot.csproj
@@ -1,15 +1,23 @@
 <Project Sdk="Godot.NET.Sdk/4.5.0-dev.5">
-	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<EnableDynamicLoading>true</EnableDynamicLoading>
-		<Nullable>enable</Nullable>
-		<LangVersion>12</LangVersion>
-		<Platforms>AnyCPU;x64;x86</Platforms>
-	</PropertyGroup>
+        <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnableDynamicLoading>true</EnableDynamicLoading>
+                <Nullable>enable</Nullable>
+                <LangVersion>12</LangVersion>
+                <Platforms>AnyCPU;x64;x86</Platforms>
+                <Configurations>Debug;Release;DebugWithDirector</Configurations>
+        </PropertyGroup>
 
-	<ItemGroup Condition="'$(Configuration)' == 'Debug'">
-		<ProjectReference Include="..\..\..\src\Director\LingoEngine.Director.LGodot\LingoEngine.Director.LGodot.csproj" />
-	</ItemGroup>
+        <PropertyGroup Condition="'$(Configuration)' == 'DebugWithDirector'">
+                <DebugSymbols>true</DebugSymbols>
+                <DebugType>portable</DebugType>
+                <Optimize>false</Optimize>
+                <DefineConstants>DEBUG;TRACE;DEBUG_WITH_DIRECTOR</DefineConstants>
+        </PropertyGroup>
+
+        <ItemGroup Condition="'$(Configuration)' == 'DebugWithDirector'">
+                <ProjectReference Include="..\..\..\src\Director\LingoEngine.Director.LGodot\LingoEngine.Director.LGodot.csproj" />
+        </ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\src\LingoEngine.LGodot\LingoEngine.LGodot.csproj" />
 		<ProjectReference Include="..\LingoEngine.Demo.TetriGrounds.Core\LingoEngine.Demo.TetriGrounds.Core.csproj" />

--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/Scenes/RootNodeTetriGrounds.cs
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/Scenes/RootNodeTetriGrounds.cs
@@ -1,10 +1,9 @@
 using Godot;
 using LingoEngine.Setup;
 using LingoEngine.LGodot;
-#if DEBUG
+#if DEBUG_WITH_DIRECTOR
 using LingoEngine.Director.Core.Projects;
 using LingoEngine.Director.LGodot;
-#else
 #endif
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -24,16 +23,16 @@ public partial class RootNodeTetriGrounds : Node2D
  var style = serviceProvider.GetRequiredService<LingoGodotStyle>();
  this.Theme = style.Theme;
 */
-#if DEBUG
+#if DEBUG_WITH_DIRECTOR
             ProjectSettings.SetSetting("display/window/stretch/mode", "disabled");
             ProjectSettings.SetSetting("display/window/stretch/aspect", "ignore");
             DisplayServer.WindowSetSize(new Vector2I(1600, 970));
 #else
-            ProjectSettings.SetSetting("display/window/size/initial_position_type","3");
-            ProjectSettings.SetSetting("display/window/stretch/mode","canvas_items");
+            ProjectSettings.SetSetting("display/window/size/initial_position_type", "3");
+            ProjectSettings.SetSetting("display/window/stretch/mode", "canvas_items");
             ProjectSettings.SetSetting("display/window/stretch/aspect", "keep");
             DisplayServer.WindowSetSize(new Vector2I(730, 546));
-#endif            
+#endif
             //DisplayServer.WindowSetPosition((DisplayServer.ScreenGetSize() - DisplayServer.WindowGetSize()) / 2);
 
             var screenSize = DisplayServer.ScreenGetSize();
@@ -45,8 +44,8 @@ public partial class RootNodeTetriGrounds : Node2D
             DisplayServer.WindowSetPosition(centeredPos);
             _services = new ServiceCollection();
             _services.RegisterLingoEngine(c => c
-            
-#if DEBUG
+
+#if DEBUG_WITH_DIRECTOR
                     .WithDirectorGodotEngine(this)
                      .AddBuildAction(b =>
                      {

--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.SDL2/LingoEngine.Demo.TetriGrounds.SDL2.csproj
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.SDL2/LingoEngine.Demo.TetriGrounds.SDL2.csproj
@@ -7,7 +7,19 @@
     <Nullable>enable</Nullable>
     <StartupObject>LingoEngine.Demo.TetriGrounds.SDL2.Program</StartupObject>
     <Platforms>AnyCPU;x64;x86</Platforms>
+    <Configurations>Debug;Release;DebugWithDirector</Configurations>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'DebugWithDirector'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE;DEBUG_WITH_DIRECTOR</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(Configuration)' == 'DebugWithDirector'">
+    <ProjectReference Include="..\..\..\src\Director\LingoEngine.Director.SDL2\LingoEngine.Director.SDL2.csproj" />
+  </ItemGroup>
 
   <ItemGroup>
     <Content Include="..\LingoEngine.Demo.TetriGrounds.Godot\Media\Data\100_bell0039.png" Link="Media\Data\100_bell0039.png">

--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.SDL2/Program.cs
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.SDL2/Program.cs
@@ -1,6 +1,10 @@
 ﻿using LingoEngine.SDL2;
 using LingoEngine.Setup;
 using Microsoft.Extensions.DependencyInjection;
+#if DEBUG_WITH_DIRECTOR
+using LingoEngine.Director.Core.Projects;
+using LingoEngine.Director.SDL2;
+#endif
 
 namespace LingoEngine.Demo.TetriGrounds.SDL2
 {
@@ -10,11 +14,22 @@ namespace LingoEngine.Demo.TetriGrounds.SDL2
         {
             var services = new ServiceCollection();
             IServiceProvider? serviceProvider = null;
+#if DEBUG_WITH_DIRECTOR
+            services.RegisterLingoEngine(c => c
+                    .WithDirectorSdlEngine("TetriGrounds", 1600, 970, d =>
+                    {
+                        d.CsProjFile = "LingoEngine.Demo.TetriGrounds.Core\\LingoEngine.Demo.TetriGrounds.Core.csproj";
+                    })
+                    .SetProjectFactory<LingoEngine.Demo.TetriGrounds.Core.TetriGroundsProjectFactory>()
+                    .BuildAndRunProject(sp => serviceProvider = sp)
+                    );
+#else
             services.RegisterLingoEngine(c => c
                     .WithLingoSdlEngine("TetriGrounds", 730, 547)
                     .SetProjectFactory<LingoEngine.Demo.TetriGrounds.Core.TetriGroundsProjectFactory>()
                     .BuildAndRunProject(sp => serviceProvider = sp)
                     );
+#endif
             serviceProvider?.GetRequiredService<LingoSdlRootContext>().Run();
             SdlSetup.Dispose();
         }


### PR DESCRIPTION
## Summary
- add DebugWithDirector configuration to Godot demo project
- gate Director features behind DEBUG_WITH_DIRECTOR symbol
- add DebugWithDirector configuration to SDL demo project

## Testing
- `dotnet build Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/LingoEngine.Demo.TetriGrounds.Godot.csproj -c Debug`
- `dotnet build Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot/LingoEngine.Demo.TetriGrounds.Godot.csproj -c DebugWithDirector` *(fails: 'AbstGodotTexture2D' does not contain a definition for 'DebugWriteToDisk')*
- `dotnet build Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.SDL2/LingoEngine.Demo.TetriGrounds.SDL2.csproj -c Debug`
- `dotnet build Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.SDL2/LingoEngine.Demo.TetriGrounds.SDL2.csproj -c DebugWithDirector`


------
https://chatgpt.com/codex/tasks/task_e_68c0e569c73883328ca840bb6152bca7