### PR TITLE
Adjust remote transport selection and ensure settings directory

### DIFF
--- a/src/Director/LingoEngine.Director.Core/Projects/LingoProjectSettingsRepository.cs
+++ b/src/Director/LingoEngine.Director.Core/Projects/LingoProjectSettingsRepository.cs
@@ -8,6 +8,9 @@ public class LingoProjectSettingsRepository
 {
     public void Save(string filePath, LingoProjectSettings settings)
     {
+        var directory = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory))
+            Directory.CreateDirectory(directory);
         var options = new JsonSerializerOptions { WriteIndented = true };
         var json = JsonSerializer.Serialize(settings, options);
         File.WriteAllText(filePath, json);


### PR DESCRIPTION
## Summary
- reorder the remote settings dialog to choose the transport before the remote role
- update transport and role population logic so host mode appears when the selected transport supports hosting
- create the destination directory when saving project settings to avoid missing path errors

## Testing
- dotnet build src/Director/LingoEngine.Director.Core/LingoEngine.Director.Core.csproj

------
https://chatgpt.com/codex/tasks/task_e_68ca8f165b988332a6b726ab806f6fa9