### PR TITLE
Enable async resource loading for Blazor and engine initialization

### DIFF
--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/TetriGroundsProjectFactory.cs
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/TetriGroundsProjectFactory.cs
@@ -17,6 +17,7 @@ using LingoEngine.Sprites;
 using LingoEngine.Texts;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Demo.TetriGrounds.Core;
 
@@ -62,14 +63,13 @@ public class TetriGroundsProjectFactory : ILingoProjectFactory
 
 
 
-    public void LoadCastLibs(ILingoCastLibsContainer castlibContainer, LingoPlayer lingoPlayer)
+    public async Task LoadCastLibsAsync(ILingoCastLibsContainer castlibContainer, LingoPlayer lingoPlayer)
     {
 
         _lingoPlayer = lingoPlayer;
 
-        lingoPlayer
-            .LoadCastLibFromCsv("InternalExt", Path.Combine("Media", "InternalExt", "Members.csv"), true)
-            .LoadCastLibFromCsv("Data", Path.Combine("Media", "Data", "Members.csv"));
+        await lingoPlayer.LoadCastLibFromCsvAsync("InternalExt", Path.Combine("Media", "InternalExt", "Members.csv"), true);
+        await lingoPlayer.LoadCastLibFromCsvAsync("Data", Path.Combine("Media", "Data", "Members.csv"));
         lingoPlayer.AddCastLib("Sounds", true, c =>
         {
             c.Add(LingoMemberType.Sound, 0, "S_Click", Path.Combine("Media", "Sounds", "click.mp3"));
@@ -96,11 +96,11 @@ public class TetriGroundsProjectFactory : ILingoProjectFactory
         lingoPlayer.CastLib("Sounds").GetMember<LingoMemberSound>("S_Nature")!.Loop = true;
         InitMembers(lingoPlayer);
     }
-    public ILingoMovie? LoadStartupMovie(ILingoServiceProvider serviceProvider, LingoPlayer lingoPlayer)
+    public Task<ILingoMovie?> LoadStartupMovieAsync(ILingoServiceProvider serviceProvider, LingoPlayer lingoPlayer)
     {
         _movie = LoadMovie(lingoPlayer);
-        
-        return _movie;
+
+        return Task.FromResult<ILingoMovie?>(_movie);
     }
     public void Run(ILingoMovie movie, bool autoPlayMovie)
     {
@@ -167,7 +167,7 @@ public class TetriGroundsProjectFactory : ILingoProjectFactory
         new TetriGroundsMembersSetup(_lingoPlayer!).InitMembers();
         var castData = _movie.CastLib["Data"];
         var MyBG = _movie.Member["Game"];
-        
+
         _movie.AddFrameBehavior<GameStopBehavior>(60);
         //_movie.AddFrameBehavior<WaiterFrameScript>(1);
         //_movie.AddFrameBehavior<StayOnFrameFrameScript>(4);
@@ -178,8 +178,8 @@ public class TetriGroundsProjectFactory : ILingoProjectFactory
         _movie.AddSprite(5, 56, 64, 591, 36, c => { c.Width = 193; c.Height = 35; }).SetMember("TetriGrounds_s"); // LOGO
         _movie.AddSprite(6, 59, 64, 503, 438).SetMember(9, 2); // copyright text
         var sprite = _movie.AddSprite(7, 60, 64, 441, 92).SetMember("T_data"); // level
-        
-        
+
+
 
 
 
@@ -256,9 +256,9 @@ public class TetriGroundsProjectFactory : ILingoProjectFactory
         var birdSprite1 = (ILingoSprite2DLight)_movie.AddSprite(6, 2, 31, 751, 394).SetMember("BirdAnim");
         birdSprite1.AddKeyframes((1, 751, 394), (16, 444, 273), (31, -33, 316));
 
-        _movie.AddSprite(36, 59, 64, 363, 238,c => {c.LocZ = 500;}).SetMember("alert"); //.Visibility = false;
-        _movie.AddSprite(37, 59, 64, 200, 200,c => {c.LocZ = 502;}).SetMember("T_PopupTitle"); // the player name text member
-        _movie.AddSprite(38, 59, 64, 200, 230,c => { c.LocZ = 502; }).SetMember("T_InputText").AddBehavior<EnterHighScoreBehavior>(c => c.SetSpriteNums([36,37,38])); // the player name text member
+        _movie.AddSprite(36, 59, 64, 363, 238, c => { c.LocZ = 500; }).SetMember("alert"); //.Visibility = false;
+        _movie.AddSprite(37, 59, 64, 200, 200, c => { c.LocZ = 502; }).SetMember("T_PopupTitle"); // the player name text member
+        _movie.AddSprite(38, 59, 64, 200, 230, c => { c.LocZ = 502; }).SetMember("T_InputText").AddBehavior<EnterHighScoreBehavior>(c => c.SetSpriteNums([36, 37, 38])); // the player name text member
     }
 
 

--- a/Test/LingoEngine.Tests/CsvImporterTests.cs
+++ b/Test/LingoEngine.Tests/CsvImporterTests.cs
@@ -14,6 +14,7 @@ using LingoEngine.Primitives;
 using LingoEngine.Sprites;
 using LingoEngine.Tests.Casts;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Tests;
 
@@ -39,7 +40,7 @@ public class CsvImporterTests
         Assert.Equal("sample.txt", row.FileName);
     }
     [Fact]
-    public void ImportInCastFromCsvFile_PrefersMarkdown()
+    public async Task ImportInCastFromCsvFile_PrefersMarkdown()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
@@ -56,7 +57,7 @@ public class CsvImporterTests
         var cast = new DummyCast();
         var importer = new CsvImporter(new TestResourceManager());
 
-        importer.ImportInCastFromCsvFile(cast, csvPath);
+        await importer.ImportInCastFromCsvFileAsync(cast, csvPath);
 
         var member = Assert.IsType<DummyTextMember>(cast.LastAddedMember);
         Assert.Equal("md text", member.Text);
@@ -65,7 +66,7 @@ public class CsvImporterTests
 
 #if DEBUG
     [Fact]
-    public void ImportInCastFromCsvFile_CreatesMarkdownWhenReadingRtf()
+    public async Task ImportInCastFromCsvFile_CreatesMarkdownWhenReadingRtf()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
@@ -82,7 +83,7 @@ public class CsvImporterTests
         var cast = new DummyCast();
         var importer = new CsvImporter(new TestResourceManager());
 
-        importer.ImportInCastFromCsvFile(cast, csvPath);
+        await importer.ImportInCastFromCsvFileAsync(cast, csvPath);
 
         var member = Assert.IsType<DummyTextMember>(cast.LastAddedMember);
         Assert.Contains("{{PARA:0}}Hello", member.Text);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Resources/ImGuiResourceManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Resources/ImGuiResourceManager.cs
@@ -1,23 +1,8 @@
-using System.IO;
 using AbstUI.Resources;
 
 namespace AbstUI.ImGui.Resources
 {
-    public class ImGuiResourceManager : IAbstResourceManager
+    public class ImGuiResourceManager : AbstResourceManager
     {
-        public bool FileExists(string fileName)
-        {
-            return File.Exists(fileName);
-        }
-
-        public string? ReadTextFile(string fileName)
-        {
-            return File.Exists(fileName) ? File.ReadAllText(fileName) : null;
-        }
-
-        public byte[]? ReadBytes(string fileName)
-        {
-            return File.Exists(fileName) ? File.ReadAllBytes(fileName) : null;
-        }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Resources/AbstResourceManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Resources/AbstResourceManager.cs
@@ -1,4 +1,7 @@
 
+using System.IO;
+using System.Threading.Tasks;
+
 namespace AbstUI.Resources
 {
     public abstract class AbstResourceManager : IAbstResourceManager
@@ -10,35 +13,49 @@ namespace AbstUI.Resources
             return File.Exists(fileName);
         }
 
+        public virtual Task<bool> FileExistsAsync(string fileName) => Task.FromResult(FileExists(fileName));
+
         public virtual string? ReadTextFile(string fileName)
         {
             return File.Exists(fileName) ? File.ReadAllText(fileName) : null;
         }
+
+        public virtual Task<string?> ReadTextFileAsync(string fileName) => Task.FromResult(ReadTextFile(fileName));
 
         public virtual byte[]? ReadBytes(string fileName)
         {
             return File.Exists(fileName) ? File.ReadAllBytes(fileName) : null;
         }
 
+        public virtual Task<byte[]?> ReadBytesAsync(string fileName) => Task.FromResult(ReadBytes(fileName));
+
         public virtual void StorageWrite<T>(string key, T data)
         {
-            string saveData = Serialize(data); 
+            string saveData = Serialize(data);
             if (!Directory.Exists(ProjectFolder))
                 Directory.CreateDirectory(ProjectFolder);
             File.WriteAllText(CreateFilename(key), saveData);
         }
 
+        public virtual Task StorageWriteAsync<T>(string key, T data)
+        {
+            StorageWrite(key, data);
+            return Task.CompletedTask;
+        }
 
         protected virtual string CreateFilename(string key) => Path.Combine(ProjectFolder, key + ".json");
 
-        public virtual T? StorageRead<T>(string key) 
+        public virtual T? StorageRead<T>(string key)
         {
             var content = ReadTextFile(Path.Combine(ProjectFolder, key + ".json"));
             if (content != null)
-                return Deserialize<T>(content); return default;
+                return Deserialize<T>(content);
+            return default;
         }
 
-        public string Serialize<T>(T data) 
+        public virtual Task<T?> StorageReadAsync<T>(string key) => Task.FromResult(StorageRead<T>(key));
+
+        public string Serialize<T>(T data)
         {
 #if NET48
             return Newtonsoft.Json.JsonConvert.SerializeObject(data);
@@ -47,10 +64,10 @@ namespace AbstUI.Resources
 #endif
         }
 
-        public T? Deserialize<T>(string content) 
+        public T? Deserialize<T>(string content)
         {
 #if NET48
-                return Newtonsoft.Json.JsonConvert.DeserializeObject<T>(content);
+            return Newtonsoft.Json.JsonConvert.DeserializeObject<T>(content);
 #else
             return System.Text.Json.JsonSerializer.Deserialize<T>(content);
 #endif

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Resources/IAbstResourceManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Resources/IAbstResourceManager.cs
@@ -1,14 +1,21 @@
 
+using System.Threading.Tasks;
+
 namespace AbstUI.Resources
 {
     public interface IAbstResourceManager
     {
         string ProjectFolder { get; set; }
         bool FileExists(string fileName);
+        Task<bool> FileExistsAsync(string fileName);
         string? ReadTextFile(string fileName);
+        Task<string?> ReadTextFileAsync(string fileName);
         byte[]? ReadBytes(string fileName);
+        Task<byte[]?> ReadBytesAsync(string fileName);
         void StorageWrite<T>(string key, T data);
+        Task StorageWriteAsync<T>(string key, T data);
         T? StorageRead<T>(string key);
+        Task<T?> StorageReadAsync<T>(string key);
         string Serialize<T>(T data);
         T? Deserialize<T>(string content);
     }

--- a/docs/ProjectSetup.md
+++ b/docs/ProjectSetup.md
@@ -69,11 +69,11 @@ public class MyGameProjectFactory : ILingoProjectFactory
             );
     }
 
-    public void LoadCastLibs(ILingoCastLibsContainer castlibs, LingoPlayer player)
-        => player.LoadCastLibFromCsv("Data", Path.Combine("Media", "Data", "Members.csv"));
+    public async Task LoadCastLibsAsync(ILingoCastLibsContainer castlibs, LingoPlayer player)
+        => await player.LoadCastLibFromCsvAsync("Data", Path.Combine("Media", "Data", "Members.csv"));
 
-    public ILingoMovie? LoadStartupMovie(ILingoServiceProvider services, LingoPlayer player)
-        => player.NewMovie("Intro");
+    public Task<ILingoMovie?> LoadStartupMovieAsync(ILingoServiceProvider services, LingoPlayer player)
+        => Task.FromResult<ILingoMovie?>(player.NewMovie("Intro"));
 
     public void Run(ILingoMovie movie, bool autoPlayMovie)
     {
@@ -84,8 +84,8 @@ public class MyGameProjectFactory : ILingoProjectFactory
 
 This implementation defines four required methods:
 - `Setup(ILingoEngineRegistration config)` registers fonts, project settings (including the 640×480 stage), movies, and services.
-- `LoadCastLibs(ILingoCastLibsContainer castlibs, LingoPlayer player)` loads external cast libraries using the provided player.
-- `LoadStartupMovie(ILingoServiceProvider services, LingoPlayer player)` chooses the movie that starts first.
+- `LoadCastLibsAsync(ILingoCastLibsContainer castlibs, LingoPlayer player)` loads external cast libraries using the provided player.
+- `LoadStartupMovieAsync(ILingoServiceProvider services, LingoPlayer player)` chooses the movie that starts first.
 - `Run(ILingoMovie movie, bool autoPlayMovie)` finalizes startup and optionally plays the movie automatically.
 
 ### Set properties of members

--- a/src/LingoEngine/Core/ILingoPlayer.cs
+++ b/src/LingoEngine/Core/ILingoPlayer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using LingoEngine.Casts;
 using LingoEngine.Movies;
 using LingoEngine.Sounds;
@@ -163,6 +164,7 @@ namespace LingoEngine.Core
         ILingoCast CastLib(int number);
         ILingoCast CastLib(string name);
         ILingoPlayer LoadCastLibFromCsv(string castlibName, string pathAndFilenameToCsv, bool isInternal = false);
+        Task<ILingoPlayer> LoadCastLibFromCsvAsync(string castlibName, string pathAndFilenameToCsv, bool isInternal = false);
         ILingoPlayer AddCastLib(string name, bool isInternal = false, Action<ILingoCast>? configure = null);
         ILingoMovie NewMovie(string movieName, bool andActivate = true);
 

--- a/src/LingoEngine/Core/LingoPlayer.cs
+++ b/src/LingoEngine/Core/LingoPlayer.cs
@@ -14,6 +14,7 @@ using LingoEngine.Tools;
 using Microsoft.Extensions.DependencyInjection;
 using LingoEngine.Transitions;
 using LingoEngine.Transitions.TransitionLibrary;
+using System.Threading.Tasks;
 
 
 namespace LingoEngine.Core
@@ -87,7 +88,7 @@ namespace LingoEngine.Core
         bool ILingoPlayer.SafePlayer { get; set; }
         public ILingoMovie? ActiveMovie { get; private set; }
 
-       
+
 
         public event Action<ILingoMovie?>? ActiveMovieChanged;
 
@@ -209,8 +210,13 @@ namespace LingoEngine.Core
         /// </summary>
         public ILingoPlayer LoadCastLibFromCsv(string castlibName, string pathAndFilenameToCsv, bool isInternal = false)
         {
+            return LoadCastLibFromCsvAsync(castlibName, pathAndFilenameToCsv, isInternal).GetAwaiter().GetResult();
+        }
+
+        public async Task<ILingoPlayer> LoadCastLibFromCsvAsync(string castlibName, string pathAndFilenameToCsv, bool isInternal = false)
+        {
             var castLib = _castLibsContainer.AddCast(castlibName, isInternal);
-            _csvImporter.Value.ImportInCastFromCsvFile(castLib, pathAndFilenameToCsv, true, x => Console.WriteLine("WARNING:" + x));
+            await _csvImporter.Value.ImportInCastFromCsvFileAsync(castLib, pathAndFilenameToCsv, true, x => Console.WriteLine("WARNING:" + x));
             return this;
         }
 

--- a/src/LingoEngine/Projects/ILingoProjectFactory.cs
+++ b/src/LingoEngine/Projects/ILingoProjectFactory.cs
@@ -1,6 +1,7 @@
 namespace LingoEngine.Projects;
 
 using System;
+using System.Threading.Tasks;
 using LingoEngine.Core;
 using LingoEngine.Setup;
 using LingoEngine.Casts;
@@ -12,7 +13,7 @@ using LingoEngine.Movies;
 public interface ILingoProjectFactory
 {
     void Setup(ILingoEngineRegistration engineRegistration);
-    void LoadCastLibs(ILingoCastLibsContainer castlibContainer, LingoPlayer lingoPlayer);
-    ILingoMovie? LoadStartupMovie(ILingoServiceProvider serviceProvider, LingoPlayer lingoPlayer);
+    Task LoadCastLibsAsync(ILingoCastLibsContainer castlibContainer, LingoPlayer lingoPlayer);
+    Task<ILingoMovie?> LoadStartupMovieAsync(ILingoServiceProvider serviceProvider, LingoPlayer lingoPlayer);
     void Run(ILingoMovie movie, bool autoPlayMovie);
 }

--- a/src/LingoEngine/Setup/ILingoEngineRegistration.cs
+++ b/src/LingoEngine/Setup/ILingoEngineRegistration.cs
@@ -4,6 +4,7 @@ using AbstUI.Styles;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Projects;
 using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Setup
 {
@@ -21,9 +22,12 @@ namespace LingoEngine.Setup
         ILingoEngineRegistration WithGlobalVarsR<TGlobalVars>(Action<TGlobalVars>? setup = null) where TGlobalVars : LingoGlobalVars;
         ILingoEngineRegistration WithGlobalVars<TGlobalVars>(Action<TGlobalVars>? setup = null) where TGlobalVars : LingoGlobalVars, new();
         LingoPlayer Build();
+        Task<LingoPlayer> BuildAsync();
         ILingoEngineRegistration BuildDelayed();
         LingoPlayer Build(IServiceProvider serviceProvider, bool allowInitializeProject = true);
+        Task<LingoPlayer> BuildAsync(IServiceProvider serviceProvider, bool allowInitializeProject = true);
         void InitializeProject();
+        Task InitializeProjectAsync();
         ILingoProjectFactory BuildAndRunProject(Action<IServiceProvider>? afterStart = null);
         ILingoProjectFactory RunProject(Action<IServiceProvider>? afterStart = null);
         ILingoEngineRegistration AddPreBuildAction(Action<IServiceProvider> buildAction);

--- a/src/LingoEngine/Tools/CsvImporter.cs
+++ b/src/LingoEngine/Tools/CsvImporter.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Text;
 using AbstUI.Resources;
 using AbstUI.Texts;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Tools
 {
@@ -42,10 +43,13 @@ namespace LingoEngine.Tools
         ///     Number,Type,Name,Registration Point,Filename
         ///     1,bitmap,BallB,"(5, 5)",
         /// </summary>
-        public void ImportInCastFromCsvFile(ILingoCast cast, string filePath, bool skipFirstLine = true, Action<string>? logWarningMethod = null)
+        public void ImportInCastFromCsvFile(ILingoCast cast, string filePath, bool skipFirstLine = true, Action<string>? logWarningMethod = null) =>
+            ImportInCastFromCsvFileAsync(cast, filePath, skipFirstLine, logWarningMethod).GetAwaiter().GetResult();
+
+        public async Task ImportInCastFromCsvFileAsync(ILingoCast cast, string filePath, bool skipFirstLine = true, Action<string>? logWarningMethod = null)
         {
             var rootFolder = Path.GetDirectoryName(GetRelativePath(Environment.CurrentDirectory, filePath)) ?? "";
-            var csv = ImportCsvCastFile(filePath, skipFirstLine);
+            var csv = await ImportCsvCastFileAsync(filePath, skipFirstLine);
             foreach (var row in csv)
             {
                 var fn = row.FileName;
@@ -77,9 +81,9 @@ namespace LingoEngine.Tools
                 {
                     var mdFile = Path.ChangeExtension(fileName, ".md");
                     var rtfFile = Path.ChangeExtension(fileName, ".rtf");
-                    if (_resourceManager.FileExists(mdFile))
+                    if (await _resourceManager.FileExistsAsync(mdFile))
                     {
-                        var mdContent = _resourceManager.ReadTextFile(mdFile) ?? string.Empty;
+                        var mdContent = await _resourceManager.ReadTextFileAsync(mdFile) ?? string.Empty;
                         var markDownData = AbstMarkdownReader.Read(mdContent);
 #if DEBUG
                         if (mdFile.Contains("39_xtraNames"))
@@ -95,9 +99,9 @@ namespace LingoEngine.Tools
 #endif
 
                     }
-                    else if (_resourceManager.FileExists(rtfFile))
+                    else if (await _resourceManager.FileExistsAsync(rtfFile))
                     {
-                        var rtfContent = _resourceManager.ReadTextFile(rtfFile) ?? string.Empty;
+                        var rtfContent = await _resourceManager.ReadTextFileAsync(rtfFile) ?? string.Empty;
                         var md = RtfToMarkdown.Convert(rtfContent, true);
                         textMember.SetTextMD(md);
 #if DEBUG
@@ -106,7 +110,7 @@ namespace LingoEngine.Tools
                     }
                     else
                     {
-                        var file = _resourceManager.ReadTextFile(textMember.FileName) ?? string.Empty;
+                        var file = await _resourceManager.ReadTextFileAsync(textMember.FileName) ?? string.Empty;
                         if (file == null)
                         {
                             logWarningMethod?.Invoke("File not found for Text :" + textMember.FileName);
@@ -117,10 +121,10 @@ namespace LingoEngine.Tools
                 }
             }
         }
-        public IReadOnlyCollection<CsvRow> ImportCsvCastFile(string filePath, bool skipFirstLine = true)
+        public async Task<IReadOnlyCollection<CsvRow>> ImportCsvCastFileAsync(string filePath, bool skipFirstLine = true)
         {
             var returnData = new List<CsvRow>();
-            var csv = Import(filePath, skipFirstLine);
+            var csv = await ImportAsync(filePath, skipFirstLine);
             foreach (var row in csv)
             {
                 var number = Convert.ToInt32(row[0]);
@@ -135,10 +139,13 @@ namespace LingoEngine.Tools
             return returnData;
         }
 
-        public List<string[]> Import(string filePath, bool skipFirstLine = true)
+        public IReadOnlyCollection<CsvRow> ImportCsvCastFile(string filePath, bool skipFirstLine = true) =>
+            ImportCsvCastFileAsync(filePath, skipFirstLine).GetAwaiter().GetResult();
+
+        public async Task<List<string[]>> ImportAsync(string filePath, bool skipFirstLine = true)
         {
             var rows = new List<string[]>();
-            var content = _resourceManager.ReadTextFile(filePath);
+            var content = await _resourceManager.ReadTextFileAsync(filePath);
             if (content == null)
                 return rows;
 
@@ -160,6 +167,9 @@ namespace LingoEngine.Tools
 
             return rows;
         }
+
+        public List<string[]> Import(string filePath, bool skipFirstLine = true) =>
+            ImportAsync(filePath, skipFirstLine).GetAwaiter().GetResult();
 
         private string[] ParseCsvLine(string line)
         {


### PR DESCRIPTION
## Summary
- add async APIs to resource manager and implement HttpClient-based async loading for Blazor
- expose async Build/Initialize flow and async cast/movie loading in project factory and player
- update CSV importer and demo project to consume async resource reads

## Testing
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI/AbstUI.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI/Resources/IAbstResourceManager.cs WillMoveToOwnRepo/AbstUI/src/AbstUI/Resources/AbstResourceManager.cs -v diagnostic`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/AbstUI.ImGui.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Resources/ImGuiResourceManager.cs -v diagnostic --no-restore`
- `dotnet format WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj --include WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Resources/BlazorResourceManager.cs -v diagnostic`
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/Projects/ILingoProjectFactory.cs src/LingoEngine/Setup/ILingoEngineRegistration.cs src/LingoEngine/Setup/LingoEngineRegistration.cs src/LingoEngine/Core/ILingoPlayer.cs src/LingoEngine/Core/LingoPlayer.cs src/LingoEngine/Tools/CsvImporter.cs -v diagnostic`
- `dotnet format Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/LingoEngine.Demo.TetriGrounds.Core.csproj --include Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/TetriGroundsProjectFactory.cs -v diagnostic`
- `dotnet format Test/LingoEngine.Tests/LingoEngine.Tests.csproj --include Test/LingoEngine.Tests/CsvImporterTests.cs -v diagnostic`
- `dotnet test Test/LingoEngine.Tests/LingoEngine.Tests.csproj`
- `dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c32e8e9e288332aaaf6b517d513a8a