### PR TITLE
Include DebugWithDirector in setup scripts

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -48,7 +48,7 @@ else
   )
   for proj in "${PROJECTS[@]}"; do
     if [ -d "$proj" ]; then
-      for config in Debug Release; do
+      for config in Debug DebugWithDirector Release; do
         TARGET="$proj/bin/$config/net8.0"
         mkdir -p "$TARGET"
         cp "$LIB_DIR"/* "$TARGET/" 2>/dev/null || true

--- a/setup-windows.bat
+++ b/setup-windows.bat
@@ -54,7 +54,7 @@ echo Copying SDL2 libraries for %ARCH%...
 set PROJECTS="Demo\TetriGrounds\LingoEngine.Demo.TetriGrounds.SDL2" "Test\LingoEngine.SDL2.GfxVisualTest" "WillMoveToOwnRepo\AbstUI\Test\AbstUI.GfxVisualTest.SDL2" "src\Director\LingoEngine.Director.Runner.SDL2" "src\Director\LingoEngine.Director.Runner.Godot"
 for %%P in (%PROJECTS%) do (
     if exist "%ROOT%%%~P" (
-        for %%C in (Debug Release) do (
+        for %%C in (Debug DebugWithDirector Release) do (
             if not exist "%ROOT%%%~P\bin\%%C\net8.0" mkdir "%ROOT%%%~P\bin\%%C\net8.0"
             copy /Y "%LIB_DIR%\*" "%ROOT%%%~P\bin\%%C\net8.0" >nul
         )


### PR DESCRIPTION
## Summary
- ensure `setup-linux` copies SDL2 libraries for DebugWithDirector builds
- ensure `setup-windows` copies SDL2 libraries for DebugWithDirector builds

## Testing
- `bash -n setup-linux.sh`
- `printf '\n' | ./setup-linux.sh`
- `wine cmd /c setup-windows.bat` *(dotnet not found under Wine; script still completed)*

------
https://chatgpt.com/codex/tasks/task_e_68c12bceeb388332aebc98d85e939396