### PR TITLE
Fix RNetTerminal ScoreView edge scrolling and hide property header

### DIFF
--- a/Test/LingoEngine.Net.RNetTerminal.Tests/ScoreViewTests.cs
+++ b/Test/LingoEngine.Net.RNetTerminal.Tests/ScoreViewTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using Terminal.Gui;
 using FluentAssertions;
 
@@ -24,6 +25,50 @@ public class ScoreViewTests
             };
 
             var act = () => view.MouseEvent(me);
+            act.Should().NotThrow();
+        }
+        finally
+        {
+            Application.Shutdown();
+        }
+    }
+
+    [Fact]
+    public void Redraw_WithNegativeOffset_DoesNotThrowAndClamps()
+    {
+        Application.Init(new FakeDriver());
+        try
+        {
+            var view = new ScoreView
+            {
+                Frame = new Rect(0, 0, 20, 10),
+                ContentOffset = new Point(-5, -5)
+            };
+
+            var act = () => view.Redraw(view.Bounds);
+            act.Should().NotThrow();
+            view.ContentOffset.X.Should().BeGreaterThanOrEqualTo(0);
+            view.ContentOffset.Y.Should().BeGreaterThanOrEqualTo(0);
+        }
+        finally
+        {
+            Application.Shutdown();
+        }
+    }
+
+    [Fact]
+    public void MoveCursor_Down_DoesNotThrow()
+    {
+        Application.Init(new FakeDriver());
+        try
+        {
+            var view = new ScoreView
+            {
+                Frame = new Rect(0, 0, 20, 10)
+            };
+            view.LayoutSubviews();
+            var move = typeof(ScoreView).GetMethod("MoveCursor", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var act = () => move.Invoke(view, new object[] { 0, 100 });
             act.Should().NotThrow();
         }
         finally

--- a/src/Net/LingoEngine.Net.RNetTerminal/PropertyInspector.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/PropertyInspector.cs
@@ -50,8 +50,8 @@ internal sealed class PropertyInspector : Window
             new PropertySpec("Behaviors", typeof(string))
         });
 
-        _memberTable.Columns.Add("Property");
-        _memberTable.Columns.Add("Value");
+        _memberTable.Columns.Add(string.Empty);
+        _memberTable.Columns.Add(string.Empty);
         _memberTableView = new TableView
         {
             Width = Dim.Fill(),
@@ -60,6 +60,9 @@ internal sealed class PropertyInspector : Window
             FullRowSelect = true
         };
         _memberTableView.Style.AlwaysShowHeaders = false;
+        _memberTableView.Style.ShowHorizontalHeaderUnderline = false;
+        _memberTableView.Style.ShowHorizontalHeaderOverline = false;
+        _memberTableView.Style.ShowVerticalHeaderLines = false;
         _memberTableView.Style.ShowVerticalCellLines = false;
         _memberTableView.SelectedColumn = 1;
         _memberTableView.SelectedCellChanged += _ => _memberTableView.SelectedColumn = 1;
@@ -171,8 +174,8 @@ internal sealed class PropertyInspector : Window
     private TableView BuildPropertyTableView(PropertySpec[] props)
     {
         var table = new DataTable();
-        table.Columns.Add("Property");
-        table.Columns.Add("Value");
+        table.Columns.Add(string.Empty);
+        table.Columns.Add(string.Empty);
         for (var i = 0; i < props.Length; i++)
         {
             table.Rows.Add(props[i].Name, GetDefaultValue(props[i].Type));
@@ -185,6 +188,9 @@ internal sealed class PropertyInspector : Window
             FullRowSelect = true
         };
         view.Style.AlwaysShowHeaders = false;
+        view.Style.ShowHorizontalHeaderUnderline = false;
+        view.Style.ShowHorizontalHeaderOverline = false;
+        view.Style.ShowVerticalHeaderLines = false;
         view.Style.ShowVerticalCellLines = false;
         view.SelectedColumn = 1;
         view.SelectedCellChanged += _ => view.SelectedColumn = 1;

--- a/src/Net/LingoEngine.Net.RNetTerminal/ScoreView.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/ScoreView.cs
@@ -199,9 +199,8 @@ internal sealed class ScoreView : ScrollView
         }
     }
 
-    private void ClampContentOffset()
+    private void ClampContentOffset(ref Point offset)
     {
-        var offset = ContentOffset;
         var scrollBarWidth = ShowVerticalScrollIndicator ? 1 : 0;
         var scrollBarHeight = ShowHorizontalScrollIndicator ? 1 : 0;
         var visibleFrames = Math.Max(0, Bounds.Width - _labelWidth - scrollBarWidth);
@@ -210,6 +209,12 @@ internal sealed class ScoreView : ScrollView
         var maxY = Math.Max(0, TotalChannels - visibleChannels);
         offset.X = Math.Clamp(offset.X, 0, maxX);
         offset.Y = Math.Clamp(offset.Y, 0, maxY);
+    }
+
+    private void ClampContentOffset()
+    {
+        var offset = ContentOffset;
+        ClampContentOffset(ref offset);
         ContentOffset = offset;
     }
 
@@ -233,7 +238,7 @@ internal sealed class ScoreView : ScrollView
         {
             offset.X = _cursorFrame;
         }
-        else if (_cursorFrame >= offset.X + visibleFrames - 1)
+        else if (_cursorFrame >= offset.X + visibleFrames)
         {
             offset.X = _cursorFrame - visibleFrames + 1;
         }
@@ -241,16 +246,17 @@ internal sealed class ScoreView : ScrollView
         {
             offset.Y = _cursorChannel;
         }
-        else if (_cursorChannel >= offset.Y + visibleChannels - 1)
+        else if (_cursorChannel >= offset.Y + visibleChannels)
         {
             offset.Y = _cursorChannel - visibleChannels + 1;
         }
+        ClampContentOffset(ref offset);
         ContentOffset = offset;
-        ClampContentOffset();
     }
 
     public override void Redraw(Rect bounds)
     {
+        ClampContentOffset();
         base.Redraw(bounds);
         var scrollBarWidth = ShowVerticalScrollIndicator ? 1 : 0;
         var scrollBarHeight = ShowHorizontalScrollIndicator ? 1 : 0;


### PR DESCRIPTION
## Summary
- Ensure ScoreView scrolls to keep the cursor visible and clamp offsets before setting
- Remove "Property | Value" header from property inspector tables

## Testing
- `dotnet test Test/LingoEngine.Net.RNetTerminal.Tests/LingoEngine.Net.RNetTerminal.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c64d3fcdf88332bc6e2dc22a893fa8