### PR TITLE
Enable async resource preloading across frameworks

### DIFF
--- a/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/TetriGroundsProjectFactory.cs
+++ b/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Core/TetriGroundsProjectFactory.cs
@@ -17,6 +17,7 @@ using LingoEngine.Sprites;
 using LingoEngine.Texts;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Demo.TetriGrounds.Core;
 
@@ -62,14 +63,13 @@ public class TetriGroundsProjectFactory : ILingoProjectFactory
 
 
 
-    public void LoadCastLibs(ILingoCastLibsContainer castlibContainer, LingoPlayer lingoPlayer)
+    public async Task LoadCastLibsAsync(ILingoCastLibsContainer castlibContainer, LingoPlayer lingoPlayer)
     {
 
         _lingoPlayer = lingoPlayer;
 
-        lingoPlayer
-            .LoadCastLibFromCsv("InternalExt", Path.Combine("Media", "InternalExt", "Members.csv"), true)
-            .LoadCastLibFromCsv("Data", Path.Combine("Media", "Data", "Members.csv"));
+        await lingoPlayer.LoadCastLibFromCsvAsync("InternalExt", Path.Combine("Media", "InternalExt", "Members.csv"), true);
+        await lingoPlayer.LoadCastLibFromCsvAsync("Data", Path.Combine("Media", "Data", "Members.csv"));
         lingoPlayer.AddCastLib("Sounds", true, c =>
         {
             c.Add(LingoMemberType.Sound, 0, "S_Click", Path.Combine("Media", "Sounds", "click.mp3"));
@@ -96,11 +96,11 @@ public class TetriGroundsProjectFactory : ILingoProjectFactory
         lingoPlayer.CastLib("Sounds").GetMember<LingoMemberSound>("S_Nature")!.Loop = true;
         InitMembers(lingoPlayer);
     }
-    public ILingoMovie? LoadStartupMovie(ILingoServiceProvider serviceProvider, LingoPlayer lingoPlayer)
+    public Task<ILingoMovie?> LoadStartupMovieAsync(ILingoServiceProvider serviceProvider, LingoPlayer lingoPlayer)
     {
         _movie = LoadMovie(lingoPlayer);
-        
-        return _movie;
+
+        return Task.FromResult<ILingoMovie?>(_movie);
     }
     public void Run(ILingoMovie movie, bool autoPlayMovie)
     {
@@ -167,7 +167,7 @@ public class TetriGroundsProjectFactory : ILingoProjectFactory
         new TetriGroundsMembersSetup(_lingoPlayer!).InitMembers();
         var castData = _movie.CastLib["Data"];
         var MyBG = _movie.Member["Game"];
-        
+
         _movie.AddFrameBehavior<GameStopBehavior>(60);
         //_movie.AddFrameBehavior<WaiterFrameScript>(1);
         //_movie.AddFrameBehavior<StayOnFrameFrameScript>(4);
@@ -178,8 +178,8 @@ public class TetriGroundsProjectFactory : ILingoProjectFactory
         _movie.AddSprite(5, 56, 64, 591, 36, c => { c.Width = 193; c.Height = 35; }).SetMember("TetriGrounds_s"); // LOGO
         _movie.AddSprite(6, 59, 64, 503, 438).SetMember(9, 2); // copyright text
         var sprite = _movie.AddSprite(7, 60, 64, 441, 92).SetMember("T_data"); // level
-        
-        
+
+
 
 
 
@@ -256,9 +256,9 @@ public class TetriGroundsProjectFactory : ILingoProjectFactory
         var birdSprite1 = (ILingoSprite2DLight)_movie.AddSprite(6, 2, 31, 751, 394).SetMember("BirdAnim");
         birdSprite1.AddKeyframes((1, 751, 394), (16, 444, 273), (31, -33, 316));
 
-        _movie.AddSprite(36, 59, 64, 363, 238,c => {c.LocZ = 500;}).SetMember("alert"); //.Visibility = false;
-        _movie.AddSprite(37, 59, 64, 200, 200,c => {c.LocZ = 502;}).SetMember("T_PopupTitle"); // the player name text member
-        _movie.AddSprite(38, 59, 64, 200, 230,c => { c.LocZ = 502; }).SetMember("T_InputText").AddBehavior<EnterHighScoreBehavior>(c => c.SetSpriteNums([36,37,38])); // the player name text member
+        _movie.AddSprite(36, 59, 64, 363, 238, c => { c.LocZ = 500; }).SetMember("alert"); //.Visibility = false;
+        _movie.AddSprite(37, 59, 64, 200, 200, c => { c.LocZ = 502; }).SetMember("T_PopupTitle"); // the player name text member
+        _movie.AddSprite(38, 59, 64, 200, 230, c => { c.LocZ = 502; }).SetMember("T_InputText").AddBehavior<EnterHighScoreBehavior>(c => c.SetSpriteNums([36, 37, 38])); // the player name text member
     }
 
 

--- a/Test/LingoEngine.Tests/Casts/DummyTextMember.cs
+++ b/Test/LingoEngine.Tests/Casts/DummyTextMember.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using AbstUI.Primitives;
 using AbstUI.Texts;
 using LingoEngine.Casts;
@@ -65,6 +66,11 @@ internal class DummyTextMember : ILingoMemberTextBase, ILingoMemberTextBaseInter
     public void Move() { }
     public void PasteClipBoardInto() { }
     public void Preload() { Preloaded = true; }
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
+    }
     public void Unload() { }
     public ILingoMember Duplicate(int? newNumber = null) => this;
     public ILingoMember? GetMemberInCastByOffset(int numberOffset) => null;
@@ -99,6 +105,7 @@ internal class DummyTextMember : ILingoMemberTextBase, ILingoMemberTextBaseInter
         public void ImportFileInto() { }
         public void PasteClipboardInto() { }
         public void Preload() { }
+        public Task PreloadAsync() => Task.CompletedTask;
         public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
         public void Unload() { }
         public bool IsPixelTransparent(int x, int y) => false;

--- a/Test/LingoEngine.Tests/CsvImporterTests.cs
+++ b/Test/LingoEngine.Tests/CsvImporterTests.cs
@@ -14,6 +14,7 @@ using LingoEngine.Primitives;
 using LingoEngine.Sprites;
 using LingoEngine.Tests.Casts;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Tests;
 
@@ -39,7 +40,7 @@ public class CsvImporterTests
         Assert.Equal("sample.txt", row.FileName);
     }
     [Fact]
-    public void ImportInCastFromCsvFile_PrefersMarkdown()
+    public async Task ImportInCastFromCsvFile_PrefersMarkdown()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
@@ -56,7 +57,7 @@ public class CsvImporterTests
         var cast = new DummyCast();
         var importer = new CsvImporter(new TestResourceManager());
 
-        importer.ImportInCastFromCsvFile(cast, csvPath);
+        await importer.ImportInCastFromCsvFileAsync(cast, csvPath);
 
         var member = Assert.IsType<DummyTextMember>(cast.LastAddedMember);
         Assert.Equal("md text", member.Text);
@@ -65,7 +66,7 @@ public class CsvImporterTests
 
 #if DEBUG
     [Fact]
-    public void ImportInCastFromCsvFile_CreatesMarkdownWhenReadingRtf()
+    public async Task ImportInCastFromCsvFile_CreatesMarkdownWhenReadingRtf()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
@@ -82,7 +83,7 @@ public class CsvImporterTests
         var cast = new DummyCast();
         var importer = new CsvImporter(new TestResourceManager());
 
-        importer.ImportInCastFromCsvFile(cast, csvPath);
+        await importer.ImportInCastFromCsvFileAsync(cast, csvPath);
 
         var member = Assert.IsType<DummyTextMember>(cast.LastAddedMember);
         Assert.Contains("{{PARA:0}}Hello", member.Text);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Resources/ImGuiResourceManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.ImGui/Resources/ImGuiResourceManager.cs
