### PR TITLE
Refactor RNet terminal selection and member references

### DIFF
--- a/src/LingoEngine.IO.Data/DTO/LingoSpriteDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoSpriteDTO.cs
@@ -6,6 +6,7 @@ public class LingoSpriteDTO
     public string Name { get; set; } = string.Empty;
     public int SpriteNum { get; set; }
     public int MemberNum { get; set; }
+    public int CastLibNum { get; set; }
     public int DisplayMember { get; set; }
     public int SpritePropertiesOffset { get; set; }
     public bool Lock { get; set; }

--- a/src/LingoEngine.IO/JsonStateRepository.cs
+++ b/src/LingoEngine.IO/JsonStateRepository.cs
@@ -355,7 +355,7 @@ public class JsonStateRepository : IJsonStateRepository
                 Comments = baseDto.Comments,
                 FileName = baseDto.FileName,
                 PurgePriority = baseDto.PurgePriority,
-                MarkDownText = field.InitialMarkdown != null? field.InitialMarkdown.Markdown :  field.Text
+                MarkDownText = field.InitialMarkdown != null ? field.InitialMarkdown.Markdown : field.Text
             },
             LingoMemberSound sound => new LingoMemberSoundDTO
             {
@@ -448,6 +448,7 @@ public class JsonStateRepository : IJsonStateRepository
             Name = state.Name,
             SpriteNum = sprite.SpriteNum,
             MemberNum = state.Member?.NumberInCast ?? sprite.MemberNum,
+            CastLibNum = state.Member?.CastLibNum ?? 0,
             DisplayMember = state.DisplayMember,
             SpritePropertiesOffset = state.SpritePropertiesOffset,
             Lock = sprite.Lock,
@@ -494,6 +495,7 @@ public class JsonStateRepository : IJsonStateRepository
             Name = state.Name,
             SpriteNum = sprite.SpriteNum,
             MemberNum = state.Member?.NumberInCast ?? sprite.MemberNum,
+            CastLibNum = state.Member?.CastLibNum ?? 0,
             DisplayMember = state.DisplayMember,
             Lock = sprite.Lock,
             LocH = state.LocH,

--- a/src/Net/LingoEngine.Net.RNetTerminal/LingoRNetTerminal.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/LingoRNetTerminal.cs
@@ -24,7 +24,6 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
     private StageView? _stageView;
     private CastView? _castView;
     private StatusItem? _infoItem;
-    private SpriteRef? _selectedSprite;
 
     public LingoRNetTerminal()
     {
@@ -96,39 +95,62 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
             Width = Dim.Fill(),
             Height = Dim.Fill()
         };
-        _propertyInspector.PropertyChanged += (n, v) =>
+        _propertyInspector.PropertyChanged += (target, n, v) =>
         {
             Log($"propertyChanged {n}={v}");
-            var sel = TerminalDataStore.Instance.GetSelectedSprite();
-            if (sel.HasValue)
+            var store = TerminalDataStore.Instance;
+            if (target == PropertyTarget.Sprite)
             {
-               
+                var sel = store.GetSelectedSprite();
+                if (sel.HasValue)
+                {
+                    var sprite = store.FindSprite(sel.Value);
+                    if (sprite != null)
+                    {
+                        switch (n)
+                        {
+                            case "LocH" when float.TryParse(v, out var locH):
+                                sprite.LocH = locH;
+                                break;
+                            case "LocV" when float.TryParse(v, out var locV):
+                                sprite.LocV = locV;
+                                break;
+                            case "Width" when float.TryParse(v, out var width):
+                                sprite.Width = width;
+                                break;
+                            case "Height" when float.TryParse(v, out var height):
+                                sprite.Height = height;
+                                break;
+                        }
+                        store.UpdateSprite(sprite);
+                    }
+                    if (_client != null)
+                    {
+                        _ = _client.SendCommandAsync(new SetSpritePropCmd(sel.Value.SpriteNum, sel.Value.BeginFrame, n, v));
+                    }
 
-                var sprite = TerminalDataStore.Instance.FindSprite(sel.Value);
-                if (sprite != null)
+                }
+            }
+            else if (target == PropertyTarget.Member)
+            {
+                var member = _propertyInspector?.CurrentMember;
+                if (member != null)
                 {
                     switch (n)
                     {
-                        case "LocH" when float.TryParse(v, out var locH):
-                            sprite.LocH = locH;
+                        case "Name":
+                            member.Name = v;
                             break;
-                        case "LocV" when float.TryParse(v, out var locV):
-                            sprite.LocV = locV;
-                            break;
-                        case "Width" when float.TryParse(v, out var width):
-                            sprite.Width = width;
-                            break;
-                        case "Height" when float.TryParse(v, out var height):
-                            sprite.Height = height;
+                        case "Comment":
+                            member.Comments = v;
                             break;
                     }
-                    TerminalDataStore.Instance.UpdateSprite(sprite);
+                    store.UpdateMember(member);
+                    if (_client != null)
+                    {
+                        _ = _client.SendCommandAsync(new SetMemberPropCmd(member.CastLibNum, member.NumberInCast, n, v));
+                    }
                 }
-                if (_client != null)
-                {
-                    _ = _client.SendCommandAsync(new SetSpritePropCmd(_selectedSprite.Value.SpriteNum, _selectedSprite.Value.BeginFrame, n, v));
-                }
-
             }
         };
         _propertyInspector.KeyPress += args =>
@@ -140,13 +162,6 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
             }
         };
         _uiWin.Add(_workspace, _propertyInspector);
