### PR TITLE
Handle Lingo constants and line continuations

### DIFF
--- a/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
+++ b/Test/LingoEngine.Lingo.Core.Tests/LingoToCSharpConverterTests.cs
@@ -1264,11 +1264,11 @@ end",
             }
 };
         var batch = _converter.Convert(scripts);
-        var sig = Assert.Single(batch.Methods["Example"].Where(m => m.Name.Equals("myHandler", System.StringComparison.OrdinalIgnoreCase)));
+        var sig = Assert.Single(batch.Methods["Example"], m => m.Name.Equals("myHandler", System.StringComparison.OrdinalIgnoreCase));
         Assert.Collection(sig.Parameters,
             p => { Assert.Equal("a", p.Name); Assert.Equal("int", p.Type); },
                     p => { Assert.Equal("b", p.Name); Assert.Equal("string", p.Type); });
-        var prop = Assert.Single(batch.Properties["Example"].Where(p => p.Name == "myProp"));
+        var prop = Assert.Single(batch.Properties["Example"], p => p.Name == "myProp");
         Assert.Equal("int", prop.Type);
     }
 
@@ -1325,5 +1325,42 @@ end";
             "{",
             "}");
         Assert.Equal(expected.Trim(), result.Replace("\r", "").Trim());
+    }
+
+    [Fact]
+    public void HandlerArgumentsWithOrWithoutParensAreEquivalent()
+    {
+        var lingoNoParens = string.Join('\n',
+            "on addThem a, b",
+            "c = a + b",
+            "end");
+        var lingoParens = string.Join('\n',
+            "on addThem(a, b)",
+            "c = a + b",
+            "end");
+        var file1 = new LingoScriptFile { Name = "Test", Source = lingoNoParens, Type = LingoScriptType.Behavior };
+        var file2 = new LingoScriptFile { Name = "Test", Source = lingoParens, Type = LingoScriptType.Behavior };
+        var result1 = _converter.Convert(file1);
+        var result2 = _converter.Convert(file2);
+        Assert.Equal(result1, result2);
+        Assert.Contains("addThem(", result1, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LineContinuationBackslashIsHandled()
+    {
+        var lingo = "tTexture = member(\"3D\").model(\"box\") \\\n.shader.texture";
+        var result = _converter.Convert(lingo).Trim();
+        Assert.Contains("Member(\"3D\").Model(\"box\").Shader.Texture", result);
+    }
+
+    [Fact]
+    public void KeyboardConstantsAreConverted()
+    {
+        Assert.Equal("x = \"\\b\";", _converter.Convert("x = BACKSPACE").Trim());
+        Assert.Equal("x = \"\\u0003\";", _converter.Convert("x = ENTER").Trim());
+        Assert.Equal("x = \"\\\"\";", _converter.Convert("x = QUOTE").Trim());
+        Assert.Equal("x = \" \";", _converter.Convert("x = SPACE").Trim());
+        Assert.Equal("x = \"\\t\";", _converter.Convert("x = TAB").Trim());
     }
 }

--- a/src/LingoEngine.Lingo.Core/CSharpWriter.Helpers.cs
+++ b/src/LingoEngine.Lingo.Core/CSharpWriter.Helpers.cs
@@ -35,6 +35,10 @@ public partial class CSharpWriter
     private static string EscapeString(string s) => s
         .Replace("\\", "\\\\")
         .Replace("\"", "\\\"")
-        .Replace("\n", "\\n");
+        .Replace("\n", "\\n")
+        .Replace("\r", "\\r")
+        .Replace("\t", "\\t")
+        .Replace("\b", "\\b")
+        .Replace("\u0003", "\\u0003");
 }
 

--- a/src/LingoEngine.Lingo.Core/LingoCodeWriterVisitor.cs
+++ b/src/LingoEngine.Lingo.Core/LingoCodeWriterVisitor.cs
@@ -213,8 +213,9 @@ namespace LingoEngine.Lingo.Core
                 case '\x03': Write("ENTER"); break;
                 case '\x08': Write("BACKSPACE"); break;
                 case '\t': Write("TAB"); break;
-                case '\r': Write("RETURN"); break;
+                case '\n': Write("RETURN"); break;
                 case '"': Write("QUOTE"); break;
+                case ' ': Write("SPACE"); break;
                 default: Write('"' + c.ToString() + '"'); break;
             }
         }

--- a/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
+++ b/src/LingoEngine.Lingo.Core/LingoToCSharpConverter.cs
@@ -28,19 +28,35 @@ public class LingoToCSharpConverter
     {
         var lines = source.Split('\n');
         if (lines.Length == 0) return source;
+
         var sb = new StringBuilder();
-        sb.Append(lines[0]);
-        for (int i = 1; i < lines.Length; i++)
+        var previousContinues = false;
+
+        for (int i = 0; i < lines.Length; i++)
         {
             var line = lines[i];
-            if (line.TrimStart().StartsWith("."))
-                sb.Append(line.Trim());
+            var trimmedEnd = line.TrimEnd();
+
+            if (previousContinues)
+                sb.Append(trimmedEnd.TrimStart());
             else
             {
-                sb.Append('\n');
-                sb.Append(line.TrimEnd());
+                if (i > 0)
+                    sb.Append('\n');
+                sb.Append(trimmedEnd);
+            }
+
+            if (trimmedEnd.EndsWith("\\"))
+            {
+                sb.Length--; // remove trailing backslash
+                previousContinues = true;
+            }
+            else
+            {
+                previousContinues = false;
             }
         }
+
         return sb.ToString();
     }
 

--- a/src/LingoEngine.Lingo.Core/Tokenizer/Datum.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/Datum.cs
@@ -155,8 +155,9 @@ namespace LingoEngine.Lingo.Core.Tokenizer
                     '\x03' => "ENTER",
                     '\x08' => "BACKSPACE",
                     '\t' => "TAB",
