### PR TITLE
Centralize RNetTerminal data and improve editing popups

### DIFF
--- a/src/Net/LingoEngine.Net.RNetTerminal/CastView.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/CastView.cs
@@ -7,10 +7,10 @@ namespace LingoEngine.Net.RNetTerminal;
 
 internal sealed class CastView : View
 {
-    private readonly TabView _tabs;
+    private TabView _tabs;
     public event Action<LingoMemberDTO>? MemberSelected;
 
-    public CastView(Dictionary<string, List<LingoMemberDTO>> casts)
+    public CastView()
     {
         CanFocus = true;
         _tabs = new TabView
@@ -19,7 +19,20 @@ internal sealed class CastView : View
             Height = Dim.Fill()
         };
         Add(_tabs);
+        ReloadData();
+    }
 
+    public void ReloadData()
+    {
+        var casts = TerminalDataStore.Instance.Casts;
+        _tabs.RemoveAll();
+        Remove(_tabs);
+        _tabs = new TabView
+        {
+            Width = Dim.Fill(),
+            Height = Dim.Fill()
+        };
+        Add(_tabs);
         var first = true;
         foreach (var cast in casts)
         {
@@ -70,6 +83,7 @@ internal sealed class CastView : View
             _tabs.AddTab(new TabView.Tab(cast.Key, tableView), first);
             first = false;
         }
+        _tabs.SetNeedsDisplay();
     }
 
     private static DataTable CreateTable(IEnumerable<LingoMemberDTO> members)

--- a/src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj
+++ b/src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj
@@ -26,5 +26,6 @@
     <ProjectReference Include="..\\LingoEngine.Net.RNetClient\\LingoEngine.Net.RNetClient.csproj" />
     <ProjectReference Include="..\\LingoEngine.Net.RNetContracts\\LingoEngine.Net.RNetContracts.csproj" />
     <ProjectReference Include="..\\..\\LingoEngine.IO.Data\\LingoEngine.IO.Data.csproj" />
+    <ProjectReference Include="..\\..\\LingoEngine.IO\\LingoEngine.IO.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Net/LingoEngine.Net.RNetTerminal/PropertyInspector.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/PropertyInspector.cs
@@ -240,6 +240,16 @@ internal sealed class PropertyInspector : Window
         if (type == typeof(bool))
         {
             var check = new CheckBox(12, 1, string.Empty, bool.TryParse(value, out var b) && b);
+            check.KeyPress += e =>
+            {
+                if (e.KeyEvent.Key == Key.Space)
+                {
+                    check.Checked = !check.Checked;
+                    result = check.Checked.ToString();
+                    Application.RequestStop();
+                    e.Handled = true;
+                }
+            };
             var ok = new Button("Ok", true);
             ok.Clicked += () =>
             {
@@ -248,6 +258,7 @@ internal sealed class PropertyInspector : Window
             };
             var dialog = new Dialog($"Edit {name}", 30, 7, ok);
             dialog.Add(new Label(name + ":") { X = 1, Y = 1 }, check);
+            check.SetFocus();
             Application.Run(dialog);
         }
         else if (type == typeof(int))

--- a/src/Net/LingoEngine.Net.RNetTerminal/StageView.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/StageView.cs
@@ -8,9 +8,9 @@ namespace LingoEngine.Net.RNetTerminal;
 
 internal sealed class StageView : View
 {
-    private const int MovieWidth = 640;
-    private const int MovieHeight = 480;
-    private readonly IReadOnlyList<LingoSpriteDTO> _sprites;
+    private int _movieWidth;
+    private int _movieHeight;
+    private IReadOnlyList<LingoSpriteDTO> _sprites = Array.Empty<LingoSpriteDTO>();
     private readonly Dictionary<int, LingoMemberDTO> _members = new();
     private int _frame;
     private int? _selectedSprite;
@@ -31,11 +31,7 @@ internal sealed class StageView : View
         {
             Normal = Application.Driver.MakeAttribute(Color.White, Color.Black)
         };
-        _sprites = TestMovieBuilder.BuildSprites();
-        foreach (var m in TestCastBuilder.BuildCastData().SelectMany(c => c.Value))
-        {
-            _members[MemberKey(m)] = m;
-        }
+        ReloadData();
     }
 
     public void SetFrame(int frame)
@@ -48,6 +44,20 @@ internal sealed class StageView : View
     public void SetSelectedSprite(int? spriteNum)
     {
         _selectedSprite = spriteNum;
+        SetNeedsDisplay();
+    }
+
+    public void ReloadData()
+    {
+        var store = TerminalDataStore.Instance;
+        _movieWidth = store.StageWidth;
+        _movieHeight = store.StageHeight;
+        _sprites = store.Sprites.ToList();
+        _members.Clear();
+        foreach (var m in store.Casts.SelectMany(c => c.Value))
+        {
+            _members[MemberKey(m)] = m;
+        }
         SetNeedsDisplay();
     }
 
