### PR TITLE
Add stage view and clamp score scrolling

### DIFF
--- a/Test/LingoEngine.Director.Client.ConsoleTest/DirectorConsoleClient.cs
+++ b/Test/LingoEngine.Director.Client.ConsoleTest/DirectorConsoleClient.cs
@@ -51,7 +51,7 @@ public sealed class DirectorConsoleClient : IAsyncDisposable
             {
                 new MenuItem("_Score", string.Empty, ShowScore),
                 new MenuItem("_Cast", string.Empty, ShowCast),
-                new MenuItem("_Stage", string.Empty, () => MessageBox.Query("Stage", "Not implemented.", "Ok")),
+                new MenuItem("_Stage", string.Empty, ShowStage),
                 new MenuItem("_Property Window", string.Empty, ShowPropertyInspector)
             }),
             new MenuBarItem("_Help", Array.Empty<MenuItem>())
@@ -140,6 +140,40 @@ public sealed class DirectorConsoleClient : IAsyncDisposable
         };
         _workspace?.Add(castView);
         castView.SetFocus();
+    }
+
+    private void ShowStage()
+    {
+        _uiWin!.Title = "Stage";
+        _workspace?.RemoveAll();
+
+        var stage = new StageView
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Percent(75)
+        };
+
+        _scoreView = new ScoreView
+        {
+            X = 0,
+            Y = Pos.Percent(75),
+            Width = Dim.Fill(),
+            Height = Dim.Fill()
+        };
+        stage.Attach(_scoreView);
+        _scoreView.SpriteSelected += (ch, st) => Log($"spriteSelected {ch}:{st}");
+        _scoreView.PlayFromHere += f => Log($"Play from {f}");
+        _scoreView.InfoChanged += (f, ch, sp, mem) =>
+        {
+            UpdateInfo(f, ch, sp, mem);
+            stage.SetFrame(f);
+        };
+
+        _workspace?.Add(stage, _scoreView);
+        _scoreView.SetFocus();
+        _scoreView.TriggerInfo();
     }
 
     private void UpdateInfo(int frame, int channel, int? sprite, string? member)

--- a/Test/LingoEngine.Director.Client.ConsoleTest/PropertyInspector.cs
+++ b/Test/LingoEngine.Director.Client.ConsoleTest/PropertyInspector.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data;
 using LingoEngine.IO.Data.DTO;
@@ -9,6 +10,7 @@ internal sealed class PropertyInspector : Window
 {
     private readonly TabView _tabs;
     private readonly DataTable _memberTable = new();
+    private readonly List<PropertySpec> _memberSpecs = new();
     private readonly TableView _memberTableView;
     private readonly TabView.Tab _memberTab;
 
@@ -22,8 +24,28 @@ internal sealed class PropertyInspector : Window
 
         AddTab("Sprite", new[]
         {
-            "Lock", "FlipH", "FlipV", "Name", "X", "Y", "Z", "Left", "Top", "Right", "Bottom", "Width", "Height",
-            "Ink", "Blend", "StartFrame", "EndFrame", "Rotation", "Skew", "ForeColor", "BackColor", "Behaviors",
+            new PropertySpec("Lock", typeof(bool)),
+            new PropertySpec("FlipH", typeof(bool)),
+            new PropertySpec("FlipV", typeof(bool)),
+            new PropertySpec("Name", typeof(string)),
+            new PropertySpec("X", typeof(int)),
+            new PropertySpec("Y", typeof(int)),
+            new PropertySpec("Z", typeof(int)),
+            new PropertySpec("Left", typeof(int)),
+            new PropertySpec("Top", typeof(int)),
+            new PropertySpec("Right", typeof(int)),
+            new PropertySpec("Bottom", typeof(int)),
+            new PropertySpec("Width", typeof(int)),
+            new PropertySpec("Height", typeof(int)),
+            new PropertySpec("Ink", typeof(int)),
+            new PropertySpec("Blend", typeof(float)),
+            new PropertySpec("StartFrame", typeof(int)),
+            new PropertySpec("EndFrame", typeof(int)),
+            new PropertySpec("Rotation", typeof(float)),
+            new PropertySpec("Skew", typeof(float)),
+            new PropertySpec("ForeColor", typeof(Color)),
+            new PropertySpec("BackColor", typeof(Color)),
+            new PropertySpec("Behaviors", typeof(string))
         });
 
         _memberTable.Columns.Add("Property");
@@ -36,63 +58,108 @@ internal sealed class PropertyInspector : Window
         };
         _memberTableView.CellActivated += args =>
         {
-            var name = _memberTable.Rows[args.Row][0]?.ToString() ?? string.Empty;
+            var spec = _memberSpecs[args.Row];
+            if (spec.ReadOnly)
+            {
+                return;
+            }
             var value = _memberTable.Rows[args.Row][1]?.ToString() ?? string.Empty;
-            var field = new TextField(value)
+            var newValue = EditValue(spec.Type, spec.Name, value);
+            if (newValue != null)
             {
-                X = 12,
-                Y = 1,
-                Width = 20,
-            };
-            var ok = new Button("Ok", true);
-            ok.Clicked += () =>
-            {
-                _memberTable.Rows[args.Row][1] = field.Text.ToString();
-                Application.RequestStop();
-            };
-            var dialog = new Dialog($"Edit {name}", 40, 7, ok);
-            dialog.Add(new Label(name + ":") { X = 1, Y = 1 }, field);
-            field.SetFocus();
-            Application.Run(dialog);
+                _memberTable.Rows[args.Row][1] = newValue;
+            }
             _memberTableView.SetNeedsDisplay();
         };
         _memberTab = new TabView.Tab("Member", _memberTableView);
         _tabs.AddTab(_memberTab, false);
 
