### PR TITLE
feat: add property change notifications

### DIFF
--- a/Test/LingoEngine.Tests/Casts/DummyTextMember.cs
+++ b/Test/LingoEngine.Tests/Casts/DummyTextMember.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using AbstUI.Primitives;
 using AbstUI.Texts;
@@ -96,6 +97,8 @@ internal class DummyTextMember : ILingoMemberTextBase, ILingoMemberTextBaseInter
     public void ChangesHasBeenApplied() { }
     public void LoadFile() { LoadFileCalled = true; }
     public void SetFileName(string name) => _fileName = name;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     private class DummyFrameworkMember : ILingoFrameworkMember
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/IHasPropertyChanged.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/IHasPropertyChanged.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel;
+
+namespace AbstUI;
+
+public interface IHasPropertyChanged
+{
+    event PropertyChangedEventHandler? PropertyChanged;
+}
+

--- a/src/LingoEngine/ColorPalettes/LingoColorPaletteMember.cs
+++ b/src/LingoEngine/ColorPalettes/LingoColorPaletteMember.cs
@@ -6,20 +6,51 @@ namespace LingoEngine.ColorPalettes
 {
     public class LingoColorPaletteMember : LingoMember
     {
-        public int ColorPaletteId { get; set; }
+        private int _colorPaletteId;
+        private int _rate;
+        private int _cycles = 10;
+        private LingoColorPaletteAction _action = LingoColorPaletteAction.PaletteTransition;
+        private LingoColorPaletteTransitionOption _transitionOption = LingoColorPaletteTransitionOption.DontFade;
+        private LingoColorPaletteCycleOption _cycleOption = LingoColorPaletteCycleOption.AutoReverse;
+
+        public int ColorPaletteId
+        {
+            get => _colorPaletteId;
+            set => SetProperty(ref _colorPaletteId, value);
+        }
         /// <summary>
         /// Range between 1 to 30 FPS
         /// in FPS
         /// </summary>
-        public int Rate { get; set; }
+        public int Rate
+        {
+            get => _rate;
+            set => SetProperty(ref _rate, value);
+        }
         /// <summary>
         /// When Action is Cycling, the number of cycles.
         /// </summary>
-        public int Cycles { get; set; } = 10;
-        public LingoColorPaletteAction Action { get; set; } = LingoColorPaletteAction.PaletteTransition;
-        public LingoColorPaletteTransitionOption TransitionOption { get; set; } = LingoColorPaletteTransitionOption.DontFade;
-        public LingoColorPaletteCycleOption CycleOption { get; set; } = LingoColorPaletteCycleOption.AutoReverse;
-        public LingoColorPaletteMember(LingoCast cast, int numberInCast, string name = "", string fileName = "", APoint regPoint = default) : base(new LingoColorPaletteMemberFW(), LingoMemberType.Palette , cast, numberInCast, name, fileName, regPoint)
+        public int Cycles
+        {
+            get => _cycles;
+            set => SetProperty(ref _cycles, value);
+        }
+        public LingoColorPaletteAction Action
+        {
+            get => _action;
+            set => SetProperty(ref _action, value);
+        }
+        public LingoColorPaletteTransitionOption TransitionOption
+        {
+            get => _transitionOption;
+            set => SetProperty(ref _transitionOption, value);
+        }
+        public LingoColorPaletteCycleOption CycleOption
+        {
+            get => _cycleOption;
+            set => SetProperty(ref _cycleOption, value);
+        }
+        public LingoColorPaletteMember(LingoCast cast, int numberInCast, string name = "", string fileName = "", APoint regPoint = default) : base(new LingoColorPaletteMemberFW(), LingoMemberType.Palette, cast, numberInCast, name, fileName, regPoint)
         {
         }
 

--- a/src/LingoEngine/FilmLoops/LingoFilmLoopMember.cs
+++ b/src/LingoEngine/FilmLoops/LingoFilmLoopMember.cs
@@ -27,7 +27,12 @@ namespace LingoEngine.FilmLoops
         public List<LingoFilmLoopMemberSprite> SpriteEntries { get; } = new();
         public List<SoundEntry> SoundEntries { get; } = new();
 
-        public int FrameCount { get; private set; }
+        private int _frameCount;
+        public int FrameCount
+        {
+            get => _frameCount;
+            private set => SetProperty(ref _frameCount, value);
+        }
         public IAbstTexture2D? TextureLingo => _frameworkFilmLoop.TextureLingo;
 
 
@@ -44,7 +49,13 @@ namespace LingoEngine.FilmLoops
         public LingoFilmLoopFraming Framing
         {
             get => _frameworkFilmLoop.Framing;
-            set => _frameworkFilmLoop.Framing = value;
+            set
+            {
+                if (_frameworkFilmLoop.Framing == value)
+                    return;
+                _frameworkFilmLoop.Framing = value;
+                OnPropertyChanged();
+            }
         }
 
         /// <summary>
@@ -54,7 +65,13 @@ namespace LingoEngine.FilmLoops
         public bool Loop
         {
             get => _frameworkFilmLoop.Loop;
-            set => _frameworkFilmLoop.Loop = value;
+            set
+            {
+                if (_frameworkFilmLoop.Loop == value)
+                    return;
+                _frameworkFilmLoop.Loop = value;
+                OnPropertyChanged();
+            }
         }
 
 

--- a/src/LingoEngine/Medias/LingoMemberMedia.cs
+++ b/src/LingoEngine/Medias/LingoMemberMedia.cs
@@ -12,7 +12,17 @@ namespace LingoEngine.Medias
         private readonly ILingoFrameworkMemberMedia _frameworkMedia;
 
         public int Duration => _frameworkMedia.Duration;
-        public int CurrentTime { get => _frameworkMedia.CurrentTime; set => _frameworkMedia.CurrentTime = value; }
+        public int CurrentTime
+        {
+            get => _frameworkMedia.CurrentTime;
+            set
+            {
+                if (_frameworkMedia.CurrentTime == value)
+                    return;
+                _frameworkMedia.CurrentTime = value;
+                OnPropertyChanged();
+            }
+        }
         public LingoMediaStatus MediaStatus => _frameworkMedia.MediaStatus;
 
         public LingoMemberMedia(ILingoFrameworkMemberMedia frameworkMember, LingoMemberType type, LingoCast cast, int numberInCast, string name = "", string fileName = "", APoint regPoint = default)

--- a/src/LingoEngine/Movies/ILingoMovie.cs
+++ b/src/LingoEngine/Movies/ILingoMovie.cs
@@ -1,4 +1,5 @@
-﻿using LingoEngine.Casts;
+using AbstUI;
+using LingoEngine.Casts;
 using LingoEngine.ColorPalettes;
 using LingoEngine.Core;
 using LingoEngine.Members;
@@ -14,7 +15,7 @@ namespace LingoEngine.Movies
     /// Represents the Lingo _movie object, providing control over playback, navigation, and transitions.
     /// Lingo equivalents are noted for each member.
     /// </summary>
-    public interface ILingoMovie : ILingoSpritesPlayer
+    public interface ILingoMovie : ILingoSpritesPlayer, IHasPropertyChanged
     {
         /// <summary>
         /// Gets the name of the movie.
@@ -34,8 +35,6 @@ namespace LingoEngine.Movies
         /// </summary>
         int FrameCount { get; }
 
-        
-
         /// <summary>
         /// Gets or sets the tempo (frames per second) of the movie.
         /// Lingo: the tempo
@@ -48,14 +47,14 @@ namespace LingoEngine.Movies
         bool IsPlaying { get; }
 
 
-        string About { get; set; } 
-        string Copyright { get; set; } 
-        string UserName { get; set; } 
+        string About { get; set; }
+        string Copyright { get; set; }
+        string UserName { get; set; }
         string CompanyName { get; set; }
 
-        ILingoSpriteAudioManager Audio {get;}
-        ILingoSpriteTransitionManager Transitions {get;}
-        ILingoTempoSpriteManager Tempos {get;}
+        ILingoSpriteAudioManager Audio { get; }
+        ILingoSpriteTransitionManager Transitions { get; }
+        ILingoTempoSpriteManager Tempos { get; }
         ILingoSpriteColorPaletteSpriteManager ColorPalettes { get; }
 
         /// <summary>
@@ -182,10 +181,10 @@ namespace LingoEngine.Movies
         /// Lingo: constrainV
         /// </summary>
         int ConstrainV(int spriteNumber, int pos);
-        
+
         void UpdateStage();
         ILingoSpriteChannel Channel(int channelNumber);
-        ActorList ActorList { get;  }
+        ActorList ActorList { get; }
         LingoTimeOutList TimeOutList { get; }
         /// <summary>
         /// The number/index of this Score within the movie.
@@ -322,7 +321,7 @@ namespace LingoEngine.Movies
         /// Lingo : // newBitmap = _movie.newMember(#bitmap)
         /// </summary>
         ILingoMemberFactory New { get; }
-        
+
 
         #endregion
         /// <summary>
@@ -336,11 +335,11 @@ namespace LingoEngine.Movies
         void SetScoreLabel(int frameNumber, string name);
         void PuppetSprite(int myNum, bool state);
 
-      
+
         int GetNextSpriteStart(int channel, int frame);
         int GetPrevSpriteEnd(int channel, int frame);
         ILingoServiceProvider GetServiceProvider();
-        T GetRequiredService<T>() where T: notnull;
+        T GetRequiredService<T>() where T : notnull;
 
 
     }

--- a/src/LingoEngine/Scripts/LingoMemberScript.cs
+++ b/src/LingoEngine/Scripts/LingoMemberScript.cs
@@ -9,7 +9,12 @@ namespace LingoEngine.Scripts
 {
     public class LingoMemberScript : LingoMember
     {
-        public LingoScriptType ScriptType { get; set; } = LingoScriptType.Behavior;
+        private LingoScriptType _scriptType = LingoScriptType.Behavior;
+        public LingoScriptType ScriptType
+        {
+            get => _scriptType;
+            set => SetProperty(ref _scriptType, value);
+        }
         public string? BehaviorTypeName { get; private set; }
 
         public LingoMemberScript(ILingoFrameworkMember frameworkMember, LingoCast cast, int numberInCast, string name = "", string fileName = "", APoint regPoint = default)

--- a/src/LingoEngine/Shapes/LingoMemberShape.cs
+++ b/src/LingoEngine/Shapes/LingoMemberShape.cs
@@ -15,17 +15,135 @@ namespace LingoEngine.Shapes
         private readonly ILingoFrameworkMemberShape _framework;
 
         public LingoList<APoint> VertexList => _framework.VertexList;
-        public LingoShapeType ShapeType { get => _framework.ShapeType; set => _framework.ShapeType = value; }
-        public int ShapeTypeInt { get => (int)ShapeType; set => ShapeType = (LingoShapeType)value; }
-        public AColor FillColor { get => _framework.FillColor; set => _framework.FillColor = value; }
-        public AColor EndColor { get => _framework.EndColor; set => _framework.EndColor = value; }
-        public AColor StrokeColor { get => _framework.StrokeColor; set => _framework.StrokeColor = value; }
-        public int StrokeWidth { get => _framework.StrokeWidth; set => _framework.StrokeWidth = value; }
-        public bool Closed { get => _framework.Closed; set => _framework.Closed = value; }
-        public bool AntiAlias { get => _framework.AntiAlias; set => _framework.AntiAlias = value; }
-        public override int Width { get => Convert.ToInt32(_framework.Width); set => _framework.Width = value; }
-        public override int Height { get => Convert.ToInt32(_framework.Height); set => _framework.Height = value; }
-        public bool Filled { get => _framework.Filled; set => _framework.Filled = value; }
+
+        public LingoShapeType ShapeType
+        {
+            get => _framework.ShapeType;
+            set
+            {
+                if (_framework.ShapeType == value)
+                    return;
+                _framework.ShapeType = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(ShapeTypeInt));
+            }
+        }
+
+        public int ShapeTypeInt
+        {
+            get => (int)ShapeType;
+            set => ShapeType = (LingoShapeType)value;
+        }
+
+        public AColor FillColor
+        {
+            get => _framework.FillColor;
+            set
+            {
+                if (_framework.FillColor == value)
+                    return;
+                _framework.FillColor = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public AColor EndColor
+        {
+            get => _framework.EndColor;
+            set
+            {
+                if (_framework.EndColor == value)
+                    return;
+                _framework.EndColor = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public AColor StrokeColor
+        {
+            get => _framework.StrokeColor;
+            set
+            {
+                if (_framework.StrokeColor == value)
+                    return;
+                _framework.StrokeColor = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public int StrokeWidth
+        {
+            get => _framework.StrokeWidth;
+            set
+            {
+                if (_framework.StrokeWidth == value)
+                    return;
+                _framework.StrokeWidth = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool Closed
+        {
+            get => _framework.Closed;
+            set
+            {
+                if (_framework.Closed == value)
+                    return;
+                _framework.Closed = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool AntiAlias
+        {
+            get => _framework.AntiAlias;
+            set
+            {
+                if (_framework.AntiAlias == value)
+                    return;
+                _framework.AntiAlias = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public override int Width
+        {
+            get => Convert.ToInt32(_framework.Width);
+            set
+            {
+                if (Convert.ToInt32(_framework.Width) == value)
+                    return;
+                _framework.Width = value;
+                base.Width = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public override int Height
+        {
+            get => Convert.ToInt32(_framework.Height);
+            set
+            {
+                if (Convert.ToInt32(_framework.Height) == value)
+                    return;
+                _framework.Height = value;
+                base.Height = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool Filled
+        {
+            get => _framework.Filled;
+            set
+            {
+                if (_framework.Filled == value)
+                    return;
+                _framework.Filled = value;
+                OnPropertyChanged();
+            }
+        }
 
         public IAbstTexture2D? TextureLingo => _framework.TextureLingo;
 

--- a/src/LingoEngine/Sounds/LingoMemberSound.cs
+++ b/src/LingoEngine/Sounds/LingoMemberSound.cs
@@ -22,7 +22,12 @@ namespace LingoEngine.Sounds
         /// Indicates whether this sound loops by default.
         /// Lingo: the loop of member
         /// </summary>
-        public bool Loop { get; set; } = false;
+        private bool _loop;
+        public bool Loop
+        {
+            get => _loop;
+            set => SetProperty(ref _loop, value);
+        }
 
         /// <summary>
         /// Whether this member is externally linked (not embedded).
@@ -36,10 +41,10 @@ namespace LingoEngine.Sounds
         public string LinkedFilePath { get; set; } = string.Empty;
 
         public LingoMemberSound(ILingoFrameworkMemberSound lingoMemberSound, LingoCast cast, int numberInCast, string name = "", string fileName = "")
-            : base(lingoMemberSound, LingoMemberType.Sound,cast, numberInCast, name, fileName)
+            : base(lingoMemberSound, LingoMemberType.Sound, cast, numberInCast, name, fileName)
         {
             _lingoFrameworkMemberSound = lingoMemberSound;
-           
+
         }
         protected override LingoMember OnDuplicate(int newNumber)
         {

--- a/src/LingoEngine/Sprites/ILingoSprite.cs
+++ b/src/LingoEngine/Sprites/ILingoSprite.cs
@@ -1,4 +1,5 @@
-﻿using AbstUI.Primitives;
+﻿using AbstUI;
+using AbstUI.Primitives;
 using LingoEngine.Casts;
 using LingoEngine.Medias;
 using LingoEngine.Members;
@@ -11,7 +12,7 @@ namespace LingoEngine.Sprites
     /// Represents a base sprite in the score.
     /// Mirrors Lingo’s sprite object functionality.
     /// </summary>
-    public interface ILingoSpriteBase
+    public interface ILingoSpriteBase : IHasPropertyChanged
     {
         /// <summary>
         /// The frame number at which the sprite appears. Read/write.

--- a/src/LingoEngine/Sprites/LingoSpriteChannel.cs
+++ b/src/LingoEngine/Sprites/LingoSpriteChannel.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using AbstUI;
 using AbstUI.Primitives;
 using LingoEngine.Casts;
 using LingoEngine.Members;
@@ -64,13 +67,14 @@ namespace LingoEngine.Sprites
         void RemoveScriptedSprite();
     }
 
-    public class LingoSpriteChannel : ILingoSpriteChannel
+    public class LingoSpriteChannel : ILingoSpriteChannel, IHasPropertyChanged
     {
         private bool _puppet;
         private readonly LingoMovie _movie;
         private bool _visibility = true;
         private ILingoSprite? _sprite;
         public event Action<LingoSpriteChannel, bool>? VisibilityChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
         /// <inheritdoc/>
         /// <inheritdoc/>
         public int Number { get; private set; }
@@ -85,6 +89,7 @@ namespace LingoEngine.Sprites
                 _visibility = value;
                 if (_sprite != null) _sprite.Visibility = value;
                 VisibilityChanged?.Invoke(this, value);
+                OnPropertyChanged();
             }
         }
         bool ILingoSpriteBase.IsPuppetCached { get; set; }
@@ -207,6 +212,7 @@ namespace LingoEngine.Sprites
                         //_sprite = null;
                     }
                 }
+                OnPropertyChanged();
             }
         }
 
@@ -252,6 +258,10 @@ namespace LingoEngine.Sprites
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
 
         public bool HasSprite() => _sprite != null;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
     }
 }

--- a/src/LingoEngine/Stages/LingoStage.cs
+++ b/src/LingoEngine/Stages/LingoStage.cs
@@ -3,19 +3,44 @@ using AbstUI.Primitives;
 using LingoEngine.Movies;
 using LingoEngine.Sprites;
 using LingoEngine.Animations;
+using AbstUI;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace LingoEngine.Stages;
 
 /// <summary>
 /// You have one stage for all movies
 /// </summary>
-public class LingoStage : ILingoStage
+public class LingoStage : ILingoStage, IHasPropertyChanged
 {
     private readonly ILingoFrameworkStage _lingoFrameworkMovieStage;
     private AColor _backgroundColor;
     public bool IsDirty { get; private set; }
-    public int Width { get; set; } = 640;
-    public int Height { get; set; } = 480;
+    private int _width = 640;
+    public int Width
+    {
+        get => _width;
+        set
+        {
+            if (_width == value) return;
+            _width = value;
+            IsDirty = true;
+            OnPropertyChanged();
+        }
+    }
+    private int _height = 480;
+    public int Height
+    {
+        get => _height;
+        set
+        {
+            if (_height == value) return;
+            _height = value;
+            IsDirty = true;
+            OnPropertyChanged();
+        }
+    }
     public int X { get; set; } = 0;
     public int Y { get; set; } = 0;
     public AColor BackgroundColor
@@ -115,4 +140,10 @@ public class LingoStage : ILingoStage
     {
         IsDirty = false;
     }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 }

--- a/src/LingoEngine/Texts/LingoMemberTextBase.cs
+++ b/src/LingoEngine/Texts/LingoMemberTextBase.cs
@@ -47,7 +47,7 @@ namespace LingoEngine.Texts
 
         public T Framework<T>() where T : class, TFrameworkType => (T)_frameworkMember;
 
-        public AbstMarkdownData? InitialMarkdown { get;  set; }
+        public AbstMarkdownData? InitialMarkdown { get; set; }
         public bool TextChanged { get; private set; }
 
         #region Properties
@@ -58,12 +58,15 @@ namespace LingoEngine.Texts
             get => _frameworkMember.Text;
             set
             {
-                _mdData = null;
                 var newValue = value.Replace("\r\n", "\r");
+                if (_frameworkMember.Text == newValue)
+                    return;
+                _mdData = null;
                 _markdown = newValue;
                 UpdateText(newValue);
                 _frameworkMember.Text = newValue;
                 Height = 0; // force re-render
+                OnPropertyChanged();
             }
         }
 
@@ -72,19 +75,32 @@ namespace LingoEngine.Texts
         public int ScrollTop
         {
             get => _frameworkMember.ScrollTop;
-            set { _frameworkMember.ScrollTop = value; }
+            set
+            {
+                if (_frameworkMember.ScrollTop == value)
+                    return;
+                _frameworkMember.ScrollTop = value;
+                OnPropertyChanged();
+            }
         }
         /// <inheritdoc/>
-        public bool Editable { get; set; }
+        private bool _editable;
+        public bool Editable
+        {
+            get => _editable;
+            set => SetProperty(ref _editable, value);
+        }
         /// <inheritdoc/>
         public bool WordWrap
         {
             get => _frameworkMember.WordWrap;
             set
             {
-                if (_frameworkMember.WordWrap == value) return;
+                if (_frameworkMember.WordWrap == value)
+                    return;
                 _frameworkMember.WordWrap = value;
                 UpdateMDStyle();
+                OnPropertyChanged();
             }
         }
         /// <inheritdoc/>
@@ -93,9 +109,11 @@ namespace LingoEngine.Texts
             get => _frameworkMember.FontName;
             set
             {
-                if (_frameworkMember.FontName == value) return;
+                if (_frameworkMember.FontName == value)
+                    return;
                 _frameworkMember.FontName = value;
                 UpdateMDStyle();
+                OnPropertyChanged();
             }
         }
         /// <inheritdoc/>
@@ -104,9 +122,11 @@ namespace LingoEngine.Texts
             get => _frameworkMember.FontSize;
             set
             {
-                if (_frameworkMember.FontSize == value) return;
+                if (_frameworkMember.FontSize == value)
+                    return;
                 _frameworkMember.FontSize = value;
                 UpdateMDStyle();
+                OnPropertyChanged();
             }
         }
 
@@ -116,9 +136,11 @@ namespace LingoEngine.Texts
             get => _frameworkMember.TextColor;
             set
             {
-                if (_frameworkMember.TextColor == value) return;
+                if (_frameworkMember.TextColor == value)
+                    return;
                 _frameworkMember.TextColor = value;
                 UpdateMDStyle();
+                OnPropertyChanged();
             }
         }
         /// <inheritdoc/>
@@ -127,9 +149,11 @@ namespace LingoEngine.Texts
             get => _frameworkMember.FontStyle;
             set
             {
-                if (_frameworkMember.FontStyle == value) return;
+                if (_frameworkMember.FontStyle == value)
+                    return;
                 _frameworkMember.FontStyle = value;
                 UpdateMDStyle();
+                OnPropertyChanged();
             }
         }
         /// <inheritdoc/>
@@ -138,6 +162,8 @@ namespace LingoEngine.Texts
             get => (_frameworkMember.FontStyle & LingoTextStyle.Bold) != 0;
             set
             {
+                if (Bold == value)
+                    return;
                 var style = _frameworkMember.FontStyle;
                 if (value)
                     style |= LingoTextStyle.Bold;
@@ -145,6 +171,8 @@ namespace LingoEngine.Texts
                     style &= ~LingoTextStyle.Bold;
                 _frameworkMember.FontStyle = style;
                 UpdateMDStyle();
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(FontStyle));
             }
         }
         /// <inheritdoc/>
@@ -153,6 +181,8 @@ namespace LingoEngine.Texts
             get => (_frameworkMember.FontStyle & LingoTextStyle.Italic) != 0;
             set
             {
+                if (Italic == value)
+                    return;
                 var style = _frameworkMember.FontStyle;
                 if (value)
                     style |= LingoTextStyle.Italic;
@@ -160,6 +190,8 @@ namespace LingoEngine.Texts
                     style &= ~LingoTextStyle.Italic;
                 _frameworkMember.FontStyle = style;
                 UpdateMDStyle();
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(FontStyle));
             }
         }
         /// <inheritdoc/>
@@ -168,6 +200,8 @@ namespace LingoEngine.Texts
             get => (_frameworkMember.FontStyle & LingoTextStyle.Underline) != 0;
             set
             {
+                if (Underline == value)
+                    return;
                 var style = _frameworkMember.FontStyle;
                 if (value)
                     style |= LingoTextStyle.Underline;
@@ -175,6 +209,8 @@ namespace LingoEngine.Texts
                     style &= ~LingoTextStyle.Underline;
                 _frameworkMember.FontStyle = style;
                 UpdateMDStyle();
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(FontStyle));
             }
         }
         /// <inheritdoc/>
@@ -183,9 +219,11 @@ namespace LingoEngine.Texts
             get => _frameworkMember.Alignment;
             set
             {
-                if (_frameworkMember.Alignment == value) return;
+                if (_frameworkMember.Alignment == value)
+                    return;
                 _frameworkMember.Alignment = value;
                 UpdateMDStyle();
+                OnPropertyChanged();
             }
         }
         /// <inheritdoc/>
@@ -194,9 +232,11 @@ namespace LingoEngine.Texts
             get => _frameworkMember.Margin;
             set
             {
-                if (_frameworkMember.Margin == value) return;
+                if (_frameworkMember.Margin == value)
+                    return;
                 _frameworkMember.Margin = value;
                 UpdateMDStyle();
+                OnPropertyChanged();
             }
         }
 