-        TerminalDataStore.Instance.SelectedSpriteChanged += n =>
-        {
-            var store = TerminalDataStore.Instance;
-            var sp = n.HasValue ? store.FindSprite(n.Value) : null;
-            _propertyInspector?.ShowSprite(sp);
-            _propertyInspector?.ShowMember(sp != null ? store.FindMember(sp.MemberNum) : null);
-        };
         top.Add(_uiWin);
 
         var logWin = new Window("Logs")
@@ -190,17 +205,11 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
             Height = Dim.Fill(),
         };
 
-        _scoreView.SpriteSelected += (n, b) =>
-        {
-            Log($"spriteSelected {n}@{b}");
-            _selectedSprite = new SpriteRef(n, b);
-        };
         _scoreView.PlayFromHere += f => Log($"Play from {f}");
         _scoreView.InfoChanged += (f, ch, sp, mem) =>
         {
             UpdateInfo(f, ch, sp, mem);
             TerminalDataStore.Instance.SetFrame(f);
-
         };
         _workspace?.Add(_scoreView);
         _scoreView.SetFocus();
@@ -246,21 +255,6 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
             Height = Dim.Fill()
         };
 
-        stage.SpriteSelected += (n, b) =>
-        {
-            Log($"spriteSelected {n}@{b}");
-            _selectedSprite = new SpriteRef(n, b);
-            stage.SetSelectedSprite(_selectedSprite);
-            _scoreView.SelectSprite(_selectedSprite);
-        };
-        _scoreView.SpriteSelected += (n, b) =>
-        {
-            Log($"spriteSelected {n}@{b}");
-            _selectedSprite = new SpriteRef(n, b);
-            stage.SetSelectedSprite(_selectedSprite);
-            _scoreView.SelectSprite(_selectedSprite);
-        };
-
         _scoreView.PlayFromHere += f => Log($"Play from {f}");
         _scoreView.InfoChanged += (f, ch, sp, mem) =>
         {
@@ -273,20 +267,13 @@ public sealed class LingoRNetTerminal : IAsyncDisposable
         _scoreView.TriggerInfo();
     }
 
