### PR TITLE
Fix member key collisions and startup crash in RNetTerminal

### DIFF
--- a/src/Net/LingoEngine.Net.RNetTerminal/LingoRNetTerminal.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/LingoRNetTerminal.cs
@@ -36,8 +36,9 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
     {
         Application.Init();
         SetNortonTheme();
-        BuildUi();
         ShowStartupDialog();
+        Application.Begin(new Toplevel());
+        BuildUi();
         Application.Run();
         Application.Shutdown();
         return Task.CompletedTask;

--- a/src/Net/LingoEngine.Net.RNetTerminal/ScoreView.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/ScoreView.cs
@@ -48,7 +48,9 @@ internal sealed class ScoreView : ScrollView
         _sprites = TestMovieBuilder.BuildSprites()
             .Select(s => new SpriteBlock(s.SpriteNum, s.BeginFrame, s.EndFrame, s.SpriteNum, s.MemberNum, s.Name, s.Width))
             .ToList();
-        _members = TestCastBuilder.BuildCastData().SelectMany(c => c.Value).ToDictionary(m => m.Number);
+        _members = TestCastBuilder.BuildCastData()
+            .SelectMany(c => c.Value)
+            .ToDictionary(MemberKey);
         _labelWidth = Math.Max(SpecialChannels.Max(s => s.Length), SpriteChannelCount.ToString().Length) + 1;
         CanFocus = true;
         ColorScheme = new ColorScheme
@@ -638,6 +640,9 @@ internal sealed class ScoreView : ScrollView
     public event Action<int>? PlayFromHere;
 
     public event Action? SpriteChanged;
+
+    private static int MemberKey(LingoMemberDTO member)
+        => (member.CastLibNum << 16) | member.NumberInCast;
 
     private sealed class SpriteBlock
     {

--- a/src/Net/LingoEngine.Net.RNetTerminal/StageView.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/StageView.cs
@@ -34,7 +34,7 @@ internal sealed class StageView : View
         _sprites = TestMovieBuilder.BuildSprites();
         foreach (var m in TestCastBuilder.BuildCastData().SelectMany(c => c.Value))
         {
-            _members[m.Number] = m;
+            _members[MemberKey(m)] = m;
         }
     }
 
@@ -173,4 +173,7 @@ internal sealed class StageView : View
         }
         return base.MouseEvent(me);
     }
+
+    private static int MemberKey(LingoMemberDTO member)
+        => (member.CastLibNum << 16) | member.NumberInCast;
 }

--- a/src/Net/LingoEngine.Net.RNetTerminal/TestMovieBuilder.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/TestMovieBuilder.cs
@@ -19,12 +19,15 @@ public static class TestMovieBuilder
     /// </summary>
     public static IReadOnlyList<LingoSpriteDTO> BuildSprites() => new List<LingoSpriteDTO>
     {
-        new() { Name = "Greeting", SpriteNum = 1, MemberNum = 1, BeginFrame = 1, EndFrame = 60, LocH = 100, LocV = 100 },
-        new() { Name = "Info", SpriteNum = 2, MemberNum = 2, BeginFrame = 1, EndFrame = 60, LocH = 300, LocV = 200 },
-        new() { Name = "Box", SpriteNum = 3, MemberNum = 3, BeginFrame = 1, EndFrame = 60, LocH = 400, LocV = 300 },
-        new() { Name = "Greeting", SpriteNum = 4, MemberNum = 1, BeginFrame = 1, EndFrame = 60, LocH = 150, LocV = 400 },
-        new() { Name = "Info", SpriteNum = 5, MemberNum = 2, BeginFrame = 1, EndFrame = 60, LocH = 500, LocV = 120 },
-        new() { Name = "score", SpriteNum = 6, MemberNum = 4, BeginFrame = 1, EndFrame = 60, LocH = 50, LocV = 50, Width = 100, Height = 20 },
-        new() { Name = "Img30x80", SpriteNum = 7, MemberNum = 5, BeginFrame = 1, EndFrame = 60, LocH = 250, LocV = 350, Width = 30, Height = 80 },
+        new() { Name = "Greeting", SpriteNum = 1, MemberNum = MemberKey(1, 1), BeginFrame = 1, EndFrame = 60, LocH = 100, LocV = 100 },
+        new() { Name = "Info", SpriteNum = 2, MemberNum = MemberKey(1, 2), BeginFrame = 1, EndFrame = 60, LocH = 300, LocV = 200 },
+        new() { Name = "Box", SpriteNum = 3, MemberNum = MemberKey(1, 3), BeginFrame = 1, EndFrame = 60, LocH = 400, LocV = 300 },
+        new() { Name = "Greeting", SpriteNum = 4, MemberNum = MemberKey(1, 1), BeginFrame = 1, EndFrame = 60, LocH = 150, LocV = 400 },
+        new() { Name = "Info", SpriteNum = 5, MemberNum = MemberKey(1, 2), BeginFrame = 1, EndFrame = 60, LocH = 500, LocV = 120 },
+        new() { Name = "score", SpriteNum = 6, MemberNum = MemberKey(1, 4), BeginFrame = 1, EndFrame = 60, LocH = 50, LocV = 50, Width = 100, Height = 20 },
+        new() { Name = "Img30x80", SpriteNum = 7, MemberNum = MemberKey(1, 5), BeginFrame = 1, EndFrame = 60, LocH = 250, LocV = 350, Width = 30, Height = 80 },
     };
+
+    private static int MemberKey(int castLibNum, int numberInCast)
+        => (castLibNum << 16) | numberInCast;
 }


### PR DESCRIPTION
## Summary
- combine cast library number and member number to uniquely identify members
- update sample sprite data to use composite member keys
- reinitialize Terminal.Gui top-level after the startup dialog to avoid null toplevel crash

## Testing
- `dotnet format src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj --include src/Net/LingoEngine.Net.RNetTerminal/LingoRNetTerminal.cs -v diagnostic`
- `dotnet build src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj`
- `dotnet run --project src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj` *(fails: terminal emulator crashed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6452f9eb08332b79b2260cbd1fe1e