-        AddTab("Bitmap", new[] { "Dimensions", "Highlight", "RegPointX", "RegPointY" });
-        AddTab("Sound", new[] { "Loop", "Duration", "SampleRate", "BitDepth", "Channels", "Play", "Stop" });
+        AddTab("Bitmap", new[]
+        {
+            new PropertySpec("Dimensions", typeof(string), true),
+            new PropertySpec("Highlight", typeof(bool)),
+            new PropertySpec("RegPointX", typeof(int)),
+            new PropertySpec("RegPointY", typeof(int))
+        });
+        AddTab("Sound", new[]
+        {
+            new PropertySpec("Loop", typeof(bool)),
+            new PropertySpec("Duration", typeof(float), true),
+            new PropertySpec("SampleRate", typeof(int), true),
+            new PropertySpec("BitDepth", typeof(int), true),
+            new PropertySpec("Channels", typeof(int), true),
+            new PropertySpec("Play", typeof(bool)),
+            new PropertySpec("Stop", typeof(bool))
+        });
         AddTab("Movie", new[]
         {
-            "StageWidth", "StageHeight", "Resolution", "Channels", "BackgroundColor", "About", "Copyright",
+            new PropertySpec("StageWidth", typeof(int)),
+            new PropertySpec("StageHeight", typeof(int)),
+            new PropertySpec("Resolution", typeof(float)),
+            new PropertySpec("Channels", typeof(int)),
+            new PropertySpec("BackgroundColor", typeof(Color)),
+            new PropertySpec("About", typeof(string)),
+            new PropertySpec("Copyright", typeof(string))
         });