-    private void UpdateInfo(int frame, int channel, int? sprite, int? member)
+    private void UpdateInfo(int frame, int channel, SpriteRef? sprite, MemberRef? member)
     {
         if (_infoItem != null)
         {
             var store = TerminalDataStore.Instance;
-            var memName = member.HasValue ? store.FindMember(member.Value)?.Name : null;
-            _infoItem.Title = $"Frame:{frame} Channel:{channel} Sprite:{(sprite?.ToString() ?? "-")} Member:{memName ?? string.Empty}";
-        }
-
-        if (_propertyInspector != null)
-        {
-            var store = TerminalDataStore.Instance;
-            _propertyInspector.ShowSprite(sprite.HasValue ? store.FindSprite(sprite.Value) : null);
-            _propertyInspector.ShowMember(member.HasValue ? store.FindMember(member.Value) : null);
+            var memName = member.HasValue ? store.FindMember(member.Value.CastLibNum, member.Value.MemberNum)?.Name : null;
+            _infoItem.Title = $"Frame:{frame} Channel:{channel} Sprite:{(sprite?.SpriteNum.ToString() ?? "-")} Member:{memName ?? string.Empty}";
         }
         _scoreView?.SetFocus();
     }

--- a/src/Net/LingoEngine.Net.RNetTerminal/MemberRef.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/MemberRef.cs
@@ -1,0 +1,3 @@
+namespace LingoEngine.Net.RNetTerminal;
+
+public readonly record struct MemberRef(int CastLibNum, int MemberNum);

--- a/src/Net/LingoEngine.Net.RNetTerminal/SpriteRef.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/SpriteRef.cs
@@ -1,4 +1,4 @@
 namespace LingoEngine.Net.RNetTerminal;
 
-internal readonly record struct SpriteRef(int SpriteNum, int BeginFrame);
+public readonly record struct SpriteRef(int SpriteNum, int BeginFrame);
 

--- a/src/Net/LingoEngine.Net.RNetTerminal/StageView.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/StageView.cs
@@ -21,9 +21,6 @@ internal sealed class StageView : View
         Color.BrightYellow
     };
 