@@ -1,23 +1,8 @@
-using System.IO;
 using AbstUI.Resources;
 
 namespace AbstUI.ImGui.Resources
 {
-    public class ImGuiResourceManager : IAbstResourceManager
+    public class ImGuiResourceManager : AbstResourceManager
     {
-        public bool FileExists(string fileName)
-        {
-            return File.Exists(fileName);
-        }
-
-        public string? ReadTextFile(string fileName)
-        {
-            return File.Exists(fileName) ? File.ReadAllText(fileName) : null;
-        }
-
-        public byte[]? ReadBytes(string fileName)
-        {
-            return File.Exists(fileName) ? File.ReadAllBytes(fileName) : null;
-        }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Resources/AbstResourceManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Resources/AbstResourceManager.cs
@@ -1,4 +1,7 @@
 
+using System.IO;
+using System.Threading.Tasks;
+
 namespace AbstUI.Resources
 {
     public abstract class AbstResourceManager : IAbstResourceManager
@@ -10,35 +13,49 @@ namespace AbstUI.Resources
             return File.Exists(fileName);
         }
 
+        public virtual Task<bool> FileExistsAsync(string fileName) => Task.FromResult(FileExists(fileName));
+
         public virtual string? ReadTextFile(string fileName)
         {
             return File.Exists(fileName) ? File.ReadAllText(fileName) : null;
         }
+
+        public virtual Task<string?> ReadTextFileAsync(string fileName) => Task.FromResult(ReadTextFile(fileName));
 
         public virtual byte[]? ReadBytes(string fileName)
         {
             return File.Exists(fileName) ? File.ReadAllBytes(fileName) : null;
         }
 
+        public virtual Task<byte[]?> ReadBytesAsync(string fileName) => Task.FromResult(ReadBytes(fileName));
+
         public virtual void StorageWrite<T>(string key, T data)
         {
-            string saveData = Serialize(data); 
+            string saveData = Serialize(data);
             if (!Directory.Exists(ProjectFolder))
                 Directory.CreateDirectory(ProjectFolder);
             File.WriteAllText(CreateFilename(key), saveData);
         }
 
+        public virtual Task StorageWriteAsync<T>(string key, T data)
+        {
+            StorageWrite(key, data);
+            return Task.CompletedTask;
+        }
 
         protected virtual string CreateFilename(string key) => Path.Combine(ProjectFolder, key + ".json");
 
-        public virtual T? StorageRead<T>(string key) 
+        public virtual T? StorageRead<T>(string key)
         {
             var content = ReadTextFile(Path.Combine(ProjectFolder, key + ".json"));
             if (content != null)
-                return Deserialize<T>(content); return default;
+                return Deserialize<T>(content);
+            return default;
         }
 
-        public string Serialize<T>(T data) 
+        public virtual Task<T?> StorageReadAsync<T>(string key) => Task.FromResult(StorageRead<T>(key));
+
+        public string Serialize<T>(T data)
         {
 #if NET48
             return Newtonsoft.Json.JsonConvert.SerializeObject(data);
@@ -47,10 +64,10 @@ namespace AbstUI.Resources
 #endif
         }
 
-        public T? Deserialize<T>(string content) 
+        public T? Deserialize<T>(string content)
         {
 #if NET48
-                return Newtonsoft.Json.JsonConvert.DeserializeObject<T>(content);
+            return Newtonsoft.Json.JsonConvert.DeserializeObject<T>(content);
 #else
             return System.Text.Json.JsonSerializer.Deserialize<T>(content);
 #endif

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Resources/IAbstResourceManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Resources/IAbstResourceManager.cs
@@ -1,14 +1,21 @@
 
+using System.Threading.Tasks;
+
 namespace AbstUI.Resources
 {
     public interface IAbstResourceManager
     {
         string ProjectFolder { get; set; }
         bool FileExists(string fileName);
+        Task<bool> FileExistsAsync(string fileName);
         string? ReadTextFile(string fileName);
+        Task<string?> ReadTextFileAsync(string fileName);
         byte[]? ReadBytes(string fileName);
+        Task<byte[]?> ReadBytesAsync(string fileName);
         void StorageWrite<T>(string key, T data);
+        Task StorageWriteAsync<T>(string key, T data);
         T? StorageRead<T>(string key);
+        Task<T?> StorageReadAsync<T>(string key);
         string Serialize<T>(T data);
         T? Deserialize<T>(string content);
     }

--- a/docs/ProjectSetup.md
+++ b/docs/ProjectSetup.md
@@ -69,11 +69,11 @@ public class MyGameProjectFactory : ILingoProjectFactory
             );
     }
 
-    public void LoadCastLibs(ILingoCastLibsContainer castlibs, LingoPlayer player)
-        => player.LoadCastLibFromCsv("Data", Path.Combine("Media", "Data", "Members.csv"));
+    public async Task LoadCastLibsAsync(ILingoCastLibsContainer castlibs, LingoPlayer player)
+        => await player.LoadCastLibFromCsvAsync("Data", Path.Combine("Media", "Data", "Members.csv"));
 
-    public ILingoMovie? LoadStartupMovie(ILingoServiceProvider services, LingoPlayer player)
-        => player.NewMovie("Intro");
+    public Task<ILingoMovie?> LoadStartupMovieAsync(ILingoServiceProvider services, LingoPlayer player)
+        => Task.FromResult<ILingoMovie?>(player.NewMovie("Intro"));
 
     public void Run(ILingoMovie movie, bool autoPlayMovie)
     {
@@ -84,8 +84,8 @@ public class MyGameProjectFactory : ILingoProjectFactory
 
 This implementation defines four required methods:
 - `Setup(ILingoEngineRegistration config)` registers fonts, project settings (including the 640×480 stage), movies, and services.
-- `LoadCastLibs(ILingoCastLibsContainer castlibs, LingoPlayer player)` loads external cast libraries using the provided player.
-- `LoadStartupMovie(ILingoServiceProvider services, LingoPlayer player)` chooses the movie that starts first.
+- `LoadCastLibsAsync(ILingoCastLibsContainer castlibs, LingoPlayer player)` loads external cast libraries using the provided player.
+- `LoadStartupMovieAsync(ILingoServiceProvider services, LingoPlayer player)` chooses the movie that starts first.
 - `Run(ILingoMovie movie, bool autoPlayMovie)` finalizes startup and optionally plays the movie automatically.
 
 ### Set properties of members

--- a/src/LingoEngine.Blazor/Bitmaps/LingoBlazorMemberBitmap.cs
+++ b/src/LingoEngine.Blazor/Bitmaps/LingoBlazorMemberBitmap.cs
@@ -13,6 +13,7 @@ using AbstUI.Tools;
 using Microsoft.JSInterop;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Blazor.Bitmaps;
 
@@ -56,13 +57,18 @@ public class LingoBlazorMemberBitmap : ILingoFrameworkMemberBitmap, IDisposable
 
     public void Preload()
     {
+        PreloadAsync().GetAwaiter().GetResult();
+    }
+
+    public async Task PreloadAsync()
+    {
         if (IsLoaded)
             return;
         if (!string.IsNullOrEmpty(_member.FileName))
         {
             try
             {
-                var bytes = _httpClient.GetByteArrayAsync(_member.FileName).GetAwaiter().GetResult();
+                var bytes = await _httpClient.GetByteArrayAsync(_member.FileName);
                 SetImageData(bytes);
             }
             catch { }

--- a/src/LingoEngine.Blazor/BlazorSetup.cs
+++ b/src/LingoEngine.Blazor/BlazorSetup.cs
@@ -24,6 +24,7 @@ public static class BlazorSetup
             )
             .WithFrameworkFactory(setup)
             .AddPreBuildAction(x => x.WithAbstUIBlazor())
+            .AddBuildAction(sp => sp.GetRequiredService<LingoPlayer>().MediaRequiresAsyncPreload = true)
             ;
         return reg;
     }

--- a/src/LingoEngine.Blazor/Core/BlazorFrameworkMemberEmpty.cs
+++ b/src/LingoEngine.Blazor/Core/BlazorFrameworkMemberEmpty.cs
@@ -1,5 +1,6 @@
 using LingoEngine.Members;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Blazor.Core;
 
@@ -15,7 +16,12 @@ public class BlazorFrameworkMemberEmpty : ILingoFrameworkMemberEmpty
     public void Erase() { }
     public void ImportFileInto() { }
     public void PasteClipboardInto() { }
-    public void Preload() { }
+    public void Preload()
+    {
+        if (IsLoaded)
+            return;
+    }
+    public Task PreloadAsync() => Task.CompletedTask;
     public void Unload() { }
 
     public bool IsPixelTransparent(int x, int y) => false;

--- a/src/LingoEngine.Blazor/FilmLoops/LingoBlazorMemberFilmLoop.cs
+++ b/src/LingoEngine.Blazor/FilmLoops/LingoBlazorMemberFilmLoop.cs
@@ -9,6 +9,7 @@ using LingoEngine.Members;
 using LingoEngine.Primitives;
 using LingoEngine.Sprites;
 using Microsoft.JSInterop;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Blazor.FilmLoops;
 
@@ -44,7 +45,15 @@ public class LingoBlazorMemberFilmLoop : ILingoFrameworkMemberFilmLoop, IDisposa
 
     public void Preload()
     {
+        if (IsLoaded)
+            return;
         IsLoaded = true;
+    }
+
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
     }
 
     public void Unload()

--- a/src/LingoEngine.Blazor/Medias/LingoBlazorMemberMedia.cs
+++ b/src/LingoEngine.Blazor/Medias/LingoBlazorMemberMedia.cs
@@ -1,6 +1,7 @@
 using LingoEngine.Medias;
 using LingoEngine.Members;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Blazor.Medias;
 
@@ -48,6 +49,12 @@ public class LingoBlazorMemberMedia : ILingoFrameworkMemberMedia
             MediaStatus = LingoMediaStatus.Opened;
         }
         IsLoaded = true;
+    }
+
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
     }
 
     public void Unload()

