### PR TITLE
chore: expand vscode debug profiles

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,84 @@
             "request": "launch",
             "project": "${workspaceFolder}/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Godot",
             "preLaunchTask": "build"
+        },
+        {
+            "name": "Launch Demo Blazor",
+            "type": "blazorwasm",
+            "request": "launch",
+            "cwd": "${workspaceFolder}/Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Blazor",
+            "preLaunchTask": "build"
+        },
+        {
+            "name": "Launch RNet Terminal",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/Net/LingoEngine.Net.RNetTerminal/bin/Debug/net8.0/LingoEngine.Net.RNetTerminal.dll",
+            "cwd": "${workspaceFolder}/src/Net/LingoEngine.Net.RNetTerminal",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Launch Director Runner SDL2",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/Director/LingoEngine.Director.Runner.SDL2/bin/Debug/net8.0/LingoEngine.Director.Runner.SDL2.dll",
+            "cwd": "${workspaceFolder}/src/Director/LingoEngine.Director.Runner.SDL2",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Launch Director Runner Godot",
+            "type": "godot",
+            "request": "launch",
+            "project": "${workspaceFolder}/src/Director/LingoEngine.Director.Runner.Godot",
+            "preLaunchTask": "build"
+        },
+        {
+            "name": "Launch SDL2 Visual Test",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/Test/LingoEngine.SDL2.GfxVisualTest/bin/Debug/net8.0/LingoEngine.SDL2.GfxVisualTest.dll",
+            "cwd": "${workspaceFolder}/Test/LingoEngine.SDL2.GfxVisualTest",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Launch AbstUI Visual Test SDL2",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/bin/Debug/net8.0/AbstUI.GfxVisualTest.SDL2.dll",
+            "cwd": "${workspaceFolder}/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Launch AbstUI Visual Test ImGui",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.ImGui/bin/Debug/net8.0/AbstUI.GfxVisualTest.ImGui.dll",
+            "cwd": "${workspaceFolder}/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.ImGui",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Launch AbstUI Visual Test Godot",
+            "type": "godot",
+            "request": "launch",
+            "project": "${workspaceFolder}/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LGodot",
+            "preLaunchTask": "build"
+        },
+        {
+            "name": "Launch AbstUI Visual Test Blazor",
+            "type": "blazorwasm",
+            "request": "launch",
+            "cwd": "${workspaceFolder}/WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor",
+            "preLaunchTask": "build"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- add debug launch profiles for RNet terminal and Director runner (SDL2/Godot)
- add launch entries for TetriGrounds Blazor demo and AbstUI visual test apps

## Testing
- `dotnet build src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj`
- `dotnet build src/Director/LingoEngine.Director.Runner.SDL2/LingoEngine.Director.Runner.SDL2.csproj`
- `dotnet build src/Director/LingoEngine.Director.Runner.Godot/LingoEngine.Director.Runner.Godot.csproj` *(failed: SDK resolver failure)*
- `dotnet build Test/LingoEngine.SDL2.GfxVisualTest/LingoEngine.SDL2.GfxVisualTest.csproj` *(failed: project file missing)*
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2/AbstUI.GfxVisualTest.SDL2.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.ImGui/AbstUI.GfxVisualTest.ImGui.csproj` *(failed: package downgrade)*
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.LGodot/AbstUI.GfxVisualTest.LGodot.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.Blazor/AbstUI.GfxVisualTest.Blazor.csproj`
- `dotnet build Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Blazor/LingoEngine.Demo.TetriGrounds.Blazor.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c62a7414688332b2525c05cb63a434