-        AddTab("Cast", new[] { "Number", "Name" });
-        AddTab("Text", new[] { "Width", "Height", "Edit" });
-        AddTab("Shape", new[] { "Shape", "Filled", "Width", "Height", "Edit" });
+        AddTab("Cast", new[]
+        {
+            new PropertySpec("Number", typeof(int)),
+            new PropertySpec("Name", typeof(string))
+        });
+        AddTab("Text", new[]
+        {
+            new PropertySpec("Width", typeof(int)),
+            new PropertySpec("Height", typeof(int)),
+            new PropertySpec("Edit", typeof(bool))
+        });
+        AddTab("Shape", new[]
+        {
+            new PropertySpec("Shape", typeof(string)),
+            new PropertySpec("Filled", typeof(bool)),
+            new PropertySpec("Width", typeof(int)),
+            new PropertySpec("Height", typeof(int)),
+            new PropertySpec("Edit", typeof(bool))
+        });
         AddTab("Guides", new[]
         {
-            "GuidesColor", "GuidesVisible", "GuidesSnap", "GuidesLock", "GridColor", "GridVisible", "GridSnap",
-            "AddVerticalGuide", "AddHorizontalGuide", "RemoveGuides", "GridWidth", "GridHeight",
+            new PropertySpec("GuidesColor", typeof(Color)),
+            new PropertySpec("GuidesVisible", typeof(bool)),
+            new PropertySpec("GuidesSnap", typeof(bool)),
+            new PropertySpec("GuidesLock", typeof(bool)),
+            new PropertySpec("GridColor", typeof(Color)),
+            new PropertySpec("GridVisible", typeof(bool)),
+            new PropertySpec("GridSnap", typeof(bool)),
+            new PropertySpec("AddVerticalGuide", typeof(bool)),
+            new PropertySpec("AddHorizontalGuide", typeof(bool)),
+            new PropertySpec("RemoveGuides", typeof(bool)),
+            new PropertySpec("GridWidth", typeof(int)),
+            new PropertySpec("GridHeight", typeof(int))
         });
-        AddTab("Behavior", new[] { "Behaviors" });
-        AddTab("FilmLoop", new[] { "Framing", "Loop", "FrameCount" });
+        AddTab("Behavior", new[] { new PropertySpec("Behaviors", typeof(string)) });
+        AddTab("FilmLoop", new[]
+        {
+            new PropertySpec("Framing", typeof(string)),
+            new PropertySpec("Loop", typeof(bool)),
+            new PropertySpec("FrameCount", typeof(int))
+        });
 
         Add(_tabs);
     }
 
-    private void AddTab(string title, string[] props)
+    private void AddTab(string title, PropertySpec[] props)
     {
         var view = BuildPropertyTableView(props);
         _tabs.AddTab(new TabView.Tab(title, view), _tabs.Tabs.Count == 0);
     }
 
