### PR TITLE
Ensure RNet status updates run on UI thread

### DIFF
--- a/src/Director/LingoEngine.Director.Core/UI/DirectorMainMenu.cs
+++ b/src/Director/LingoEngine.Director.Core/UI/DirectorMainMenu.cs
@@ -357,12 +357,14 @@ namespace LingoEngine.Director.Core.UI
 
         private void OnServerStateChanged(LingoNetConnectionState state)
         {
-            _hostItem.Name = state == LingoNetConnectionState.Connected ? "Stop Host" : "Start Host";
+            _player.RunOnUIThread(() =>
+                _hostItem.Name = state == LingoNetConnectionState.Connected ? "Stop Host" : "Start Host");
         }
 
         private void OnClientStateChanged(LingoNetConnectionState state)
         {
-            _clientItem.Name = state == LingoNetConnectionState.Connected ? "Stop Client" : "Start Client";
+            _player.RunOnUIThread(() =>
+                _clientItem.Name = state == LingoNetConnectionState.Connected ? "Stop Client" : "Start Client");
         }
 
 


### PR DESCRIPTION
## Summary
- wrap Director main menu host and client status updates in `LingoPlayer.RunOnUIThread` to safely touch Godot UI from connection callbacks

## Testing
- dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj

------
https://chatgpt.com/codex/tasks/task_e_68c9bf1fccac833286ef79b08184064d