### PR TITLE
feat(debugterminal): add score keyframe editing

### DIFF
--- a/src/LingoEngine/Net/LingoEngine.Net.DebugTerminal/PropertyInspector.cs
+++ b/src/LingoEngine/Net/LingoEngine.Net.DebugTerminal/PropertyInspector.cs
@@ -14,6 +14,8 @@ internal sealed class PropertyInspector : Window
     private readonly TableView _memberTableView;
     private readonly TabView.Tab _memberTab;
 
+    public event Action<string, string>? PropertyChanged;
+
     public PropertyInspector() : base("Properties")
     {
         _tabs = new TabView
@@ -68,6 +70,7 @@ internal sealed class PropertyInspector : Window
             if (newValue != null)
             {
                 _memberTable.Rows[args.Row][1] = newValue;
+                PropertyChanged?.Invoke(spec.Name, newValue);
             }
             _memberTableView.SetNeedsDisplay();
         };
@@ -152,7 +155,7 @@ internal sealed class PropertyInspector : Window
         _tabs.AddTab(new TabView.Tab(title, view), _tabs.Tabs.Count == 0);
     }
 
-    private static TableView BuildPropertyTableView(PropertySpec[] props)
+    private TableView BuildPropertyTableView(PropertySpec[] props)
     {
         var table = new DataTable();
         table.Columns.Add("Property");
@@ -179,6 +182,7 @@ internal sealed class PropertyInspector : Window
             if (newValue != null)
             {
                 table.Rows[args.Row][1] = newValue;
+                PropertyChanged?.Invoke(spec.Name, newValue);
             }
             view.SetNeedsDisplay();
         };

--- a/src/LingoEngine/Net/LingoEngine.Net.DebugTerminal/StageView.cs
+++ b/src/LingoEngine/Net/LingoEngine.Net.DebugTerminal/StageView.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using LingoEngine.IO.Data.DTO;
@@ -10,27 +11,43 @@ internal sealed class StageView : View
     private const int MovieWidth = 640;
     private const int MovieHeight = 480;
     private readonly IReadOnlyList<LingoSpriteDTO> _sprites;
+    private readonly Dictionary<int, string> _memberNames = new();
     private int _frame;
+    private int? _selectedSprite;
+    private static readonly Color[] OverlapColors =
+    {
+        Color.DarkGray,
+        Color.Gray,
+        Color.White,
+        Color.BrightYellow
+    };
+
+    public event Action<int>? SpriteSelected;
 
     public StageView()
     {
-        CanFocus = false;
+        CanFocus = true;
+        ColorScheme = new ColorScheme
+        {
+            Normal = Application.Driver.MakeAttribute(Color.White, Color.Gray)
+        };
         _sprites = TestMovieBuilder.BuildSprites();
+        foreach (var m in TestCastBuilder.BuildCastData().SelectMany(c => c.Value))
+        {
+            _memberNames[m.Number] = m.Name;
+        }
     }
 
     public void SetFrame(int frame)
     {
         _frame = frame;
-        SetNeedsDisplay();
     }
 
-    public void Attach(ScoreView score)
-    {
-        score.SpriteChanged += OnSpriteChanged;
-    }
+    public void RequestRedraw() => SetNeedsDisplay();
 
-    private void OnSpriteChanged()
+    public void SetSelectedSprite(int? spriteNum)
     {
+        _selectedSprite = spriteNum;
         SetNeedsDisplay();
     }
 
@@ -50,16 +67,92 @@ internal sealed class StageView : View
             }
         }
 
