### PR TITLE
Update Director remote UI for host/client selection

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Projects/DirectorProjectManager.cs
+++ b/src/Director/LingoEngine.Director.Core/Projects/DirectorProjectManager.cs
@@ -117,6 +117,7 @@ public class DirectorProjectManager : IAbstCommandHandler<SaveDirProjectSettings
         _dirSettings.RNet.Port = _rnetConfig.Port;
         _dirSettings.RNet.AutoStartRNetHostOnStartup = _rnetConfig.AutoStartRNetHostOnStartup;
         _dirSettings.RNet.ClientType = _rnetConfig.ClientType;
+        _dirSettings.RNet.RemoteRole = _rnetConfig.RemoteRole;
 
         var states = new Dictionary<string, DirectorWindowState>();
         if (_windowManager is AbstWindowManager dm)
@@ -153,10 +154,12 @@ public class DirectorProjectManager : IAbstCommandHandler<SaveDirProjectSettings
         _dirSettings.RNet.Port = loaded.RNet.Port;
         _dirSettings.RNet.AutoStartRNetHostOnStartup = loaded.RNet.AutoStartRNetHostOnStartup;
         _dirSettings.RNet.ClientType = loaded.RNet.ClientType;
+        _dirSettings.RNet.RemoteRole = loaded.RNet.RemoteRole;
 
         _rnetConfig.Port = loaded.RNet.Port;
         _rnetConfig.AutoStartRNetHostOnStartup = loaded.RNet.AutoStartRNetHostOnStartup;
         _rnetConfig.ClientType = loaded.RNet.ClientType;
+        _rnetConfig.RemoteRole = loaded.RNet.RemoteRole;
 
         _dirSettings.WindowStates = loaded.WindowStates;
 

