### PR TITLE
feat: allow setting tween values and improve stage/score rendering

### DIFF
--- a/src/Net/LingoEngine.Net.RNetTerminal/LingoRNetTerminal.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/LingoRNetTerminal.cs
@@ -2,6 +2,7 @@ using LingoEngine.IO.Data.DTO;
 using LingoEngine.Net.RNetClient;
 using LingoEngine.Net.RNetContracts;
 using Terminal.Gui;
+using System.Linq;
 using Timer = System.Timers.Timer;
 
 namespace LingoEngine.Net.RNetTerminal;
@@ -131,15 +132,70 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
 
     private void ShowStartupDialog()
     {
+        const string asciiArt = @" ____                      _         _   _      _
+|  _ \ ___ _ __ ___   ___ | |_ ___  | \ | | ___| |_
+| |_) / _ \ '_ ` _ \ / _ \| __/ _ \ |  \| |/ _ \ __|
+|  _ <  __/ | | | | | (_) | ||  __/ | |\  |  __/ |_
+|_| \_\___|_| |_| |_|\___/ \__\___| |_| \_|\___|\__|
+ _____                   _             _
+|_   _|__ _ __ _ __ ___ (_)_ __   __ _| |
+  | |/ _ \ '__| '_ ` _ \| | '_ \ / _` | |
+  | |  __/ |  | | | | | | | | | | (_| | |
+  |_|\___|_|  |_| |_| |_|_|_| |_|\__,_|_|";
+
+        var standalone = new Button("Run Standalone", true);
+        var connect = new Button("Connect");
+        var dialog = new Dialog("LingoEngine Remote Net Terminal", 80, 24, standalone, connect)
+        {
+            ColorScheme = new ColorScheme
+            {
+                Normal = Application.Driver.MakeAttribute(Color.White, Color.Black),
+                Focus = Application.Driver.MakeAttribute(Color.Black, Color.Gray),
+                HotNormal = Application.Driver.MakeAttribute(Color.BrightYellow, Color.Black),
+                HotFocus = Application.Driver.MakeAttribute(Color.Black, Color.Gray),
+                Disabled = Application.Driver.MakeAttribute(Color.Gray, Color.Black)
+            }
+        };
+
+        var title = new Label("LingoEngine")
+        {
+            X = Pos.Center(),
+            Y = 1
+        };
+        dialog.Add(title);
+
+        var artLines = asciiArt.Split('\n');
+        var artWidth = artLines.Max(l => l.Length);
+        var ascii = new Label(asciiArt)
+        {
+            X = Pos.Center() - artWidth / 2,
+            Y = Pos.Bottom(title),
+            Width = artWidth,
+            Height = artLines.Length
+        };
+        dialog.Add(ascii);
+
+        var credit = new Label("By Emmanuel The Creator")
+        {
+            X = Pos.Center(),
+            Y = Pos.AnchorEnd(7)
+        };
+        dialog.Add(credit);
+
+        var portLabel = new Label("Port:")
+        {
+            X = Pos.Center() - 14,
+            Y = Pos.AnchorEnd(4)
+        };
         var portField = new TextField(_port.ToString())
         {
-            X = 1,
-            Y = 2,
+            X = Pos.Center() - 9,
+            Y = Pos.AnchorEnd(4),
             Width = 10
         };
-        var standalone = new Button("Run Standalone", true);
-        standalone.Clicked += () => Application.RequestStop();
-        var connect = new Button("Connect");
+        dialog.Add(portLabel, portField);
+
+        standalone.Clicked += () => dialog.Running = false;
         connect.Clicked += async () =>
         {
             if (int.TryParse(portField.Text.ToString(), out var p))
@@ -148,10 +204,16 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
                 SaveSettings();
             }
             await ToggleConnectionAsync();
-            Application.RequestStop();
+            dialog.Running = false;
         };
