### PR TITLE
Improve RNetTerminal sprite editing and navigation

### DIFF
--- a/src/Net/LingoEngine.Net.RNetTerminal/ScoreView.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/ScoreView.cs
@@ -237,6 +237,14 @@ internal sealed class ScoreView : ScrollView
     private void ClampContentOffset()
     {
         var offset = GetOffset();
+        if (ContentOffset.X < 0)
+        {
+            offset.X = 0;
+        }
+        if (ContentOffset.Y < 0)
+        {
+            offset.Y = 0;
+        }
         ClampContentOffset(ref offset);
         SetOffset(offset);
     }
@@ -627,7 +635,14 @@ internal sealed class ScoreView : ScrollView
                 Width = 10,
                 Visible = cb.Checked
             };
-            cb.Toggled += _ => field.Visible = cb.Checked;
+            cb.Toggled += _ =>
+            {
+                field.Visible = cb.Checked;
+                if (cb.Checked)
+                {
+                    field.SetFocus();
+                }
+            };
             rows.Add((cb, field, name));
         }
         var ok = new Button("Ok", true);
@@ -649,6 +664,8 @@ internal sealed class ScoreView : ScrollView
         {
             dialog.Add(cb, field);
         }
+        dialog.Add(new Label("Use Space to toggle") { X = 1, Y = TweenProperties.Length + 1 });
+        rows[0].cb.SetFocus();
         Application.Run(dialog);
     }
 


### PR DESCRIPTION
## Summary
- keep score view responsive when no sprite is under the cursor
- restore and populate the Sprite tab in the property inspector
- streamline keyframe dialog focus and hint at space toggling
- refresh the stage when sprite position or size changes

## Testing
- `dotnet test Test/LingoEngine.Net.RNetTerminal.Tests/LingoEngine.Net.RNetTerminal.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68c79c6f1b0c8332814214f29883c856