### PR TITLE
Refine sprite behavior conversion pipeline

### DIFF
--- a/src/LingoEngine.IO.Data/DTO/Members/LingoMemberShapeDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/Members/LingoMemberShapeDTO.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using LingoEngine.IO.Data.DTO;
+
 namespace LingoEngine.IO.Data.DTO.Members;
 
 public enum LingoShapeTypeDto
@@ -17,4 +20,6 @@ public class LingoMemberShapeDTO : LingoMemberDTO
     public LingoColorDTO EndColor { get; set; }
     public bool Closed { get; set; }
     public bool Filled { get; set; }
+    public bool AntiAlias { get; set; }
+    public List<LingoPointDTO> VertexList { get; set; } = new();
 }

--- a/src/LingoEngine.IO.Data/DTO/Sprites/LingoSpriteBehaviorDTO.cs
+++ b/src/LingoEngine.IO.Data/DTO/Sprites/LingoSpriteBehaviorDTO.cs
@@ -1,9 +1,19 @@
-﻿using LingoEngine.IO.Data.DTO.Members;
+using System.Collections.Generic;
+using LingoEngine.IO.Data.DTO;
+using LingoEngine.IO.Data.DTO.Members;
 
 namespace LingoEngine.IO.Data.DTO.Sprites
 {
     public class LingoSpriteBehaviorDTO : LingoMemberDTO
     {
-        // Todo : initial values
+        public string BehaviorType { get; set; } = string.Empty;
+        public List<LingoSpriteBehaviorPropertyDTO> UserProperties { get; set; } = new();
+    }
+    public class LingoSpriteBehaviorPropertyDTO
+    {
+        public string Key { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+        public string? Value { get; set; }
+        public LingoColorDTO? ColorValue { get; set; }
     }
 }

--- a/src/LingoEngine.IO/JsonStateRepository.cs
+++ b/src/LingoEngine.IO/JsonStateRepository.cs
@@ -12,6 +12,8 @@ using LingoEngine.IO.Data.DTO.Members;
 using LingoEngine.IO.Data.DTO.Sprites;
 using LingoEngine.Members;
 using LingoEngine.Movies;
+using LingoEngine.Scripts;
+using LingoEngine.Shapes;
 using LingoEngine.Sounds;
 using LingoEngine.Sprites;
 using LingoEngine.Tempos;
@@ -184,6 +186,10 @@ public class JsonStateRepository : IJsonStateRepository
                             flMem.AddSound(sndEntry.Channel, sndEntry.StartFrame, sndMem2);
                     }
                 }
+                if (member is LingoMemberShape shapeMem && memDto is LingoMemberShapeDTO shapeDto)
+                {
+                    ShapeDtoConverter.Apply(shapeDto, shapeMem);
+                }
 
                 memberMap[(member.CastLibNum, member.NumberInCast)] = member;
             }
@@ -251,6 +257,10 @@ public class JsonStateRepository : IJsonStateRepository
         sprite.LoadState(state);
 
         AddAnimator(sDto, sprite, movie, eventMediator);
+        foreach (var behaviorDto in sDto.Behaviors)
+        {
+            behaviorDto.Apply(sprite, memberMap);
+        }
         return sprite;
     }
 

--- a/src/LingoEngine.IO/ShapeDtoConverter.cs
+++ b/src/LingoEngine.IO/ShapeDtoConverter.cs
@@ -1,4 +1,7 @@
-﻿using LingoEngine.IO.Data.DTO.Members;
+using System;
+using AbstUI.Primitives;
+using LingoEngine.IO.Data.DTO;
+using LingoEngine.IO.Data.DTO.Members;
 using LingoEngine.Shapes;
 
 namespace LingoEngine.IO
@@ -15,21 +18,37 @@ namespace LingoEngine.IO
             dto.Closed = field.Closed;
             dto.Filled = field.Filled;
             dto.ShapeType = field.ShapeType.ToDto();
+            dto.AntiAlias = field.AntiAlias;
+            dto.VertexList.Clear();
+            foreach (var vertex in field.VertexList)
+            {
+                dto.VertexList.Add(new LingoPointDTO { X = vertex.X, Y = vertex.Y });
+            }
+
             return dto;
         }
