### PR TITLE
feat: add logging and global vars support

### DIFF
--- a/src/LingoEngine/Core/LingoGlobalVars.cs
+++ b/src/LingoEngine/Core/LingoGlobalVars.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Logging;
+using System.Reflection;
+
+namespace LingoEngine.Core
+{
+    public class LingoGlobalVars
+    {
+        public void ClearGlobals()
+        {
+            OnClearGlobals();
+        }
+
+        protected virtual void OnClearGlobals()
+        {
+        }
+
+        public void ShowGlobals(ILogger logger)
+        {
+            var type = GetType();
+            while (type != null && typeof(LingoGlobalVars).IsAssignableFrom(type))
+            {
+                foreach (var prop in type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly))
+                {
+                    if (prop.GetIndexParameters().Length > 0)
+                        continue;
+                    object? value = null;
+                    try
+                    {
+                        value = prop.GetValue(this);
+                    }
+                    catch
+                    {
+                    }
+                    logger.LogInformation("{Property} = {Value}", prop.Name, value);
+                }
+                type = type.BaseType;
+            }
+        }
+    }
+}

--- a/src/LingoEngine/Core/LingoPlayer.cs
+++ b/src/LingoEngine/Core/LingoPlayer.cs
@@ -29,6 +29,7 @@ namespace LingoEngine.Core
         private readonly LingoSound _sound;
         private readonly ILingoWindow _window;
         private readonly ILingoServiceProvider _serviceProvider;
+        private readonly LingoGlobalVars _globals;
         private Action<LingoMovie> _actionOnNewMovie;
         private Dictionary<string, LingoMovieEnvironment> _moviesByName = new();
         private List<LingoMovieEnvironment> _movies = new();
@@ -85,7 +86,7 @@ namespace LingoEngine.Core
         public ILingoMovie? ActiveMovie { get; private set; }
         public event Action<ILingoMovie?>? ActiveMovieChanged;
 
-        public LingoPlayer(ILingoServiceProvider serviceProvider, ILingoFrameworkFactory factory, ILingoCastLibsContainer castLibsContainer, ILingoWindow window, ILingoClock lingoClock, ILingoSystem lingoSystem, IAbstResourceManager resourceManager)
+        public LingoPlayer(ILingoServiceProvider serviceProvider, ILingoFrameworkFactory factory, ILingoCastLibsContainer castLibsContainer, ILingoWindow window, ILingoClock lingoClock, ILingoSystem lingoSystem, IAbstResourceManager resourceManager, LingoGlobalVars globals)
         {
             _csvImporter = new Lazy<CsvImporter>(() => new CsvImporter(resourceManager));
             _actionOnNewMovie = m => { };
@@ -100,6 +101,7 @@ namespace LingoEngine.Core
             _stage = Factory.CreateStage(this);
             _mouse = Factory.CreateMouse(_stage);
             _uiContext = SynchronizationContext.Current;
+            _globals = globals;
         }
         public void Dispose()
         {
@@ -113,7 +115,7 @@ namespace LingoEngine.Core
             Stage.Width = width;
             Stage.Height = height;
             Stage.BackgroundColor = backgroundColor;
-            
+
         }
 
         /// <inheritdoc/>
@@ -170,7 +172,7 @@ namespace LingoEngine.Core
                 var movieEnvironment = m.GetEnvironment();
                 _movies.Remove(movieEnvironment);
                 _moviesByName.Remove(m.Name);
-            });
+            }, _globals);
             var movieTyped = (LingoMovie)movieEnv.Movie;
 
             // Add him
@@ -203,7 +205,7 @@ namespace LingoEngine.Core
         public ILingoPlayer LoadCastLibFromCsv(string castlibName, string pathAndFilenameToCsv, bool isInternal = false)
         {
             var castLib = _castLibsContainer.AddCast(castlibName, isInternal);
-            _csvImporter.Value.ImportInCastFromCsvFile(castLib, pathAndFilenameToCsv,true, x=> Console.WriteLine("WARNING:"+x));
+            _csvImporter.Value.ImportInCastFromCsvFile(castLib, pathAndFilenameToCsv, true, x => Console.WriteLine("WARNING:" + x));
             return this;
         }
 