--- a/src/LingoEngine.Blazor/Scripts/LingoBlazorMemberScript.cs
+++ b/src/LingoEngine.Blazor/Scripts/LingoBlazorMemberScript.cs
@@ -1,5 +1,6 @@
 using LingoEngine.Scripts;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Blazor.Scripts;
 
@@ -14,7 +15,15 @@ public class LingoBlazorMemberScript : ILingoFrameworkMemberScript
     public void Erase() { }
     public void ImportFileInto() { }
     public void PasteClipboardInto() { }
-    public void Preload() { }
+    public void Preload()
+    {
+        if (IsLoaded)
+            return;
+    }
+    public Task PreloadAsync()
+    {
+        return Task.CompletedTask;
+    }
     public void Unload() { }
     public bool IsPixelTransparent(int x, int y) => false;
 }

--- a/src/LingoEngine.Blazor/Shapes/LingoBlazorMemberShape.cs
+++ b/src/LingoEngine.Blazor/Shapes/LingoBlazorMemberShape.cs
@@ -10,6 +10,7 @@ using LingoEngine.Primitives;
 using LingoEngine.Shapes;
 using LingoEngine.Sprites;
 using Microsoft.JSInterop;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Blazor.Shapes;
 
@@ -93,6 +94,12 @@ public class LingoBlazorMemberShape : ILingoFrameworkMemberShape, IDisposable
         _pixelData = _texture.GetPixelDataAsync(_scripts).GetAwaiter().GetResult();
         _stride = w * 4;
         IsLoaded = true;
+    }
+
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
     }
 
     public void Unload()

--- a/src/LingoEngine.Blazor/Sounds/LingoBlazorMemberSound.cs
+++ b/src/LingoEngine.Blazor/Sounds/LingoBlazorMemberSound.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using LingoEngine.Sounds;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Blazor.Sounds;
 
@@ -36,7 +37,9 @@ public class LingoBlazorMemberSound : ILingoFrameworkMemberSound, IDisposable
 
     public void Erase() => Unload();
 