-    private static TableView BuildPropertyTableView(string[] props)
+    private static TableView BuildPropertyTableView(PropertySpec[] props)
     {
         var table = new DataTable();
         table.Columns.Add("Property");
         table.Columns.Add("Value");
-        foreach (var prop in props)
+        for (var i = 0; i < props.Length; i++)
         {
-            table.Rows.Add(prop, string.Empty);
+            table.Rows.Add(props[i].Name, string.Empty);
         }
         var view = new TableView
         {
@@ -102,37 +169,137 @@ internal sealed class PropertyInspector : Window
         };
         view.CellActivated += args =>
         {
-            var name = table.Rows[args.Row][0]?.ToString() ?? string.Empty;
-            var value = table.Rows[args.Row][1]?.ToString() ?? string.Empty;
-            var field = new TextField(value)
+            var spec = props[args.Row];
+            if (spec.ReadOnly)
             {
-                X = 12,
-                Y = 1,
-                Width = 20,
-            };
+                return;
+            }
+            var value = table.Rows[args.Row][1]?.ToString() ?? string.Empty;
+            var newValue = EditValue(spec.Type, spec.Name, value);
+            if (newValue != null)
+            {
+                table.Rows[args.Row][1] = newValue;
+            }
+            view.SetNeedsDisplay();
+        };
+        return view;
+    }
+
+    private static string? EditValue(Type type, string name, string value)
+    {
+        string? result = null;
+        if (type == typeof(bool))
+        {
+            var check = new CheckBox(12, 1, string.Empty, bool.TryParse(value, out var b) && b);
             var ok = new Button("Ok", true);
             ok.Clicked += () =>
             {
-                table.Rows[args.Row][1] = field.Text.ToString();
+                result = check.Checked.ToString();
+                Application.RequestStop();
+            };
+            var dialog = new Dialog($"Edit {name}", 30, 7, ok);
+            dialog.Add(new Label(name + ":") { X = 1, Y = 1 }, check);
+            Application.Run(dialog);
+        }
+        else if (type == typeof(int))
+        {
+            var field = new TextField(value) { X = 12, Y = 1, Width = 20 };
+            var ok = new Button("Ok", true);
+            ok.Clicked += () =>
+            {
+                if (int.TryParse(field.Text.ToString(), out var v))
+                {
+                    result = v.ToString();
+                }
                 Application.RequestStop();
             };
             var dialog = new Dialog($"Edit {name}", 40, 7, ok);
             dialog.Add(new Label(name + ":") { X = 1, Y = 1 }, field);
             field.SetFocus();
             Application.Run(dialog);
-            view.SetNeedsDisplay();
-        };
-        return view;
+        }
+        else if (type == typeof(float))
+        {
+            var field = new TextField(value) { X = 12, Y = 1, Width = 20 };
+            var ok = new Button("Ok", true);
+            ok.Clicked += () =>
+            {
+                if (float.TryParse(field.Text.ToString(), out var v))
+                {
+                    result = v.ToString();
+                }
+                Application.RequestStop();
+            };
+            var dialog = new Dialog($"Edit {name}", 40, 7, ok);
+            dialog.Add(new Label(name + ":") { X = 1, Y = 1 }, field);
+            field.SetFocus();
+            Application.Run(dialog);
+        }
+        else if (type == typeof(Color))
+        {
+            var colors = Enum.GetNames<Color>();
+            var list = new ListView(colors)
+            {
+                Width = Dim.Fill(),
+                Height = Dim.Fill()
+            };
+            var ok = new Button("Ok", true);
+            ok.Clicked += () =>
+            {
+                result = colors[list.SelectedItem];
+                Application.RequestStop();
+            };
+            var dialog = new Dialog($"Edit {name}", 30, 15, ok);
+            dialog.Add(list);
+            Application.Run(dialog);
+        }
+        else
+        {
+            var field = new TextField(value) { X = 12, Y = 1, Width = 20 };
+            var ok = new Button("Ok", true);
+            ok.Clicked += () =>
+            {
+                result = field.Text.ToString();
+                Application.RequestStop();
+            };
+            var dialog = new Dialog($"Edit {name}", 40, 7, ok);
+            dialog.Add(new Label(name + ":") { X = 1, Y = 1 }, field);
+            field.SetFocus();
+            Application.Run(dialog);
+        }
+        return result;
     }
 
     public void ShowMember(LingoMemberDTO member)
     {
         _memberTable.Rows.Clear();
-        _memberTable.Rows.Add("Name", member.Name);
-        _memberTable.Rows.Add("Number", member.Number.ToString());
-        _memberTable.Rows.Add("Type", member.Type.ToString());
-        _memberTable.Rows.Add("Comment", member.Comments);
+        _memberSpecs.Clear();
+        AddMember("Name", member.Name, typeof(string));
+        AddMember("Number", member.Number.ToString(), typeof(int), true);
+        AddMember("Type", member.Type.ToString(), typeof(string), true);
+        AddMember("Comment", member.Comments, typeof(string));
         _memberTableView.SetNeedsDisplay();
         _tabs.SelectedTab = _memberTab;
     }
+
+    private void AddMember(string name, string value, Type type, bool readOnly = false)
+    {
+        _memberTable.Rows.Add(name, value);
+        _memberSpecs.Add(new PropertySpec(name, type, readOnly));
+    }
+
+    private sealed class PropertySpec
+    {
+        public string Name { get; }
+        public Type Type { get; }
+        public bool ReadOnly { get; }
+
+        public PropertySpec(string name, Type type, bool readOnly = false)
+        {
+            Name = name;
+            Type = type;
+            ReadOnly = readOnly;
+        }
+    }
 }
+

