### PR TITLE
refactor: centralize terminal state

### DIFF
--- a/src/Net/LingoEngine.Net.RNetTerminal/CastView.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/CastView.cs
@@ -19,12 +19,15 @@ internal sealed class CastView : View
             Height = Dim.Fill()
         };
         Add(_tabs);
+        var store = TerminalDataStore.Instance;
+        store.CastsChanged += ReloadData;
+        store.MemberChanged += _ => ReloadData();
         ReloadData();
     }
 
     public void ReloadData()
     {
-        var casts = TerminalDataStore.Instance.Casts;
+        var casts = TerminalDataStore.Instance.GetCasts();
         _tabs.RemoveAll();
         Remove(_tabs);
         _tabs = new TabView
@@ -71,6 +74,7 @@ internal sealed class CastView : View
                         ok.Clicked += () =>
                         {
                             member.Comments = text.Text.ToString() ?? string.Empty;
+                            TerminalDataStore.Instance.UpdateMember(member);
                             Application.RequestStop();
                         };
                         var dialog = new Dialog($"Edit {member.Name}", 60, 20, ok);

--- a/src/Net/LingoEngine.Net.RNetTerminal/LingoRNetTerminal.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/LingoRNetTerminal.cs
@@ -2,7 +2,6 @@ using LingoEngine.IO.Data.DTO;
 using LingoEngine.Net.RNetClient;
 using LingoEngine.Net.RNetContracts;
 using Terminal.Gui;
-using System.Linq;
 using Timer = System.Timers.Timer;
 using LingoEngine.IO;
 
@@ -25,7 +24,6 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
     private StageView? _stageView;
     private CastView? _castView;
     private StatusItem? _infoItem;
-    private int? _selectedSprite;
 
     public LingoRNetTerminal()
     {
@@ -100,9 +98,10 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
         _propertyInspector.PropertyChanged += (n, v) =>
         {
             Log($"propertyChanged {n}={v}");
-            if (_selectedSprite.HasValue)
+            var sel = TerminalDataStore.Instance.GetSelectedSprite();
+            if (sel.HasValue)
             {
-                var sprite = FindSprite(_selectedSprite.Value);
+                var sprite = TerminalDataStore.Instance.FindSprite(sel.Value);
                 if (sprite != null)
                 {
                     switch (n)
@@ -120,12 +119,11 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
                             sprite.Height = height;
                             break;
                     }
-                    _stageView?.ReloadData();
-                    _stageView?.RequestRedraw();
+                    TerminalDataStore.Instance.UpdateSprite(sprite);
                 }
                 if (_client != null)
                 {
-                    _ = _client.SendCommandAsync(new SetSpritePropCmd(_selectedSprite.Value, n, v));
+                    _ = _client.SendCommandAsync(new SetSpritePropCmd(sel.Value, n, v));
                 }
             }
         };
@@ -138,6 +136,13 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
             }
         };
         _uiWin.Add(_workspace, _propertyInspector);
+        TerminalDataStore.Instance.SelectedSpriteChanged += n =>
+        {
+            var store = TerminalDataStore.Instance;
+            var sp = n.HasValue ? store.FindSprite(n.Value) : null;
+            _propertyInspector?.ShowSprite(sp);
+            _propertyInspector?.ShowMember(sp != null ? store.FindMember(sp.MemberNum) : null);
+        };
         top.Add(_uiWin);
 
         var logWin = new Window("Logs")
@@ -180,16 +185,12 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
             Width = Dim.Fill(),
             Height = Dim.Fill(),
         };
-        _scoreView.SpriteSelected += n =>
-        {
-            Log($"spriteSelected {n}");
-            _selectedSprite = n;
-            var sp = FindSprite(n);
-            _propertyInspector?.ShowSprite(sp);
-            _propertyInspector?.ShowMember(sp != null ? FindMember(sp.MemberNum) : null);
-        };
         _scoreView.PlayFromHere += f => Log($"Play from {f}");