-    public void Preload()
+    public void Preload() => PreloadAsync().GetAwaiter().GetResult();
+
+    public async Task PreloadAsync()
     {
         if (IsLoaded)
             return;
@@ -45,7 +48,7 @@ public class LingoBlazorMemberSound : ILingoFrameworkMemberSound, IDisposable
             Url = _member.FileName;
             try
             {
-                _data = _httpClient.GetByteArrayAsync(_member.FileName).GetAwaiter().GetResult();
+                _data = await _httpClient.GetByteArrayAsync(_member.FileName);
                 _member.Size = _data.Length;
                 Length = _data.Length / 44100.0;
                 Stereo = true;

--- a/src/LingoEngine.Blazor/Texts/LingoBlazorMemberTextBase.cs
+++ b/src/LingoEngine.Blazor/Texts/LingoBlazorMemberTextBase.cs
@@ -13,6 +13,7 @@ using LingoEngine.Texts;
 using LingoEngine.Texts.FrameworkCommunication;
 using Microsoft.JSInterop;
 using LingoEngine.Blazor.Util;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Blazor.Texts;
 
@@ -208,7 +209,18 @@ public abstract class LingoBlazorMemberTextBase<TText> : ILingoFrameworkMemberTe
 
     public void PasteClipboardInto() => Text = PasteClipboard();
 
-    public void Preload() => IsLoaded = true;
+    public void Preload()
+    {
+        if (IsLoaded)
+            return;
+        IsLoaded = true;
+    }
+
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
+    }
 
     public void Unload()
     {

--- a/src/LingoEngine.LGodot/Bitmaps/LingoGodotMemberBitmap.cs
+++ b/src/LingoEngine.LGodot/Bitmaps/LingoGodotMemberBitmap.cs
@@ -9,6 +9,7 @@ using LingoEngine.Tools;
 using Microsoft.Extensions.Logging;
 using AbstUI.LGodot.Helpers;
 using AbstUI.LGodot.Bitmaps;
+using System.Threading.Tasks;
 
 namespace LingoEngine.LGodot.Bitmaps
 {
@@ -55,7 +56,7 @@ namespace LingoEngine.LGodot.Bitmaps
             _lingoMemberPicture = lingoInstance;
             CreateTexture();
         }
-       
+
         public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
 
 
@@ -88,6 +89,12 @@ namespace LingoEngine.LGodot.Bitmaps
                 return;
         }
 
+        public Task PreloadAsync()
+        {
+            Preload();
+            return Task.CompletedTask;
+        }
+
         public void Unload()
         {
             ClearCache();
@@ -102,7 +109,7 @@ namespace LingoEngine.LGodot.Bitmaps
             _image?.Dispose();
             _texture?.Texture.Dispose();
         }
-      
+
         public void ImportFileInto()
         {
         }

--- a/src/LingoEngine.LGodot/Core/LingoFrameworkMemberEmpty.cs
+++ b/src/LingoEngine.LGodot/Core/LingoFrameworkMemberEmpty.cs
@@ -1,5 +1,6 @@
 ﻿using LingoEngine.Members;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.LGodot.Core
 {
@@ -25,7 +26,11 @@ namespace LingoEngine.LGodot.Core
 
         public void Preload()
         {
+            if (IsLoaded)
+                return;
         }
+
+        public Task PreloadAsync() => Task.CompletedTask;
 
         public void Unload()
         {

--- a/src/LingoEngine.LGodot/FilmLoops/LingoGodotFilmLoopMember.cs
+++ b/src/LingoEngine.LGodot/FilmLoops/LingoGodotFilmLoopMember.cs
@@ -7,6 +7,7 @@ using LingoEngine.Members;
 using AbstUI.Primitives;
 using AbstUI.LGodot.Bitmaps;
 using AbstUI.LGodot.Helpers;
+using System.Threading.Tasks;
 
 namespace LingoEngine.LGodot.FilmLoops
 {
@@ -37,7 +38,15 @@ namespace LingoEngine.LGodot.FilmLoops
         public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
         public void Preload()
         {
+            if (IsLoaded)
+                return;
             IsLoaded = true;
+        }
+
+        public Task PreloadAsync()
+        {
+            Preload();
+            return Task.CompletedTask;
         }
 
         public void Unload()

--- a/src/LingoEngine.LGodot/Medias/LingoGodotMemberMedia.cs
+++ b/src/LingoEngine.LGodot/Medias/LingoGodotMemberMedia.cs
@@ -2,6 +2,7 @@
 using LingoEngine.Medias;
 using LingoEngine.Sprites;
 using AbstUI.LGodot.Helpers;
+using System.Threading.Tasks;
 
 namespace LingoEngine.LGodot.Medias
 {
@@ -26,7 +27,7 @@ namespace LingoEngine.LGodot.Medias
         internal void Init(LingoMemberMedia member)
         {
             _member = member;
-            
+
             Preload();
         }
 
@@ -75,6 +76,12 @@ namespace LingoEngine.LGodot.Medias
                 MediaStatus = LingoMediaStatus.Opened;
             }
             IsLoaded = true;
+        }
+
+        public Task PreloadAsync()
+        {
+            Preload();
+            return Task.CompletedTask;
         }
 
         public void Unload()

--- a/src/LingoEngine.LGodot/Scripts/LingoFrameworkMemberScript.cs
+++ b/src/LingoEngine.LGodot/Scripts/LingoFrameworkMemberScript.cs
@@ -1,6 +1,7 @@
 ﻿using LingoEngine.Members;
 using LingoEngine.Scripts;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.LGodot.Scripts
 {
@@ -26,7 +27,11 @@ namespace LingoEngine.LGodot.Scripts
 
         public void Preload()
         {
+            if (IsLoaded)
+                return;
         }
+
+        public Task PreloadAsync() => Task.CompletedTask;
 
         public void Unload()
         {

--- a/src/LingoEngine.LGodot/Shapes/LingoGodotMemberShape.cs
+++ b/src/LingoEngine.LGodot/Shapes/LingoGodotMemberShape.cs
@@ -5,6 +5,7 @@ using LingoEngine.Primitives;
 using LingoEngine.Shapes;
 using LingoEngine.Sprites;
 using AbstUI.LGodot.Primitives;
+using System.Threading.Tasks;
 
 namespace LingoEngine.LGodot.Shapes
 {
@@ -19,8 +20,9 @@ namespace LingoEngine.LGodot.Shapes
 
         public bool IsLoaded { get; private set; }
         public bool IsDirty { get; private set; } = true;
-        public LingoList<APoint> VertexList 
-        { get => _vertexList;
+        public LingoList<APoint> VertexList
+        {
+            get => _vertexList;
             set
             {
                 _vertexList = value;
@@ -28,8 +30,9 @@ namespace LingoEngine.LGodot.Shapes
                 IsLoaded = false;
             }
         }
-        public LingoShapeType ShapeType { 
-            get => _shapeType; 
+        public LingoShapeType ShapeType
+        {
+            get => _shapeType;
             set
             {
                 _shapeType = value;
@@ -37,13 +40,15 @@ namespace LingoEngine.LGodot.Shapes
                 IsLoaded = false;
             }
         }
-        public AColor FillColor { get => _fillColor; 
+        public AColor FillColor
+        {
+            get => _fillColor;
             set
             {
                 _fillColor = value;
                 IsDirty = true;
                 IsLoaded = false;
-            } 
+            }
         }
         public AColor EndColor { get; set; } = AColor.FromRGB(255, 255, 255);
         public AColor StrokeColor { get; set; } = AColor.FromRGB(0, 0, 0);
@@ -52,7 +57,7 @@ namespace LingoEngine.LGodot.Shapes
         public bool AntiAlias { get; set; } = true;
         public float Width { get => width; set { width = value; } }
         public float Height { get => height; set => height = value; }
-        public (int TL, int TR, int BR, int BL) CornerRadius { get; set; }  = (5, 5, 5, 5);
+        public (int TL, int TR, int BR, int BL) CornerRadius { get; set; } = (5, 5, 5, 5);
         public bool Filled { get; set; } = true;
 
         public IAbstTexture2D? TextureLingo => null;
@@ -104,19 +109,19 @@ namespace LingoEngine.LGodot.Shapes
                     break;
 
                 case LingoShapeType.Rectangle:
-                    DrawRect(new Rect2(0,0, new Vector2(Width, Height)), fill, Filled);
+                    DrawRect(new Rect2(0, 0, new Vector2(Width, Height)), fill, Filled);
                     break;
 
                 case LingoShapeType.Oval:
-                    DrawCircle(new Vector2(Width/2, Height/2),Width, fill, Filled);
+                    DrawCircle(new Vector2(Width / 2, Height / 2), Width, fill, Filled);
                     break;
 
                 case LingoShapeType.RoundRect:
-                    var rect = new Rect2(0,0, new Vector2(Width,Height));
+                    var rect = new Rect2(0, 0, new Vector2(Width, Height));
 
                     var stylebox = new StyleBoxFlat
                     {
-                        BgColor = Filled?fill: Colors.Transparent,
+                        BgColor = Filled ? fill : Colors.Transparent,
                         CornerRadiusTopLeft = CornerRadius.TL,
                         CornerRadiusTopRight = CornerRadius.TR,
                         CornerRadiusBottomLeft = CornerRadius.BL,
@@ -128,8 +133,8 @@ namespace LingoEngine.LGodot.Shapes
                     break;
             }
 
-           
-            
+
+
             IsDirty = false;
         }
 
@@ -140,12 +145,20 @@ namespace LingoEngine.LGodot.Shapes
         public void Erase() { VertexList.Clear(); }
         public void ImportFileInto() { }
         public void PasteClipboardInto() { }
-        public void Preload() 
-        { 
-            IsLoaded = true; 
+        public void Preload()
+        {
+            if (IsLoaded)
+                return;
+            IsLoaded = true;
+        }
+
+        public Task PreloadAsync()
+        {
+            Preload();
+            return Task.CompletedTask;
         }
         public void Unload() { IsLoaded = false; IsDirty = true; }
-        public new void Dispose() 
+        public new void Dispose()
         {
             base.Dispose();
         }

--- a/src/LingoEngine.LGodot/Sounds/LingoGodotMemberSound.cs
+++ b/src/LingoEngine.LGodot/Sounds/LingoGodotMemberSound.cs
@@ -1,6 +1,7 @@
 ﻿using Godot;
 using LingoEngine.Sounds;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.LGodot.Sounds
 {
@@ -68,6 +69,12 @@ namespace LingoEngine.LGodot.Sounds
             StreamName = AudioStream._GetStreamName();
             Stereo = !AudioStream.IsMonophonic();
             _lingoMemberSound.Size = (long)AudioStream._GetLength() * 44100;
+        }
+
+        public Task PreloadAsync()
+        {
+            Preload();
+            return Task.CompletedTask;
         }
 
         public void Unload()

--- a/src/LingoEngine.LGodot/Texts/LingoGodotMemberTextBase.cs
+++ b/src/LingoEngine.LGodot/Texts/LingoGodotMemberTextBase.cs
@@ -13,6 +13,7 @@ using AbstUI.LGodot.Helpers;
 using AbstUI.LGodot.Texts;
 using AbstUI.LGodot.Bitmaps;
 using AbstUI.LGodot.Primitives;
+using System.Threading.Tasks;
 
 namespace LingoEngine.LGodot.Texts
 {
@@ -330,7 +331,7 @@ namespace LingoEngine.LGodot.Texts
             return _texture;
         }
 
-       
+
         private void UpdateText(string value)
         {
             if (_text == value) return;
@@ -368,9 +369,17 @@ namespace LingoEngine.LGodot.Texts
 
         public void Preload()
         {
+            if (IsLoaded)
+                return;
             //if (!_hasLoadedTexTure)
             //    RenderToTexture(LingoInkType.Copy, AColors.White);
             IsLoaded = true;
+        }
+
+        public Task PreloadAsync()
+        {
+            Preload();
+            return Task.CompletedTask;
         }
 
         public void Unload()

--- a/src/LingoEngine.SDL2/Bitmaps/SdlMemberBitmap.cs
+++ b/src/LingoEngine.SDL2/Bitmaps/SdlMemberBitmap.cs
@@ -10,6 +10,7 @@ using AbstUI.Tools;
 using AbstUI.SDL2.SDLL;
 using AbstUI.SDL2.Bitmaps;
 using AbstUI.SDL2.Core;
+using System.Threading.Tasks;
 
 namespace LingoEngine.SDL2.Bitmaps;
 public class SdlMemberBitmap : ILingoFrameworkMemberBitmap, IDisposable
@@ -72,6 +73,12 @@ public class SdlMemberBitmap : ILingoFrameworkMemberBitmap, IDisposable
         _texture = new SdlTexture2D(SDL.SDL_CreateTextureFromSurface(_sdlRootContext.Renderer, _surface), Width, Height);
         _textureSubscription = _texture.AddUser(this);
         IsLoaded = true;
+    }
+
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
     }
 
     public void Unload()

--- a/src/LingoEngine.SDL2/Core/SdlFrameworkMemberEmpty.cs
+++ b/src/LingoEngine.SDL2/Core/SdlFrameworkMemberEmpty.cs
@@ -1,5 +1,6 @@
 using LingoEngine.Members;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.SDL2.Core;
 
@@ -11,7 +12,12 @@ public class SdlFrameworkMemberEmpty : ILingoFrameworkMemberEmpty
     public void Erase() { }
     public void ImportFileInto() { }
     public void PasteClipboardInto() { }
-    public void Preload() { }
+    public void Preload()
+    {
+        if (IsLoaded)
+            return;
+    }
+    public Task PreloadAsync() => Task.CompletedTask;
     public void Unload() { }
 
     public bool IsPixelTransparent(int x, int y) => false;

--- a/src/LingoEngine.SDL2/FilmLoops/SdlMemberFilmLoop.cs
+++ b/src/LingoEngine.SDL2/FilmLoops/SdlMemberFilmLoop.cs
@@ -10,6 +10,7 @@ using LingoEngine.SDL2.Bitmaps;
 using LingoEngine.SDL2.Inputs;
 using LingoEngine.Sprites;
 using AbstUI.Tools;
+using System.Threading.Tasks;
 
 
 namespace LingoEngine.SDL2.FilmLoops;
@@ -47,7 +48,15 @@ public class SdlMemberFilmLoop : ILingoFrameworkMemberFilmLoop, IDisposable
     /// <summary>Marks the film loop as loaded.</summary>
     public void Preload()
     {
+        if (IsLoaded)
+            return;
         IsLoaded = true;
+    }
+
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
     }
 
     /// <summary>Releases any GPU resources held by the film loop.</summary>

--- a/src/LingoEngine.SDL2/Medias/SdlMemberMedia.cs
+++ b/src/LingoEngine.SDL2/Medias/SdlMemberMedia.cs
@@ -4,6 +4,7 @@ using AbstUI.SDL2.Medias;
 using LingoEngine.Medias;
 using LingoEngine.Members;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.SDL2.Medias;
 
@@ -58,6 +59,12 @@ public class SdlMemberMedia : ILingoFrameworkMemberMedia
             _status = LingoMediaStatus.Opened;
         }
         IsLoaded = true;
+    }
+
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
     }
 
     public void Unload()

--- a/src/LingoEngine.SDL2/Scripts/SdlFrameworkMemberScript.cs
+++ b/src/LingoEngine.SDL2/Scripts/SdlFrameworkMemberScript.cs
@@ -1,5 +1,6 @@
 ﻿using LingoEngine.Scripts;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.SDL2.Scripts;
 
@@ -11,7 +12,12 @@ public class SdlFrameworkMemberScript : ILingoFrameworkMemberScript
     public void Erase() { }
     public void ImportFileInto() { }
     public void PasteClipboardInto() { }
-    public void Preload() { }
+    public void Preload()
+    {
+        if (IsLoaded)
+            return;
+    }
+    public Task PreloadAsync() => Task.CompletedTask;
     public void Unload() { }
     public bool IsPixelTransparent(int x, int y) => false;
 }

--- a/src/LingoEngine.SDL2/Shapes/SdlMemberShape.cs
+++ b/src/LingoEngine.SDL2/Shapes/SdlMemberShape.cs
@@ -9,6 +9,7 @@ using AbstUI.Primitives;
 using AbstUI.SDL2.Bitmaps;
 using AbstUI.SDL2.SDLL;
 using AbstUI.SDL2.Core;
+using System.Threading.Tasks;
 
 namespace LingoEngine.SDL2.Shapes
 {
@@ -87,6 +88,12 @@ namespace LingoEngine.SDL2.Shapes
             IsLoaded = true;
         }
 
+        public Task PreloadAsync()
+        {
+            Preload();
+            return Task.CompletedTask;
+        }
+
         public void Unload()
         {
             if (_surface != nint.Zero)
@@ -97,9 +104,9 @@ namespace LingoEngine.SDL2.Shapes
             IsLoaded = false;
         }
 
-        public void Dispose() 
+        public void Dispose()
         {
-            Unload(); 
+            Unload();
         }
 
         public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
@@ -107,7 +114,7 @@ namespace LingoEngine.SDL2.Shapes
 
         public IAbstTexture2D? RenderToTexture(LingoInkType ink, AColor transparentColor)
         {
-            
+
             if (_texture == null)
                 Preload();
             else if (_texture.IsDisposed)

--- a/src/LingoEngine.SDL2/Sounds/SdlMemberSound.cs
+++ b/src/LingoEngine.SDL2/Sounds/SdlMemberSound.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using LingoEngine.Sounds;
 using LingoEngine.Sprites;
 using AbstUI.SDL2.SDLL;
+using System.Threading.Tasks;
 
 namespace LingoEngine.SDL2.Sounds;
 
@@ -45,6 +46,12 @@ public class SdlMemberSound : ILingoFrameworkMemberSound, IDisposable
         Length = fi.Length / 44100.0;
         Stereo = true;
         IsLoaded = true;
+    }
+
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
     }
     public void Unload()
     {

--- a/src/LingoEngine.SDL2/Texts/SdlMemberTextBase.cs
+++ b/src/LingoEngine.SDL2/Texts/SdlMemberTextBase.cs
@@ -11,6 +11,7 @@ using LingoEngine.SDL2.Inputs;
 using LingoEngine.Sprites;
 using LingoEngine.Texts;
 using LingoEngine.Texts.FrameworkCommunication;
+using System.Threading.Tasks;
 
 namespace LingoEngine.SDL2.Texts;
 
@@ -176,7 +177,18 @@ public abstract class SdlMemberTextBase<TText> : ILingoFrameworkMemberTextBase, 
     public void Erase() { Unload(); }
     public void ImportFileInto() { }
     public void PasteClipboardInto() => _lingoMemberText.Text = SdlClipboard.GetText();
-    public void Preload() { IsLoaded = true; }
+    public void Preload()
+    {
+        if (IsLoaded)
+            return;
+        IsLoaded = true;
+    }
+
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
+    }
     public void Unload()
     {
         IsLoaded = false;

--- a/src/LingoEngine.Unity/Bitmaps/UnityMemberBitmap.cs
+++ b/src/LingoEngine.Unity/Bitmaps/UnityMemberBitmap.cs
@@ -12,6 +12,7 @@ using System.IO;
 using UnityEngine;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Unity.Bitmaps;
 
@@ -62,6 +63,12 @@ public class UnityMemberBitmap : ILingoFrameworkMemberBitmap, IDisposable
             }
         }
         IsLoaded = true;