@@ -229,7 +231,7 @@ namespace LingoEngine.Core
 
         void ILingoPlayer.SetActiveMovie(ILingoMovie? movie) => SetActiveMovie(movie as LingoMovie);
 
-        
+
 
         internal void SetActionOnNewMovie(Action<LingoMovie> actionOnNewMovie)
         {
@@ -316,7 +318,7 @@ namespace LingoEngine.Core
                     else
                         action();
                 }
-                _delayedActionsCts.Remove(cts); 
+                _delayedActionsCts.Remove(cts);
             }, TaskScheduler.Default);
         }
     }

--- a/src/LingoEngine/Core/LingoScriptBase.cs
+++ b/src/LingoEngine/Core/LingoScriptBase.cs
@@ -1,5 +1,4 @@
-﻿using AbstUI.Primitives;
-using LingoEngine.Bitmaps;
+﻿using LingoEngine.Bitmaps;
 using LingoEngine.Casts;
 using LingoEngine.Inputs;
 using LingoEngine.Members;
@@ -8,6 +7,7 @@ using LingoEngine.Primitives;
 using LingoEngine.Sounds;
 using LingoEngine.Sprites;
 using LingoEngine.Texts;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Numerics;
 
@@ -16,7 +16,11 @@ namespace LingoEngine.Core
 
     public interface ILingoScriptBase
     {
-        
+        void Trace(string message);
+        void Log(string message);
+        T Global<T>() where T : LingoGlobalVars;
+        void ClearGlobals();
+        void ShowGlobals();
     }
 
     // https://usermanual.wiki/adobe/drmx2004scripting.537266374.pdf
@@ -27,10 +31,14 @@ namespace LingoEngine.Core
     public abstract class LingoScriptBase : ILingoScriptBase
     {
         protected readonly ILingoMovieEnvironment _env;
+        private readonly ILogger _logger;
+        private LingoGlobalVars _globals;
         private static readonly Random _random = new Random();
         protected LingoScriptBase(ILingoMovieEnvironment env)
         {
             _env = env;
+            _logger = env.Logger;
+            _globals = env.Globals;
         }
 
         // Global objects ("the mouse", etc.)
@@ -47,8 +55,8 @@ namespace LingoEngine.Core
         protected ILingoSystem _System => _env.System;
 
         #endregion
-        protected LingoMemberBitmap? CursorImage { get  => _env.Mouse.Cursor.Image; set => _env.Mouse.Cursor.Image = value; }
-        protected int Cursor { get  => _env.Mouse.Cursor.Cursor; set => _env.Mouse.Cursor.Cursor = value; }
+        protected LingoMemberBitmap? CursorImage { get => _env.Mouse.Cursor.Image; set => _env.Mouse.Cursor.Image = value; }
+        protected int Cursor { get => _env.Mouse.Cursor.Cursor; set => _env.Mouse.Cursor.Cursor = value; }
 
 
         // We dont need scripts in c#
@@ -99,27 +107,33 @@ namespace LingoEngine.Core
         #endregion
 
         protected void Put(object obj) => Console.WriteLine(obj);
-        
-        
+
+
 
 
         #region Lists
 
         // list
         protected LingoList<TValue> List<TValue>() => new LingoList<TValue>();
-        protected TValue? GetAt<TValue>(LingoPropertyList<TValue> list,int number) => list.GetAt(number);
-        protected void SetAt<TValue>(LingoPropertyList<TValue> list,int number, TValue value) => list.SetAt(number, value);
-        protected void DeleteAt<TValue>(LingoPropertyList<TValue> list,int number, TValue value) => list.DeleteAt(number);
+        protected TValue? GetAt<TValue>(LingoPropertyList<TValue> list, int number) => list.GetAt(number);
+        protected void SetAt<TValue>(LingoPropertyList<TValue> list, int number, TValue value) => list.SetAt(number, value);
+        protected void DeleteAt<TValue>(LingoPropertyList<TValue> list, int number, TValue value) => list.DeleteAt(number);
 
         // Property list
         protected LingoPropertyList<TValue> PropList<TValue>() => new LingoPropertyList<TValue>();
-        protected TValue? GetAt<TValue>(LingoList<TValue> list,int number) => list.GetAt(number);
-        protected void SetAt<TValue>(LingoList<TValue> list,int number, TValue value) => list.SetAt(number, value);
-        protected void DeleteAt<TValue>(LingoList<TValue> list,int number, TValue value) => list.DeleteAt(number);
-        
+        protected TValue? GetAt<TValue>(LingoList<TValue> list, int number) => list.GetAt(number);
+        protected void SetAt<TValue>(LingoList<TValue> list, int number, TValue value) => list.SetAt(number, value);
+        protected void DeleteAt<TValue>(LingoList<TValue> list, int number, TValue value) => list.DeleteAt(number);
+
 
 
         #endregion
+
+        public void Trace(string message) => _logger.LogTrace(message);
+        public void Log(string message) => _logger.LogInformation(message);
+        public T Global<T>() where T : LingoGlobalVars => (T)_globals;
+        public void ClearGlobals() => _globals.ClearGlobals();
+        public void ShowGlobals() => _globals.ShowGlobals(_logger);
 
 
         #region Members
@@ -155,7 +169,7 @@ namespace LingoEngine.Core
             var member = _Movie.CastLib.GetMember(number, castLib ?? 1) as T;
             if (member != null && action != null)
                 action(member);
-            
+
             return member as T;
         }
         protected T? TryMember<T>(string name, int? castLib = null, Action<T>? action = null) where T : class, ILingoMember