-
-    public event Action<int, int>? SpriteSelected;
-
     public StageView()
     {
         CanFocus = true;
@@ -54,10 +51,6 @@ internal sealed class StageView : View
 
     public void RequestRedraw() => SetNeedsDisplay();
 
-    public void SetSelectedSprite(SpriteRef? sprite)
-    {
-        _selectedSprite = sprite;
-}
     private void ReloadData()
     {
         var store = TerminalDataStore.Instance;
@@ -92,7 +85,7 @@ internal sealed class StageView : View
                      .Where(s => s.BeginFrame <= _frame && _frame <= s.EndFrame)
                      .OrderBy(s => s.LocZ))
         {
-            var member = TerminalDataStore.Instance.FindMember(sprite.MemberNum);
+            var member = TerminalDataStore.Instance.FindMember(sprite.CastLibNum, sprite.MemberNum);
             if (member == null)
             {
                 continue;
@@ -183,9 +176,8 @@ internal sealed class StageView : View
                 }
                 if (me.X >= x && me.X < x + sw && me.Y >= y && me.Y < y + sh)
                 {
-                    SpriteSelected?.Invoke(sprite.SpriteNum, sprite.BeginFrame);
-
-                    TerminalDataStore.Instance.SelectSprite(sprite.SpriteNum);
+                    var sel = new SpriteRef(sprite.SpriteNum, sprite.BeginFrame);
+                    TerminalDataStore.Instance.SelectSprite(sel);
 
                     break;
                 }

--- a/src/Net/LingoEngine.Net.RNetTerminal/TerminalDataStore.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/TerminalDataStore.cs
@@ -15,7 +15,7 @@ public sealed class TerminalDataStore
     private readonly List<LingoSpriteDTO> _sprites = new();
     private readonly Dictionary<string, List<LingoMemberDTO>> _casts = new();
     private int _currentFrame;
-    private int? _selectedSprite;
+    private SpriteRef? _selectedSprite;
 
     private TerminalDataStore()
     {
@@ -35,17 +35,14 @@ public sealed class TerminalDataStore
     public event Action? CastsChanged;
     public event Action<LingoMemberDTO>? MemberChanged;
     public event Action<int>? FrameChanged;
-    public event Action<int?>? SelectedSpriteChanged;
+    public event Action<SpriteRef?>? SelectedSpriteChanged;
 
     public IReadOnlyList<LingoSpriteDTO> GetSprites() => _sprites;
 
     public IReadOnlyDictionary<string, List<LingoMemberDTO>> GetCasts() => _casts;
 
-    public LingoSpriteDTO? FindSprite(int spriteNum)
-        => _sprites.FirstOrDefault(s => s.SpriteNum == spriteNum);
-
-    public LingoMemberDTO? FindMember(int memberNum)
-        => _casts.Values.SelectMany(c => c).FirstOrDefault(m => MemberKey(m) == memberNum);
+    public LingoSpriteDTO? FindSprite(SpriteRef sprite)
+        => _sprites.FirstOrDefault(s => s.SpriteNum == sprite.SpriteNum && s.BeginFrame == sprite.BeginFrame);
 
     public LingoMemberDTO? FindMember(int castLibNum, int numberInCast)
         => _casts.Values.SelectMany(c => c)
@@ -67,21 +64,21 @@ public sealed class TerminalDataStore
         FrameChanged?.Invoke(frame);
     }
 
-    public int? GetSelectedSprite() => _selectedSprite;
+    public SpriteRef? GetSelectedSprite() => _selectedSprite;
 
-    public void SelectSprite(int? spriteNum)
+    public void SelectSprite(SpriteRef? sprite)
     {
-        if (_selectedSprite == spriteNum)
+        if (_selectedSprite == sprite)
         {
             return;
         }
-        _selectedSprite = spriteNum;
-        SelectedSpriteChanged?.Invoke(spriteNum);
+        _selectedSprite = sprite;
+        SelectedSpriteChanged?.Invoke(sprite);
     }
 
     public void UpdateSprite(LingoSpriteDTO sprite)
     {
-        var idx = _sprites.FindIndex(s => s.SpriteNum == sprite.SpriteNum);
+        var idx = _sprites.FindIndex(s => s.SpriteNum == sprite.SpriteNum && s.BeginFrame == sprite.BeginFrame);
         if (idx >= 0)
         {
             _sprites[idx] = sprite;
@@ -96,6 +93,20 @@ public sealed class TerminalDataStore
 
     public void UpdateMember(LingoMemberDTO member)
     {
+        var list = _casts.Values.FirstOrDefault(c =>
+            c.Any(m => m.CastLibNum == member.CastLibNum && m.NumberInCast == member.NumberInCast));
+        if (list != null)
+        {
+            var idx = list.FindIndex(m => m.CastLibNum == member.CastLibNum && m.NumberInCast == member.NumberInCast);
+            if (idx >= 0)
+            {
+                list[idx] = member;
+            }
+            else
+            {
+                list.Add(member);
+            }
+        }
         MemberChanged?.Invoke(member);
     }
 
@@ -114,6 +125,7 @@ public sealed class TerminalDataStore
         FrameCount = 600;
         SpritesChanged?.Invoke();
         CastsChanged?.Invoke();
+        SelectSprite(null);
     }
 
     public void LoadFromProject(LingoProjectDTO project)
@@ -132,6 +144,7 @@ public sealed class TerminalDataStore
             MovieState = new MovieStateDto(0, movie.Tempo, false);
             SpritesChanged?.Invoke();
             CastsChanged?.Invoke();
+            SelectSprite(null);
         }
         if (project.Stage != null)
         {
@@ -140,7 +153,5 @@ public sealed class TerminalDataStore
         }
     }
 
-    private static int MemberKey(LingoMemberDTO member)
-        => (member.CastLibNum << 16) | member.NumberInCast;
 }
 