+    }
+
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
     }
 
     public void Unload()

--- a/src/LingoEngine.Unity/Core/UnityFrameworkMemberEmpty.cs
+++ b/src/LingoEngine.Unity/Core/UnityFrameworkMemberEmpty.cs
@@ -1,5 +1,6 @@
 using LingoEngine.Members;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Unity.Core;
 
@@ -15,7 +16,13 @@ public class UnityFrameworkMemberEmpty : ILingoFrameworkMemberEmpty
 
     public void PasteClipboardInto() { }
 
-    public void Preload() { }
+    public void Preload()
+    {
+        if (IsLoaded)
+            return;
+    }
+
+    public Task PreloadAsync() => Task.CompletedTask;
 
     public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
 

--- a/src/LingoEngine.Unity/FilmLoops/UnityFilmLoopMember.cs
+++ b/src/LingoEngine.Unity/FilmLoops/UnityFilmLoopMember.cs
@@ -11,6 +11,7 @@ using LingoEngine.Primitives;
 using LingoEngine.Sprites;
 using LingoEngine.Tools;
 using UnityEngine;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Unity.FilmLoops;
 
@@ -53,7 +54,18 @@ public class UnityFilmLoopMember : ILingoFrameworkMemberFilmLoop, IDisposable
     public void ReleaseFromSprite(LingoSprite2D lingoSprite) { }
 
     /// <inheritdoc/>
