### PR TITLE
Clarify Godot selection dialog with version guidance

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -39,6 +39,10 @@ else
   done
 fi
 echo "  - Copy demo media from '$MEDIA_SRC' to '$MEDIA_DEST'."
+echo "  - At the end you will be prompted to locate your Godot executable."
+echo "    When the file dialog appears, select the Godot 4 binary you want to use."
+echo "    Example: /path/to/Godot_v4.5-stable_mono_linux_x86_64"
+echo "    Minimum required version is 4.5."
 echo
 echo "Press Enter to continue or Ctrl+C to abort."
 read -r
@@ -75,10 +79,13 @@ fi
 
 GODOT_PATH=""
 if command -v zenity >/dev/null 2>&1; then
+  echo "Select the Godot executable (e.g., /path/to/Godot_v4.5-stable_mono_linux_x86_64)"
+  echo "Minimum version 4.5 required."
   GODOT_PATH=$(zenity --file-selection --title="Select Godot executable" 2>/dev/null || true)
 fi
 if [ -z "$GODOT_PATH" ]; then
-  read -p "Enter path to Godot executable: " GODOT_PATH
+  echo "Select the Godot executable (e.g., /path/to/Godot_v4.5-stable_mono_linux_x86_64)"
+  read -p "Minimum version 4.5 required. Enter path to Godot executable: " GODOT_PATH
 fi
 
 if [ -n "$GODOT_PATH" ]; then

--- a/setup-windows.bat
+++ b/setup-windows.bat
@@ -33,6 +33,9 @@ if defined LIB_DIR (
     echo   - SDL2 libraries will not be copied ^(unsupported architecture %ARCH%^).
 )
 echo   - Copy demo media from %MEDIA_SRC% to %MEDIA_DEST%.
+echo   - At the end you will be asked to locate your Godot executable.
+echo     When the file dialog appears, select the Godot 4 executable to use (minimum version 4.5).
+echo     Example: C:\path\to\Godot_v4.5-stable_mono_win64.exe
 echo.
 echo Press any key to continue or Ctrl+C to abort.
 pause >nul
@@ -74,6 +77,7 @@ if exist "%MEDIA_SRC%" (
 )
 
 echo.
+echo Select the Godot executable (e.g., C:\path\to\Godot_v4.5-stable_mono_win64.exe). Minimum version 4.5 required.
 powershell -NoProfile -ExecutionPolicy Bypass -Command "Add-Type -AssemblyName System.Windows.Forms; $dlg=New-Object System.Windows.Forms.OpenFileDialog; $dlg.Filter='Godot executable|Godot*.exe'; if($dlg.ShowDialog() -eq 'OK'){ $path=$dlg.FileName; $settingsPath='.vscode/settings.json'; $json=Get-Content $settingsPath | ConvertFrom-Json; $json.'godotTools.editorPath.godot4'=$path; $json | ConvertTo-Json | Set-Content $settingsPath; $ver=[regex]::Match((Split-Path $path -Leaf), 'Godot_v([^_]+)_').Groups[1].Value; & 'scripts\\SetGodotVersion.ps1' $ver } else { Write-Host 'No Godot executable selected.' }"
 
 echo Setup complete.


### PR DESCRIPTION
## Summary
- Highlight example Godot binary and minimum 4.5 requirement when prompting in `setup-windows.bat`
- Add matching example and version requirement text for Godot selection in `setup-linux.sh`

## Testing
- `bash -n setup-linux.sh`
- `cmd.exe /c "echo testing"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d36910d083329cb8631378eac9aa