--- a/src/Director/LingoEngine.Director.Core/Remote/DirectorRNetClient.cs
+++ b/src/Director/LingoEngine.Director.Core/Remote/DirectorRNetClient.cs
@@ -38,6 +38,11 @@ public sealed class DirectorRNetClient :
 
     public bool CanExecute(ConnectRNetClientCommand command)
     {
+        if (_config.RemoteRole != RNetRemoteRole.Client)
+        {
+            return false;
+        }
+
         if (_activeClient is { IsConnected: true })
         {
             return false;
@@ -48,6 +53,11 @@ public sealed class DirectorRNetClient :
 
     public bool Handle(ConnectRNetClientCommand command)
     {
+        if (_config.RemoteRole != RNetRemoteRole.Client)
+        {
+            return false;
+        }
+
         var client = GetClientForConfiguration();
         SwapActiveClient(client);
 
@@ -58,6 +68,11 @@ public sealed class DirectorRNetClient :
 
     public bool CanExecute(DisconnectRNetClientCommand command)
     {
+        if (_config.RemoteRole != RNetRemoteRole.Client)
+        {
+            return false;
+        }
+
         if (_activeClient is not null)
         {
             return _activeClient.IsConnected;
@@ -68,6 +83,11 @@ public sealed class DirectorRNetClient :
 
     public bool Handle(DisconnectRNetClientCommand command)
     {
+        if (_config.RemoteRole != RNetRemoteRole.Client)
+        {
+            return false;
+        }
+
         var client = _activeClient ?? GetClientForConfiguration();
         client.DisconnectAsync().GetAwaiter().GetResult();
         return true;

--- a/src/Director/LingoEngine.Director.Core/Remote/RNetSettingsDialog.cs
+++ b/src/Director/LingoEngine.Director.Core/Remote/RNetSettingsDialog.cs
@@ -1,17 +1,19 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using AbstUI.Commands;
 using AbstUI.Components.Containers;
+using AbstUI.Components.Inputs;
 using AbstUI.Primitives;
 using AbstUI.Windowing;
 using LingoEngine.Director.Core.Projects.Commands;
 using LingoEngine.Director.Core.Remote.Commands;
 using LingoEngine.FrameworkCommunication;
 using LingoEngine.Net.RNetContracts;
+using LingoEngine.Net.RNetHost.Common;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LingoEngine.Director.Core.Remote;
-
 
 public class RNetSettingsDialogHandler : IAbstCommandHandler<OpenRNetSettingsCommand>
 {
@@ -28,39 +30,59 @@ public class RNetSettingsDialogHandler : IAbstCommandHandler<OpenRNetSettingsCom
 
     public bool Handle(OpenRNetSettingsCommand command)
     {
-        Action requestClose = new Action(() => { });
         var dialog = _serviceProvider.GetRequiredService<RNetSettingsDialog>();
+        var projectServer = _serviceProvider.GetRequiredService<IRNetProjectServer>();
+        var pipeServer = _serviceProvider.GetService<IRNetPipeServer>();
+        dialog.ProjectServerAvailable = projectServer is not DummyRNetProjectServer;
+        dialog.PipeServerAvailable = pipeServer is not null;
+
         var rootNode = dialog.Create();
         var window = _windowManager.ShowCustomDialog("Remote Settings", rootNode.Framework<IAbstFrameworkPanel>());
         if (window != null)
+        {
             dialog.RequestClose = window.Close;
+        }
+
         return true;
     }
 }
 
-
 /// <summary>Displays and edits RNet configuration settings.</summary>
 public class RNetSettingsDialog
 {
+    private static readonly KeyValuePair<string, string> HostRoleItem = new(RNetRemoteRole.Host.ToString(), "Remote Host");
+    private static readonly KeyValuePair<string, string> ClientRoleItem = new(RNetRemoteRole.Client.ToString(), "Remote Client");
+
     private readonly ILingoFrameworkFactory _factory;
     private readonly IRNetConfiguration _settings;
     private readonly IAbstCommandManager _commandManager;
     private readonly IAbstWindowManager _windowManager;
-    private static readonly KeyValuePair<string, string>[] ClientTypes =
-    [
-        new KeyValuePair<string, string>(RNetClientType.Project.ToString(), "Project Client (SignalR)"),
-        new KeyValuePair<string, string>(RNetClientType.Pipe.ToString(), "Pipe Client"),
-    ];
-    private Action _requestClose = new Action(() => { });
-    public Action RequestClose {
+
+    private Action _requestClose = new(() => { });
+    private AbstInputCombobox? _roleCombo;
+    private AbstInputCombobox? _transportCombo;
+    private AbstInputCheckbox? _autoStartCheckbox;
+
+    public bool ProjectServerAvailable { get; set; } = true;
+    public bool PipeServerAvailable { get; set; } = true;
+
+    public Action RequestClose
+    {
         get => _requestClose;
         set
         {
             if (value != null)
+            {
                 _requestClose = value;
+            }
         }
     }
-    public RNetSettingsDialog(ILingoFrameworkFactory factory, IRNetConfiguration settings, IAbstCommandManager commandManager, IAbstWindowManager windowManager)
+
+    public RNetSettingsDialog(
+        ILingoFrameworkFactory factory,
+        IRNetConfiguration settings,
+        IAbstCommandManager commandManager,
+        IAbstWindowManager windowManager)
     {
         _factory = factory;
         _settings = settings;
@@ -68,47 +90,225 @@ public class RNetSettingsDialog
         _windowManager = windowManager;
     }
 
-   
     public AbstPanel Create()
     {
+        EnsureValidConfiguration();
+
         var root = _factory.CreatePanel("RemoteSettingsRoot");
-        root.Width = 300;
-        root.Height = 140;
-        AbstWrapPanel wrap = _factory.CreateWrapPanel(AOrientation.Vertical, "RemoteSettingsWrap");
+        root.Width = 340;
+        root.Height = 190;
+
+        var wrap = _factory.CreateWrapPanel(AOrientation.Vertical, "RemoteSettingsWrap");
         wrap.Width = root.Width - 30;
         wrap.Height = root.Height - 30;
         wrap.Margin = new AMargin(15, 15, 15, 15);
+        wrap.ItemMargin = new APoint(0, 6);
+
         wrap.Compose()
-            .NewLine("ClientTypeRow")
-            .AddLabel("ClientTypeLabel", "Client:", 11, 60)
-            .AddCombobox(
-                "ClientTypeCombo",
-                ClientTypes,
-                180,
-                _settings.ClientType.ToString(),
-                selected =>
-                {
-                    if (!string.IsNullOrWhiteSpace(selected))
-                    {
-                        _settings.ClientType = Enum.Parse<RNetClientType>(selected);
-                    }
-                })
+            .NewLine("RoleRow")
+            .AddLabel("RoleLabel", "Remote Mode:", 11, 120)
+            .Configure(row =>
+            {
+                _roleCombo = _factory.CreateInputCombobox("RemoteModeCombo", OnRoleChanged);
+                _roleCombo.Width = 180;
+                PopulateRoleOptions();
+                row.AddItem(_roleCombo);
+            })
+            .NewLine("TransportRow")
+            .AddLabel("TransportLabel", "Transport:", 11, 120)
+            .Configure(row =>
+            {
+                _transportCombo = _factory.CreateInputCombobox("RemoteTransportCombo", OnTransportChanged);
+                _transportCombo.Width = 180;
+                PopulateTransportOptions(_settings.RemoteRole);
+                row.AddItem(_transportCombo);
+            })
             .NewLine("PortRow")
-            .AddLabel("PortLabel", "Port:", 11, 60)
-            .AddNumericInputInt("PortInput", _settings, s => s.Port, 60)
+            .AddLabel("PortLabel", "Port:", 11, 120)
+            .AddNumericInputInt("PortInput", _settings, s => s.Port, 80)
             .NewLine("AutoStartRow")
+            .AddLabel("AutoStartLabel", "Auto-start host:", 11, 120)
+            .Configure(row =>
+            {
+                _autoStartCheckbox = _factory.CreateInputCheckbox("AutoStartCheckbox", value => _settings.AutoStartRNetHostOnStartup = value);
+                _autoStartCheckbox.Checked = _settings.AutoStartRNetHostOnStartup;
+                row.AddItem(_autoStartCheckbox);
+            })
+            .NewLine("ButtonsRow")
             .AddButton("BtnSave", "Save", () =>
             {
-                var result = _commandManager.Handle(new SaveDirProjectSettingsCommand());
-                if (!result)
+                if (!_commandManager.Handle(new SaveDirProjectSettingsCommand()))
                 {
-                    _windowManager.ShowNotification("Project not set correcty. Set project settings first.", AbstUINotificationType.Error);
+                    _windowManager.ShowNotification(
+                        "Project not set correcty. Set project settings first.",
+                        AbstUINotificationType.Error);
+                    return;
                 }
-                else
-                    _requestClose();
+
+                _requestClose();
             })
-            ;
+            .Finalize();
+
+        UpdateControlAvailability();
+
         root.AddItem(wrap, 0, 0);
         return root;
+    }
+
+    private void OnRoleChanged(string? selectedKey)
+    {
+        if (string.IsNullOrWhiteSpace(selectedKey))
+        {
+            return;
+        }
+
+        _settings.RemoteRole = Enum.Parse<RNetRemoteRole>(selectedKey);
+        EnsureValidConfiguration();
+
+        if (_roleCombo is not null)
+        {
+            var current = _settings.RemoteRole.ToString();
+            if (_roleCombo.SelectedKey != current)
+            {
+                _roleCombo.SelectedKey = current;
+            }
+        }
+
+        PopulateTransportOptions(_settings.RemoteRole);
+        UpdateControlAvailability();
+    }
+
+    private void OnTransportChanged(string? selectedKey)
+    {
+        if (string.IsNullOrWhiteSpace(selectedKey))
+        {
+            return;
+        }
+
+        _settings.ClientType = Enum.Parse<RNetClientType>(selectedKey);
+    }
+
+    private void PopulateRoleOptions()
+    {
+        if (_roleCombo is null)
+        {
+            return;
+        }
+
+        _roleCombo.ClearItems();
+        foreach (var item in BuildRoleItems())
+        {
+            _roleCombo.AddItem(item.Key, item.Value);
+        }
+
+        _roleCombo.SelectedKey = _settings.RemoteRole.ToString();
+    }
+
+    private void PopulateTransportOptions(RNetRemoteRole role)
+    {
+        if (_transportCombo is null)
+        {
+            return;
+        }
+
+        var items = BuildTransportItems(role).ToList();
+        _transportCombo.ClearItems();
+        foreach (var item in items)
+        {
+            _transportCombo.AddItem(item.Key, item.Value);
+        }
+
+        if (!items.Any(i => i.Key == _settings.ClientType.ToString()))
+        {
+            if (items.FirstOrDefault() is { Key: { } key })
+            {
+                _settings.ClientType = Enum.Parse<RNetClientType>(key);
+            }
+        }
+
+        var transportKey = _settings.ClientType.ToString();
+        if (_transportCombo.SelectedKey != transportKey)
+        {
+            _transportCombo.SelectedKey = transportKey;
+        }
+    }
+
+    private IEnumerable<KeyValuePair<string, string>> BuildRoleItems()
+    {
+        if (HostModeAvailable())
+        {
+            yield return HostRoleItem;
+        }
+
+        yield return ClientRoleItem;
+    }
+
+    private IEnumerable<KeyValuePair<string, string>> BuildTransportItems(RNetRemoteRole role)
+    {
+        var prefix = role == RNetRemoteRole.Host ? "Server" : "Client";
+
+        if (role != RNetRemoteRole.Host || PipeServerAvailable)
+        {
+            yield return new KeyValuePair<string, string>(RNetClientType.Pipe.ToString(), $"{prefix} Pipe");
+        }
+
+        if (role != RNetRemoteRole.Host || ProjectServerAvailable)
+        {
+            yield return new KeyValuePair<string, string>(RNetClientType.Project.ToString(), $"{prefix} Project (Socket)");
+        }
+    }
+
+    private bool HostModeAvailable() => ProjectServerAvailable || PipeServerAvailable;
+
+    private void EnsureValidConfiguration()
+    {
+        if (_settings.RemoteRole == RNetRemoteRole.Host)
+        {
+            if (!HostModeAvailable())
+            {
+                _settings.RemoteRole = RNetRemoteRole.Client;
+            }
+            else
+            {
+                if (_settings.ClientType == RNetClientType.Project && !ProjectServerAvailable)
+                {
+                    if (PipeServerAvailable)
+                    {
+                        _settings.ClientType = RNetClientType.Pipe;
+                    }
+                    else
+                    {
+                        _settings.RemoteRole = RNetRemoteRole.Client;
+                    }
+                }
+
+                if (_settings.ClientType == RNetClientType.Pipe && !PipeServerAvailable)
+                {
+                    if (ProjectServerAvailable)
+                    {
+                        _settings.ClientType = RNetClientType.Project;
+                    }
+                    else
+                    {
+                        _settings.RemoteRole = RNetRemoteRole.Client;
+                    }
+                }
+            }
+        }
+    }
+
+    private void UpdateControlAvailability()
+    {
+        var isHost = _settings.RemoteRole == RNetRemoteRole.Host;
+        if (_autoStartCheckbox is not null)
+        {
+            _autoStartCheckbox.Enabled = isHost;
+            _autoStartCheckbox.Checked = _settings.AutoStartRNetHostOnStartup;
+        }
+
+        if (_transportCombo is not null)
+        {
+            _transportCombo.Enabled = isHost ? HostModeAvailable() : true;
+        }
     }
 }

--- a/src/Net/LingoEngine.Net.RNetContracts/IRNetConfiguration.cs
+++ b/src/Net/LingoEngine.Net.RNetContracts/IRNetConfiguration.cs
@@ -11,6 +11,9 @@ public interface IRNetConfiguration
     /// <summary>Name of the client application.</summary>
     string ClientName { get; set; }
 
+    /// <summary>Indicates whether the instance runs as a remote host or client.</summary>
+    RNetRemoteRole RemoteRole { get; set; }
+
     /// <summary>The transport implementation that should be used by the client.</summary>
     RNetClientType ClientType { get; set; }
 }

--- a/src/Net/LingoEngine.Net.RNetContracts/RNetConfiguration.cs
+++ b/src/Net/LingoEngine.Net.RNetContracts/RNetConfiguration.cs
@@ -13,6 +13,9 @@ public class RNetConfiguration : IRNetConfiguration
     public string ClientName { get; set; } = "Someone";
 
     /// <inheritdoc />
+    public RNetRemoteRole RemoteRole { get; set; } = RNetRemoteRole.Client;
+
+    /// <inheritdoc />
     public RNetClientType ClientType { get; set; } = RNetClientType.Project;
 }
 

--- a/src/Net/LingoEngine.Net.RNetContracts/RNetRemoteRole.cs
+++ b/src/Net/LingoEngine.Net.RNetContracts/RNetRemoteRole.cs
@@ -1,0 +1,13 @@
+namespace LingoEngine.Net.RNetContracts;
+
+/// <summary>
+/// Describes whether the current instance should act as a remote host or client.
+/// </summary>
+public enum RNetRemoteRole
+{
+    /// <summary>Expose the current project as a remote host.</summary>
+    Host,
+
+    /// <summary>Connect to an external host as a client.</summary>
+    Client
+}

--- a/src/Net/LingoEngine.Net.RNetHost.Common/IRNetPipeServer.cs
+++ b/src/Net/LingoEngine.Net.RNetHost.Common/IRNetPipeServer.cs
@@ -1,0 +1,8 @@
+namespace LingoEngine.Net.RNetHost.Common;
+
+/// <summary>
+/// Contract for RNet servers that communicate over named pipes or Unix domain sockets.
+/// </summary>
+public interface IRNetPipeServer : ILingoRNetServer
+{
+}

--- a/src/Net/LingoEngine.Net.RNetPipeServer/RNetPipeServer.cs
+++ b/src/Net/LingoEngine.Net.RNetPipeServer/RNetPipeServer.cs
@@ -22,8 +22,6 @@ namespace LingoEngine.Net.RNetPipeServer;
 /// <summary>
 /// Pipe-based implementation of the RNet host.
 /// </summary>
-public interface IRNetPipeServer : ILingoRNetServer { }
-
 /// <inheritdoc />
 public sealed class RNetPipeServer : IRNetPipeServer
 {
@@ -63,6 +61,7 @@ public sealed class RNetPipeServer : IRNetPipeServer
         public bool AutoStartRNetHostOnStartup { get; set; }
         public string ClientName { get; set; } = "PipeHost";
         public RNetClientType ClientType { get; set; } = RNetClientType.Pipe;
+        public RNetRemoteRole RemoteRole { get; set; } = RNetRemoteRole.Host;
     }
 
     /// <inheritdoc />

--- a/src/Net/LingoEngine.Net.RNetProjectClient/LingoRNetProjectClient.cs
+++ b/src/Net/LingoEngine.Net.RNetProjectClient/LingoRNetProjectClient.cs
@@ -33,6 +33,7 @@ public sealed class LingoRNetProjectClient : ILingoRNetProjectClient
         public bool AutoStartRNetHostOnStartup { get; set; }
         public string ClientName { get; set; } = "Some client";
         public RNetClientType ClientType { get; set; } = RNetClientType.Project;
+        public RNetRemoteRole RemoteRole { get; set; } = RNetRemoteRole.Client;
     }
 
     /// <inheritdoc />

--- a/src/Net/LingoEngine.Net.RNetProjectHost/RNetProjectServer.cs
+++ b/src/Net/LingoEngine.Net.RNetProjectHost/RNetProjectServer.cs
@@ -35,6 +35,7 @@ public sealed class RNetProjectServer : IRNetProjectServer
         public bool AutoStartRNetHostOnStartup { get; set; }
         public string ClientName { get; set; } = "TheHost";
         public RNetClientType ClientType { get; set; } = RNetClientType.Project;
+        public RNetRemoteRole RemoteRole { get; set; } = RNetRemoteRole.Host;
     }
     public bool DetailedLogging { get; set; } = true;
 


### PR DESCRIPTION
## Summary
- add remote role support to the shared RNet configuration and default implementations
- overhaul the Director remote settings dialog to choose host/client mode, transport, and auto-start with host availability checks
- update the Director remote server/client wrappers and main menu to respect the selected mode and surface only the relevant actions
- expose an IRNetPipeServer contract in RNetHost.Common so Director depends only on interfaces

## Testing
- dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj
- dotnet build src/Net/LingoEngine.Net.RNetPipeServer/LingoEngine.Net.RNetPipeServer.csproj

------
https://chatgpt.com/codex/tasks/task_e_68ca2c98463083329a70e25020039097