-    public void Preload() => IsLoaded = true;
+    public void Preload()
+    {
+        if (IsLoaded)
+            return;
+        IsLoaded = true;
+    }
+
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
+    }
 
     /// <inheritdoc/>
     public void Unload()

--- a/src/LingoEngine.Unity/Medias/LingoUnityMemberMedia.cs
+++ b/src/LingoEngine.Unity/Medias/LingoUnityMemberMedia.cs
@@ -3,6 +3,7 @@ using System.IO;
 using LingoEngine.Medias;
 using LingoEngine.Members;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Unity.Medias;
 
@@ -54,6 +55,12 @@ public class LingoUnityMemberMedia : ILingoFrameworkMemberMedia
             MediaStatus = LingoMediaStatus.Opened;
         }
         IsLoaded = true;
+    }
+
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
     }
 
     public void Unload()

--- a/src/LingoEngine.Unity/Scripts/UnityFrameworkMemberScript.cs
+++ b/src/LingoEngine.Unity/Scripts/UnityFrameworkMemberScript.cs
@@ -1,6 +1,7 @@
 using LingoEngine.Members;
 using LingoEngine.Scripts;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Unity.Scripts;
 
@@ -12,7 +13,12 @@ internal class UnityFrameworkMemberScript : ILingoFrameworkMemberScript
     public void Erase() { }
     public void ImportFileInto() { }
     public void PasteClipboardInto() { }
-    public void Preload() { }
+    public void Preload()
+    {
+        if (IsLoaded)
+            return;
+    }
+    public Task PreloadAsync() => Task.CompletedTask;
     public void Unload() { }
     public bool IsPixelTransparent(int x, int y) => false;
 }

--- a/src/LingoEngine.Unity/Shapes/UnityMemberShape.cs
+++ b/src/LingoEngine.Unity/Shapes/UnityMemberShape.cs
@@ -7,6 +7,7 @@ using AbstUI.Primitives;
 using AbstUI.LUnity.Bitmaps;
 using UnityEngine;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Unity.Shapes;
 
@@ -143,6 +144,12 @@ public class UnityMemberShape : ILingoFrameworkMemberShape, IDisposable
         _texture = new UnityTexture2D(tex, "Shape");
         IsLoaded = true;
         IsDirty = false;
+    }
+
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc/>

--- a/src/LingoEngine.Unity/Sounds/UnityMemberSound.cs
+++ b/src/LingoEngine.Unity/Sounds/UnityMemberSound.cs
@@ -3,6 +3,7 @@ using System.IO;
 using LingoEngine.Sounds;
 using LingoEngine.Sprites;
 using UnityEngine;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Unity.Sounds;
 
@@ -38,6 +39,12 @@ public class UnityMemberSound : ILingoFrameworkMemberSound, IDisposable
         Stereo = stereo;
         _member.Size = size;
         IsLoaded = true;
+    }
+
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
     }
 
     public void Unload()

--- a/src/LingoEngine.Unity/Texts/UnityMemberTextBase.cs
+++ b/src/LingoEngine.Unity/Texts/UnityMemberTextBase.cs
@@ -12,6 +12,7 @@ using LingoEngine.Texts.FrameworkCommunication;
 using AbstUI.LUnity.Bitmaps;
 using UnityEngine;
 using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Unity.Texts;
 
@@ -113,7 +114,7 @@ public abstract class UnityMemberTextBase<TText> : ILingoFrameworkMemberTextBase
         return prop?.GetValue(null) as string ?? string.Empty;
     }
 
-   
+
     public void CopyToClipboard() => Copy(Text);
     public void Erase()
     {
@@ -122,7 +123,18 @@ public abstract class UnityMemberTextBase<TText> : ILingoFrameworkMemberTextBase
     }
     public void ImportFileInto() { }
     public void PasteClipboardInto() => _lingoMemberText.Text = PasteClipboard();
