### PR TITLE
Add Director runner projects and copy configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ These instructions apply to the entire repository.
 | src/Director/LingoEngine.Director.Host/LingoEngine.Director.Host.csproj | SignalR host for Director tooling |
 | src/Director/LingoEngine.Director.SDL2/LingoEngine.Director.SDL2.csproj | SDL2 integration for Director tooling |
 | src/Director/LingoEngine.Director.LGodot/LingoEngine.Director.LGodot.csproj | Godot integration for Director tooling |
+| src/Director/LingoEngine.Director.Runner.SDL2/LingoEngine.Director.Runner.SDL2.csproj | Standalone SDL2 runner for Director tooling |
+| src/Director/LingoEngine.Director.Runner.Godot/LingoEngine.Director.Runner.Godot.csproj | Standalone Godot runner for Director tooling |
 | Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/LingoEngine.Demo.TetriGrounds.Core.csproj | Shared code for the TetriGrounds demo |
 | Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.SDL2/LingoEngine.Demo.TetriGrounds.SDL2.csproj | SDL2-based TetriGrounds demo |
 | Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Blazor/LingoEngine.Demo.TetriGrounds.Blazor.csproj | Blazor-based TetriGrounds demo |

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -43,6 +43,8 @@ else
     "Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.SDL2"
     "Test/LingoEngine.SDL2.GfxVisualTest"
     "WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2"
+    "src/Director/LingoEngine.Director.Runner.SDL2"
+    "src/Director/LingoEngine.Director.Runner.Godot"
   )
   for proj in "${PROJECTS[@]}"; do
     if [ -d "$proj" ]; then

--- a/setup-windows.bat
+++ b/setup-windows.bat
@@ -51,7 +51,7 @@ if not exist "%LIB_DIR%" (
 )
 
 echo Copying SDL2 libraries for %ARCH%...
-set PROJECTS="Demo\TetriGrounds\LingoEngine.Demo.TetriGrounds.SDL2" "Test\LingoEngine.SDL2.GfxVisualTest" "WillMoveToOwnRepo\AbstUI\Test\AbstUI.GfxVisualTest.SDL2"
+set PROJECTS="Demo\TetriGrounds\LingoEngine.Demo.TetriGrounds.SDL2" "Test\LingoEngine.SDL2.GfxVisualTest" "WillMoveToOwnRepo\AbstUI\Test\AbstUI.GfxVisualTest.SDL2" "src\Director\LingoEngine.Director.Runner.SDL2" "src\Director\LingoEngine.Director.Runner.Godot"
 for %%P in (%PROJECTS%) do (
     if exist "%ROOT%%%~P" (
         for %%C in (Debug Release) do (


### PR DESCRIPTION
## Summary
- list new Director runner projects in AGENTS.md
- include Director runners in setup scripts so SDL2 libs copy to both Debug and Release

## Testing
- `bash -n setup-linux.sh`
- `./setup-linux.sh`
- `wine cmd /c setup-windows.bat` *(fails: wine32 and X server missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c12699a3dc833286e78e1dddc063df