### PR TITLE
Add setup completion pauses and log Godot version updates

### DIFF
--- a/scripts/SetGodotVersion.ps1
+++ b/scripts/SetGodotVersion.ps1
@@ -15,6 +15,7 @@ foreach($file in $csprojs){
     $content = $content -replace '<GodotVersion>[^<]+</GodotVersion>', "<GodotVersion>$NugetVersion</GodotVersion>"
     $content = $content -replace '<PackageReference Include="Godot.NET.Sdk" Version="[^"\s]+" />', "<PackageReference Include="Godot.NET.Sdk" Version="$NugetVersion" />"
     Set-Content -Encoding UTF8 $file.FullName $content
+    Write-Host ("Updated Godot version in {0}" -f $file.FullName)
 }
 # Update launchSettings.json files
 $execVersion = "v$VersionTag"
@@ -24,5 +25,6 @@ foreach($file in $launchFiles){
     $content = $content -replace 'Godot_v[^_"\\]+', "Godot_$execVersion"
     $content = $content -replace 'Godot\.[0-9A-Za-z\.-]+', "Godot.$VersionTag"
     Set-Content -Encoding UTF8 $file.FullName $content
+    Write-Host ("Updated Godot version in {0}" -f $file.FullName)
 }
 Write-Host ('Godot version updated to {0} (NuGet: {1})' -f $VersionTag, $NugetVersion)

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -6,6 +6,15 @@
 
 set -e
 
+FAILED=0
+trap 'FAILED=1' ERR
+trap 'if [ $FAILED -eq 0 ]; then
+  echo "Setup complete."
+else
+  echo "Setup encountered an error."
+fi
+read -p "Press Enter to exit..."' EXIT
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
@@ -101,4 +110,3 @@ PY
   ./scripts/SetGodotVersion.sh "$GODOT_VERSION"
 fi
 
-echo "Setup complete."


### PR DESCRIPTION
## Summary
- Pause with success or error message before exiting setup scripts
- Report which files were updated when setting Godot version

## Testing
- `bash -n setup-linux.sh`
- `pwsh -NoProfile -Command "[System.Management.Automation.PSParser]::Tokenize(..."` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c7d861a5108332a78e274cbb7edc0e