-    public void Preload() { _isLoaded = true; }
+    public void Preload()
+    {
+        if (_isLoaded)
+            return;
+        _isLoaded = true;
+    }
+
+    public Task PreloadAsync()
+    {
+        Preload();
+        return Task.CompletedTask;
+    }
     public void Unload()
     {
         _isLoaded = false;

--- a/src/LingoEngine/Bitmaps/LingoMemberBitmap.cs
+++ b/src/LingoEngine/Bitmaps/LingoMemberBitmap.cs
@@ -2,6 +2,7 @@
 using LingoEngine.Casts;
 using LingoEngine.Members;
 using LingoEngine.Primitives;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Bitmaps
 {
@@ -10,7 +11,7 @@ namespace LingoEngine.Bitmaps
     /// Represents a bitmap or picture cast member in a Director movie.
     /// Lingo: member("name").type = #bitmap or #picture
     /// </summary>
-    public class LingoMemberBitmap : LingoMember , ILingoMemberWithTexture
+    public class LingoMemberBitmap : LingoMember, ILingoMemberWithTexture
     {
         private readonly ILingoFrameworkMemberBitmap _lingoFrameworkMemberPicture;
 
@@ -65,6 +66,7 @@ namespace LingoEngine.Bitmaps
         /// Corresponds to: member.picture.preload
         /// </summary>
         public override void Preload() => _lingoFrameworkMemberPicture.Preload();
+        public override Task PreloadAsync() => _lingoFrameworkMemberPicture.PreloadAsync();
 
         /// <summary>
         /// Unloads the picture from memory using <see cref="ILingoFrameworkMemberBitmap.Unload"/>.

--- a/src/LingoEngine/ColorPalettes/LingoColorPaletteMemberFW.cs
+++ b/src/LingoEngine/ColorPalettes/LingoColorPaletteMemberFW.cs
@@ -1,5 +1,6 @@
 ﻿using LingoEngine.Members;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.ColorPalettes
 {
@@ -13,39 +14,46 @@ namespace LingoEngine.ColorPalettes
 
         public void CopyToClipboard()
         {
-            
+
         }
 
         public void Erase()
         {
-            
+
         }
 
         public void ImportFileInto()
         {
-            
+
         }
 
         public bool IsPixelTransparent(int x, int y) => false;
 
         public void PasteClipboardInto()
         {
-            
+
         }
 
         public void Preload()
         {
-            
+            if (IsLoaded)
+                return;
+        }
+
+        public Task PreloadAsync()
+        {
+            Preload();
+            return Task.CompletedTask;
         }
 
         public void ReleaseFromSprite(LingoSprite2D lingoSprite)
         {
-            
+
         }
 
         public void Unload()
         {
-            
+
         }
     }
 }

--- a/src/LingoEngine/Core/ILingoPlayer.cs
+++ b/src/LingoEngine/Core/ILingoPlayer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using LingoEngine.Casts;
 using LingoEngine.Movies;
 using LingoEngine.Sounds;
@@ -33,6 +34,11 @@ namespace LingoEngine.Core
         /// Lingo: the sound
         /// </summary>
         ILingoSound Sound { get; }
+
+        /// <summary>
+        /// Indicates whether media assets must be preloaded asynchronously before use.
+        /// </summary>
+        bool MediaRequiresAsyncPreload { get; set; }
 
         /// <summary>
         /// Indicates the sprite channel number of the sprite whose script is currently executing.
@@ -163,6 +169,7 @@ namespace LingoEngine.Core
         ILingoCast CastLib(int number);
         ILingoCast CastLib(string name);
         ILingoPlayer LoadCastLibFromCsv(string castlibName, string pathAndFilenameToCsv, bool isInternal = false);
+        Task<ILingoPlayer> LoadCastLibFromCsvAsync(string castlibName, string pathAndFilenameToCsv, bool isInternal = false);
         ILingoPlayer AddCastLib(string name, bool isInternal = false, Action<ILingoCast>? configure = null);
         ILingoMovie NewMovie(string movieName, bool andActivate = true);
 

--- a/src/LingoEngine/FilmLoops/LingoFilmLoopMember.cs
+++ b/src/LingoEngine/FilmLoops/LingoFilmLoopMember.cs
@@ -7,6 +7,7 @@ using LingoEngine.Bitmaps;
 using LingoEngine.Events;
 using System;
 using AbstUI.Primitives;
+using System.Threading.Tasks;
 
 namespace LingoEngine.FilmLoops
 {
@@ -56,7 +57,7 @@ namespace LingoEngine.FilmLoops
             set => _frameworkFilmLoop.Loop = value;
         }
 
-        
+
 
         public LingoFilmLoopMember(ILingoFrameworkMemberFilmLoop frameworkMember, LingoCast cast, int numberInCast, string name = "", string fileName = "", APoint regPoint = default)
             : base(frameworkMember, LingoMemberType.FilmLoop, cast, numberInCast, name, fileName, regPoint)
@@ -70,10 +71,12 @@ namespace LingoEngine.FilmLoops
             HasChanged = true;
         }
 
-        public override void Preload()
+        public override void Preload() => PreloadAsync().GetAwaiter().GetResult();
+        public override async Task PreloadAsync()
         {
-            if (_isLoaded) return;
-            _frameworkFilmLoop.Preload();
+            if (_isLoaded)
+                return;
+            await _frameworkFilmLoop.PreloadAsync();
             UpdateSize();
             _isLoaded = true;
         }

--- a/src/LingoEngine/Members/ILingoFrameworkMember.cs
+++ b/src/LingoEngine/Members/ILingoFrameworkMember.cs
@@ -2,6 +2,7 @@
 using LingoEngine.Bitmaps;
 using LingoEngine.Primitives;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Members
 {
@@ -38,6 +39,7 @@ namespace LingoEngine.Members
         void ImportFileInto();
         void PasteClipboardInto();
         void Preload();
+        Task PreloadAsync();
         void ReleaseFromSprite(LingoSprite2D lingoSprite);
         void Unload();
 

--- a/src/LingoEngine/Members/LingoMember.cs
+++ b/src/LingoEngine/Members/LingoMember.cs
@@ -5,6 +5,7 @@ using LingoEngine.Primitives;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Members
 {
@@ -176,6 +177,7 @@ namespace LingoEngine.Members
         /// Lingo: preload member
         /// </summary>
         void Preload();
+        Task PreloadAsync();
 
         /// <summary>
         /// Unloads the cast member from memory.
@@ -314,6 +316,7 @@ namespace LingoEngine.Members
         public virtual void CopyToClipBoard() => _frameworkMember.CopyToClipboard();
         public virtual void PasteClipBoardInto() => _frameworkMember.PasteClipboardInto();
         public virtual void Preload() => _frameworkMember.Preload();
+        public virtual Task PreloadAsync() => _frameworkMember.PreloadAsync();
         public virtual void Unload() => _frameworkMember.Unload();
 
         public ILingoMember Duplicate(int? newNumber = null)

--- a/src/LingoEngine/Projects/ILingoProjectFactory.cs
+++ b/src/LingoEngine/Projects/ILingoProjectFactory.cs
@@ -1,6 +1,7 @@
 namespace LingoEngine.Projects;
 
 using System;
+using System.Threading.Tasks;
 using LingoEngine.Core;
 using LingoEngine.Setup;
 using LingoEngine.Casts;
@@ -12,7 +13,7 @@ using LingoEngine.Movies;
 public interface ILingoProjectFactory
 {
     void Setup(ILingoEngineRegistration engineRegistration);
-    void LoadCastLibs(ILingoCastLibsContainer castlibContainer, LingoPlayer lingoPlayer);
-    ILingoMovie? LoadStartupMovie(ILingoServiceProvider serviceProvider, LingoPlayer lingoPlayer);
+    Task LoadCastLibsAsync(ILingoCastLibsContainer castlibContainer, LingoPlayer lingoPlayer);
+    Task<ILingoMovie?> LoadStartupMovieAsync(ILingoServiceProvider serviceProvider, LingoPlayer lingoPlayer);
     void Run(ILingoMovie movie, bool autoPlayMovie);
 }

--- a/src/LingoEngine/Setup/ILingoEngineRegistration.cs
+++ b/src/LingoEngine/Setup/ILingoEngineRegistration.cs
@@ -4,6 +4,7 @@ using AbstUI.Styles;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Projects;
 using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Setup
 {
@@ -21,9 +22,12 @@ namespace LingoEngine.Setup
         ILingoEngineRegistration WithGlobalVarsR<TGlobalVars>(Action<TGlobalVars>? setup = null) where TGlobalVars : LingoGlobalVars;
         ILingoEngineRegistration WithGlobalVars<TGlobalVars>(Action<TGlobalVars>? setup = null) where TGlobalVars : LingoGlobalVars, new();
         LingoPlayer Build();
+        Task<LingoPlayer> BuildAsync();
         ILingoEngineRegistration BuildDelayed();
         LingoPlayer Build(IServiceProvider serviceProvider, bool allowInitializeProject = true);
+        Task<LingoPlayer> BuildAsync(IServiceProvider serviceProvider, bool allowInitializeProject = true);
         void InitializeProject();
+        Task InitializeProjectAsync();
         ILingoProjectFactory BuildAndRunProject(Action<IServiceProvider>? afterStart = null);
         ILingoProjectFactory RunProject(Action<IServiceProvider>? afterStart = null);
         ILingoEngineRegistration AddPreBuildAction(Action<IServiceProvider> buildAction);

--- a/src/LingoEngine/Shapes/LingoMemberShape.cs
+++ b/src/LingoEngine/Shapes/LingoMemberShape.cs
@@ -3,6 +3,7 @@ using LingoEngine.Bitmaps;
 using LingoEngine.Casts;
 using LingoEngine.Members;
 using LingoEngine.Primitives;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Shapes
 {
@@ -43,6 +44,7 @@ namespace LingoEngine.Shapes
         }
 
         public override void Preload() => _framework.Preload();
+        public override Task PreloadAsync() => _framework.PreloadAsync();
 
         public IAbstTexture2D? RenderToTexture(LingoInkType ink, AColor transparentColor)
            => _framework.RenderToTexture(ink, transparentColor);

--- a/src/LingoEngine/Texts/LingoMemberTextBase.cs
+++ b/src/LingoEngine/Texts/LingoMemberTextBase.cs
@@ -8,6 +8,7 @@ using LingoEngine.Texts.FrameworkCommunication;
 using AbstUI.Components;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Texts
 {
@@ -55,7 +56,7 @@ namespace LingoEngine.Texts
             set
             {
                 _mdData = null;
-                var newValue = value.Replace("\r\n","\r");
+                var newValue = value.Replace("\r\n", "\r");
                 _markdown = newValue;
                 UpdateText(newValue);
                 _frameworkMember.Text = newValue;
@@ -76,7 +77,8 @@ namespace LingoEngine.Texts
         public bool WordWrap
         {
             get => _frameworkMember.WordWrap;
-            set { 
+            set
+            {
                 if (_frameworkMember.WordWrap == value) return;
                 _frameworkMember.WordWrap = value;
                 UpdateMDStyle();
@@ -86,7 +88,8 @@ namespace LingoEngine.Texts
         public string Font
         {
             get => _frameworkMember.FontName;
-            set { 
+            set
+            {
                 if (_frameworkMember.FontName == value) return;
                 _frameworkMember.FontName = value;
                 UpdateMDStyle();
@@ -96,9 +99,10 @@ namespace LingoEngine.Texts
         public int FontSize
         {
             get => _frameworkMember.FontSize;
-            set {
+            set
+            {
                 if (_frameworkMember.FontSize == value) return;
-                _frameworkMember.FontSize = value; 
+                _frameworkMember.FontSize = value;
                 UpdateMDStyle();
             }
         }
@@ -107,7 +111,8 @@ namespace LingoEngine.Texts
         public AColor Color
         {
             get => _frameworkMember.TextColor;
-            set { 
+            set
+            {
                 if (_frameworkMember.TextColor == value) return;
                 _frameworkMember.TextColor = value;
                 UpdateMDStyle();
@@ -117,7 +122,8 @@ namespace LingoEngine.Texts
         public LingoTextStyle FontStyle
         {
             get => _frameworkMember.FontStyle;
-            set {
+            set
+            {
                 if (_frameworkMember.FontStyle == value) return;
                 _frameworkMember.FontStyle = value;
                 UpdateMDStyle();
@@ -172,7 +178,8 @@ namespace LingoEngine.Texts
         public AbstTextAlignment Alignment
         {
             get => _frameworkMember.Alignment;
-            set { 
+            set
+            {
                 if (_frameworkMember.Alignment == value) return;
                 _frameworkMember.Alignment = value;
                 UpdateMDStyle();
@@ -182,7 +189,8 @@ namespace LingoEngine.Texts
         public int Margin
         {
             get => _frameworkMember.Margin;
-            set {
+            set
+            {
                 if (_frameworkMember.Margin == value) return;
                 _frameworkMember.Margin = value;
                 UpdateMDStyle();
@@ -315,9 +323,11 @@ namespace LingoEngine.Texts
             RenderText();
             return _texture;
         }
-        public override void Preload()
+        public override void Preload() => PreloadAsync().GetAwaiter().GetResult();
+
+        public override async Task PreloadAsync()
         {
-            base.Preload();
+            await base.PreloadAsync();
             RenderText();
         }
         /// <inheritdoc/>
@@ -328,7 +338,7 @@ namespace LingoEngine.Texts
             UpdateText(data.PlainText);
             _frameworkMember.Text = data.PlainText;
         }
-        
+
 
         private void RenderText()
         {

--- a/src/LingoEngine/Transitions/LingoTransitionMemberFW.cs
+++ b/src/LingoEngine/Transitions/LingoTransitionMemberFW.cs
@@ -1,5 +1,6 @@
 ﻿using LingoEngine.Members;
 using LingoEngine.Sprites;
+using System.Threading.Tasks;
 
 namespace LingoEngine.Transitions
 {
@@ -13,39 +14,46 @@ namespace LingoEngine.Transitions
 
         public void CopyToClipboard()
         {
-            
+
         }
 
         public void Erase()
         {
-            
+
         }
 
         public void ImportFileInto()
         {
-            
+
         }
 
         public bool IsPixelTransparent(int x, int y) => false;
 
         public void PasteClipboardInto()
         {
-            
+
         }
 
         public void Preload()
         {
-            
+            if (IsLoaded)
+                return;
+        }
+
+        public Task PreloadAsync()
+        {
+            Preload();
+            return Task.CompletedTask;
         }
 
         public void ReleaseFromSprite(LingoSprite2D lingoSprite)
         {
-            
+
         }
 
         public void Unload()
         {
-            
+
         }
     }
 }


### PR DESCRIPTION
## Summary
- deduplicate sync and async preload paths so members reuse a single async implementation
- guard all member `Preload` methods with `IsLoaded` checks to avoid redundant loading

## Testing
- `dotnet format src/LingoEngine/LingoEngine.csproj --include src/LingoEngine/ColorPalettes/LingoColorPaletteMemberFW.cs src/LingoEngine/FilmLoops/LingoFilmLoopMember.cs src/LingoEngine/Texts/LingoMemberTextBase.cs src/LingoEngine/Transitions/LingoTransitionMemberFW.cs -v diagnostic`
- `dotnet format src/LingoEngine.Blazor/LingoEngine.Blazor.csproj --include src/LingoEngine.Blazor/Bitmaps/LingoBlazorMemberBitmap.cs src/LingoEngine.Blazor/Core/BlazorFrameworkMemberEmpty.cs src/LingoEngine.Blazor/FilmLoops/LingoBlazorMemberFilmLoop.cs src/LingoEngine.Blazor/Scripts/LingoBlazorMemberScript.cs src/LingoEngine.Blazor/Sounds/LingoBlazorMemberSound.cs src/LingoEngine.Blazor/Texts/LingoBlazorMemberTextBase.cs -v diagnostic`
- `dotnet format src/LingoEngine.LGodot/LingoEngine.LGodot.csproj --include src/LingoEngine.LGodot/Core/LingoFrameworkMemberEmpty.cs src/LingoEngine.LGodot/FilmLoops/LingoGodotFilmLoopMember.cs src/LingoEngine.LGodot/Scripts/LingoFrameworkMemberScript.cs src/LingoEngine.LGodot/Shapes/LingoGodotMemberShape.cs src/LingoEngine.LGodot/Texts/LingoGodotMemberTextBase.cs -v diagnostic`
- `dotnet format src/LingoEngine.SDL2/LingoEngine.SDL2.csproj --include src/LingoEngine.SDL2/Core/SdlFrameworkMemberEmpty.cs src/LingoEngine.SDL2/FilmLoops/SdlMemberFilmLoop.cs src/LingoEngine.SDL2/Scripts/SdlFrameworkMemberScript.cs src/LingoEngine.SDL2/Texts/SdlMemberTextBase.cs -v diagnostic`
- `dotnet format src/LingoEngine.Unity/LingoEngine.Unity.csproj --include src/LingoEngine.Unity/Core/UnityFrameworkMemberEmpty.cs src/LingoEngine.Unity/FilmLoops/UnityFilmLoopMember.cs src/LingoEngine.Unity/Scripts/UnityFrameworkMemberScript.cs src/LingoEngine.Unity/Texts/UnityMemberTextBase.cs -v diagnostic`
- `dotnet test Test/LingoEngine.Tests/LingoEngine.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c32e8e9e288332aaaf6b517d513a8a