@@ -163,7 +177,7 @@ namespace LingoEngine.Core
             var member = _Movie.CastLib.GetMember(name, castLib ?? 1) as T;
             if (member != null && action != null)
                 action(member);
-            
+
             return member as T;
         }
 
@@ -189,7 +203,7 @@ namespace LingoEngine.Core
 
         protected void UpdateStage() => _Movie.UpdateStage();
         protected void StartTimer() => _env.Movie.StartTimer();
-        protected int Timer => _env.Movie.Timer; 
+        protected int Timer => _env.Movie.Timer;
         #endregion
     }
 

--- a/src/LingoEngine/Movies/LingoMovieEnvironment.cs
+++ b/src/LingoEngine/Movies/LingoMovieEnvironment.cs
@@ -8,6 +8,7 @@ using LingoEngine.Projects;
 using LingoEngine.Sounds;
 using LingoEngine.Stages;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using LingoEngine.Transitions;
 
 namespace LingoEngine.Movies
@@ -26,6 +27,8 @@ namespace LingoEngine.Movies
         ILingoClock Clock { get; }
         ILingoFrameworkFactory Factory { get; }
         ILingoEventMediator Events { get; }
+        ILogger Logger { get; }
+        LingoGlobalVars Globals { get; }
 
         ILingoCast? GetCastLib(int number);
         ILingoCast? GetCastLib(string name);
@@ -50,6 +53,8 @@ namespace LingoEngine.Movies
         private readonly LingoProjectSettings _projectSettings;
         private readonly Lazy<ILingoMemberFactory> _memberFactory;
         private readonly ILingoServiceProvider _rootServiceProvider;
+        private readonly ILogger<LingoMovieEnvironment> _logger;
+        private LingoGlobalVars _globals = null!;
         public ILingoEventMediator Events => _eventMediator;
 
         public ILingoPlayer Player => _player;
@@ -67,18 +72,21 @@ namespace LingoEngine.Movies
         public ILingoClock Clock => _clock;
 
         public ILingoFrameworkFactory Factory => _factory;
+        public ILogger Logger => _logger;
+        public LingoGlobalVars Globals => _globals;
 
