### PR TITLE
Synchronize TetriGrounds media via setup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,4 @@ Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Blazor/wwwroot/Media/Data/
 Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Blazor/wwwroot/Media/Sounds/
 Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Blazor/wwwroot/Media/Icons/
 Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Blazor/wwwroot/Media/InternalExt/
+Demo/TetriGrounds/LingoEngine.Demo.TetriGrounds.Blazor/Media/

--- a/setup-windows.bat
+++ b/setup-windows.bat
@@ -7,9 +7,32 @@ setlocal enabledelayedexpansion
 set "ROOT=%~dp0"
 cd /d "%ROOT%"
 
+set "ARCH=%PROCESSOR_ARCHITECTURE%"
+if /i "%ARCH%"=="AMD64" (
+    set "LIB_DIR=%ROOT%Libs\SDL2_WIN_X64"
+) else if /i "%ARCH%"=="x86" (
+    set "LIB_DIR=%ROOT%Libs\SDL2_WIN_X86"
+) else if /i "%ARCH%"=="ARM64" (
+    set "LIB_DIR=%ROOT%Libs\SDL2_WIN_ARM64"
+) else if /i "%ARCH%"=="ARM" (
+    set "LIB_DIR=%ROOT%Libs\SDL2_WIN_ARM"
+) else (
+    set "LIB_DIR="
+)
+
+set PROJECTS="Demo\TetriGrounds\LingoEngine.Demo.TetriGrounds.SDL2" "Test\LingoEngine.SDL2.GfxVisualTest" "WillMoveToOwnRepo\AbstUI\Test\AbstUI.GfxVisualTest.SDL2" "src\Director\LingoEngine.Director.Runner.SDL2"
+set "MEDIA_SRC=%ROOT%Demo\TetriGrounds\LingoEngine.Demo.TetriGrounds.Godot\Media"
+set "MEDIA_DEST=%ROOT%Demo\TetriGrounds\LingoEngine.Demo.TetriGrounds.Blazor\Media"
+
 echo This script will:
 echo   - Ensure the .NET 8 SDK is installed.
-echo   - Copy SDL2 native libraries into build output folders for the TetriGrounds SDL demo and SDL-based test projects.
+if defined LIB_DIR (
+    echo   - Copy SDL2 native libraries for %ARCH% from %LIB_DIR% into:
+    for %%P in (%PROJECTS%) do echo       - %%~P\bin\^<config^>\net8.0
+) else (
+    echo   - SDL2 libraries will not be copied ^(unsupported architecture %ARCH%^).
+)
+echo   - Copy demo media from %MEDIA_SRC% to %MEDIA_DEST%.
 echo.
 echo Press any key to continue or Ctrl+C to abort.
 pause >nul
@@ -27,38 +50,27 @@ if errorlevel 1 (
     echo .NET SDK found: !DOTNET_VER!
 )
 
-set "ARCH=%PROCESSOR_ARCHITECTURE%"
-if /i "%ARCH%"=="AMD64" (
-    set "LIB_DIR=%ROOT%Libs\SDL2_WIN_X64"
-) else if /i "%ARCH%"=="x86" (
-    set "LIB_DIR=%ROOT%Libs\SDL2_WIN_X86"
-) else if /i "%ARCH%"=="ARM64" (
-    set "LIB_DIR=%ROOT%Libs\SDL2_WIN_ARM64"
-) else if /i "%ARCH%"=="ARM" (
-    set "LIB_DIR=%ROOT%Libs\SDL2_WIN_ARM"
-) else (
-    set "LIB_DIR="
-)
-
-if not defined LIB_DIR (
-    echo Unsupported or unknown architecture: %ARCH%
-    goto :EOF
-)
-
-if not exist "%LIB_DIR%" (
-    echo No SDL2 libraries found for %ARCH% in %LIB_DIR%.
-    goto :EOF
-)
-
-echo Copying SDL2 libraries for %ARCH%...
-set PROJECTS="Demo\TetriGrounds\LingoEngine.Demo.TetriGrounds.SDL2" "Test\LingoEngine.SDL2.GfxVisualTest" "WillMoveToOwnRepo\AbstUI\Test\AbstUI.GfxVisualTest.SDL2" "src\Director\LingoEngine.Director.Runner.SDL2" "src\Director\LingoEngine.Director.Runner.Godot"
-for %%P in (%PROJECTS%) do (
-    if exist "%ROOT%%%~P" (
-        for %%C in (Debug DebugWithDirector Release) do (
-            if not exist "%ROOT%%%~P\bin\%%C\net8.0" mkdir "%ROOT%%%~P\bin\%%C\net8.0"
-            copy /Y "%LIB_DIR%\*" "%ROOT%%%~P\bin\%%C\net8.0" >nul
+if defined LIB_DIR (
+    if not exist "%LIB_DIR%" (
+        echo No SDL2 libraries found for %ARCH% in %LIB_DIR%.
+    ) else (
+        echo Copying SDL2 libraries for %ARCH%...
+        for %%P in (%PROJECTS%) do (
+            if exist "%ROOT%%%~P" (
+                for %%C in (Debug DebugWithDirector Release) do (
+                    if not exist "%ROOT%%%~P\bin\%%C\net8.0" mkdir "%ROOT%%%~P\bin\%%C\net8.0"
+                    copy /Y "%LIB_DIR%\*" "%ROOT%%%~P\bin\%%C\net8.0" >nul
+                )
+            )
         )
     )
+)
+
+if exist "%MEDIA_SRC%" (
+    echo Copying demo media...
+    robocopy "%MEDIA_SRC%" "%MEDIA_DEST%" /MIR >nul
+) else (
+    echo Demo media source not found: %MEDIA_SRC%
 )
 
 echo.


### PR DESCRIPTION
## Summary
- Copy TetriGrounds Godot media into the Blazor demo project during setup
- Display architecture and SDL2 copy destinations in setup scripts
- Remove committed TetriGrounds media and ignore generated assets

## Testing
- `bash -n setup-linux.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c7c9d81b3c83329e84097e1919f68e