### PR TITLE
Add member reference DTO for sprite serialization

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Importer/DirectorRaysDtoExtensions.cs
+++ b/src/Director/LingoEngine.Director.Core/Importer/DirectorRaysDtoExtensions.cs
@@ -28,7 +28,7 @@ internal static class DirectorRaysDtoExtensions
         if (dir.Score != null)
         {
             foreach (var f in dir.Score.Sprites)
-                movie.Sprites.Add(f.ToDto());
+                movie.Sprite2Ds.Add(f.ToDto());
         }
 
         return (stage, movie);
@@ -157,12 +157,14 @@ internal static class DirectorRaysDtoExtensions
         return dto;
     }
 
-    public static LingoSpriteDTO ToDto(this RaySprite f)
-        => new LingoSpriteDTO
+    public static Lingo2DSpriteDTO ToDto(this RaySprite f)
+        => new Lingo2DSpriteDTO
         {
             Name = $"Sprite{f.SpriteNumber}",
             SpriteNum = f.SpriteNumber,
-            MemberNum = f.SpriteNumber,
+            Member = f.MemberNum > 0 && f.MemberCastLib > 0
+                ? new LingoMemberRefDTO { MemberNum = f.MemberNum, CastNum = f.MemberCastLib }
+                : null,
             // todo : DisplayMember = f.DisplayMember,
             SpritePropertiesOffset = f.SpritePropertiesOffset,
             Lock = false,

--- a/src/Director/LingoEngine.Director.Core/Projects/DirectorMovieCodeGenerator.cs
+++ b/src/Director/LingoEngine.Director.Core/Projects/DirectorMovieCodeGenerator.cs
@@ -117,12 +117,15 @@ public class DirectorMovieCodeGenerator
         sb.AppendLine("{");
         sb.AppendLine("    public async Task BuildAsync(ILingoMovie movie)");
         sb.AppendLine("    {");
-        foreach (var sp in movie.Sprites)
+        foreach (var sp in movie.Sprite2Ds)
         {
-            var member = movie.Casts.SelectMany(c => c.Members)
-                .FirstOrDefault(m => m.Number == sp.MemberNum || m.NumberInCast == sp.MemberNum);
-            var castNum = member?.CastLibNum ?? 0;
-            var memberNum = member?.NumberInCast ?? sp.MemberNum;
+            var memberRef = sp.Member;
+            var member = memberRef != null
+                ? movie.Casts.SelectMany(c => c.Members)
+                    .FirstOrDefault(m => m.CastLibNum == memberRef.CastNum && m.NumberInCast == memberRef.MemberNum)
+                : null;
+            var castNum = member?.CastLibNum ?? memberRef?.CastNum ?? 0;
+            var memberNum = member?.NumberInCast ?? memberRef?.MemberNum ?? 0;
             sb.AppendLine($"        movie.AddSprite({sp.SpriteNum}, {sp.BeginFrame}, {sp.EndFrame}, {FormatFloat(sp.LocH)}, {FormatFloat(sp.LocV)}, s =>");
             sb.AppendLine("        {");
             var props = new List<string>();

--- a/src/LingoEngine.IO.Data/DTO/Lingo2DSpriteDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/Lingo2DSpriteDTO.cs
@@ -1,15 +1,11 @@
-
-
 namespace LingoEngine.IO.Data.DTO;
-public class LingoSpriteDTO
+
+public class Lingo2DSpriteDTO : LingoSpriteBaseDTO
 {
-    public string Name { get; set; } = string.Empty;
     public int SpriteNum { get; set; }
-    public int MemberNum { get; set; }
-    public int CastLibNum { get; set; }
+    public LingoMemberRefDTO? Member { get; set; }
     public int DisplayMember { get; set; }
     public int SpritePropertiesOffset { get; set; }
-    public bool Lock { get; set; }
     public bool Visibility { get; set; }
     public float LocH { get; set; }
     public float LocV { get; set; }
@@ -27,8 +23,6 @@ public class LingoSpriteDTO
     public int ScoreColor { get; set; }
     public float Width { get; set; }
     public float Height { get; set; }
-    public int BeginFrame { get; set; }
-    public int EndFrame { get; set; }
 
     public LingoSpriteAnimatorDTO? Animator { get; set; }
 }

--- a/src/LingoEngine.IO.Data/DTO/LingoColorPaletteSpriteDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoColorPaletteSpriteDTO.cs
@@ -1,0 +1,37 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public enum LingoColorPaletteActionDTO
+{
+    PaletteTransition,
+    ColorCycling
+}
+
+public enum LingoColorPaletteTransitionOptionDTO
+{
+    FadeToBlack,
+    FadeToWhite,
+    DontFade
+}
+
+public enum LingoColorPaletteCycleOptionDTO
+{
+    AutoReverse,
+    Loop
+}
+
+public class LingoColorPaletteFrameSettingsDTO
+{
+    public int ColorPaletteId { get; set; }
+    public int Rate { get; set; }
+    public int Cycles { get; set; }
+    public LingoColorPaletteActionDTO Action { get; set; }
+    public LingoColorPaletteTransitionOptionDTO TransitionOption { get; set; }
+    public LingoColorPaletteCycleOptionDTO CycleOption { get; set; }
+}
+
+public class LingoColorPaletteSpriteDTO : LingoSpriteBaseDTO
+{
+    public int Frame { get; set; }
+    public LingoMemberRefDTO? Member { get; set; }
+    public LingoColorPaletteFrameSettingsDTO? Settings { get; set; }
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoFilmLoopMemberSpriteDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoFilmLoopMemberSpriteDTO.cs
@@ -5,8 +5,7 @@ namespace LingoEngine.IO.Data.DTO;
 public class LingoFilmLoopMemberSpriteDTO
 {
     public string Name { get; set; } = "";
-    public int MemberNumberInCast { get; set; }
-    public int CastNum { get; set; }
+    public LingoMemberRefDTO Member { get; set; } = new();
     public int DisplayMember { get; set; }
     public int SpriteNum { get; set; }
 

--- a/src/LingoEngine.IO.Data/DTO/LingoFilmLoopSoundEntryDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoFilmLoopSoundEntryDTO.cs
@@ -4,6 +4,5 @@ public class LingoFilmLoopSoundEntryDTO
 {
     public int Channel { get; set; }
     public int StartFrame { get; set; }
-    public int SoundMemberNum { get; set; }
-    public int CastlibNum { get; set; }
+    public LingoMemberRefDTO Member { get; set; } = new();
 }

--- a/src/LingoEngine.IO.Data/DTO/LingoFilmLoopSpriteEntryDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoFilmLoopSpriteEntryDTO.cs
@@ -5,5 +5,5 @@ public class LingoFilmLoopSpriteEntryDTO
     public int Channel { get; set; }
     public int BeginFrame { get; set; }
     public int EndFrame { get; set; }
-    public LingoSpriteDTO Sprite { get; set; } = new();
+    public Lingo2DSpriteDTO Sprite { get; set; } = new();
 }

--- a/src/LingoEngine.IO.Data/DTO/LingoMemberRefDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoMemberRefDTO.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public class LingoMemberRefDTO
+{
+    public int MemberNum { get; set; }
+    public int CastNum { get; set; }
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoMovieDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoMovieDTO.cs
@@ -8,7 +8,11 @@ public class LingoMovieDTO
     public string About { get; set; } = string.Empty;
     public string Copyright { get; set; } = string.Empty;
     public List<LingoCastDTO> Casts { get; set; } = new();
-    public List<LingoSpriteDTO> Sprites { get; set; } = new();
+    public List<Lingo2DSpriteDTO> Sprite2Ds { get; set; } = new();
+    public List<LingoTempoSpriteDTO> TempoSprites { get; set; } = new();
+    public List<LingoColorPaletteSpriteDTO> ColorPaletteSprites { get; set; } = new();
+    public List<LingoTransitionSpriteDTO> TransitionSprites { get; set; } = new();
+    public List<LingoSpriteSoundDTO> SoundSprites { get; set; } = new();
     public string UserName { get; set; } =string.Empty;
     public string CompanyName { get; set; } = string.Empty;
 

--- a/src/LingoEngine.IO.Data/DTO/LingoRectDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoRectDTO.cs
@@ -1,0 +1,9 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public class LingoRectDTO
+{
+    public float Left { get; set; }
+    public float Top { get; set; }
+    public float Right { get; set; }
+    public float Bottom { get; set; }
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoSpriteBaseDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoSpriteBaseDTO.cs
@@ -1,0 +1,9 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public abstract class LingoSpriteBaseDTO
+{
+    public string Name { get; set; } = string.Empty;
+    public int BeginFrame { get; set; }
+    public int EndFrame { get; set; }
+    public bool Lock { get; set; }
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoSpriteSoundDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoSpriteSoundDTO.cs
@@ -1,0 +1,7 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public class LingoSpriteSoundDTO : LingoSpriteBaseDTO
+{
+    public int Channel { get; set; }
+    public LingoMemberRefDTO? Member { get; set; }
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoTempoSpriteDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoTempoSpriteDTO.cs
@@ -1,0 +1,19 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public enum LingoTempoSpriteActionDTO
+{
+    ChangeTempo,
+    WaitSeconds,
+    WaitForUserInput,
+    WaitForCuePoint
+}
+
+public class LingoTempoSpriteDTO : LingoSpriteBaseDTO
+{
+    public int Frame { get; set; }
+    public LingoTempoSpriteActionDTO Action { get; set; }
+    public int Tempo { get; set; }
+    public float WaitSeconds { get; set; }
+    public int CueChannel { get; set; }
+    public int CuePoint { get; set; }
+}

--- a/src/LingoEngine.IO.Data/DTO/LingoTransitionSpriteDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/LingoTransitionSpriteDTO.cs
@@ -1,0 +1,24 @@
+namespace LingoEngine.IO.Data.DTO;
+
+public enum LingoTransitionAffectsDTO
+{
+    EntireStage,
+    ChangingAreaOnly,
+    Custom
+}
+
+public class LingoTransitionFrameSettingsDTO
+{
+    public int TransitionId { get; set; }
+    public string TransitionName { get; set; } = string.Empty;
+    public float Duration { get; set; }
+    public float Smoothness { get; set; }
+    public LingoTransitionAffectsDTO Affects { get; set; }
+    public LingoRectDTO Rect { get; set; } = new();
+}
+
+public class LingoTransitionSpriteDTO : LingoSpriteBaseDTO
+{
+    public LingoMemberRefDTO? Member { get; set; }
+    public LingoTransitionFrameSettingsDTO? Settings { get; set; }
+}

--- a/src/LingoEngine.IO/AudioMemberDtoConverter.cs
+++ b/src/LingoEngine.IO/AudioMemberDtoConverter.cs
@@ -1,0 +1,59 @@
+using LingoEngine.IO.Data.DTO;
+using LingoEngine.Sounds;
+using System.IO;
+
+namespace LingoEngine.IO;
+
+internal static class AudioMemberDtoConverter
+{
+    public static LingoMemberSoundDTO ToDto(LingoMemberSound sound, LingoMemberDTO baseDto, JsonStateRepository.MovieStoreOptions options)
+    {
+        var dto = MemberDtoConverter.PopulateBase(baseDto, new LingoMemberSoundDTO());
+        dto.Stereo = sound.Stereo;
+        dto.Length = sound.Length;
+        dto.Loop = sound.Loop;
+        dto.IsLinked = sound.IsLinked;
+        dto.LinkedFilePath = sound.LinkedFilePath;
+        dto.SoundFile = SaveSound(sound, options);
+        return dto;
+    }
+
+    private static string SaveSound(LingoMemberSound sound, JsonStateRepository.MovieStoreOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.TargetDirectory))
+        {
+            return string.Empty;
+        }
+
+        var source = !string.IsNullOrEmpty(sound.FileName) && File.Exists(sound.FileName)
+            ? sound.FileName
+            : sound.LinkedFilePath;
+
+        if (string.IsNullOrEmpty(source) || !File.Exists(source))
+        {
+            return string.Empty;
+        }
+
+        var ext = GetSoundExtension(source);
+        var name = $"{sound.NumberInCast}_{MediaFileNameHelper.SanitizeFileName(sound.Name)}{ext}";
+        if (!options.WithMedia)
+        {
+            return name;
+        }
+
+        var dest = Path.Combine(options.TargetDirectory, name);
+        File.Copy(source, dest, true);
+        return name;
+    }
+
+    private static string GetSoundExtension(string path)
+    {
+        var ext = Path.GetExtension(path);
+        if (string.IsNullOrEmpty(ext))
+        {
+            return ".wav";
+        }
+
+        return ext.ToLowerInvariant();
+    }
+}

--- a/src/LingoEngine.IO/BitmapMemberDtoConverter.cs
+++ b/src/LingoEngine.IO/BitmapMemberDtoConverter.cs
@@ -1,0 +1,40 @@
+using LingoEngine.Bitmaps;
+using LingoEngine.IO.Data.DTO;
+using System.IO;
+
+namespace LingoEngine.IO;
+
+internal static class BitmapMemberDtoConverter
+{
+    public static LingoMemberPictureDTO ToDto(LingoMemberBitmap picture, LingoMemberDTO baseDto, JsonStateRepository.MovieStoreOptions options)
+    {
+        var dto = MemberDtoConverter.PopulateBase(baseDto, new LingoMemberPictureDTO());
+        dto.ImageFile = SavePicture(picture, options);
+        return dto;
+    }
+
+    private static string SavePicture(LingoMemberBitmap picture, JsonStateRepository.MovieStoreOptions options)
+    {
+        if (picture.ImageData == null || string.IsNullOrWhiteSpace(options.TargetDirectory) || !options.WithMedia)
+        {
+            return string.Empty;
+        }
+
+        var ext = GetPictureExtension(picture);
+        var name = $"{picture.NumberInCast}_{MediaFileNameHelper.SanitizeFileName(picture.Name)}.{ext}";
+        var path = Path.Combine(options.TargetDirectory, name);
+        File.WriteAllBytes(path, picture.ImageData);
+        return name;
+    }
+
+    private static string GetPictureExtension(LingoMemberBitmap picture)
+    {
+        var format = picture.Format.ToLowerInvariant();
+        if (format.Contains("png") || format.Contains("gif") || format.Contains("tiff"))
+        {
+            return "png";
+        }
+
+        return "bmp";
+    }
+}

--- a/src/LingoEngine.IO/ColorDtoConverter.cs
+++ b/src/LingoEngine.IO/ColorDtoConverter.cs
@@ -1,0 +1,19 @@
+using AbstUI.Primitives;
+using LingoEngine.IO.Data.DTO;
+
+namespace LingoEngine.IO;
+
+internal static class ColorDtoConverter
+{
+    public static LingoColorDTO ToDto(AColor color)
+    {
+        return new LingoColorDTO
+        {
+            Code = color.Code,
+            Name = color.Name,
+            R = color.R,
+            G = color.G,
+            B = color.B
+        };
+    }
+}

--- a/src/LingoEngine.IO/ColorPaletteSpriteDtoConverter.cs
+++ b/src/LingoEngine.IO/ColorPaletteSpriteDtoConverter.cs
@@ -1,0 +1,66 @@
+using LingoEngine.ColorPalettes;
+using LingoEngine.IO.Data.DTO;
+
+namespace LingoEngine.IO;
+
+internal static class ColorPaletteSpriteDtoConverter
+{
+    public static LingoColorPaletteSpriteDTO ToDto(LingoColorPaletteSprite sprite)
+    {
+        return new LingoColorPaletteSpriteDTO
+        {
+            Name = sprite.Name,
+            BeginFrame = sprite.BeginFrame,
+            EndFrame = sprite.EndFrame,
+            Lock = sprite.Lock,
+            Frame = sprite.Frame,
+            Member = MemberRefDtoConverter.ToDto(sprite.Member),
+            Settings = sprite.GetSettings() is { } settings ? ToDto(settings) : null
+        };
+    }
+
+    public static void Apply(LingoColorPaletteSpriteDTO dto, LingoColorPaletteSprite sprite)
+    {
+        sprite.Name = dto.Name;
+        sprite.BeginFrame = dto.BeginFrame;
+        sprite.EndFrame = dto.EndFrame;
+        sprite.Lock = dto.Lock;
+        sprite.Frame = dto.Frame;
+
+        if (dto.Settings != null)
+        {
+            var settings = FromDto(dto.Settings);
+            sprite.SetSettings(settings);
+            if (sprite.Member != null)
+            {
+                sprite.Member.Cycles = settings.Cycles;
+            }
+        }
+    }
+
+    public static LingoColorPaletteFrameSettingsDTO ToDto(LingoColorPaletteFrameSettings settings)
+    {
+        return new LingoColorPaletteFrameSettingsDTO
+        {
+            ColorPaletteId = settings.ColorPaletteId,
+            Rate = settings.Rate,
+            Cycles = settings.Cycles,
+            Action = (LingoColorPaletteActionDTO)settings.Action,
+            TransitionOption = (LingoColorPaletteTransitionOptionDTO)settings.TransitionOption,
+            CycleOption = (LingoColorPaletteCycleOptionDTO)settings.CycleOption
+        };
+    }
+
+    public static LingoColorPaletteFrameSettings FromDto(LingoColorPaletteFrameSettingsDTO dto)
+    {
+        return new LingoColorPaletteFrameSettings
+        {
+            ColorPaletteId = dto.ColorPaletteId,
+            Rate = dto.Rate,
+            Cycles = dto.Cycles,
+            Action = (LingoColorPaletteAction)dto.Action,
+            TransitionOption = (LingoColorPaletteTransitionOption)dto.TransitionOption,
+            CycleOption = (LingoColorPaletteCycleOption)dto.CycleOption
+        };
+    }
+}

--- a/src/LingoEngine.IO/FilmLoopMemberDtoConverter.cs
+++ b/src/LingoEngine.IO/FilmLoopMemberDtoConverter.cs
@@ -1,0 +1,24 @@
+using LingoEngine.FilmLoops;
+using LingoEngine.IO.Data.DTO;
+using System.Linq;
+
+namespace LingoEngine.IO;
+
+internal static class FilmLoopMemberDtoConverter
+{
+    public static LingoMemberFilmLoopDTO ToDto(LingoFilmLoopMember filmLoop, LingoMemberDTO baseDto)
+    {
+        var dto = MemberDtoConverter.PopulateBase(baseDto, new LingoMemberFilmLoopDTO());
+        dto.Framing = (LingoFilmLoopFramingDTO)filmLoop.Framing;
+        dto.Loop = filmLoop.Loop;
+        dto.FrameCount = filmLoop.FrameCount;
+        dto.SpriteEntries = filmLoop.SpriteEntries.Select(SpriteDtoConverter.ToDto).ToList();
+        dto.SoundEntries = filmLoop.SoundEntries.Select(e => new LingoFilmLoopSoundEntryDTO
+        {
+            Channel = e.Channel,
+            StartFrame = e.StartFrame,
+            Member = MemberRefDtoConverter.ToDto(e.Sound) ?? new LingoMemberRefDTO()
+        }).ToList();
+        return dto;
+    }
+}

--- a/src/LingoEngine.IO/MediaFileNameHelper.cs
+++ b/src/LingoEngine.IO/MediaFileNameHelper.cs
@@ -1,0 +1,16 @@
+using System.IO;
+
+namespace LingoEngine.IO;
+
+internal static class MediaFileNameHelper
+{
+    public static string SanitizeFileName(string name)
+    {
+        foreach (var c in Path.GetInvalidFileNameChars())
+        {
+            name = name.Replace(c, '_');
+        }
+
+        return name;
+    }
+}

--- a/src/LingoEngine.IO/MemberDtoConverter.cs
+++ b/src/LingoEngine.IO/MemberDtoConverter.cs
@@ -1,0 +1,63 @@
+using LingoEngine.Bitmaps;
+using LingoEngine.FilmLoops;
+using LingoEngine.IO.Data.DTO;
+using LingoEngine.Members;
+using LingoEngine.Sounds;
+using LingoEngine.Texts;
+
+namespace LingoEngine.IO;
+
+internal static class MemberDtoConverter
+{
+    public static LingoMemberDTO ToDto(ILingoMember member, JsonStateRepository.MovieStoreOptions options)
+    {
+        var baseDto = CreateBaseDto(member);
+
+        return member switch
+        {
+            LingoMemberField field => TextMemberDtoConverter.ToDto(field, baseDto),
+            LingoMemberText text => TextMemberDtoConverter.ToDto(text, baseDto),
+            LingoMemberSound sound => AudioMemberDtoConverter.ToDto(sound, baseDto, options),
+            LingoMemberBitmap bitmap => BitmapMemberDtoConverter.ToDto(bitmap, baseDto, options),
+            LingoFilmLoopMember filmLoop => FilmLoopMemberDtoConverter.ToDto(filmLoop, baseDto),
+            _ => baseDto,
+        };
+    }
+
+    public static T PopulateBase<T>(LingoMemberDTO source, T target)
+        where T : LingoMemberDTO
+    {
+        target.Name = source.Name;
+        target.Number = source.Number;
+        target.CastLibNum = source.CastLibNum;
+        target.NumberInCast = source.NumberInCast;
+        target.Type = source.Type;
+        target.RegPoint = source.RegPoint;
+        target.Width = source.Width;
+        target.Height = source.Height;
+        target.Size = source.Size;
+        target.Comments = source.Comments;
+        target.FileName = source.FileName;
+        target.PurgePriority = source.PurgePriority;
+        return target;
+    }
+
+    private static LingoMemberDTO CreateBaseDto(ILingoMember member)
+    {
+        return new LingoMemberDTO
+        {
+            Name = member.Name,
+            Number = member.Number,
+            CastLibNum = member.CastLibNum,
+            NumberInCast = member.NumberInCast,
+            Type = (LingoMemberTypeDTO)member.Type,
+            RegPoint = new LingoPointDTO { X = member.RegPoint.X, Y = member.RegPoint.Y },
+            Width = member.Width,
+            Height = member.Height,
+            Size = member.Size,
+            Comments = member.Comments,
+            FileName = member.FileName,
+            PurgePriority = member.PurgePriority
+        };
+    }
+}

--- a/src/LingoEngine.IO/MemberRefDtoConverter.cs
+++ b/src/LingoEngine.IO/MemberRefDtoConverter.cs
@@ -1,0 +1,35 @@
+using LingoEngine.IO.Data.DTO;
+using LingoEngine.Members;
+
+namespace LingoEngine.IO;
+
+internal static class MemberRefDtoConverter
+{
+    public static LingoMemberRefDTO? ToDto(ILingoMember? member)
+    {
+        if (member == null)
+        {
+            return null;
+        }
+
+        return new LingoMemberRefDTO
+        {
+            MemberNum = member.NumberInCast,
+            CastNum = member.CastLibNum
+        };
+    }
+
+    public static LingoMemberRefDTO? ToDto(int memberNum, int castNum)
+    {
+        if (memberNum <= 0 || castNum <= 0)
+        {
+            return null;
+        }
+
+        return new LingoMemberRefDTO
+        {
+            MemberNum = memberNum,
+            CastNum = castNum
+        };
+    }
+}

--- a/src/LingoEngine.IO/MovieDtoConverter.cs
+++ b/src/LingoEngine.IO/MovieDtoConverter.cs
@@ -1,0 +1,44 @@
+using LingoEngine.Casts;
+using LingoEngine.IO.Data.DTO;
+using LingoEngine.Members;
+using LingoEngine.Movies;
+using System.Linq;
+
+namespace LingoEngine.IO;
+
+internal static class MovieDtoConverter
+{
+    public static LingoMovieDTO ToDto(LingoMovie movie, JsonStateRepository.MovieStoreOptions options)
+    {
+        return new LingoMovieDTO
+        {
+            Name = movie.Name,
+            Number = movie.Number,
+            Tempo = movie.Tempo,
+            FrameCount = movie.FrameCount,
+            MaxSpriteChannelCount = movie.MaxSpriteChannelCount,
+            About = movie.About,
+            Copyright = movie.Copyright,
+            UserName = movie.UserName,
+            CompanyName = movie.CompanyName,
+            Casts = movie.CastLib.GetAll().Select(c => ToDto((LingoCast)c, options)).ToList(),
+            Sprite2Ds = movie.GetAll2DSpritesToStore().Select(SpriteDtoConverter.ToDto).ToList(),
+            TempoSprites = movie.Tempos.GetAllSprites().Select(TempoSpriteDtoConverter.ToDto).ToList(),
+            ColorPaletteSprites = movie.ColorPalettes.GetAllSprites().Select(ColorPaletteSpriteDtoConverter.ToDto).ToList(),
+            TransitionSprites = movie.Transitions.GetAllSprites().Select(TransitionSpriteDtoConverter.ToDto).ToList(),
+            SoundSprites = movie.Audio.GetAllSprites().Select(SoundSpriteDtoConverter.ToDto).ToList()
+        };
+    }
+
+    public static LingoCastDTO ToDto(LingoCast cast, JsonStateRepository.MovieStoreOptions options)
+    {
+        return new LingoCastDTO
+        {
+            Name = cast.Name,
+            FileName = cast.FileName,
+            Number = cast.Number,
+            PreLoadMode = (PreLoadModeTypeDTO)cast.PreLoadMode,
+            Members = cast.GetAll().Select(m => MemberDtoConverter.ToDto(m, options)).ToList()
+        };
+    }
+}

--- a/src/LingoEngine.IO/RectDtoConverter.cs
+++ b/src/LingoEngine.IO/RectDtoConverter.cs
@@ -1,0 +1,23 @@
+using AbstUI.Primitives;
+using LingoEngine.IO.Data.DTO;
+
+namespace LingoEngine.IO;
+
+internal static class RectDtoConverter
+{
+    public static LingoRectDTO ToDto(ARect rect)
+    {
+        return new LingoRectDTO
+        {
+            Left = rect.Left,
+            Top = rect.Top,
+            Right = rect.Right,
+            Bottom = rect.Bottom
+        };
+    }
+
+    public static ARect FromDto(LingoRectDTO dto)
+    {
+        return new ARect(dto.Left, dto.Top, dto.Right, dto.Bottom);
+    }
+}

--- a/src/LingoEngine.IO/SoundSpriteDtoConverter.cs
+++ b/src/LingoEngine.IO/SoundSpriteDtoConverter.cs
@@ -1,0 +1,28 @@
+using LingoEngine.IO.Data.DTO;
+using LingoEngine.Sounds;
+
+namespace LingoEngine.IO;
+
+internal static class SoundSpriteDtoConverter
+{
+    public static LingoSpriteSoundDTO ToDto(LingoSpriteSound sprite)
+    {
+        return new LingoSpriteSoundDTO
+        {
+            Name = sprite.Name,
+            Channel = sprite.Channel,
+            BeginFrame = sprite.BeginFrame,
+            EndFrame = sprite.EndFrame,
+            Lock = sprite.Lock,
+            Member = MemberRefDtoConverter.ToDto(sprite.Sound)
+        };
+    }
+
+    public static void Apply(LingoSpriteSoundDTO dto, LingoSpriteSound sprite)
+    {
+        sprite.Name = dto.Name;
+        sprite.BeginFrame = dto.BeginFrame;
+        sprite.EndFrame = dto.EndFrame;
+        sprite.Lock = dto.Lock;
+    }
+}

--- a/src/LingoEngine.IO/SpriteDtoConverter.cs
+++ b/src/LingoEngine.IO/SpriteDtoConverter.cs
@@ -1,0 +1,198 @@
+using AbstUI.Primitives;
+using LingoEngine.Animations;
+using LingoEngine.FilmLoops;
+using LingoEngine.IO.Data.DTO;
+using LingoEngine.Sprites;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace LingoEngine.IO;
+
+internal static class SpriteDtoConverter
+{
+    public static Lingo2DSpriteDTO ToDto(LingoSprite2D sprite)
+    {
+        var state = sprite.InitialState as LingoSprite2DState ?? (LingoSprite2DState)sprite.GetState();
+        var dto = new Lingo2DSpriteDTO
+        {
+            Name = state.Name,
+            SpriteNum = sprite.SpriteNum,
+            Member = MemberRefDtoConverter.ToDto(state.Member)
+                ?? MemberRefDtoConverter.ToDto(sprite.MemberNum, sprite.Cast?.Number ?? sprite.Member?.CastLibNum ?? 0),
+            DisplayMember = state.DisplayMember,
+            SpritePropertiesOffset = state.SpritePropertiesOffset,
+            Lock = sprite.Lock,
+            Visibility = sprite.Visibility,
+            LocH = state.LocH,
+            LocV = state.LocV,
+            LocZ = state.LocZ,
+            Rotation = state.Rotation,
+            Skew = state.Skew,
+            RegPoint = new LingoPointDTO { X = state.RegPoint.X, Y = state.RegPoint.Y },
+            Ink = state.Ink,
+            ForeColor = ColorDtoConverter.ToDto(state.ForeColor),
+            BackColor = ColorDtoConverter.ToDto(state.BackColor),
+            Blend = state.Blend,
+            Editable = state.Editable,
+            FlipH = state.FlipH,
+            FlipV = state.FlipV,
+            Width = state.Width,
+            Height = state.Height,
+            BeginFrame = sprite.BeginFrame,
+            EndFrame = sprite.EndFrame
+        };
+
+        foreach (var actor in GetSpriteActors(sprite))
+        {
+            switch (actor)
+            {
+                case LingoSpriteAnimator anim:
+                    dto.Animator = ToDto(anim);
+                    break;
+                case LingoFilmLoopPlayer:
+                    break;
+            }
+        }
+
+        return dto;
+    }
+
+    public static Lingo2DSpriteDTO ToDto(LingoSprite2DVirtual sprite)
+    {
+        var state = sprite.InitialState as LingoSprite2DVirtualState ?? (LingoSprite2DVirtualState)sprite.GetState();
+        return new Lingo2DSpriteDTO
+        {
+            Name = state.Name,
+            SpriteNum = sprite.SpriteNum,
+            Member = MemberRefDtoConverter.ToDto(state.Member)
+                ?? MemberRefDtoConverter.ToDto(sprite.MemberNum, sprite.Member?.CastLibNum ?? 0),
+            DisplayMember = state.DisplayMember,
+            Lock = sprite.Lock,
+            LocH = state.LocH,
+            LocV = state.LocV,
+            LocZ = state.LocZ,
+            Rotation = state.Rotation,
+            Skew = state.Skew,
+            RegPoint = new LingoPointDTO { X = state.RegPoint.X, Y = state.RegPoint.Y },
+            Ink = state.Ink,
+            ForeColor = ColorDtoConverter.ToDto(state.ForeColor),
+            BackColor = ColorDtoConverter.ToDto(state.BackColor),
+            Blend = state.Blend,
+            Width = state.Width,
+            Height = state.Height,
+            FlipH = state.FlipH,
+            FlipV = state.FlipV,
+            BeginFrame = sprite.BeginFrame,
+            EndFrame = sprite.EndFrame
+        };
+    }
+
+    public static LingoFilmLoopMemberSpriteDTO ToDto(LingoFilmLoopMemberSprite sprite)
+    {
+        return new LingoFilmLoopMemberSpriteDTO
+        {
+            Name = sprite.Name,
+            SpriteNum = sprite.SpriteNum,
+            Member = MemberRefDtoConverter.ToDto(sprite.MemberNumberInCast, sprite.CastNum) ?? new LingoMemberRefDTO(),
+            DisplayMember = sprite.DisplayMember,
+            LocH = sprite.LocH,
+            LocV = sprite.LocV,
+            LocZ = sprite.LocZ,
+            Rotation = sprite.Rotation,
+            Skew = sprite.Skew,
+            RegPoint = new LingoPointDTO { X = sprite.RegPoint.X, Y = sprite.RegPoint.Y },
+            Ink = sprite.Ink,
+            ForeColor = ColorDtoConverter.ToDto(sprite.ForeColor),
+            BackColor = ColorDtoConverter.ToDto(sprite.BackColor),
+            Blend = sprite.Blend,
+            Width = sprite.Width,
+            Height = sprite.Height,
+            BeginFrame = sprite.BeginFrame,
+            EndFrame = sprite.EndFrame,
+            Channel = sprite.Channel,
+            FlipH = sprite.FlipH,
+            FlipV = sprite.FlipV,
+            Hilite = sprite.Hilite,
+            Animator = ToDto(sprite.AnimatorProperties)
+        };
+    }
+
+    public static LingoSpriteAnimatorDTO ToDto(LingoSpriteAnimator animator)
+    {
+        return ToDto(animator.Properties);
+    }
+
+    public static LingoSpriteAnimatorDTO ToDto(LingoSpriteAnimatorProperties animProps)
+    {
+        return new LingoSpriteAnimatorDTO
+        {
+            Position = animProps.Position.KeyFrames.Select(k => new LingoPointKeyFrameDTO
+            {
+                Frame = k.Frame,
+                Value = new LingoPointDTO { X = k.Value.X, Y = k.Value.Y },
+                Ease = (LingoEaseTypeDTO)k.Ease
+            }).ToList(),
+            PositionOptions = ToDto(animProps.Position.Options),
+            Rotation = animProps.Rotation.KeyFrames.Select(k => new LingoFloatKeyFrameDTO
+            {
+                Frame = k.Frame,
+                Value = k.Value,
+                Ease = (LingoEaseTypeDTO)k.Ease
+            }).ToList(),
+            RotationOptions = ToDto(animProps.Rotation.Options),
+            Skew = animProps.Skew.KeyFrames.Select(k => new LingoFloatKeyFrameDTO
+            {
+                Frame = k.Frame,
+                Value = k.Value,
+                Ease = (LingoEaseTypeDTO)k.Ease
+            }).ToList(),
+            SkewOptions = ToDto(animProps.Skew.Options),
+            ForegroundColor = animProps.ForegroundColor.KeyFrames.Select(k => new LingoColorKeyFrameDTO
+            {
+                Frame = k.Frame,
+                Value = ColorDtoConverter.ToDto(k.Value),
+                Ease = (LingoEaseTypeDTO)k.Ease
+            }).ToList(),
+            ForegroundColorOptions = ToDto(animProps.ForegroundColor.Options),
+            BackgroundColor = animProps.BackgroundColor.KeyFrames.Select(k => new LingoColorKeyFrameDTO
+            {
+                Frame = k.Frame,
+                Value = ColorDtoConverter.ToDto(k.Value),
+                Ease = (LingoEaseTypeDTO)k.Ease
+            }).ToList(),
+            BackgroundColorOptions = ToDto(animProps.BackgroundColor.Options),
+            Blend = animProps.Blend.KeyFrames.Select(k => new LingoFloatKeyFrameDTO
+            {
+                Frame = k.Frame,
+                Value = k.Value,
+                Ease = (LingoEaseTypeDTO)k.Ease
+            }).ToList(),
+            BlendOptions = ToDto(animProps.Blend.Options)
+        };
+    }
+
+    private static IEnumerable<object> GetSpriteActors(LingoSprite2D sprite)
+    {
+        var field = typeof(LingoSprite2D).GetField("_spriteActors", BindingFlags.NonPublic | BindingFlags.Instance);
+        if (field?.GetValue(sprite) is IEnumerable<object> actors)
+        {
+            return actors;
+        }
+
+        return Enumerable.Empty<object>();
+    }
+
+    private static LingoTweenOptionsDTO ToDto(LingoTweenOptions options)
+    {
+        return new LingoTweenOptionsDTO
+        {
+            Enabled = options.Enabled,
+            Curvature = options.Curvature,
+            ContinuousAtEndpoints = options.ContinuousAtEndpoints,
+            SpeedChange = (LingoSpeedChangeTypeDTO)options.SpeedChange,
+            EaseIn = options.EaseIn,
+            EaseOut = options.EaseOut
+        };
+    }
+}

--- a/src/LingoEngine.IO/TempoSpriteDtoConverter.cs
+++ b/src/LingoEngine.IO/TempoSpriteDtoConverter.cs
@@ -1,0 +1,38 @@
+using LingoEngine.IO.Data.DTO;
+using LingoEngine.Tempos;
+
+namespace LingoEngine.IO;
+
+internal static class TempoSpriteDtoConverter
+{
+    public static LingoTempoSpriteDTO ToDto(LingoTempoSprite sprite)
+    {
+        return new LingoTempoSpriteDTO
+        {
+            Name = sprite.Name,
+            BeginFrame = sprite.BeginFrame,
+            EndFrame = sprite.EndFrame,
+            Lock = sprite.Lock,
+            Frame = sprite.Frame,
+            Action = (LingoTempoSpriteActionDTO)sprite.Action,
+            Tempo = sprite.Tempo,
+            WaitSeconds = sprite.WaitSeconds,
+            CueChannel = sprite.CueChannel,
+            CuePoint = sprite.CuePoint
+        };
+    }
+
+    public static void Apply(LingoTempoSpriteDTO dto, LingoTempoSprite sprite)
+    {
+        sprite.Name = dto.Name;
+        sprite.BeginFrame = dto.BeginFrame;
+        sprite.EndFrame = dto.EndFrame;
+        sprite.Lock = dto.Lock;
+        sprite.Frame = dto.Frame;
+        sprite.Action = (LingoTempoSpriteAction)dto.Action;
+        sprite.Tempo = dto.Tempo;
+        sprite.WaitSeconds = dto.WaitSeconds;
+        sprite.CueChannel = dto.CueChannel;
+        sprite.CuePoint = dto.CuePoint;
+    }
+}

--- a/src/LingoEngine.IO/TextMemberDtoConverter.cs
+++ b/src/LingoEngine.IO/TextMemberDtoConverter.cs
@@ -1,0 +1,21 @@
+using LingoEngine.IO.Data.DTO;
+using LingoEngine.Texts;
+
+namespace LingoEngine.IO;
+
+internal static class TextMemberDtoConverter
+{
+    public static LingoMemberFieldDTO ToDto(LingoMemberField field, LingoMemberDTO baseDto)
+    {
+        var dto = MemberDtoConverter.PopulateBase(baseDto, new LingoMemberFieldDTO());
+        dto.MarkDownText = field.InitialMarkdown != null ? field.InitialMarkdown.Markdown : field.Text;
+        return dto;
+    }
+
+    public static LingoMemberTextDTO ToDto(LingoMemberText text, LingoMemberDTO baseDto)
+    {
+        var dto = MemberDtoConverter.PopulateBase(baseDto, new LingoMemberTextDTO());
+        dto.MarkDownText = text.InitialMarkdown != null ? text.InitialMarkdown.Markdown : text.Text;
+        return dto;
+    }
+}

--- a/src/LingoEngine.IO/TransitionSpriteDtoConverter.cs
+++ b/src/LingoEngine.IO/TransitionSpriteDtoConverter.cs
@@ -1,0 +1,59 @@
+using LingoEngine.IO.Data.DTO;
+using LingoEngine.Transitions;
+
+namespace LingoEngine.IO;
+
+internal static class TransitionSpriteDtoConverter
+{
+    public static LingoTransitionSpriteDTO ToDto(LingoTransitionSprite sprite)
+    {
+        return new LingoTransitionSpriteDTO
+        {
+            Name = sprite.Name,
+            BeginFrame = sprite.BeginFrame,
+            EndFrame = sprite.EndFrame,
+            Lock = sprite.Lock,
+            Member = MemberRefDtoConverter.ToDto(sprite.Member),
+            Settings = sprite.GetSettings() is { } settings ? ToDto(settings) : null
+        };
+    }
+
+    public static void Apply(LingoTransitionSpriteDTO dto, LingoTransitionSprite sprite)
+    {
+        sprite.Name = dto.Name;
+        sprite.BeginFrame = dto.BeginFrame;
+        sprite.EndFrame = dto.EndFrame;
+        sprite.Lock = dto.Lock;
+
+        if (dto.Settings != null)
+        {
+            sprite.SetSettings(FromDto(dto.Settings));
+        }
+    }
+
+    public static LingoTransitionFrameSettingsDTO ToDto(LingoTransitionFrameSettings settings)
+    {
+        return new LingoTransitionFrameSettingsDTO
+        {
+            TransitionId = settings.TransitionId,
+            TransitionName = settings.TransitionName,
+            Duration = settings.Duration,
+            Smoothness = settings.Smoothness,
+            Affects = (LingoTransitionAffectsDTO)settings.Affects,
+            Rect = RectDtoConverter.ToDto(settings.Rect)
+        };
+    }
+
+    public static LingoTransitionFrameSettings FromDto(LingoTransitionFrameSettingsDTO dto)
+    {
+        return new LingoTransitionFrameSettings
+        {
+            TransitionId = dto.TransitionId,
+            TransitionName = dto.TransitionName,
+            Duration = dto.Duration,
+            Smoothness = dto.Smoothness,
+            Affects = (LingoTransitionAffects)dto.Affects,
+            Rect = RectDtoConverter.FromDto(dto.Rect)
+        };
+    }
+}

--- a/src/Net/LingoEngine.Net.RNetTerminal/PropertyInspector.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/PropertyInspector.cs
@@ -34,7 +34,7 @@ internal sealed class PropertyInspector : Window
     private readonly TabView.Tab _guidesTab;
     private readonly TabView.Tab _behaviorTab;
     private readonly TabView.Tab _filmLoopTab;
-    private LingoSpriteDTO? _sprite;
+    private Lingo2DSpriteDTO? _sprite;
     private LingoMemberDTO? _member;
     private string _lastTab = "Sprite";
 
@@ -290,7 +290,7 @@ internal sealed class PropertyInspector : Window
         }
     }
 
-    public void ShowSprite(LingoSpriteDTO? sprite)
+    public void ShowSprite(Lingo2DSpriteDTO? sprite)
     {
         _sprite = sprite;
         for (var i = 0; i < _spriteSpecs.Count; i++)

--- a/src/Net/LingoEngine.Net.RNetTerminal/StageView.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/StageView.cs
@@ -10,7 +10,7 @@ internal sealed class StageView : View
 {
     private int _movieWidth;
     private int _movieHeight;
-    private IReadOnlyList<LingoSpriteDTO> _sprites = Array.Empty<LingoSpriteDTO>();
+    private IReadOnlyList<Lingo2DSpriteDTO> _sprites = Array.Empty<Lingo2DSpriteDTO>();
     private int _frame;
     private SpriteRef? _selectedSprite;
     private static readonly Color[] _overlapColors =

--- a/src/Net/LingoEngine.Net.RNetTerminal/TerminalDataStore.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/TerminalDataStore.cs
@@ -8,7 +8,7 @@ public sealed class TerminalDataStore
     private static readonly Lazy<TerminalDataStore> _instance = new(() => new TerminalDataStore());
     public static TerminalDataStore Instance => _instance.Value;
 
-    private readonly List<LingoSpriteDTO> _sprites = new();
+    private readonly List<Lingo2DSpriteDTO> _sprites = new();
     private readonly Dictionary<string, List<LingoMemberDTO>> _casts = new();
     private int _currentFrame;
     private SpriteRef? _selectedSprite;
@@ -26,17 +26,17 @@ public sealed class TerminalDataStore
     public int FrameCount { get; private set; } = 600;
 
     public event Action? SpritesChanged;
-    public event Action<LingoSpriteDTO>? SpriteChanged;
+    public event Action<Lingo2DSpriteDTO>? SpriteChanged;
     public event Action? CastsChanged;
     public event Action<LingoMemberDTO>? MemberChanged;
     public event Action<int>? FrameChanged;
     public event Action<SpriteRef?>? SelectedSpriteChanged;
 
-    public IReadOnlyList<LingoSpriteDTO> GetSprites() => _sprites;
+    public IReadOnlyList<Lingo2DSpriteDTO> GetSprites() => _sprites;
 
     public IReadOnlyDictionary<string, List<LingoMemberDTO>> GetCasts() => _casts;
 
-    public LingoSpriteDTO? FindSprite(SpriteRef sprite)
+    public Lingo2DSpriteDTO? FindSprite(SpriteRef sprite)
         => _sprites.FirstOrDefault(s => s.SpriteNum == sprite.SpriteNum && s.BeginFrame == sprite.BeginFrame);
 
     public LingoMemberDTO? FindMember(int castLibNum, int numberInCast)
@@ -71,7 +71,7 @@ public sealed class TerminalDataStore
         SelectedSpriteChanged?.Invoke(sprite);
     }
 
-    public void UpdateSprite(LingoSpriteDTO sprite)
+    public void UpdateSprite(Lingo2DSpriteDTO sprite)
     {
         var idx = _sprites.FindIndex(s => s.SpriteNum == sprite.SpriteNum && s.BeginFrame == sprite.BeginFrame);
         if (idx >= 0)
@@ -175,7 +175,7 @@ public sealed class TerminalDataStore
     public void Load(LingoMovieDTO movie)
     {
         _sprites.Clear();
-        _sprites.AddRange(movie.Sprites);
+        _sprites.AddRange(movie.Sprite2Ds);
         _casts.Clear();
         foreach (var cast in movie.Casts)
         {

--- a/src/Net/LingoEngine.Net.RNetTerminal/TestMovieBuilder.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/TestMovieBuilder.cs
@@ -17,7 +17,7 @@ public static class TestMovieBuilder
     /// <summary>
     /// Provides sample sprite channel data.
     /// </summary>
-    public static IReadOnlyList<LingoSpriteDTO> BuildSprites() => new List<LingoSpriteDTO>
+    public static IReadOnlyList<Lingo2DSpriteDTO> BuildSprites() => new List<Lingo2DSpriteDTO>
     {
         new() { Name = "Greeting", SpriteNum = 1, CastLibNum = 1, MemberNum = 1, BeginFrame = 1, EndFrame = 60, LocH = 100, LocV = 100 },
         new() { Name = "Info", SpriteNum = 2, CastLibNum = 1, MemberNum = 2, BeginFrame = 1, EndFrame = 60, LocH = 300, LocV = 200 },


### PR DESCRIPTION
## Summary
- introduce `LingoMemberRefDTO` and replace legacy member number fields across sprite DTOs so both cast and member numbers are captured together
- update the sprite/media converters and `JsonStateRepository` to emit and resolve member references using the new DTO plus a tuple keyed member map
- adjust the Director importer, generator, and unit tests to consume the shared member reference shape

## Testing
- dotnet build src/LingoEngine.IO/LingoEngine.IO.csproj -v minimal
- dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj -v minimal
- dotnet test Test/LingoEngine.Director.Core.Tests/LingoEngine.Director.Core.Tests.csproj -v minimal
- dotnet test Test/LingoEngine.Lingo.Core.Tests/LingoEngine.Lingo.Core.Tests.csproj -v minimal

------
https://chatgpt.com/codex/tasks/task_e_68c837c3ca2c833282aeb483b065f9e8