-#pragma warning disable CS8618 
-#pragma warning restore CS8618 
-        public LingoMovieEnvironment(ILingoServiceProvider rootServiceProvider, ILingoFrameworkFactory factory, LingoProjectSettings projectSettings)
+#pragma warning disable CS8618
+#pragma warning restore CS8618
+        public LingoMovieEnvironment(ILingoServiceProvider rootServiceProvider, ILingoFrameworkFactory factory, LingoProjectSettings projectSettings, ILogger<LingoMovieEnvironment> logger)
         {
             _memberFactory = rootServiceProvider.GetRequiredService<Lazy<ILingoMemberFactory>>();
             _rootServiceProvider = rootServiceProvider;
             _factory = factory;
             _projectSettings = projectSettings;
+            _logger = logger;
         }
 
-        internal void Init(string name, int number, LingoPlayer player, LingoKey lingoKey, LingoSound sound, LingoStageMouse mouse, LingoStage stage, LingoSystem system, ILingoClock clock, LingoCastLibsContainer lingoCastLibsContainer, IServiceScope scopedServiceProvider, ILingoTransitionPlayer transitionPlayer, Action<LingoMovie> onRemoveMe)
+        internal void Init(string name, int number, LingoPlayer player, LingoKey lingoKey, LingoSound sound, LingoStageMouse mouse, LingoStage stage, LingoSystem system, ILingoClock clock, LingoCastLibsContainer lingoCastLibsContainer, IServiceScope scopedServiceProvider, ILingoTransitionPlayer transitionPlayer, Action<LingoMovie> onRemoveMe, LingoGlobalVars globals)
         {
             _scopedServiceProvider = scopedServiceProvider;
             _serviceProvider = new LingoServiceProvider();
@@ -90,10 +98,11 @@ namespace LingoEngine.Movies
             _mouse = mouse;
             _system = system;
             _clock = clock;
+            _globals = globals;
             _mouse.Subscribe(_eventMediator);
             _key.Subscribe(_eventMediator);
             _castLibsContainer = lingoCastLibsContainer;
-           
+
             _movie = new LingoMovie(this, stage, transitionPlayer, _castLibsContainer, _memberFactory.Value, name, number, _eventMediator, m =>
             {
                 onRemoveMe(m);

--- a/src/LingoEngine/Setup/ILingoEngineRegistration.cs
+++ b/src/LingoEngine/Setup/ILingoEngineRegistration.cs
@@ -18,6 +18,7 @@ namespace LingoEngine.Setup
         ILingoEngineRegistration ForMovie(string name, Action<IMovieRegistration> action);
         ILingoEngineRegistration WithFrameworkFactory<T>(Action<T>? setup = null) where T : class, ILingoFrameworkFactory;
         ILingoEngineRegistration WithProjectSettings(Action<LingoProjectSettings> setup);
+        ILingoEngineRegistration WithGlobalVars<TGlobalVars>(Action<TGlobalVars>? setup = null) where TGlobalVars : LingoGlobalVars;
         LingoPlayer Build();
         ILingoEngineRegistration BuildDelayed();
         LingoPlayer Build(IServiceProvider serviceProvider);

--- a/src/LingoEngine/Setup/LingoEngineRegistrationExtensions.cs
+++ b/src/LingoEngine/Setup/LingoEngineRegistrationExtensions.cs
@@ -12,6 +12,7 @@ namespace LingoEngine.Setup
             engineRegistration.RegisterCommonServices();
             container.AddSingleton<ILingoEngineRegistration>(engineRegistration);
             config(engineRegistration);
+            engineRegistration.EnsureGlobalVars();
             return container;
         }
     }


### PR DESCRIPTION
## Summary
- inject logger into LingoMovieEnvironment and expose to scripts
- add LingoGlobalVars for cross-movie globals with clear/show helpers
- extend LingoScriptBase and LingoPlayer to use logger and global vars
- allow custom LingoGlobalVars via `WithGlobalVars<T>()` with default fallback

## Testing
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c251cfc2ac8332b178001e7c0640ac