### PR TITLE
Fix ScoreView scrollbar interaction

### DIFF
--- a/Test/LingoEngine.Net.RNetTerminal.Tests/LingoEngine.Net.RNetTerminal.Tests.csproj
+++ b/Test/LingoEngine.Net.RNetTerminal.Tests/LingoEngine.Net.RNetTerminal.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="8.6.0" />
+    <PackageReference Include="Terminal.Gui" Version="1.17.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Net\LingoEngine.Net.RNetTerminal\LingoEngine.Net.RNetTerminal.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/Test/LingoEngine.Net.RNetTerminal.Tests/ScoreViewTests.cs
+++ b/Test/LingoEngine.Net.RNetTerminal.Tests/ScoreViewTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Terminal.Gui;
+using FluentAssertions;
+
+namespace LingoEngine.Net.RNetTerminal.Tests;
+
+public class ScoreViewTests
+{
+    [Fact]
+    public void MouseEvent_OnScrollBar_DoesNotThrow()
+    {
+        Application.Init(new FakeDriver());
+        try
+        {
+            var view = new ScoreView
+            {
+                Frame = new Rect(0, 0, 20, 10)
+            };
+            var me = new MouseEvent
+            {
+                X = 19,
+                Y = 1,
+                Flags = MouseFlags.Button1Clicked
+            };
+
+            var act = () => view.MouseEvent(me);
+            act.Should().NotThrow();
+        }
+        finally
+        {
+            Application.Shutdown();
+        }
+    }
+}

--- a/src/Net/LingoEngine.Net.RNetTerminal/AssemblyInfo.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("LingoEngine.Net.RNetTerminal.Tests")]
+


### PR DESCRIPTION
## Summary
- guard ScoreView input handlers with error logging
- ignore scrollbar clicks so built-in scrollbars work
- expose internals and add regression test for scrollbar mouse events

## Testing
- `dotnet format src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj --include src/Net/LingoEngine.Net.RNetTerminal/ScoreView.cs src/Net/LingoEngine.Net.RNetTerminal/AssemblyInfo.cs -v diag`
- `dotnet format Test/LingoEngine.Net.RNetTerminal.Tests/LingoEngine.Net.RNetTerminal.Tests.csproj --include Test/LingoEngine.Net.RNetTerminal.Tests/ScoreViewTests.cs -v diag`
- `dotnet test Test/LingoEngine.Net.RNetTerminal.Tests/LingoEngine.Net.RNetTerminal.Tests.csproj`
- `timeout 5 dotnet run --project src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c64946f3b483329783d4b0da488136