-        var dialog = new Dialog("Start Mode", 40, 8, standalone, connect);
-        dialog.Add(new Label("Port:") { X = 1, Y = 2 }, portField);
+        dialog.KeyPress += e =>
+        {
+            if (e.KeyEvent.Key == Key.Esc)
+            {
+                dialog.Running = false;
+                e.Handled = true;
+            }
+        };
         portField.SetFocus();
         Application.Run(dialog);
     }

--- a/src/Net/LingoEngine.Net.RNetTerminal/Program.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/Program.cs
@@ -1,9 +1,12 @@
+using System;
+
 namespace LingoEngine.Net.RNetTerminal;
 
 internal static class Program
 {
     private static async Task Main()
     {
+        Console.Title = "LingoEngine Remote Net Terminal";
         await using var app = new LingoRNetTerminal();
         await app.RunAsync();
     }

--- a/src/Net/LingoEngine.Net.RNetTerminal/TestCastBuilder.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/TestCastBuilder.cs
@@ -19,7 +19,9 @@ public static class TestCastBuilder
             {
                 new() { Name = "Greeting", Number = 1, NumberInCast = 1, CastLibNum = 1, Type = LingoMemberTypeDTO.Text },
                 new() { Name = "Info", Number = 2, NumberInCast = 2, CastLibNum = 1, Type = LingoMemberTypeDTO.Text },
-                new() { Name = "Box", Number = 3, NumberInCast = 3, CastLibNum = 1, Type = LingoMemberTypeDTO.Shape }
+                new() { Name = "Box", Number = 3, NumberInCast = 3, CastLibNum = 1, Type = LingoMemberTypeDTO.Shape },
+                new() { Name = "score", Number = 4, NumberInCast = 4, CastLibNum = 1, Type = LingoMemberTypeDTO.Text, Width = 100 },
+                new() { Name = "Img30x80", Number = 5, NumberInCast = 5, CastLibNum = 1, Type = LingoMemberTypeDTO.Bitmap, Width = 30, Height = 80 }
             },
             ["ExtraCast"] = new List<LingoMemberDTO>
             {

--- a/src/Net/LingoEngine.Net.RNetTerminal/TestMovieBuilder.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/TestMovieBuilder.cs
@@ -24,5 +24,7 @@ public static class TestMovieBuilder
         new() { Name = "Box", SpriteNum = 3, MemberNum = 3, BeginFrame = 1, EndFrame = 60, LocH = 400, LocV = 300 },
         new() { Name = "Greeting", SpriteNum = 4, MemberNum = 1, BeginFrame = 1, EndFrame = 60, LocH = 150, LocV = 400 },
         new() { Name = "Info", SpriteNum = 5, MemberNum = 2, BeginFrame = 1, EndFrame = 60, LocH = 500, LocV = 120 },
+        new() { Name = "score", SpriteNum = 6, MemberNum = 4, BeginFrame = 1, EndFrame = 60, LocH = 50, LocV = 50, Width = 100, Height = 20 },
+        new() { Name = "Img30x80", SpriteNum = 7, MemberNum = 5, BeginFrame = 1, EndFrame = 60, LocH = 250, LocV = 350, Width = 30, Height = 80 },
     };
 }


### PR DESCRIPTION
## Summary
- enable setting tween property values in keyframe popup
- track per-property values for keyframes
- add stylized startup screen with ASCII banner, bottom selection, and credit
- set console window title and ensure Run Standalone dismisses the popup
- render text sprites with layered background shading
- prevent score view crash on scroll and scroll cursor into view
- include sample text and image members for testing

## Testing
- `dotnet format src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj --include src/Net/LingoEngine.Net.RNetTerminal/ScoreView.cs src/Net/LingoEngine.Net.RNetTerminal/StageView.cs src/Net/LingoEngine.Net.RNetTerminal/TestCastBuilder.cs src/Net/LingoEngine.Net.RNetTerminal/TestMovieBuilder.cs -v diagnostic`
- `dotnet build src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c63bc677f883329ab9badb0c1b4c7b