--- a/Test/LingoEngine.Director.Client.ConsoleTest/StageView.cs
+++ b/Test/LingoEngine.Director.Client.ConsoleTest/StageView.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Linq;
+using LingoEngine.IO.Data.DTO;
+using Terminal.Gui;
+
+namespace LingoEngine.Director.Client.ConsoleTest;
+
+internal sealed class StageView : View
+{
+    private const int MovieWidth = 640;
+    private const int MovieHeight = 480;
+    private readonly IReadOnlyList<LingoSpriteDTO> _sprites;
+    private int _frame;
+
+    public StageView()
+    {
+        CanFocus = false;
+        _sprites = TestMovieBuilder.BuildSprites();
+    }
+
+    public void SetFrame(int frame)
+    {
+        _frame = frame;
+        SetNeedsDisplay();
+    }
+
+    public void Attach(ScoreView score)
+    {
+        score.SpriteChanged += OnSpriteChanged;
+    }
+
+    private void OnSpriteChanged()
+    {
+        SetNeedsDisplay();
+    }
+
+    public override void Redraw(Rect bounds)
+    {
+        base.Redraw(bounds);
+        var w = bounds.Width;
+        var h = bounds.Height;
+        Driver.SetAttribute(ColorScheme.Normal);
+
+        for (var y = 0; y < h; y++)
+        {
+            Move(0, y);
+            for (var x = 0; x < w; x++)
+            {
+                Driver.AddRune(' ');
+            }
+        }
+
+        foreach (var sprite in _sprites.Where(s => s.BeginFrame <= _frame && _frame <= s.EndFrame))
+        {
+            var ch = sprite.Name.Length > 0 ? sprite.Name[0] : '?';
+            var x = (int)(sprite.LocH / MovieWidth * w);
+            var y = (int)(sprite.LocV / MovieHeight * h);
+            if (x >= 0 && x < w && y >= 0 && y < h)
+            {
+                Move(x, y);
+                Driver.AddRune(ch);
+            }
+        }
+    }
+}

--- a/Test/LingoEngine.Director.Client.ConsoleTest/TestMovieBuilder.cs
+++ b/Test/LingoEngine.Director.Client.ConsoleTest/TestMovieBuilder.cs
@@ -19,10 +19,10 @@ public static class TestMovieBuilder
     /// </summary>
     public static IReadOnlyList<LingoSpriteDTO> BuildSprites() => new List<LingoSpriteDTO>
     {
-        new() { Name = "Greeting", SpriteNum = 1, MemberNum = 1, BeginFrame = 1, EndFrame = 60 },
-        new() { Name = "Info", SpriteNum = 2, MemberNum = 2, BeginFrame = 1, EndFrame = 60 },
-        new() { Name = "Box", SpriteNum = 3, MemberNum = 3, BeginFrame = 1, EndFrame = 60 },
-        new() { Name = "Greeting", SpriteNum = 4, MemberNum = 1, BeginFrame = 1, EndFrame = 60 },
-        new() { Name = "Info", SpriteNum = 5, MemberNum = 2, BeginFrame = 1, EndFrame = 60 },
+        new() { Name = "Greeting", SpriteNum = 1, MemberNum = 1, BeginFrame = 1, EndFrame = 60, LocH = 100, LocV = 100 },
+        new() { Name = "Info", SpriteNum = 2, MemberNum = 2, BeginFrame = 1, EndFrame = 60, LocH = 300, LocV = 200 },
+        new() { Name = "Box", SpriteNum = 3, MemberNum = 3, BeginFrame = 1, EndFrame = 60, LocH = 400, LocV = 300 },
+        new() { Name = "Greeting", SpriteNum = 4, MemberNum = 1, BeginFrame = 1, EndFrame = 60, LocH = 150, LocV = 400 },
+        new() { Name = "Info", SpriteNum = 5, MemberNum = 2, BeginFrame = 1, EndFrame = 60, LocH = 500, LocV = 120 },
     };
 }


### PR DESCRIPTION
## Summary
- Prevent ScoreView mouse scrolling from offsetting into negative channels
- Provide sample sprite locations and new StageView to render characters at scaled positions
- Integrate StageView into console client with layout that allocates 75% height to stage and 25% to score
- Refresh StageView when ScoreView sprite data changes
- Update property inspector to open type-specific editors and block edits to read-only fields

## Testing
- `dotnet format Test/LingoEngine.Director.Client.ConsoleTest/LingoEngine.Director.Client.ConsoleTest.csproj --include Test/LingoEngine.Director.Client.ConsoleTest/StageView.cs --include Test/LingoEngine.Director.Client.ConsoleTest/ScoreView.cs --include Test/LingoEngine.Director.Client.ConsoleTest/DirectorConsoleClient.cs --include Test/LingoEngine.Director.Client.ConsoleTest/PropertyInspector.cs -v diagnostic`
- `dotnet build Test/LingoEngine.Director.Client.ConsoleTest/LingoEngine.Director.Client.ConsoleTest.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c4fbdc6f988332aa535e7a160a4869