### PR TITLE
Hide irrelevant tabs in RNetTerminal PropertyInspector

### DIFF
--- a/src/Net/LingoEngine.Net.RNetTerminal/PropertyInspector.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/PropertyInspector.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using LingoEngine.IO.Data.DTO;
 using Terminal.Gui;
 
@@ -13,6 +14,16 @@ internal sealed class PropertyInspector : Window
     private readonly List<PropertySpec> _memberSpecs = new();
     private readonly TableView _memberTableView;
     private readonly TabView.Tab _memberTab;
+    private readonly TabView.Tab _spriteTab;
+    private readonly TabView.Tab _bitmapTab;
+    private readonly TabView.Tab _soundTab;
+    private readonly TabView.Tab _movieTab;
+    private readonly TabView.Tab _castTab;
+    private readonly TabView.Tab _textTab;
+    private readonly TabView.Tab _shapeTab;
+    private readonly TabView.Tab _guidesTab;
+    private readonly TabView.Tab _behaviorTab;
+    private readonly TabView.Tab _filmLoopTab;
 
     public event Action<string, string>? PropertyChanged;
 
@@ -24,7 +35,7 @@ internal sealed class PropertyInspector : Window
             Height = Dim.Fill()
         };
 
-        AddTab("Sprite", new[]
+        _spriteTab = CreateTab("Sprite", new[]
         {
             new PropertySpec("Lock", typeof(bool)),
             new PropertySpec("FlipH", typeof(bool)),
@@ -50,8 +61,8 @@ internal sealed class PropertyInspector : Window
             new PropertySpec("Behaviors", typeof(string))
         });
 
-        _memberTable.Columns.Add(string.Empty);
-        _memberTable.Columns.Add(string.Empty);
+        _memberTable.Columns.Add("\u200B");
+        _memberTable.Columns.Add("\u200B\u200B");
         _memberTableView = new TableView
         {
             Width = Dim.Fill(),
@@ -91,16 +102,15 @@ internal sealed class PropertyInspector : Window
             _memberTableView.SetNeedsDisplay();
         };
         _memberTab = new TabView.Tab("Member", _memberTableView);
-        _tabs.AddTab(_memberTab, false);
 
-        AddTab("Bitmap", new[]
+        _bitmapTab = CreateTab("Bitmap", new[]
         {
             new PropertySpec("Dimensions", typeof(string), true),
             new PropertySpec("Highlight", typeof(bool)),
             new PropertySpec("RegPointX", typeof(int)),
             new PropertySpec("RegPointY", typeof(int))
         });
-        AddTab("Sound", new[]
+        _soundTab = CreateTab("Sound", new[]
         {
             new PropertySpec("Loop", typeof(bool)),
             new PropertySpec("Duration", typeof(float), true),
@@ -110,7 +120,7 @@ internal sealed class PropertyInspector : Window
             new PropertySpec("Play", typeof(bool)),
             new PropertySpec("Stop", typeof(bool))
         });
-        AddTab("Movie", new[]
+        _movieTab = CreateTab("Movie", new[]
         {
             new PropertySpec("StageWidth", typeof(int)),
             new PropertySpec("StageHeight", typeof(int)),
@@ -120,18 +130,18 @@ internal sealed class PropertyInspector : Window
             new PropertySpec("About", typeof(string)),
             new PropertySpec("Copyright", typeof(string))
         });
-        AddTab("Cast", new[]
+        _castTab = CreateTab("Cast", new[]
         {
             new PropertySpec("Number", typeof(int)),
             new PropertySpec("Name", typeof(string))
         });
-        AddTab("Text", new[]
+        _textTab = CreateTab("Text", new[]
         {
             new PropertySpec("Width", typeof(int)),
             new PropertySpec("Height", typeof(int)),
             new PropertySpec("Edit", typeof(bool))
         });
-        AddTab("Shape", new[]
+        _shapeTab = CreateTab("Shape", new[]
         {
             new PropertySpec("Shape", typeof(string)),
             new PropertySpec("Filled", typeof(bool)),
@@ -139,7 +149,7 @@ internal sealed class PropertyInspector : Window
             new PropertySpec("Height", typeof(int)),
             new PropertySpec("Edit", typeof(bool))
         });
-        AddTab("Guides", new[]
+        _guidesTab = CreateTab("Guides", new[]
         {
             new PropertySpec("GuidesColor", typeof(Color)),
             new PropertySpec("GuidesVisible", typeof(bool)),
@@ -154,8 +164,8 @@ internal sealed class PropertyInspector : Window
             new PropertySpec("GridWidth", typeof(int)),
             new PropertySpec("GridHeight", typeof(int))
         });
-        AddTab("Behavior", new[] { new PropertySpec("Behaviors", typeof(string)) });
-        AddTab("FilmLoop", new[]
+        _behaviorTab = CreateTab("Behavior", new[] { new PropertySpec("Behaviors", typeof(string)) });
+        _filmLoopTab = CreateTab("FilmLoop", new[]
         {
             new PropertySpec("Framing", typeof(string)),
             new PropertySpec("Loop", typeof(bool)),
@@ -163,19 +173,33 @@ internal sealed class PropertyInspector : Window
         });
 
         Add(_tabs);
+        SetTabs(_memberTab);
     }
 
-    private void AddTab(string title, PropertySpec[] props)
+    private TabView.Tab CreateTab(string title, PropertySpec[] props)
     {
         var view = BuildPropertyTableView(props);
-        _tabs.AddTab(new TabView.Tab(title, view), _tabs.Tabs.Count == 0);
+        return new TabView.Tab(title, view);
+    }
+
+    private void SetTabs(params TabView.Tab[] tabs)
+    {
+        foreach (var existing in _tabs.Tabs.ToList())
+        {
+            _tabs.RemoveTab(existing);
+        }
+
+        foreach (var tab in tabs)
+        {
+            _tabs.AddTab(tab, _tabs.Tabs.Count == 0);
+        }
     }
 
     private TableView BuildPropertyTableView(PropertySpec[] props)
     {
         var table = new DataTable();
-        table.Columns.Add(string.Empty);
-        table.Columns.Add(string.Empty);
+        table.Columns.Add("\u200B");
+        table.Columns.Add("\u200B\u200B");
         for (var i = 0; i < props.Length; i++)
         {
             table.Rows.Add(props[i].Name, GetDefaultValue(props[i].Type));
@@ -326,6 +350,7 @@ internal sealed class PropertyInspector : Window
         if (member == null)
         {
             _memberTableView.SetNeedsDisplay();
+            SetTabs(_memberTab);
             return;
         }
 
@@ -344,6 +369,34 @@ internal sealed class PropertyInspector : Window
         AddMember("PurgePriority", member.PurgePriority.ToString(), typeof(int), true);
 
         _memberTableView.SetNeedsDisplay();
+
+        var tabs = new List<TabView.Tab> { _memberTab, _castTab };
+
+        switch (member.Type)
+        {
+            case LingoMemberTypeDTO.Bitmap:
+            case LingoMemberTypeDTO.Picture:
+                tabs.Add(_bitmapTab);
+                break;
+            case LingoMemberTypeDTO.Sound:
+                tabs.Add(_soundTab);
+                break;
+            case LingoMemberTypeDTO.Text:
+            case LingoMemberTypeDTO.Field:
+                tabs.Add(_textTab);
+                break;
+            case LingoMemberTypeDTO.Shape:
+                tabs.Add(_shapeTab);
+                break;
+            case LingoMemberTypeDTO.FilmLoop:
+                tabs.Add(_filmLoopTab);
+                break;
+            case LingoMemberTypeDTO.Movie:
+                tabs.Add(_movieTab);
+                break;
+        }
+
+        SetTabs(tabs.ToArray());
         _tabs.SelectedTab = _memberTab;
     }
 


### PR DESCRIPTION
## Summary
- remove placeholder column headers from property tables
- dynamically show property tabs only when relevant to the selected member

## Testing
- `dotnet format src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj --include src/Net/LingoEngine.Net.RNetTerminal/PropertyInspector.cs -v diagnostic`
- `dotnet build src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c79565e60c8332a6e63163e5ff50e1