### PR TITLE
feat: add missing blazor utilities

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.5" />
+        <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Inputs/BlazorKey.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Inputs/BlazorKey.cs
@@ -10,6 +10,7 @@ namespace AbstUI.Blazor.Inputs;
 public class BlazorKey : IAbstFrameworkKey, IFrameworkFor<AbstKey>
 {
     private readonly HashSet<string> _keys = new();
+    private readonly HashSet<string> _codes = new();
     private AbstKey? _lingoKey;
     private string _lastKey = string.Empty;
     private int _lastCode;
@@ -19,16 +20,18 @@ public class BlazorKey : IAbstFrameworkKey, IFrameworkFor<AbstKey>
     public void KeyDown(KeyboardEventArgs e)
     {
         _keys.Add(e.Key);
+        _codes.Add(e.Code);
         _lastKey = e.Key;
-        _lastCode = e.Key.Length == 1 ? char.ToUpperInvariant(e.Key[0]) : 0;
+        _lastCode = BlazorKeyCodeMap.ToLingo(e.Code);
         _lingoKey?.DoKeyDown();
     }
 
     public void KeyUp(KeyboardEventArgs e)
     {
         _keys.Remove(e.Key);
+        _codes.Remove(e.Code);
         _lastKey = e.Key;
-        _lastCode = e.Key.Length == 1 ? char.ToUpperInvariant(e.Key[0]) : 0;
+        _lastCode = BlazorKeyCodeMap.ToLingo(e.Code);
         _lingoKey?.DoKeyUp();
     }
 
@@ -39,17 +42,18 @@ public class BlazorKey : IAbstFrameworkKey, IFrameworkFor<AbstKey>
 
     public bool KeyPressed(AbstUIKeyType key) => key switch
     {
-        AbstUIKeyType.BACKSPACE => _keys.Contains("Backspace"),
-        AbstUIKeyType.ENTER or AbstUIKeyType.RETURN => _keys.Contains("Enter"),
-        AbstUIKeyType.QUOTE => _keys.Contains("'"),
-        AbstUIKeyType.SPACE => _keys.Contains(" "),
-        AbstUIKeyType.TAB => _keys.Contains("Tab"),
+        AbstUIKeyType.BACKSPACE => _codes.Contains("Backspace"),
+        AbstUIKeyType.ENTER or AbstUIKeyType.RETURN => _codes.Contains("Enter"),
+        AbstUIKeyType.QUOTE => _codes.Contains("Quote"),
+        AbstUIKeyType.SPACE => _codes.Contains("Space"),
+        AbstUIKeyType.TAB => _codes.Contains("Tab"),
         _ => false
     };
+    public bool KeyPressed(char key)
+        => _codes.Contains(BlazorKeyCodeMap.ToBlazor(char.IsLetter(key) ? char.ToUpperInvariant(key) : key));
 
-    public bool KeyPressed(char key) => _keys.Contains(key.ToString().ToUpperInvariant());
-
-    public bool KeyPressed(int keyCode) => _keys.Contains(((char)keyCode).ToString().ToUpperInvariant());
+    public bool KeyPressed(int keyCode)
+        => _codes.Contains(BlazorKeyCodeMap.ToBlazor(keyCode));
 
     public string Key => _lastKey;
     public int KeyCode => _lastCode;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Inputs/BlazorKeyCodeMap.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Inputs/BlazorKeyCodeMap.cs
@@ -1,0 +1,162 @@
+using System.Collections.Generic;
+
+namespace AbstUI.Blazor.Inputs;
+
+/// <summary>
+/// Maps between DOM keyboard <c>code</c> strings and Lingo numeric key codes.
+/// </summary>
+public static class BlazorKeyCodeMap
+{
+    private static readonly Dictionary<string, int> Mac = new()
+    {
+        // Editing / Navigation
+        { "Enter", 36 },
+        { "Escape", 53 },
+        { "Tab", 48 },
+        { "Space", 49 },
+        { "Backspace", 51 },
+        { "Delete", 117 },
+        { "Home", 115 },
+        { "End", 119 },
+        { "PageUp", 116 },
+        { "PageDown", 121 },
+        { "ArrowLeft", 123 },
+        { "ArrowRight", 124 },
+        { "ArrowDown", 125 },
+        { "ArrowUp", 126 },
+        { "Help", 114 },
+        { "Clear", 71 },
+        { "NumpadEnter", 76 },
+        // Modifiers
+        { "ShiftLeft", 56 },
+        { "ControlLeft", 59 },
+        { "AltLeft", 58 },
+        { "MetaLeft", 55 },
+        { "CapsLock", 57 },
+        // Function keys
+        { "F1", 122 },
+        { "F2", 120 },
+        { "F3", 99 },
+        { "F4", 118 },
+        { "F5", 96 },
+        { "F6", 97 },
+        { "F7", 98 },
+        { "F8", 100 },
+        { "F9", 101 },
+        { "F10", 109 },
+        { "F11", 103 },
+        { "F12", 111 },
+        // Letters
+        { "KeyA", 0 },
+        { "KeyB", 11 },
+        { "KeyC", 8 },
+        { "KeyD", 2 },
+        { "KeyE", 14 },
+        { "KeyF", 3 },
+        { "KeyG", 5 },
+        { "KeyH", 4 },
+        { "KeyI", 34 },
+        { "KeyJ", 38 },
+        { "KeyK", 40 },
+        { "KeyL", 37 },
+        { "KeyM", 46 },
+        { "KeyN", 45 },
+        { "KeyO", 31 },
+        { "KeyP", 35 },
+        { "KeyQ", 12 },
+        { "KeyR", 15 },
+        { "KeyS", 1 },
+        { "KeyT", 17 },
+        { "KeyU", 32 },
+        { "KeyV", 9 },
+        { "KeyW", 13 },
+        { "KeyX", 7 },
+        { "KeyY", 16 },
+        { "KeyZ", 6 },
+        // Numbers & Symbols
+        { "Digit1", 18 },
+        { "Digit2", 19 },
+        { "Digit3", 20 },
+        { "Digit4", 21 },
+        { "Digit5", 23 },
+        { "Digit6", 22 },
+        { "Digit7", 26 },
+        { "Digit8", 28 },
+        { "Digit9", 25 },
+        { "Digit0", 29 },
+        { "Minus", 27 },
+        { "Equal", 24 },
+        { "Backquote", 50 },
+        { "BracketLeft", 33 },
+        { "BracketRight", 30 },
+        { "Backslash", 42 },
+        { "Semicolon", 41 },
+        { "Quote", 39 },
+        { "Comma", 43 },
+        { "Period", 47 },
+        { "Slash", 44 },
+        // Numpad
+        { "Numpad0", 82 },
+        { "Numpad1", 83 },
+        { "Numpad2", 84 },
+        { "Numpad3", 85 },
+        { "Numpad4", 86 },
+        { "Numpad5", 87 },
+        { "Numpad6", 88 },
+        { "Numpad7", 89 },
+        { "Numpad8", 91 },
+        { "Numpad9", 92 },
+        { "NumpadDecimal", 65 },
+        { "NumpadDivide", 75 },
+        { "NumpadMultiply", 67 },
+        { "NumpadSubtract", 78 },
+        { "NumpadAdd", 69 },
+    };
+
+    private static Dictionary<int, string> _reverse = BuildReverse(Mac);
+
+    private static Dictionary<int, string> BuildReverse(Dictionary<string, int> source)
+    {
+        var dict = new Dictionary<int, string>();
+        foreach (var kv in source)
+            if (!dict.ContainsKey(kv.Value))
+                dict[kv.Value] = kv.Key;
+        return dict;
+    }
+
+    public static int ToLingo(string code)
+    {
+        if (Mac.TryGetValue(code, out var val))
+            return val;
+        if (code.Length == 1)
+        {
+            char c = char.ToUpperInvariant(code[0]);
+            if (char.IsLetterOrDigit(c))
+                return c;
+        }
+        if (code.StartsWith("Key") && code.Length == 4)
+        {
+            char c = code[3];
+            if (char.IsLetter(c))
+                return char.ToUpperInvariant(c);
+        }
+        if (code.StartsWith("Digit") && code.Length == 6)
+        {
+            char c = code[5];
+            if (char.IsDigit(c))
+                return c;
+        }
+        return 0;
+    }
+
+    public static string ToBlazor(int lingoCode)
+    {
+        if (_reverse.TryGetValue(lingoCode, out var code))
+            return code;
+        if (lingoCode >= 65 && lingoCode <= 90)
+            return "Key" + (char)lingoCode;
+        if (lingoCode >= 48 && lingoCode <= 57)
+            return "Digit" + (char)lingoCode;
+        return ((char)lingoCode).ToString();
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Primitives/AbstBlazorPixelFormatExtensions.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Primitives/AbstBlazorPixelFormatExtensions.cs
@@ -1,0 +1,38 @@
+using System.Drawing.Imaging;
+using AbstUI.Primitives;
+
+namespace AbstUI.Blazor.Primitives;
+
+/// <summary>
+/// Extensions for converting <see cref="APixelFormat"/> to and from <see cref="PixelFormat"/>.
+/// </summary>
+public static class AbstBlazorPixelFormatExtensions
+{
+    /// <summary>
+    /// Converts an <see cref="APixelFormat"/> to a <see cref="PixelFormat"/> understood by <c>System.Drawing</c>.
+    /// </summary>
+    public static PixelFormat ToDrawingFormat(this APixelFormat format) => format switch
+    {
+        APixelFormat.Rgba8888 => PixelFormat.Format32bppArgb,
+        APixelFormat.Rgb888 => PixelFormat.Format24bppRgb,
+        APixelFormat.Rgb5650 => PixelFormat.Format16bppRgb565,
+        APixelFormat.Rgb5550 => PixelFormat.Format16bppRgb555,
+        APixelFormat.Rgba5551 => PixelFormat.Format16bppArgb1555,
+        // System.Drawing does not support a true 4-4-4-4 format; map to the closest 16bpp ARGB option.
+        APixelFormat.Rgba4444 => PixelFormat.Format16bppArgb1555,
+        _ => PixelFormat.Format24bppRgb,
+    };
+
+    /// <summary>
+    /// Converts a <see cref="PixelFormat"/> to an <see cref="APixelFormat"/>.
+    /// </summary>
+    public static APixelFormat ToAbstFormat(this PixelFormat format) => format switch
+    {
+        PixelFormat.Format32bppArgb or PixelFormat.Format32bppPArgb => APixelFormat.Rgba8888,
+        PixelFormat.Format24bppRgb => APixelFormat.Rgb888,
+        PixelFormat.Format16bppRgb565 => APixelFormat.Rgb5650,
+        PixelFormat.Format16bppRgb555 => APixelFormat.Rgb5550,
+        PixelFormat.Format16bppArgb1555 => APixelFormat.Rgba5551,
+        _ => APixelFormat.Rgb888,
+    };
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Primitives/AbstBlazorPointExtensions.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Primitives/AbstBlazorPointExtensions.cs
@@ -1,0 +1,22 @@
+using System.Drawing;
+using AbstUI.Primitives;
+
+namespace AbstUI.Blazor.Primitives;
+
+/// <summary>
+/// Helpers for translating between <see cref="APoint"/>/<see cref="ARect"/> and System.Drawing types.
+/// </summary>
+public static class AbstBlazorPointExtensions
+{
+    public static PointF ToPointF(this APoint point)
+        => new(point.X, point.Y);
+
+    public static APoint ToAbstPoint(this PointF point)
+        => new(point.X, point.Y);
+
+    public static RectangleF ToRectangleF(this ARect rect)
+        => new(rect.Left, rect.Top, rect.Width, rect.Height);
+
+    public static ARect ToAbstRect(this RectangleF rect)
+        => ARect.New(rect.Left, rect.Top, rect.Width, rect.Height);
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Texts/AbstBlazorLabelExtensions.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Texts/AbstBlazorLabelExtensions.cs
@@ -1,0 +1,51 @@
+using AbstUI.Blazor.Components.Texts;
+using AbstUI.Primitives;
+using AbstUI.Styles;
+using AbstUI.Texts;
+
+namespace AbstUI.Blazor.Texts;
+
+/// <summary>
+/// Helper extensions for working with <see cref="AbstBlazorLabelComponent"/>.
+/// </summary>
+public static class AbstBlazorLabelExtensions
+{
+    public static AbstBlazorLabelComponent SetAbstFont(this AbstBlazorLabelComponent label, IAbstFontManager fontManager, string fontName)
+    {
+        if (fontManager.Get<object>(fontName) != null)
+            label.Font = fontName;
+        return label;
+    }
+
+    public static AbstBlazorLabelComponent SetAbstFontSize(this AbstBlazorLabelComponent label, int fontSize)
+    {
+        if (fontSize > 0)
+            label.FontSize = fontSize;
+        return label;
+    }
+
+    public static AbstBlazorLabelComponent SetAbstColor(this AbstBlazorLabelComponent label, AColor color)
+    {
+        label.FontColor = color;
+        return label;
+    }
+
+    public static string ToCss(this AbstTextAlignment alignment) => alignment switch
+    {
+        AbstTextAlignment.Center => "center",
+        AbstTextAlignment.Right => "right",
+        AbstTextAlignment.Justified => "justify",
+        _ => "left"
+    };
+
+    public static AbstTextAlignment ToAbst(this string alignment) => alignment?.ToLowerInvariant() switch
+    {
+        "center" => AbstTextAlignment.Center,
+        "right" => AbstTextAlignment.Right,
+        "justify" => AbstTextAlignment.Justified,
+        _ => AbstTextAlignment.Left
+    };
+
+    public static AColor GetAbstColor(this AbstBlazorLabelComponent label)
+        => label.FontColor;
+}

--- a/src/LingoEngine.Blazor/BlazorFactory.cs
+++ b/src/LingoEngine.Blazor/BlazorFactory.cs
@@ -73,8 +73,9 @@ public class BlazorFactory : ILingoFrameworkFactory, IDisposable
         var js = _services.GetRequiredService<IJSRuntime>();
         var scripts = _services.GetRequiredService<AbstUIScriptResolver>();
         var root = _services.GetRequiredService<LingoBlazorRootPanel>();
-        var impl = new LingoBlazorStage((LingoClock)lingoPlayer.Clock, js, scripts);
-        root.Stage = impl;
+        var container = _services.GetRequiredService<ILingoFrameworkStageContainer>();
+        var impl = new LingoBlazorStage(lingoPlayer, js, scripts, root, _gfxFactory);
+        container.SetStage(impl);
         var stage = new LingoStage(impl);
         impl.Init(stage);
         _disposables.Add(impl);

--- a/src/LingoEngine.Blazor/BlazorSetup.cs
+++ b/src/LingoEngine.Blazor/BlazorSetup.cs
@@ -5,6 +5,8 @@ using LingoEngine.Core;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Setup;
 using LingoEngine.Blazor.Movies;
+using LingoEngine.Blazor.Stages;
+using LingoEngine.Stages;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LingoEngine.Blazor;
@@ -17,6 +19,7 @@ public static class BlazorSetup
         reg.ServicesMain(s => s
                 .AddSingleton<ILingoFrameworkFactory, BlazorFactory>()
                 .AddSingleton<LingoBlazorRootPanel>()
+                .AddSingleton<ILingoFrameworkStageContainer, LingoBlazorStageContainer>()
                 .WithAbstUIBlazor(windowRegistrations)
             )
             .WithFrameworkFactory(setup)

--- a/src/LingoEngine.Blazor/Stages/LingoBlazorDebugOverlay.cs
+++ b/src/LingoEngine.Blazor/Stages/LingoBlazorDebugOverlay.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using AbstUI.Blazor.Components.Texts;
+using AbstUI.Components;
+using LingoEngine.Blazor.Movies;
+using LingoEngine.FrameworkCommunication;
+
+namespace LingoEngine.Blazor.Stages;
+
+/// <summary>
+/// Minimal debug overlay that renders lines of text using AbstUI labels.
+/// </summary>
+public class LingoBlazorDebugOverlay : ILingoFrameworkDebugOverlay
+{
+    private readonly LingoBlazorRootPanel _root;
+    private readonly IAbstComponentFactory _factory;
+    private readonly List<AbstBlazorLabelComponent> _labels = new();
+
+    public LingoBlazorDebugOverlay(LingoBlazorRootPanel root, IAbstComponentFactory factory)
+    {
+        _root = root;
+        _factory = factory;
+    }
+
+    public void ShowDebugger()
+    {
+        foreach (var l in _labels)
+            l.Visibility = true;
+    }
+
+    public void HideDebugger()
+    {
+        foreach (var l in _labels)
+            l.Visibility = false;
+    }
+
+    public void Begin() { }
+
+    public int PrepareLine(int id, string text)
+    {
+        var label = _factory.CreateLabel($"Dbg{id}", text);
+        var impl = label.Framework<AbstBlazorLabelComponent>();
+        impl.X = 10;
+        impl.Y = (id - 1) * 15;
+        impl.Visibility = false;
+        _root.Component.AddItem(impl);
+        _labels.Add(impl);
+        return id;
+    }
+
+    public void SetLineText(int id, string text)
+    {
+        var index = id - 1;
+        if (index >= 0 && index < _labels.Count)
+            _labels[index].Text = text;
+    }
+
+    public void End() { }
+}
+

--- a/src/LingoEngine.Blazor/Stages/LingoBlazorStageContainer.cs
+++ b/src/LingoEngine.Blazor/Stages/LingoBlazorStageContainer.cs
@@ -1,0 +1,26 @@
+using LingoEngine.Blazor.Movies;
+using LingoEngine.Stages;
+
+namespace LingoEngine.Blazor.Stages;
+
+/// <summary>
+/// Simple stage container that assigns the active Blazor stage
+/// to the root panel.
+/// </summary>
+public class LingoBlazorStageContainer : ILingoFrameworkStageContainer
+{
+    private readonly LingoBlazorRootPanel _root;
+
+    public LingoBlazorStageContainer(LingoBlazorRootPanel root)
+    {
+        _root = root;
+    }
+
+    /// <inheritdoc />
+    public void SetStage(ILingoFrameworkStage stage)
+    {
+        if (stage is LingoBlazorStage blazorStage)
+            _root.Stage = blazorStage;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add APixelFormat <-> System.Drawing.PixelFormat conversions
- map DOM key codes to Lingo hardware codes
- expose point/rect helpers and label styling extensions for Blazor
- implement stage container and debug overlay for Blazor backend

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj -c Release -v minimal`
- `dotnet format src/LingoEngine.Blazor/LingoEngine.Blazor.csproj --include src/LingoEngine.Blazor/Stages/LingoBlazorStageContainer.cs src/LingoEngine.Blazor/Stages/LingoBlazorDebugOverlay.cs src/LingoEngine.Blazor/Stages/LingoBlazorStage.cs src/LingoEngine.Blazor/BlazorFactory.cs src/LingoEngine.Blazor/BlazorSetup.cs -v diagnostic`
- `dotnet build src/LingoEngine.Blazor/LingoEngine.Blazor.csproj -c Release -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68c0e428f8648332877d269398be2149