-        //public static LingoMemberShape ToLingo(this LingoMemberShapeDTO field, LingoMemberDTO baseDto)
-        //{
-        //    dto.FillColor = field.FillColor.ToDTO();
-        //    dto.EndColor = field.EndColor.ToDTO();
-        //    dto.StrokeColor = field.StrokeColor.ToDTO();
-        //    dto.StrokeWidth = field.StrokeWidth;
-        //    dto.Closed = field.Closed;
-        //    dto.Filled = field.Filled;
-        //    dto.ShapeType = field.ShapeType.ToDto();
-        //    return dto;
-        //}
 
-        
+        public static void Apply(LingoMemberShapeDTO dto, LingoMemberShape shape)
+        {
+            shape.FillColor = dto.FillColor.ToAColor();
+            shape.EndColor = dto.EndColor.ToAColor();
+            shape.StrokeColor = dto.StrokeColor.ToAColor();
+            shape.StrokeWidth = dto.StrokeWidth;
+            shape.Closed = dto.Closed;
+            shape.Filled = dto.Filled;
+            shape.AntiAlias = dto.AntiAlias;
+            shape.ShapeType = dto.ShapeType.ToLingo();
+
+            shape.VertexList.Clear();
+            if (dto.VertexList != null)
+            {
+                foreach (var vertex in dto.VertexList)
+                {
+                    shape.VertexList.Add(new APoint(vertex.X, vertex.Y));
+                }
+            }
+        }
+
         public static LingoShapeTypeDto ToDto(this LingoShapeType shapeType)
         {
             return shapeType switch

--- a/src/LingoEngine.IO/SpriteBehaviorDtoConverter.cs
+++ b/src/LingoEngine.IO/SpriteBehaviorDtoConverter.cs
@@ -1,0 +1,343 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using AbstUI.Primitives;
+using LingoEngine.IO.Data.DTO;
+using LingoEngine.IO.Data.DTO.Members;
+using LingoEngine.IO.Data.DTO.Sprites;
+using LingoEngine.Members;
+using LingoEngine.Primitives;
+using LingoEngine.Scripts;
+using LingoEngine.Sprites;
+
+namespace LingoEngine.IO;
+
+internal static class SpriteBehaviorDtoConverter
+{
+    public static LingoSpriteBehavior? Apply(this LingoSpriteBehaviorDTO dto, LingoSprite2D sprite, Dictionary<(int CastNum, int MemberNum), LingoMember> memberMap)
+    {
+        var behavior = CreateSpriteBehavior(sprite, dto, memberMap);
+        if (behavior == null)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(dto.Name))
+        {
+            behavior.Name = dto.Name;
+        }
+
+        ApplyUserProperties(dto, behavior);
+
+        return behavior;
+    }
+
+    public static LingoSpriteBehaviorDTO ToDto(this LingoSpriteBehavior behavior)
+    {
+        var dto = new LingoSpriteBehaviorDTO
+        {
+            BehaviorType = behavior.GetType().FullName ?? string.Empty,
+            Type = LingoMemberTypeDTO.Script,
+            Name = behavior.Name,
+            RegPoint = new LingoPointDTO()
+        };
+
+        if (behavior.ScriptMember != null)
+        {
+            dto.CastLibNum = behavior.ScriptMember.CastLibNum;
+            dto.NumberInCast = behavior.ScriptMember.NumberInCast;
+            dto.Name = behavior.ScriptMember.Name;
+            dto.FileName = behavior.ScriptMember.FileName;
+            dto.Comments = behavior.ScriptMember.Comments;
+            dto.PurgePriority = behavior.ScriptMember.PurgePriority;
+            dto.RegPoint = new LingoPointDTO { X = behavior.ScriptMember.RegPoint.X, Y = behavior.ScriptMember.RegPoint.Y };
+            dto.Width = behavior.ScriptMember.Width;
+            dto.Height = behavior.ScriptMember.Height;
+            dto.Size = behavior.ScriptMember.Size;
+        }
+        else if (string.IsNullOrWhiteSpace(dto.Name))
+        {
+            dto.Name = behavior.GetType().Name;
+        }
+
+        dto.UserProperties = behavior.UserProperties.ToDto();
+        return dto;
+    }
+
+    private static void ApplyUserProperties(LingoSpriteBehaviorDTO dto, LingoSpriteBehavior behavior)
+    {
+        var userProperties = dto.ToBehaviorProperties();
+        if (userProperties.Count <= 0)
+        {
+            return;
+        }
+
+        var targetProperties = behavior.UserProperties;
+        foreach (var key in targetProperties.Keys.ToList())
+        {
+            targetProperties.Remove(key);
+        }
+
+        foreach (var property in userProperties)
+        {
+            targetProperties.Add(property.Key, property.Value);
+        }
+
+        if (behavior is ILingoPropertyDescriptionList descriptionProvider)
+        {
+            var definitions = descriptionProvider.GetPropertyDescriptionList();
+            if (definitions != null)
+            {
+                targetProperties.Apply(definitions);
+            }
+        }
+    }
+
+    public static List<LingoSpriteBehaviorPropertyDTO> ToDto(this BehaviorPropertiesContainer container)
+    {
+        var list = new List<LingoSpriteBehaviorPropertyDTO>();
+        foreach (var item in container)
+        {
+            if (string.IsNullOrEmpty(item.Key.Name))
+            {
+                continue;
+            }
+
+            var dto = new LingoSpriteBehaviorPropertyDTO
+            {
+                Key = item.Key.Name
+            };
+
+            switch (item.Value)
+            {
+                case null:
+                    dto.Type = LingoSymbol.String.Name;
+                    dto.Value = null;
+                    break;
+                case string str:
+                    dto.Type = LingoSymbol.String.Name;
+                    dto.Value = str;
+                    break;
+                case bool boolean:
+                    dto.Type = LingoSymbol.Boolean.Name;
+                    dto.Value = boolean ? bool.TrueString : bool.FalseString;
+                    break;
+                case int intValue:
+                    dto.Type = LingoSymbol.Int.Name;
+                    dto.Value = intValue.ToString(CultureInfo.InvariantCulture);
+                    break;
+                case long longValue:
+                    dto.Type = LingoSymbol.Int.Name;
+                    dto.Value = longValue.ToString(CultureInfo.InvariantCulture);
+                    break;
+                case float floatValue:
+                    dto.Type = LingoSymbol.Float.Name;
+                    dto.Value = floatValue.ToString(CultureInfo.InvariantCulture);
+                    break;
+                case double doubleValue:
+                    dto.Type = LingoSymbol.Float.Name;
+                    dto.Value = doubleValue.ToString(CultureInfo.InvariantCulture);
+                    break;
+                case AColor colorValue:
+                    dto.Type = LingoSymbol.Color.Name;
+                    dto.ColorValue = colorValue.ToDTO();
+                    break;
+                default:
+                    dto.Type = item.Value.GetType().FullName ?? string.Empty;
+                    dto.Value = item.Value?.ToString();
+                    break;
+            }
+
+            list.Add(dto);
+        }
+
+        return list;
+    }
+
+    public static BehaviorPropertiesContainer ToBehaviorProperties(this LingoSpriteBehaviorDTO dto)
+    {
+        var container = new BehaviorPropertiesContainer();
+        if (dto.UserProperties == null)
+        {
+            return container;
+        }
+
+        foreach (var property in dto.UserProperties)
+        {
+            if (property == null || string.IsNullOrWhiteSpace(property.Key))
+            {
+                continue;
+            }
+
+            var symbol = LingoSymbol.New(property.Key);
+            var type = property.Type?.Trim() ?? string.Empty;
+            object? value;
+
+            if (type.Equals(LingoSymbol.Color.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                if (!property.ColorValue.HasValue)
+                {
+                    continue;
+                }
+
+                value = property.ColorValue.Value.ToAColor();
+            }
+            else if (type.Equals(LingoSymbol.Int.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                if (property.Value == null || !int.TryParse(property.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+                {
+                    continue;
+                }
+
+                value = parsed;
+            }
+            else if (type.Equals(LingoSymbol.Float.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                if (property.Value == null || !float.TryParse(property.Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedFloat))
+                {
+                    continue;
+                }
+
+                value = parsedFloat;
+            }
+            else if (type.Equals(LingoSymbol.Boolean.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                if (property.Value == null || !bool.TryParse(property.Value, out var parsedBool))
+                {
+                    continue;
+                }
+
+                value = parsedBool;
+            }
+            else
+            {
+                value = property.Value;
+            }
+
+            container.Add(symbol, value);
+        }
+
+        return container;
+    }
+
+    private static LingoSpriteBehavior? CreateSpriteBehavior(LingoSprite2D sprite, LingoSpriteBehaviorDTO dto, Dictionary<(int CastNum, int MemberNum), LingoMember> memberMap)
+    {
+        LingoSpriteBehavior? behavior = null;
+
+        if (dto.CastLibNum > 0 && dto.NumberInCast > 0)
+        {
+            var reference = new LingoMemberRefDTO
+            {
+                CastLibNum = dto.CastLibNum,
+                MemberNum = dto.NumberInCast
+            };
+
+            if (TryResolveMember<LingoMemberScript>(memberMap, reference, out var scriptMember) && scriptMember != null)
+            {
+                behavior = sprite.AddBehavior(scriptMember);
+            }
+        }
+
+        if (behavior != null)
+        {
+            return behavior;
+        }
+
+        var behaviorType = ResolveBehaviorType(dto.BehaviorType);
+        if (behaviorType == null)
+        {
+            return null;
+        }
+
+        return CreateBehaviorByType(sprite, behaviorType);
+    }
+
+    private static LingoSpriteBehavior? CreateBehaviorByType(LingoSprite2D sprite, Type behaviorType)
+    {
+        if (!typeof(LingoSpriteBehavior).IsAssignableFrom(behaviorType))
+        {
+            return null;
+        }
+
+        var method = typeof(LingoSprite2D).GetMethod(nameof(LingoSprite2D.SetBehavior), BindingFlags.Instance | BindingFlags.Public);
+        if (method == null)
+        {
+            return null;
+        }
+
+        return method.MakeGenericMethod(behaviorType).Invoke(sprite, new object?[] { null }) as LingoSpriteBehavior;
+    }
+
+    private static Type? ResolveBehaviorType(string? behaviorTypeName)
+    {
+        if (string.IsNullOrWhiteSpace(behaviorTypeName))
+        {
+            return null;
+        }
+
+        var direct = Type.GetType(behaviorTypeName);
+        if (direct != null && typeof(LingoSpriteBehavior).IsAssignableFrom(direct))
+        {
+            return direct;
+        }
+
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            Type? found;
+            try
+            {
+                found = assembly
+                    .GetTypes()
+                    .FirstOrDefault(t => typeof(LingoSpriteBehavior).IsAssignableFrom(t) && (t.FullName == behaviorTypeName || t.Name == behaviorTypeName));
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (found != null)
+            {
+                return found;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryResolveMember<TMember>(Dictionary<(int CastNum, int MemberNum), LingoMember> memberMap, LingoMemberRefDTO? reference, out TMember? member)
+        where TMember : LingoMember
+    {
+        member = null;
+        if (!TryResolveMember(memberMap, reference, out var baseMember))
+        {
+            return false;
+        }
+
+        if (baseMember is TMember typed)
+        {
+            member = typed;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveMember(Dictionary<(int CastNum, int MemberNum), LingoMember> memberMap, LingoMemberRefDTO? reference, out LingoMember? member)
+    {
+        member = null;
+        if (reference == null || reference.CastLibNum <= 0 || reference.MemberNum <= 0)
+        {
+            return false;
+        }
+
+        if (memberMap.TryGetValue((reference.CastLibNum, reference.MemberNum), out var found))
+        {
+            member = found;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/LingoEngine.IO/SpriteDtoConverter.cs
+++ b/src/LingoEngine.IO/SpriteDtoConverter.cs
@@ -57,6 +57,11 @@ internal static class SpriteDtoConverter
             }
         }
 
+        foreach (var behavior in sprite.Behaviors)
+        {
+            dto.Behaviors.Add(behavior.ToDto());
+        }
+
         return dto;
     }
 


### PR DESCRIPTION
## Summary
- move sprite behavior instantiation and property hydration logic into `SpriteBehaviorDtoConverter`
- update `JsonStateRepository` to rely on the converter when rebuilding sprite behaviors from DTOs

## Testing
- dotnet build src/LingoEngine.IO.Data/LingoEngine.IO.Data.csproj
- dotnet build src/LingoEngine.IO/LingoEngine.IO.csproj

------
https://chatgpt.com/codex/tasks/task_e_68c997c93d508332be2c5e98d22d6695