@@ -257,6 +297,7 @@ namespace LingoEngine.Texts
                 _frameworkMember.Width = value;
                 //if (_width>0 && !_hasLoadedTexTure)
                 //    RenderText();
+                OnPropertyChanged();
             }
         }
         private int _height;
@@ -275,6 +316,7 @@ namespace LingoEngine.Texts
                 base.Height = value;
                 _height = value;
                 _frameworkMember.Height = value;
+                OnPropertyChanged();
 
             }
         }

--- a/src/LingoEngine/Transitions/LingoTransitionMember.cs
+++ b/src/LingoEngine/Transitions/LingoTransitionMember.cs
@@ -14,15 +14,51 @@ public enum LingoTransitionAffects
 
 public class LingoTransitionMember : LingoMember
 {
-    public int TransitionId { get; set; }
-    public string TransitionName { get; set; } = "";
+    private int _transitionId;
+    private string _transitionName = "";
     /// <summary>
     /// Duration in Seconds from 0 to 30 seconds
     /// </summary>
-    public float Duration { get; set; }
-    public float Smoothness { get; set; }
-    public LingoTransitionAffects Affects { get; set; } = LingoTransitionAffects.ChangingAreaOnly;
-    public ARect Rect { get; set; }
+    private float _duration;
+    private float _smoothness;
+    private LingoTransitionAffects _affects = LingoTransitionAffects.ChangingAreaOnly;
+    private ARect _rect;
+
+    public int TransitionId
+    {
+        get => _transitionId;
+        set => SetProperty(ref _transitionId, value);
+    }
+
+    public string TransitionName
+    {
+        get => _transitionName;
+        set => SetProperty(ref _transitionName, value);
+    }
+
+    public float Duration
+    {
+        get => _duration;
+        set => SetProperty(ref _duration, value);
+    }
+
+    public float Smoothness
+    {
+        get => _smoothness;
+        set => SetProperty(ref _smoothness, value);
+    }
+
+    public LingoTransitionAffects Affects
+    {
+        get => _affects;
+        set => SetProperty(ref _affects, value);
+    }
+
+    public ARect Rect
+    {
+        get => _rect;
+        set => SetProperty(ref _rect, value);
+    }
 
     public LingoTransitionMember(LingoCast cast, int numberInCast, string name = "", string fileName = "", APoint regPoint = default)
         : base(new LingoTransitionMemberFW(), LingoMemberType.Transition, cast, numberInCast, name, fileName, regPoint)


### PR DESCRIPTION
## Summary
- drop movie size properties and emit change events from stage width/height
- forward sprite channel visibility and puppet updates via `PropertyChanged`
- notify listeners when a member's reg point changes

## Testing
- `dotnet test Test/LingoEngine.Tests/LingoEngine.Tests.csproj`
- `dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c517618d988332a5f08a803c91e4b5