@@ -79,10 +89,10 @@ internal sealed class StageView : View
             {
                 continue;
             }
-            var x = (int)(sprite.LocH / MovieWidth * w);
-            var y = (int)(sprite.LocV / MovieHeight * h);
-            var sw = (int)(sprite.Width / MovieWidth * w);
-            var sh = (int)(sprite.Height / MovieHeight * h);
+            var x = (int)(sprite.LocH / _movieWidth * w);
+            var y = (int)(sprite.LocV / _movieHeight * h);
+            var sw = (int)(sprite.Width / _movieWidth * w);
+            var sh = (int)(sprite.Height / _movieHeight * h);
             if (sw <= 0 || sh <= 0 || sh > 2 || sw > 10)
             {
                 sw = 1;
@@ -154,10 +164,10 @@ internal sealed class StageView : View
                          .Where(s => s.BeginFrame <= _frame && _frame <= s.EndFrame)
                          .OrderByDescending(s => s.LocZ))
             {
-                var x = (int)(sprite.LocH / MovieWidth * w);
-                var y = (int)(sprite.LocV / MovieHeight * h);
-                var sw = (int)(sprite.Width / MovieWidth * w);
-                var sh = (int)(sprite.Height / MovieHeight * h);
+                var x = (int)(sprite.LocH / _movieWidth * w);
+                var y = (int)(sprite.LocV / _movieHeight * h);
+                var sw = (int)(sprite.Width / _movieWidth * w);
+                var sh = (int)(sprite.Height / _movieHeight * h);
                 if (sw <= 0 || sh <= 0 || sh > 2 || sw > 10)
                 {
                     sw = 1;

--- a/src/Net/LingoEngine.Net.RNetTerminal/TerminalDataStore.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/TerminalDataStore.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LingoEngine.IO;
+using LingoEngine.IO.Data.DTO;
+using LingoEngine.Net.RNetContracts;
+
+namespace LingoEngine.Net.RNetTerminal;
+
+public sealed class TerminalDataStore
+{
+    private static readonly Lazy<TerminalDataStore> _instance = new(() => new TerminalDataStore());
+    public static TerminalDataStore Instance => _instance.Value;
+
+    private TerminalDataStore()
+    {
+        LoadTestData();
+    }
+
+    public MovieStateDto MovieState { get; private set; } = TestMovieBuilder.BuildMovieState();
+    public IReadOnlyList<LingoSpriteDTO> Sprites { get; private set; } = TestMovieBuilder.BuildSprites();
+    public Dictionary<string, List<LingoMemberDTO>> Casts { get; private set; } = TestCastBuilder.BuildCastData();
+    public int StageWidth { get; private set; } = 640;
+    public int StageHeight { get; private set; } = 480;
+    public int FrameCount { get; private set; } = 600;
+
+    public void LoadTestData()
+    {
+        MovieState = TestMovieBuilder.BuildMovieState();
+        Sprites = TestMovieBuilder.BuildSprites();
+        Casts = TestCastBuilder.BuildCastData();
+        StageWidth = 640;
+        StageHeight = 480;
+        FrameCount = 600;
+    }
+
+    public void LoadFromProject(LingoProjectDTO project)
+    {
+        if (project.Movies.Count > 0)
+        {
+            var movie = project.Movies[0];
+            Sprites = movie.Sprites;
+            Casts = movie.Casts.ToDictionary(c => c.Name, c => c.Members);
+            FrameCount = movie.FrameCount;
+            MovieState = new MovieStateDto(0, movie.Tempo, false);
+        }
+        if (project.Stage != null)
+        {
+            StageWidth = project.Stage.Width;
+            StageHeight = project.Stage.Height;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- centralize movie, sprite, and cast data in a TerminalDataStore singleton
- load host movie data into the store on connect and refresh views
- streamline boolean property popups and remove frame prompt when adding keyframes

## Testing
- `dotnet format src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj --include src/Net/LingoEngine.Net.RNetTerminal/CastView.cs --include src/Net/LingoEngine.Net.RNetTerminal/LingoRNetTerminal.cs --include src/Net/LingoEngine.Net.RNetTerminal/PropertyInspector.cs --include src/Net/LingoEngine.Net.RNetTerminal/ScoreView.cs --include src/Net/LingoEngine.Net.RNetTerminal/StageView.cs --include src/Net/LingoEngine.Net.RNetTerminal/TerminalDataStore.cs --include src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj -v diagnostic`
- `dotnet build src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c7928c47108332aa36402cab88dbec