### PR TITLE
Refactor DTO converters and enhance RNet terminal UI

### DIFF
--- a/src/LingoEngine.IO/AudioMemberDtoConverter.cs
+++ b/src/LingoEngine.IO/AudioMemberDtoConverter.cs
@@ -6,7 +6,7 @@ namespace LingoEngine.IO;
 
 internal static class AudioMemberDtoConverter
 {
-    public static LingoMemberSoundDTO ToDto(LingoMemberSound sound, LingoMemberDTO baseDto, JsonStateRepository.MovieStoreOptions options)
+    public static LingoMemberSoundDTO ToDto(this LingoMemberSound sound, LingoMemberDTO baseDto, JsonStateRepository.MovieStoreOptions options)
     {
         var dto = MemberDtoConverter.PopulateBase(baseDto, new LingoMemberSoundDTO());
         dto.Stereo = sound.Stereo;

--- a/src/LingoEngine.IO/BitmapMemberDtoConverter.cs
+++ b/src/LingoEngine.IO/BitmapMemberDtoConverter.cs
@@ -6,7 +6,7 @@ namespace LingoEngine.IO;
 
 internal static class BitmapMemberDtoConverter
 {
-    public static LingoMemberPictureDTO ToDto(LingoMemberBitmap picture, LingoMemberDTO baseDto, JsonStateRepository.MovieStoreOptions options)
+    public static LingoMemberPictureDTO ToDto(this LingoMemberBitmap picture, LingoMemberDTO baseDto, JsonStateRepository.MovieStoreOptions options)
     {
         var dto = MemberDtoConverter.PopulateBase(baseDto, new LingoMemberPictureDTO());
         dto.ImageFile = SavePicture(picture, options);

--- a/src/LingoEngine.IO/ColorDtoConverter.cs
+++ b/src/LingoEngine.IO/ColorDtoConverter.cs
@@ -5,7 +5,7 @@ namespace LingoEngine.IO;
 
 internal static class ColorDtoConverter
 {
-    public static LingoColorDTO ToDto(AColor color)
+    public static LingoColorDTO ToDto(this AColor color)
     {
         return new LingoColorDTO
         {

--- a/src/LingoEngine.IO/ColorPaletteSpriteDtoConverter.cs
+++ b/src/LingoEngine.IO/ColorPaletteSpriteDtoConverter.cs
@@ -5,7 +5,7 @@ namespace LingoEngine.IO;
 
 internal static class ColorPaletteSpriteDtoConverter
 {
-    public static LingoColorPaletteSpriteDTO ToDto(LingoColorPaletteSprite sprite)
+    public static LingoColorPaletteSpriteDTO ToDto(this LingoColorPaletteSprite sprite)
     {
         return new LingoColorPaletteSpriteDTO
         {
@@ -14,8 +14,8 @@ internal static class ColorPaletteSpriteDtoConverter
             EndFrame = sprite.EndFrame,
             Lock = sprite.Lock,
             Frame = sprite.Frame,
-            Member = MemberRefDtoConverter.ToDto(sprite.Member),
-            Settings = sprite.GetSettings() is { } settings ? ToDto(settings) : null
+            Member = sprite.Member.ToDto(),
+            Settings = sprite.GetSettings() is { } settings ? settings.ToDto() : null
         };
     }
 
@@ -38,7 +38,7 @@ internal static class ColorPaletteSpriteDtoConverter
         }
     }
 
-    public static LingoColorPaletteFrameSettingsDTO ToDto(LingoColorPaletteFrameSettings settings)
+    public static LingoColorPaletteFrameSettingsDTO ToDto(this LingoColorPaletteFrameSettings settings)
     {
         return new LingoColorPaletteFrameSettingsDTO
         {

--- a/src/LingoEngine.IO/FilmLoopMemberDtoConverter.cs
+++ b/src/LingoEngine.IO/FilmLoopMemberDtoConverter.cs
@@ -6,18 +6,18 @@ namespace LingoEngine.IO;
 
 internal static class FilmLoopMemberDtoConverter
 {
-    public static LingoMemberFilmLoopDTO ToDto(LingoFilmLoopMember filmLoop, LingoMemberDTO baseDto)
+    public static LingoMemberFilmLoopDTO ToDto(this LingoFilmLoopMember filmLoop, LingoMemberDTO baseDto)
     {
         var dto = MemberDtoConverter.PopulateBase(baseDto, new LingoMemberFilmLoopDTO());
         dto.Framing = (LingoFilmLoopFramingDTO)filmLoop.Framing;
         dto.Loop = filmLoop.Loop;
         dto.FrameCount = filmLoop.FrameCount;
-        dto.SpriteEntries = filmLoop.SpriteEntries.Select(SpriteDtoConverter.ToDto).ToList();
+        dto.SpriteEntries = filmLoop.SpriteEntries.Select(sprite => sprite.ToDto()).ToList();
         dto.SoundEntries = filmLoop.SoundEntries.Select(e => new LingoFilmLoopSoundEntryDTO
         {
             Channel = e.Channel,
             StartFrame = e.StartFrame,
-            Member = MemberRefDtoConverter.ToDto(e.Sound) ?? new LingoMemberRefDTO()
+            Member = e.Sound.ToDto() ?? new LingoMemberRefDTO()
         }).ToList();
         return dto;
     }

--- a/src/LingoEngine.IO/JsonStateRepository.cs
+++ b/src/LingoEngine.IO/JsonStateRepository.cs
@@ -68,16 +68,16 @@ public class JsonStateRepository : IJsonStateRepository
             {
                 Width = player.Stage.Width,
                 Height = player.Stage.Height,
-                BackgroundColor = ColorDtoConverter.ToDto(player.Stage.BackgroundColor),
+                BackgroundColor = player.Stage.BackgroundColor.ToDto(),
             },
         };
         if (player.ActiveMovie != null)
-            projectDTO.Movies = [MovieDtoConverter.ToDto((LingoMovie)player.ActiveMovie, options)];
+            projectDTO.Movies = [((LingoMovie)player.ActiveMovie).ToDto(options)];
         return projectDTO;
     }
     public (string JsonString, LingoMovieDTO MovieDto) Serialize(LingoMovie movie, MovieStoreOptions options)
     {
-        LingoMovieDTO dto = MovieDtoConverter.ToDto(movie, options);
+        LingoMovieDTO dto = movie.ToDto(options);
         var joptions = new JsonSerializerOptions { WriteIndented = true };
         var json = JsonSerializer.Serialize(dto, joptions);
         return (json, dto);

--- a/src/LingoEngine.IO/MemberDtoConverter.cs
+++ b/src/LingoEngine.IO/MemberDtoConverter.cs
@@ -9,17 +9,17 @@ namespace LingoEngine.IO;
 
 internal static class MemberDtoConverter
 {
-    public static LingoMemberDTO ToDto(ILingoMember member, JsonStateRepository.MovieStoreOptions options)
+    public static LingoMemberDTO ToDto(this ILingoMember member, JsonStateRepository.MovieStoreOptions options)
     {
         var baseDto = CreateBaseDto(member);
 
         return member switch
         {
-            LingoMemberField field => TextMemberDtoConverter.ToDto(field, baseDto),
-            LingoMemberText text => TextMemberDtoConverter.ToDto(text, baseDto),
-            LingoMemberSound sound => AudioMemberDtoConverter.ToDto(sound, baseDto, options),
-            LingoMemberBitmap bitmap => BitmapMemberDtoConverter.ToDto(bitmap, baseDto, options),
-            LingoFilmLoopMember filmLoop => FilmLoopMemberDtoConverter.ToDto(filmLoop, baseDto),
+            LingoMemberField field => field.ToDto(baseDto),
+            LingoMemberText text => text.ToDto(baseDto),
+            LingoMemberSound sound => sound.ToDto(baseDto, options),
+            LingoMemberBitmap bitmap => bitmap.ToDto(baseDto, options),
+            LingoFilmLoopMember filmLoop => filmLoop.ToDto(baseDto),
             _ => baseDto,
         };
     }

--- a/src/LingoEngine.IO/MemberRefDtoConverter.cs
+++ b/src/LingoEngine.IO/MemberRefDtoConverter.cs
@@ -5,7 +5,7 @@ namespace LingoEngine.IO;
 
 internal static class MemberRefDtoConverter
 {
-    public static LingoMemberRefDTO? ToDto(ILingoMember? member)
+    public static LingoMemberRefDTO? ToDto(this ILingoMember? member)
     {
         if (member == null)
         {
@@ -19,7 +19,7 @@ internal static class MemberRefDtoConverter
         };
     }
 
-    public static LingoMemberRefDTO? ToDto(int memberNum, int castNum)
+    public static LingoMemberRefDTO? ToDto(this int memberNum, int castNum)
     {
         if (memberNum <= 0 || castNum <= 0)
         {

--- a/src/LingoEngine.IO/MovieDtoConverter.cs
+++ b/src/LingoEngine.IO/MovieDtoConverter.cs
@@ -8,7 +8,7 @@ namespace LingoEngine.IO;
 
 internal static class MovieDtoConverter
 {
-    public static LingoMovieDTO ToDto(LingoMovie movie, JsonStateRepository.MovieStoreOptions options)
+    public static LingoMovieDTO ToDto(this LingoMovie movie, JsonStateRepository.MovieStoreOptions options)
     {
         return new LingoMovieDTO
         {
@@ -21,16 +21,16 @@ internal static class MovieDtoConverter
             Copyright = movie.Copyright,
             UserName = movie.UserName,
             CompanyName = movie.CompanyName,
-            Casts = movie.CastLib.GetAll().Select(c => ToDto((LingoCast)c, options)).ToList(),
-            Sprite2Ds = movie.GetAll2DSpritesToStore().Select(SpriteDtoConverter.ToDto).ToList(),
-            TempoSprites = movie.Tempos.GetAllSprites().Select(TempoSpriteDtoConverter.ToDto).ToList(),
-            ColorPaletteSprites = movie.ColorPalettes.GetAllSprites().Select(ColorPaletteSpriteDtoConverter.ToDto).ToList(),
-            TransitionSprites = movie.Transitions.GetAllSprites().Select(TransitionSpriteDtoConverter.ToDto).ToList(),
-            SoundSprites = movie.Audio.GetAllSprites().Select(SoundSpriteDtoConverter.ToDto).ToList()
+            Casts = movie.CastLib.GetAll().Select(c => ((LingoCast)c).ToDto(options)).ToList(),
+            Sprite2Ds = movie.GetAll2DSpritesToStore().Select(sprite => sprite.ToDto()).ToList(),
+            TempoSprites = movie.Tempos.GetAllSprites().Select(sprite => sprite.ToDto()).ToList(),
+            ColorPaletteSprites = movie.ColorPalettes.GetAllSprites().Select(sprite => sprite.ToDto()).ToList(),
+            TransitionSprites = movie.Transitions.GetAllSprites().Select(sprite => sprite.ToDto()).ToList(),
+            SoundSprites = movie.Audio.GetAllSprites().Select(sprite => sprite.ToDto()).ToList()
         };
     }
 
-    public static LingoCastDTO ToDto(LingoCast cast, JsonStateRepository.MovieStoreOptions options)
+    public static LingoCastDTO ToDto(this LingoCast cast, JsonStateRepository.MovieStoreOptions options)
     {
         return new LingoCastDTO
         {
@@ -38,7 +38,7 @@ internal static class MovieDtoConverter
             FileName = cast.FileName,
             Number = cast.Number,
             PreLoadMode = (PreLoadModeTypeDTO)cast.PreLoadMode,
-            Members = cast.GetAll().Select(m => MemberDtoConverter.ToDto(m, options)).ToList()
+            Members = cast.GetAll().Select(m => m.ToDto(options)).ToList()
         };
     }
 }

--- a/src/LingoEngine.IO/RectDtoConverter.cs
+++ b/src/LingoEngine.IO/RectDtoConverter.cs
@@ -5,7 +5,7 @@ namespace LingoEngine.IO;
 
 internal static class RectDtoConverter
 {
-    public static LingoRectDTO ToDto(ARect rect)
+    public static LingoRectDTO ToDto(this ARect rect)
     {
         return new LingoRectDTO
         {

--- a/src/LingoEngine.IO/SoundSpriteDtoConverter.cs
+++ b/src/LingoEngine.IO/SoundSpriteDtoConverter.cs
@@ -5,7 +5,7 @@ namespace LingoEngine.IO;
 
 internal static class SoundSpriteDtoConverter
 {
-    public static LingoSpriteSoundDTO ToDto(LingoSpriteSound sprite)
+    public static LingoSpriteSoundDTO ToDto(this LingoSpriteSound sprite)
     {
         return new LingoSpriteSoundDTO
         {
@@ -14,7 +14,7 @@ internal static class SoundSpriteDtoConverter
             BeginFrame = sprite.BeginFrame,
             EndFrame = sprite.EndFrame,
             Lock = sprite.Lock,
-            Member = MemberRefDtoConverter.ToDto(sprite.Sound)
+            Member = sprite.Sound.ToDto()
         };
     }
 

--- a/src/LingoEngine.IO/SpriteDtoConverter.cs
+++ b/src/LingoEngine.IO/SpriteDtoConverter.cs
@@ -11,15 +11,15 @@ namespace LingoEngine.IO;
 
 internal static class SpriteDtoConverter
 {
-    public static Lingo2DSpriteDTO ToDto(LingoSprite2D sprite)
+    public static Lingo2DSpriteDTO ToDto(this LingoSprite2D sprite)
     {
         var state = sprite.InitialState as LingoSprite2DState ?? (LingoSprite2DState)sprite.GetState();
         var dto = new Lingo2DSpriteDTO
         {
             Name = state.Name,
             SpriteNum = sprite.SpriteNum,
-            Member = MemberRefDtoConverter.ToDto(state.Member)
-                ?? MemberRefDtoConverter.ToDto(sprite.MemberNum, sprite.Cast?.Number ?? sprite.Member?.CastLibNum ?? 0),
+            Member = state.Member.ToDto()
+                ?? sprite.MemberNum.ToDto(sprite.Cast?.Number ?? sprite.Member?.CastLibNum ?? 0),
             DisplayMember = state.DisplayMember,
             SpritePropertiesOffset = state.SpritePropertiesOffset,
             Lock = sprite.Lock,
@@ -31,8 +31,8 @@ internal static class SpriteDtoConverter
             Skew = state.Skew,
             RegPoint = new LingoPointDTO { X = state.RegPoint.X, Y = state.RegPoint.Y },
             Ink = state.Ink,
-            ForeColor = ColorDtoConverter.ToDto(state.ForeColor),
-            BackColor = ColorDtoConverter.ToDto(state.BackColor),
+            ForeColor = state.ForeColor.ToDto(),
+            BackColor = state.BackColor.ToDto(),
             Blend = state.Blend,
             Editable = state.Editable,
             FlipH = state.FlipH,
@@ -58,15 +58,15 @@ internal static class SpriteDtoConverter
         return dto;
     }
 
-    public static Lingo2DSpriteDTO ToDto(LingoSprite2DVirtual sprite)
+    public static Lingo2DSpriteDTO ToDto(this LingoSprite2DVirtual sprite)
     {
         var state = sprite.InitialState as LingoSprite2DVirtualState ?? (LingoSprite2DVirtualState)sprite.GetState();
         return new Lingo2DSpriteDTO
         {
             Name = state.Name,
             SpriteNum = sprite.SpriteNum,
-            Member = MemberRefDtoConverter.ToDto(state.Member)
-                ?? MemberRefDtoConverter.ToDto(sprite.MemberNum, sprite.Member?.CastLibNum ?? 0),
+            Member = state.Member.ToDto()
+                ?? sprite.MemberNum.ToDto(sprite.Member?.CastLibNum ?? 0),
             DisplayMember = state.DisplayMember,
             Lock = sprite.Lock,
             LocH = state.LocH,
@@ -76,8 +76,8 @@ internal static class SpriteDtoConverter
             Skew = state.Skew,
             RegPoint = new LingoPointDTO { X = state.RegPoint.X, Y = state.RegPoint.Y },
             Ink = state.Ink,
-            ForeColor = ColorDtoConverter.ToDto(state.ForeColor),
-            BackColor = ColorDtoConverter.ToDto(state.BackColor),
+            ForeColor = state.ForeColor.ToDto(),
+            BackColor = state.BackColor.ToDto(),
             Blend = state.Blend,
             Width = state.Width,
             Height = state.Height,
@@ -88,13 +88,13 @@ internal static class SpriteDtoConverter
         };
     }
 
-    public static LingoFilmLoopMemberSpriteDTO ToDto(LingoFilmLoopMemberSprite sprite)
+    public static LingoFilmLoopMemberSpriteDTO ToDto(this LingoFilmLoopMemberSprite sprite)
     {
         return new LingoFilmLoopMemberSpriteDTO
         {
             Name = sprite.Name,
             SpriteNum = sprite.SpriteNum,
-            Member = MemberRefDtoConverter.ToDto(sprite.MemberNumberInCast, sprite.CastNum) ?? new LingoMemberRefDTO(),
+            Member = sprite.MemberNumberInCast.ToDto(sprite.CastNum) ?? new LingoMemberRefDTO(),
             DisplayMember = sprite.DisplayMember,
             LocH = sprite.LocH,
             LocV = sprite.LocV,
@@ -103,8 +103,8 @@ internal static class SpriteDtoConverter
             Skew = sprite.Skew,
             RegPoint = new LingoPointDTO { X = sprite.RegPoint.X, Y = sprite.RegPoint.Y },
             Ink = sprite.Ink,
-            ForeColor = ColorDtoConverter.ToDto(sprite.ForeColor),
-            BackColor = ColorDtoConverter.ToDto(sprite.BackColor),
+            ForeColor = sprite.ForeColor.ToDto(),
+            BackColor = sprite.BackColor.ToDto(),
             Blend = sprite.Blend,
             Width = sprite.Width,
             Height = sprite.Height,
@@ -114,16 +114,16 @@ internal static class SpriteDtoConverter
             FlipH = sprite.FlipH,
             FlipV = sprite.FlipV,
             Hilite = sprite.Hilite,
-            Animator = ToDto(sprite.AnimatorProperties)
+            Animator = sprite.AnimatorProperties.ToDto()
         };
     }
 
-    public static LingoSpriteAnimatorDTO ToDto(LingoSpriteAnimator animator)
+    public static LingoSpriteAnimatorDTO ToDto(this LingoSpriteAnimator animator)
     {
-        return ToDto(animator.Properties);
+        return animator.Properties.ToDto();
     }
 
-    public static LingoSpriteAnimatorDTO ToDto(LingoSpriteAnimatorProperties animProps)
+    public static LingoSpriteAnimatorDTO ToDto(this LingoSpriteAnimatorProperties animProps)
     {
         return new LingoSpriteAnimatorDTO
         {
@@ -133,42 +133,42 @@ internal static class SpriteDtoConverter
                 Value = new LingoPointDTO { X = k.Value.X, Y = k.Value.Y },
                 Ease = (LingoEaseTypeDTO)k.Ease
             }).ToList(),
-            PositionOptions = ToDto(animProps.Position.Options),
+            PositionOptions = animProps.Position.Options.ToDto(),
             Rotation = animProps.Rotation.KeyFrames.Select(k => new LingoFloatKeyFrameDTO
             {
                 Frame = k.Frame,
                 Value = k.Value,
                 Ease = (LingoEaseTypeDTO)k.Ease
             }).ToList(),
-            RotationOptions = ToDto(animProps.Rotation.Options),
+            RotationOptions = animProps.Rotation.Options.ToDto(),
             Skew = animProps.Skew.KeyFrames.Select(k => new LingoFloatKeyFrameDTO
             {
                 Frame = k.Frame,
                 Value = k.Value,
                 Ease = (LingoEaseTypeDTO)k.Ease
             }).ToList(),
-            SkewOptions = ToDto(animProps.Skew.Options),
+            SkewOptions = animProps.Skew.Options.ToDto(),
             ForegroundColor = animProps.ForegroundColor.KeyFrames.Select(k => new LingoColorKeyFrameDTO
             {
                 Frame = k.Frame,
-                Value = ColorDtoConverter.ToDto(k.Value),
+                Value = k.Value.ToDto(),
                 Ease = (LingoEaseTypeDTO)k.Ease
             }).ToList(),
-            ForegroundColorOptions = ToDto(animProps.ForegroundColor.Options),
+            ForegroundColorOptions = animProps.ForegroundColor.Options.ToDto(),
             BackgroundColor = animProps.BackgroundColor.KeyFrames.Select(k => new LingoColorKeyFrameDTO
             {
                 Frame = k.Frame,
-                Value = ColorDtoConverter.ToDto(k.Value),
+                Value = k.Value.ToDto(),
                 Ease = (LingoEaseTypeDTO)k.Ease
             }).ToList(),
-            BackgroundColorOptions = ToDto(animProps.BackgroundColor.Options),
+            BackgroundColorOptions = animProps.BackgroundColor.Options.ToDto(),
             Blend = animProps.Blend.KeyFrames.Select(k => new LingoFloatKeyFrameDTO
             {
                 Frame = k.Frame,
                 Value = k.Value,
                 Ease = (LingoEaseTypeDTO)k.Ease
             }).ToList(),
-            BlendOptions = ToDto(animProps.Blend.Options)
+            BlendOptions = animProps.Blend.Options.ToDto()
         };
     }
 
@@ -183,7 +183,7 @@ internal static class SpriteDtoConverter
         return Enumerable.Empty<object>();
     }
 
-    private static LingoTweenOptionsDTO ToDto(LingoTweenOptions options)
+    private static LingoTweenOptionsDTO ToDto(this LingoTweenOptions options)
     {
         return new LingoTweenOptionsDTO
         {

--- a/src/LingoEngine.IO/TempoSpriteDtoConverter.cs
+++ b/src/LingoEngine.IO/TempoSpriteDtoConverter.cs
@@ -5,7 +5,7 @@ namespace LingoEngine.IO;
 
 internal static class TempoSpriteDtoConverter
 {
-    public static LingoTempoSpriteDTO ToDto(LingoTempoSprite sprite)
+    public static LingoTempoSpriteDTO ToDto(this LingoTempoSprite sprite)
     {
         return new LingoTempoSpriteDTO
         {

--- a/src/LingoEngine.IO/TextMemberDtoConverter.cs
+++ b/src/LingoEngine.IO/TextMemberDtoConverter.cs
@@ -5,14 +5,14 @@ namespace LingoEngine.IO;
 
 internal static class TextMemberDtoConverter
 {
-    public static LingoMemberFieldDTO ToDto(LingoMemberField field, LingoMemberDTO baseDto)
+    public static LingoMemberFieldDTO ToDto(this LingoMemberField field, LingoMemberDTO baseDto)
     {
         var dto = MemberDtoConverter.PopulateBase(baseDto, new LingoMemberFieldDTO());
         dto.MarkDownText = field.InitialMarkdown != null ? field.InitialMarkdown.Markdown : field.Text;
         return dto;
     }
 
-    public static LingoMemberTextDTO ToDto(LingoMemberText text, LingoMemberDTO baseDto)
+    public static LingoMemberTextDTO ToDto(this LingoMemberText text, LingoMemberDTO baseDto)
     {
         var dto = MemberDtoConverter.PopulateBase(baseDto, new LingoMemberTextDTO());
         dto.MarkDownText = text.InitialMarkdown != null ? text.InitialMarkdown.Markdown : text.Text;

--- a/src/LingoEngine.IO/TransitionSpriteDtoConverter.cs
+++ b/src/LingoEngine.IO/TransitionSpriteDtoConverter.cs
@@ -5,7 +5,7 @@ namespace LingoEngine.IO;
 
 internal static class TransitionSpriteDtoConverter
 {
-    public static LingoTransitionSpriteDTO ToDto(LingoTransitionSprite sprite)
+    public static LingoTransitionSpriteDTO ToDto(this LingoTransitionSprite sprite)
     {
         return new LingoTransitionSpriteDTO
         {
@@ -13,8 +13,8 @@ internal static class TransitionSpriteDtoConverter
             BeginFrame = sprite.BeginFrame,
             EndFrame = sprite.EndFrame,
             Lock = sprite.Lock,
-            Member = MemberRefDtoConverter.ToDto(sprite.Member),
-            Settings = sprite.GetSettings() is { } settings ? ToDto(settings) : null
+            Member = sprite.Member.ToDto(),
+            Settings = sprite.GetSettings() is { } settings ? settings.ToDto() : null
         };
     }
 
@@ -31,7 +31,7 @@ internal static class TransitionSpriteDtoConverter
         }
     }
 
-    public static LingoTransitionFrameSettingsDTO ToDto(LingoTransitionFrameSettings settings)
+    public static LingoTransitionFrameSettingsDTO ToDto(this LingoTransitionFrameSettings settings)
     {
         return new LingoTransitionFrameSettingsDTO
         {
@@ -40,7 +40,7 @@ internal static class TransitionSpriteDtoConverter
             Duration = settings.Duration,
             Smoothness = settings.Smoothness,
             Affects = (LingoTransitionAffectsDTO)settings.Affects,
-            Rect = RectDtoConverter.ToDto(settings.Rect)
+            Rect = settings.Rect.ToDto()
         };
     }
 

--- a/src/Net/LingoEngine.Net.RNetTerminal/TestMovieBuilder.cs
+++ b/src/Net/LingoEngine.Net.RNetTerminal/TestMovieBuilder.cs
@@ -27,4 +27,87 @@ public static class TestMovieBuilder
         new() { Name = "score", SpriteNum = 6, Member =new LingoMemberRefDTO{CastLibNum = 1, MemberNum = 4}, BeginFrame = 1, EndFrame = 60, LocH = 50, LocV = 50, Width = 100, Height = 20 },
         new() { Name = "Img30x80", SpriteNum = 7, Member =new LingoMemberRefDTO{CastLibNum = 1, MemberNum = 5 }, BeginFrame = 1, EndFrame = 60, LocH = 250, LocV = 350, Width = 30, Height = 80 },
     };
+
+    public static IReadOnlyList<LingoTempoSpriteDTO> BuildTempoSprites() => new List<LingoTempoSpriteDTO>
+    {
+        new()
+        {
+            Name = "Tempo Change",
+            BeginFrame = 1,
+            EndFrame = 1,
+            Frame = 1,
+            Action = LingoTempoSpriteActionDTO.ChangeTempo,
+            Tempo = 60
+        },
+        new()
+        {
+            Name = "Wait",
+            BeginFrame = 120,
+            EndFrame = 120,
+            Frame = 120,
+            Action = LingoTempoSpriteActionDTO.WaitSeconds,
+            WaitSeconds = 1.5f
+        }
+    };
+
+    public static IReadOnlyList<LingoColorPaletteSpriteDTO> BuildPaletteSprites() => new List<LingoColorPaletteSpriteDTO>
+    {
+        new()
+        {
+            Name = "Palette",
+            BeginFrame = 1,
+            EndFrame = 60,
+            Frame = 1,
+            Settings = new LingoColorPaletteFrameSettingsDTO
+            {
+                ColorPaletteId = 1,
+                Rate = 12,
+                Cycles = 2,
+                Action = LingoColorPaletteActionDTO.ColorCycling,
+                TransitionOption = LingoColorPaletteTransitionOptionDTO.FadeToBlack,
+                CycleOption = LingoColorPaletteCycleOptionDTO.AutoReverse
+            }
+        }
+    };
+
+    public static IReadOnlyList<LingoTransitionSpriteDTO> BuildTransitionSprites() => new List<LingoTransitionSpriteDTO>
+    {
+        new()
+        {
+            Name = "Fade",
+            BeginFrame = 1,
+            EndFrame = 20,
+            Member = new LingoMemberRefDTO { CastLibNum = 1, MemberNum = 6 },
+            Settings = new LingoTransitionFrameSettingsDTO
+            {
+                TransitionId = 1,
+                TransitionName = "Fade",
+                Duration = 0.5f,
+                Smoothness = 0.5f,
+                Affects = LingoTransitionAffectsDTO.EntireStage,
+                Rect = new LingoRectDTO { Left = 0, Top = 0, Right = 640, Bottom = 480 }
+            }
+        }
+    };
+
+    public static IReadOnlyList<LingoSpriteSoundDTO> BuildSoundSprites() => new List<LingoSpriteSoundDTO>
+    {
+        new()
+        {
+            Name = "Intro Sound",
+            Channel = 1,
+            BeginFrame = 1,
+            EndFrame = 30,
+            Member = new LingoMemberRefDTO { CastLibNum = 1, MemberNum = 7 }
+        },
+        new()
+        {
+            Name = "Effect",
+            Channel = 2,
+            BeginFrame = 10,
+            EndFrame = 40,
+            Member = new LingoMemberRefDTO { CastLibNum = 1, MemberNum = 8 }
+        }
+    };
+
 }


### PR DESCRIPTION
## Summary
- convert the LingoEngine.IO converter methods into extension methods and update their call sites for members, sprites and casts
- extend the score view and data store to surface tempo/transition/sound channels, allow horizontal dragging, and populate sample data for them
- rework the RNet terminal layout with separate stage/score windows, connection status, fixed-width property inspector, and a collapsible log panel

## Testing
- `dotnet build src/LingoEngine.IO/LingoEngine.IO.csproj`
- `dotnet build src/Net/LingoEngine.Net.RNetTerminal/LingoEngine.Net.RNetTerminal.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c850fc72488332917810f823973477