### PR TITLE
Fix text extraction for cast members

### DIFF
--- a/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/XMED/XmedReaderTests.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/XMED/XmedReaderTests.cs
@@ -122,6 +122,17 @@ public class XmedReaderTests
     }
 
     [Fact]
+    public void CastMemberReadIncludesStyleDeclarations()
+    {
+        var path = GetPath("Texts_Fields/Text_Single_Line_Multi_Style.xmed.txt");
+        var data = TestFileReader.ReadHexFile(path);
+        var view = CreateView(data);
+        var dir = new RaysDirectorFile(_logger, path);
+        var read = RaysCastMemberTextRead.FromXmedChunk(view, dir);
+        Assert.True(read.StyleDeclarations.Count > 1);
+    }
+
+    [Fact]
     public void ParsesWiderWidth4Text()
     {
         var view = CreateView(XmedTestData.WiderWidth4);

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/CastMembers/RaysCastMemberTextRead.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/CastMembers/RaysCastMemberTextRead.cs
@@ -127,6 +127,10 @@ namespace ProjectorRays.CastMembers
 
         public string Text { get; set; } = string.Empty;
         public List<TextStyleRun> Styles { get; set; } = new();
+        public List<XmedStyleDeclaration> StyleDeclarations { get; } = new();
+        public List<XmedStyleMapEntry> StyleMapEntries { get; } = new();
+        public uint Width { get; set; }
+        public uint LineSpacing { get; set; }
         public List<TextPart> TextParts { get; set; } = new();
         public int TextLength { get; private set; }
         public bool WordWrap { get; set; }
@@ -154,6 +158,11 @@ namespace ProjectorRays.CastMembers
                 var doc = XmedReaderFactory().Read(view);
                 result.Text = doc.Text;
                 result.Styles = doc.Runs;
+                result.StyleDeclarations.AddRange(doc.Styles);
+                result.StyleMapEntries.AddRange(doc.MapEntries);
+                result.Width = doc.Width;
+                result.LineSpacing = doc.LineSpacing;
+                result.TextLength = (int)doc.TextLength;
             }
             catch (Exception ex)
             {

--- a/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/CastMembers/XmedReader.cs
+++ b/WillMoveToOwnRepo/ProjectorRays/src/ProjectorRays.DotNet/CastMembers/XmedReader.cs
@@ -245,6 +245,10 @@ public class XmedReader : IXmedReader
                             {
                                 run.FontName = currentStyle.FontName;
                                 run.ForeColor = new RayColor(currentStyle.ColorIndex, currentStyle.ColorIndex, currentStyle.ColorIndex);
+                                run.FontSize = currentStyle.FontSize == 0 ? fontSize : currentStyle.FontSize;
+                                run.Bold = currentStyle.Bold;
+                                run.Italic = currentStyle.Italic;
+                                run.Underline = currentStyle.Underline;
                             }
 
                             if (printable)


### PR DESCRIPTION
## Summary
- ensure cast member text extraction falls back to XMED-decoded text
- decode member data using Latin1 instead of UTF-8
- expose XMED style declarations and map entries for text members

## Testing
- `dotnet test WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/ProjectorRays.DotNet.Test.csproj` *(fails: DirScriptParsingTests.CanParseScriptFromHex; MSBuild InternalLoggerException)*
- `dotnet test WillMoveToOwnRepo/ProjectorRays/Test/ProjectorRays.DotNet.Test/ProjectorRays.DotNet.Test.csproj --filter XmedReaderTests`


------
https://chatgpt.com/codex/tasks/task_e_68c3df2beb1083328516e15ca8ef48a1