-        foreach (var sprite in _sprites.Where(s => s.BeginFrame <= _frame && _frame <= s.EndFrame))
+        var chars = new char[w, h];
+        var colors = new Color[w, h];
+        var counts = new int[w, h];
+
+        foreach (var sprite in _sprites
+                     .Where(s => s.BeginFrame <= _frame && _frame <= s.EndFrame)
+                     .OrderBy(s => s.LocZ))
         {
-            var ch = sprite.Name.Length > 0 ? sprite.Name[0] : '?';
+            var ch = ' ';
+            if (_memberNames.TryGetValue(sprite.MemberNum, out var name) && !string.IsNullOrEmpty(name))
+            {
+                ch = name[0];
+            }
             var x = (int)(sprite.LocH / MovieWidth * w);
             var y = (int)(sprite.LocV / MovieHeight * h);
-            if (x >= 0 && x < w && y >= 0 && y < h)
+            var sw = (int)(sprite.Width / MovieWidth * w);
+            var sh = (int)(sprite.Height / MovieHeight * h);
+            if (sw <= 0 || sh <= 0 || sh > 2 || sw > 10)
             {
-                Move(x, y);
-                Driver.AddRune(ch);
+                sw = 1;
+                sh = 1;
+            }
+            for (var dy = 0; dy < sh; dy++)
+            {
+                for (var dx = 0; dx < sw; dx++)
+                {
+                    var sx = x + dx;
+                    var sy = y + dy;
+                    if (sx < 0 || sx >= w || sy < 0 || sy >= h)
+                    {
+                        continue;
+                    }
+                    counts[sx, sy]++;
+                    chars[sx, sy] = ch;
+                    if (_selectedSprite.HasValue && sprite.SpriteNum == _selectedSprite.Value)
+                    {
+                        colors[sx, sy] = Color.Blue;
+                    }
+                    else
+                    {
+                        var idx = Math.Min(counts[sx, sy] - 1, OverlapColors.Length - 1);
+                        colors[sx, sy] = OverlapColors[idx];
+                    }
+                }
             }
         }
+
+        for (var y = 0; y < h; y++)
+        {
+            Move(0, y);
+            for (var x = 0; x < w; x++)
+            {
+                var col = colors[x, y];
+                Driver.SetAttribute(Application.Driver.MakeAttribute(col, Color.Gray));
+                Driver.AddRune(chars[x, y] == '\0' ? ' ' : chars[x, y]);
+            }
+        }
+    }
+
+    public override bool MouseEvent(MouseEvent me)
+    {
+        if (me.Flags.HasFlag(MouseFlags.Button1Clicked))
+        {
+            var w = Bounds.Width;
+            var h = Bounds.Height;
+            foreach (var sprite in _sprites
+                         .Where(s => s.BeginFrame <= _frame && _frame <= s.EndFrame)
+                         .OrderByDescending(s => s.LocZ))
+            {
+                var x = (int)(sprite.LocH / MovieWidth * w);
+                var y = (int)(sprite.LocV / MovieHeight * h);
+                var sw = (int)(sprite.Width / MovieWidth * w);
+                var sh = (int)(sprite.Height / MovieHeight * h);
+                if (sw <= 0 || sh <= 0 || sh > 2 || sw > 10)
+                {
+                    sw = 1;
+                    sh = 1;
+                }
+                if (me.X >= x && me.X < x + sw && me.Y >= y && me.Y < y + sh)
+                {
+                    SpriteSelected?.Invoke(sprite.SpriteNum);
+                    break;
+                }
+            }
+            return true;
+        }
+        return base.MouseEvent(me);
     }
 }


### PR DESCRIPTION
## Summary
- size sprites on stage with depth-based overlap colors and selection highlighting
- highlight selected sprites in score and list top 5 special channels
- render sprite keyframes as `o` in the score and allow editing tween properties

## Testing
- `dotnet format src/LingoEngine/Net/LingoEngine.Net.DebugTerminal/LingoEngine.Net.DebugTerminal.csproj --include src/LingoEngine/Net/LingoEngine.Net.DebugTerminal/ScoreView.cs -v diagnostic`
- `dotnet build src/LingoEngine/Net/LingoEngine.Net.DebugTerminal/LingoEngine.Net.DebugTerminal.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c51bb1247c8332b4c93850dbdec118