-                    '\r' => "RETURN",
+                    '\n' => "RETURN",
                     '"' => "QUOTE",
+                    ' ' => "SPACE",
                     _ => "\"" + value + "\""
                 };
             }

--- a/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
+++ b/src/LingoEngine.Lingo.Core/Tokenizer/LingoAstParser.cs
@@ -682,60 +682,81 @@ namespace LingoEngine.Lingo.Core.Tokenizer
                 case LingoTokenType.Identifier:
                     var name = _currentToken.Lexeme;
                     AdvanceToken();
-                    if (name.Equals("sprite", StringComparison.OrdinalIgnoreCase) && Match(LingoTokenType.LeftParen))
+                    var upper = name.ToUpperInvariant();
+                    switch (upper)
                     {
-                        var indexExpr = ParseSpriteIndex();
-                        Expect(LingoTokenType.RightParen);
-                        if (Match(LingoTokenType.Dot))
-                        {
-                            var pTok = Expect(LingoTokenType.Identifier);
-                            expr = new LingoSpritePropExprNode
+                        case "BACKSPACE":
+                            expr = new LingoDatumNode(new LingoDatum("\b"));
+                            break;
+                        case "ENTER":
+                            expr = new LingoDatumNode(new LingoDatum("\u0003"));
+                            break;
+                        case "QUOTE":
+                            expr = new LingoDatumNode(new LingoDatum("\""));
+                            break;
+                        case "SPACE":
+                            expr = new LingoDatumNode(new LingoDatum(" "));
+                            break;
+                        case "TAB":
+                            expr = new LingoDatumNode(new LingoDatum("\t"));
+                            break;
+                        default:
+                            if (name.Equals("sprite", StringComparison.OrdinalIgnoreCase) && Match(LingoTokenType.LeftParen))
                             {
-                                Sprite = indexExpr,
-                                Property = new LingoVarNode { VarName = pTok.Lexeme }
-                            };
-                        }
-                        else
-                        {
-                            expr = new LingoCallNode
+                                var indexExpr = ParseSpriteIndex();
+                                Expect(LingoTokenType.RightParen);
+                                if (Match(LingoTokenType.Dot))
+                                {
+                                    var pTok = Expect(LingoTokenType.Identifier);
+                                    expr = new LingoSpritePropExprNode
+                                    {
+                                        Sprite = indexExpr,
+                                        Property = new LingoVarNode { VarName = pTok.Lexeme }
+                                    };
+                                }
+                                else
+                                {
+                                    expr = new LingoCallNode
+                                    {
+                                        Callee = new LingoVarNode { VarName = name },
+                                        Arguments = indexExpr
+                                    };
+                                }
+                            }
+                            else if (name.Equals("member", StringComparison.OrdinalIgnoreCase) && Match(LingoTokenType.LeftParen))
                             {
-                                Callee = new LingoVarNode { VarName = name },
-                                Arguments = indexExpr
-                            };
-                        }
-                    }
-                    else if (name.Equals("member", StringComparison.OrdinalIgnoreCase) && Match(LingoTokenType.LeftParen))
-                    {
-                        var inner = ParseExpression();
-                        LingoNode? castExpr = null;
-                        if (Match(LingoTokenType.Comma))
-                        {
-                            castExpr = ParseExpression();
-                        }
-                        Expect(LingoTokenType.RightParen);
-                        expr = new LingoMemberExprNode { Expr = inner, CastLib = castExpr };
-                        while (Match(LingoTokenType.Dot))
-                        {
-                            var pTok = Expect(LingoTokenType.Identifier);
-                            expr = new LingoObjPropExprNode
+                                var inner = ParseExpression();
+                                LingoNode? castExpr = null;
+                                if (Match(LingoTokenType.Comma))
+                                {
+                                    castExpr = ParseExpression();
+                                }
+                                Expect(LingoTokenType.RightParen);
+                                expr = new LingoMemberExprNode { Expr = inner, CastLib = castExpr };
+                                while (Match(LingoTokenType.Dot))
+                                {
+                                    var pTok = Expect(LingoTokenType.Identifier);
+                                    expr = new LingoObjPropExprNode
+                                    {
+                                        Object = expr,
+                                        Property = new LingoVarNode { VarName = pTok.Lexeme }
+                                    };
+                                }
+                            }
+                            else if (name.Equals("field", StringComparison.OrdinalIgnoreCase))
                             {
-                                Object = expr,
-                                Property = new LingoVarNode { VarName = pTok.Lexeme }
-                            };
-                        }
-                    }
-                    else if (name.Equals("field", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var arg = ParseExpression();
-                        expr = new LingoObjPropExprNode
-                        {
-                            Object = new LingoMemberExprNode { Expr = arg },
-                            Property = new LingoVarNode { VarName = "Text" }
-                        };
-                    }
-                    else
-                    {
-                        expr = new LingoVarNode { VarName = name };
+                                var arg = ParseExpression();
+                                expr = new LingoObjPropExprNode
+                                {
+                                    Object = new LingoMemberExprNode { Expr = arg },
+                                    Property = new LingoVarNode { VarName = "Text" }
+                                };
+                            }
+                            else
+                            {
+                                expr = new LingoVarNode { VarName = name };
+                            }
+                            break;
                     }
                     break;
 


### PR DESCRIPTION
## Summary
- support Lingo's backslash line continuation in the C# converter
- recognize BACKSPACE, ENTER, QUOTE, RETURN, SPACE and TAB constants
- cover handler parameter variants and keyboard constants with tests

## Testing
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c24d36a56c8332b69ef9ba08ac80dd