--- a/src/Net/LingoEngine.Net.RNetTerminal/TestMovieBuilder.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/TestMovieBuilder.cs
@@ -19,15 +19,12 @@ public static class TestMovieBuilder
     /// </summary>
     public static IReadOnlyList<LingoSpriteDTO> BuildSprites() => new List<LingoSpriteDTO>
     {
-        new() { Name = "Greeting", SpriteNum = 1, MemberNum = MemberKey(1, 1), BeginFrame = 1, EndFrame = 60, LocH = 100, LocV = 100 },
-        new() { Name = "Info", SpriteNum = 2, MemberNum = MemberKey(1, 2), BeginFrame = 1, EndFrame = 60, LocH = 300, LocV = 200 },
-        new() { Name = "Box", SpriteNum = 3, MemberNum = MemberKey(1, 3), BeginFrame = 1, EndFrame = 60, LocH = 400, LocV = 300 },
-        new() { Name = "Greeting", SpriteNum = 4, MemberNum = MemberKey(1, 1), BeginFrame = 1, EndFrame = 60, LocH = 150, LocV = 400 },
-        new() { Name = "Info", SpriteNum = 5, MemberNum = MemberKey(1, 2), BeginFrame = 1, EndFrame = 60, LocH = 500, LocV = 120 },
-        new() { Name = "score", SpriteNum = 6, MemberNum = MemberKey(1, 4), BeginFrame = 1, EndFrame = 60, LocH = 50, LocV = 50, Width = 100, Height = 20 },
-        new() { Name = "Img30x80", SpriteNum = 7, MemberNum = MemberKey(1, 5), BeginFrame = 1, EndFrame = 60, LocH = 250, LocV = 350, Width = 30, Height = 80 },
+        new() { Name = "Greeting", SpriteNum = 1, CastLibNum = 1, MemberNum = 1, BeginFrame = 1, EndFrame = 60, LocH = 100, LocV = 100 },
+        new() { Name = "Info", SpriteNum = 2, CastLibNum = 1, MemberNum = 2, BeginFrame = 1, EndFrame = 60, LocH = 300, LocV = 200 },
+        new() { Name = "Box", SpriteNum = 3, CastLibNum = 1, MemberNum = 3, BeginFrame = 1, EndFrame = 60, LocH = 400, LocV = 300 },
+        new() { Name = "Greeting", SpriteNum = 4, CastLibNum = 1, MemberNum = 1, BeginFrame = 1, EndFrame = 60, LocH = 150, LocV = 400 },
+        new() { Name = "Info", SpriteNum = 5, CastLibNum = 1, MemberNum = 2, BeginFrame = 1, EndFrame = 60, LocH = 500, LocV = 120 },
+        new() { Name = "score", SpriteNum = 6, CastLibNum = 1, MemberNum = 4, BeginFrame = 1, EndFrame = 60, LocH = 50, LocV = 50, Width = 100, Height = 20 },
+        new() { Name = "Img30x80", SpriteNum = 7, CastLibNum = 1, MemberNum = 5, BeginFrame = 1, EndFrame = 60, LocH = 250, LocV = 350, Width = 30, Height = 80 },
     };
-
-    private static int MemberKey(int castLibNum, int numberInCast)
-        => (castLibNum << 16) | numberInCast;
 }


### PR DESCRIPTION
## Summary
- Distinguish sprite and member property edits in the inspector, updating the data store and remote host appropriately
- Refresh stage and property panes on member updates by tracking the current member and raising store events
- Store and propagate member changes by cast library and member number

## Testing
- `dotnet format src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj --include src/Net/LingoEngine.Net.RNetTerminal/PropertyInspector.cs src/Net/LingoEngine.Net.RNetTerminal/LingoRNetTerminal.cs src/Net/LingoEngine.Net.RNetTerminal/TerminalDataStore.cs -v diagnostic`
- `dotnet build src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c7efcd95d08332be20ee06eaf2febf