### PR TITLE
Fix ScoreView scrolling and add navigation tests

### DIFF
--- a/Test/LingoEngine.Net.RNetTerminal.Tests/ScoreViewTests.cs
+++ b/Test/LingoEngine.Net.RNetTerminal.Tests/ScoreViewTests.cs
@@ -7,6 +7,14 @@ namespace LingoEngine.Net.RNetTerminal.Tests;
 
 public class ScoreViewTests
 {
+    private static void SetPrivateField(object obj, string name, object value)
+        => obj.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(obj, value);
+
+    private static T GetPrivateField<T>(object obj, string name)
+        => (T)obj.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(obj)!;
+
+    private static Point GetOffset(ScoreView view)
+        => (Point)view.GetType().GetMethod("GetOffset", BindingFlags.NonPublic | BindingFlags.Instance)!.Invoke(view, null)!;
     [Fact]
     public void MouseEvent_OnScrollBar_DoesNotThrow()
     {
@@ -70,6 +78,142 @@ public class ScoreViewTests
             var move = typeof(ScoreView).GetMethod("MoveCursor", BindingFlags.NonPublic | BindingFlags.Instance)!;
             var act = () => move.Invoke(view, new object[] { 0, 100 });
             act.Should().NotThrow();
+        }
+        finally
+        {
+            Application.Shutdown();
+        }
+    }
+
+    [Theory]
+    [InlineData(Key.CursorUp, "_cursorChannel", -1)]
+    [InlineData(Key.CursorDown, "_cursorChannel", 1)]
+    [InlineData(Key.CursorLeft, "_cursorFrame", -1)]
+    [InlineData(Key.CursorRight, "_cursorFrame", 1)]
+    public void ProcessKey_MovesCursor_WhenNotOverSprite(Key key, string field, int delta)
+    {
+        Application.Init(new FakeDriver());
+        try
+        {
+            var view = new ScoreView
+            {
+                Frame = new Rect(0, 0, 20, 10)
+            };
+            view.LayoutSubviews();
+            SetPrivateField(view, "_cursorFrame", 1);
+            SetPrivateField(view, "_cursorChannel", 1);
+            var before = GetPrivateField<int>(view, field);
+            view.ProcessKey(new KeyEvent(key, new KeyModifiers()));
+            var after = GetPrivateField<int>(view, field);
+            after.Should().Be(before + delta);
+        }
+        finally
+        {
+            Application.Shutdown();
+        }
+    }
+
+    [Theory]
+    [InlineData(Key.CursorUp, "_cursorChannel", -1)]
+    [InlineData(Key.CursorDown, "_cursorChannel", 1)]
+    [InlineData(Key.CursorLeft, "_cursorFrame", -1)]
+    [InlineData(Key.CursorRight, "_cursorFrame", 1)]
+    public void ProcessKey_MovesCursor_WhenOverSprite(Key key, string field, int delta)
+    {
+        Application.Init(new FakeDriver());
+        try
+        {
+            var view = new ScoreView
+            {
+                Frame = new Rect(0, 0, 20, 10)
+            };
+            view.LayoutSubviews();
+            SetPrivateField(view, "_cursorFrame", 1);
+            SetPrivateField(view, "_cursorChannel", 5);
+            var before = GetPrivateField<int>(view, field);
+            view.ProcessKey(new KeyEvent(key, new KeyModifiers()));
+            var after = GetPrivateField<int>(view, field);
+            after.Should().Be(before + delta);
+        }
+        finally
+        {
+            Application.Shutdown();
+        }
+    }
+
+    [Fact]
+    public void ProcessKey_RightAtEdge_ScrollsHorizontally()
+    {
+        Application.Init(new FakeDriver());
+        try
+        {
+            var view = new ScoreView
+            {
+                Frame = new Rect(0, 0, 20, 10)
+            };
+            view.LayoutSubviews();
+            var labelWidth = GetPrivateField<int>(view, "_labelWidth");
+            var visibleFrames = view.Frame.Width - labelWidth - 1;
+            SetPrivateField(view, "_cursorFrame", visibleFrames - 1);
+            SetPrivateField(view, "_cursorChannel", 1);
+            var before = GetOffset(view).X;
+            view.ProcessKey(new KeyEvent(Key.CursorRight, new KeyModifiers()));
+            var after = GetOffset(view).X;
+            after.Should().BeGreaterThan(before);
+        }
+        finally
+        {
+            Application.Shutdown();
+        }
+    }
+
+    [Fact]
+    public void ProcessKey_DownAtEdge_ScrollsVertically()
+    {
+        Application.Init(new FakeDriver());
+        try
+        {
+            var view = new ScoreView
+            {
+                Frame = new Rect(0, 0, 20, 10)
+            };
+            view.LayoutSubviews();
+            var scrollBarHeight = 1;
+            var visibleChannels = view.Frame.Height - 1 - scrollBarHeight;
+            SetPrivateField(view, "_cursorChannel", visibleChannels - 1);
+            SetPrivateField(view, "_cursorFrame", 1);
+            var before = GetOffset(view).Y;
+            view.ProcessKey(new KeyEvent(Key.CursorDown, new KeyModifiers()));
+            var after = GetOffset(view).Y;
+            after.Should().BeGreaterThan(before);
+        }
+        finally
+        {
+            Application.Shutdown();
+        }
+    }
+
+    [Fact]
+    public void MouseWheel_ScrollsContent()
+    {
+        Application.Init(new FakeDriver());
+        try
+        {
+            var view = new ScoreView
+            {
+                Frame = new Rect(0, 0, 20, 10)
+            };
+            view.LayoutSubviews();
+            var before = GetOffset(view).Y;
+            var me = new MouseEvent
+            {
+                X = 0,
+                Y = 0,
+                Flags = MouseFlags.WheeledDown
+            };
+            view.MouseEvent(me);
+            var after = GetOffset(view).Y;
+            after.Should().BeGreaterThan(before);
         }
         finally
         {

--- a/src/Net/LingoEngine.Net.RNetTerminal/ScoreView.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/ScoreView.cs
@@ -213,6 +213,7 @@ internal sealed class ScoreView : ScrollView
             }
             var handled = base.MouseEvent(me);
             ClampContentOffset();
+            SetNeedsDisplay();
             return handled;
         }
         catch (Exception ex)
@@ -257,6 +258,7 @@ internal sealed class ScoreView : ScrollView
     {
         _cursorFrame = Math.Clamp(_cursorFrame + dx, 0, FrameCount - 1);
         _cursorChannel = Math.Clamp(_cursorChannel + dy, 0, TotalChannels - 1);
+        _selectedSprite = FindSprite(_cursorChannel + 1, _cursorFrame + 1)?.Number;
         EnsureVisible();
         SetNeedsDisplay();
         NotifyInfoChanged();


### PR DESCRIPTION
## Summary
- Ensure ScoreView redraws after mouse events and updates selected sprite while moving
- Add comprehensive keyboard and mouse scrolling tests for ScoreView

## Testing
- `dotnet test Test/LingoEngine.Net.RNetTerminal.Tests/LingoEngine.Net.RNetTerminal.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c7c5eba9f08332970e33a68fc1e722