-        _scoreView.InfoChanged += UpdateInfo;
+        _scoreView.InfoChanged += (f, ch, sp, mem) =>
+        {
+            UpdateInfo(f, ch, sp, mem);
+            TerminalDataStore.Instance.SetFrame(f);
+        };
         _workspace?.Add(_scoreView);
         _scoreView.SetFocus();
         _scoreView.TriggerInfo();
@@ -233,32 +234,11 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
             Width = Dim.Fill(),
             Height = Dim.Fill()
         };
-        _stageView.SpriteSelected += n =>
-        {
-            Log($"spriteSelected {n}");
-            _selectedSprite = n;
-            _stageView.SetSelectedSprite(n);
-            _scoreView.SelectSprite(n);
-            var sp = FindSprite(n);
-            _propertyInspector?.ShowSprite(sp);
-            _propertyInspector?.ShowMember(sp != null ? FindMember(sp.MemberNum) : null);
-        };
-        _scoreView.SpriteSelected += n =>
-        {
-            Log($"spriteSelected {n}");
-            _selectedSprite = n;
-            _stageView.SetSelectedSprite(n);
-            _scoreView.SelectSprite(n);
-            var sp = FindSprite(n);
-            _propertyInspector?.ShowSprite(sp);
-            _propertyInspector?.ShowMember(sp != null ? FindMember(sp.MemberNum) : null);
-        };
         _scoreView.PlayFromHere += f => Log($"Play from {f}");
         _scoreView.InfoChanged += (f, ch, sp, mem) =>
         {
             UpdateInfo(f, ch, sp, mem);
-            _stageView.SetFrame(f);
-            _stageView.RequestRedraw();
+            TerminalDataStore.Instance.SetFrame(f);
         };
 
         _workspace?.Add(_stageView, _scoreView);
@@ -266,49 +246,22 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
         _scoreView.TriggerInfo();
     }
 
-    private void UpdateInfo(int frame, int channel, int? sprite, string? member)
+    private void UpdateInfo(int frame, int channel, int? sprite, int? member)
     {
         if (_infoItem != null)
         {
-            _infoItem.Title = $"Frame:{frame} Channel:{channel} Sprite:{(sprite?.ToString() ?? "-")} Member:{member ?? string.Empty}";
+            var store = TerminalDataStore.Instance;
+            var memName = member.HasValue ? store.FindMember(member.Value)?.Name : null;
+            _infoItem.Title = $"Frame:{frame} Channel:{channel} Sprite:{(sprite?.ToString() ?? "-")} Member:{memName ?? string.Empty}";
         }
 
         if (_propertyInspector != null)
         {
-            _propertyInspector.ShowSprite(sprite.HasValue ? FindSprite(sprite.Value) : null);
-            _propertyInspector.ShowMember(member != null ? FindMember(member) : null);
+            var store = TerminalDataStore.Instance;
+            _propertyInspector.ShowSprite(sprite.HasValue ? store.FindSprite(sprite.Value) : null);
+            _propertyInspector.ShowMember(member.HasValue ? store.FindMember(member.Value) : null);
         }
         _scoreView?.SetFocus();
-    }
-
-    private LingoMemberDTO? FindMember(string name)
-    {
-        foreach (var cast in TerminalDataStore.Instance.Casts.Values)
-        {
-            foreach (var m in cast)
-            {
-                if (m.Name == name)
-                {
-                    return m;
-                }
-            }
-        }
-        return null;
-    }
-
-    private LingoMemberDTO? FindMember(int key)
-    {
-        foreach (var cast in TerminalDataStore.Instance.Casts.Values)
-        {
-            foreach (var m in cast)
-            {
-                if (((m.CastLibNum << 16) | m.NumberInCast) == key)
-                {
-                    return m;
-                }
-            }
-        }
-        return null;
     }
 
     private static void SetNortonTheme()
@@ -339,9 +292,6 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
             top.ColorScheme = baseScheme;
         }
     }
-
-    private LingoSpriteDTO? FindSprite(int number)
-        => TerminalDataStore.Instance.Sprites.FirstOrDefault(s => s.SpriteNum == number);
 
     private async Task ToggleConnectionAsync()
     {
@@ -374,9 +324,6 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
             _connected = false;
             Log("Disconnected.");
             TerminalDataStore.Instance.LoadTestData();
-            _scoreView?.ReloadData();
-            _stageView?.ReloadData();
-            _castView?.ReloadData();
         }
     }
 
@@ -392,9 +339,6 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
             var repo = new JsonStateRepository();
             var project = repo.Deserialize(movieJson.json);
             TerminalDataStore.Instance.LoadFromProject(project);
-            _scoreView?.ReloadData();
-            _stageView?.ReloadData();
-            _castView?.ReloadData();
         }
         catch (Exception ex)
         {

--- a/src/Net/LingoEngine.Net.RNetTerminal/PropertyInspector.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/PropertyInspector.cs
@@ -29,6 +29,7 @@ internal sealed class PropertyInspector : Window
     private readonly TabView.Tab _behaviorTab;
     private readonly TabView.Tab _filmLoopTab;
     private LingoSpriteDTO? _sprite;
+    private string _lastTab = "Sprite";
 
     public event Action<string, string>? PropertyChanged;
 
@@ -38,6 +39,13 @@ internal sealed class PropertyInspector : Window
         {
             Width = Dim.Fill(),
             Height = Dim.Fill()
+        };
+        _tabs.SelectedTabChanged += (_, e) =>
+        {
+            if (e.NewTab != null)
+            {
+                _lastTab = e.NewTab.Text?.ToString() ?? _lastTab;
+            }
         };
 
         _spriteSpecs.AddRange(new[]
@@ -224,7 +232,9 @@ internal sealed class PropertyInspector : Window
         });
 
         Add(_tabs);
-        SetTabs(_memberTab);
+        SetTabs(_spriteTab, _memberTab);
+        var initial = _tabs.Tabs.FirstOrDefault(t => t.Text.ToString() == _lastTab) ?? _spriteTab;
+        _tabs.SelectedTab = initial;
     }
 
     public void ShowSprite(LingoSpriteDTO? sprite)
@@ -457,7 +467,8 @@ internal sealed class PropertyInspector : Window
             }
             tabsEmpty.Add(_memberTab);
             SetTabs(tabsEmpty.ToArray());
-            _tabs.SelectedTab = _sprite != null ? _spriteTab : _memberTab;
+            var target = _tabs.Tabs.FirstOrDefault(t => t.Text.ToString() == _lastTab);
+            _tabs.SelectedTab = target ?? (_sprite != null ? _spriteTab : _memberTab);
             return;
         }
 
@@ -510,7 +521,8 @@ internal sealed class PropertyInspector : Window
         }
 
         SetTabs(tabs.ToArray());
-        _tabs.SelectedTab = _sprite != null ? _spriteTab : _memberTab;
+        var desired = _tabs.Tabs.FirstOrDefault(t => t.Text.ToString() == _lastTab);
+        _tabs.SelectedTab = desired ?? (_sprite != null ? _spriteTab : _memberTab);
     }
 
     private void AddMember(string name, string value, Type type, bool readOnly = false)


### PR DESCRIPTION
## Summary
- enforce member references in `TerminalDataStore` and consumers
- require cast library and member numbers when creating sprites
- persist last-opened Property Inspector tab and default to sprite tab

## Testing
- `dotnet format src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj --include src/Net/LingoEngine.Net.RNetTerminal/PropertyInspector.cs -v diagnostic`
- `dotnet test Test/LingoEngine.Net.RNetTerminal.Tests/LingoEngine.Net.RNetTerminal.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c7d76ce4a0833283903eb21ba47527