### PR TITLE
[Coded] Fix TetriGrounds path resolution and sprite APIs

### DIFF
--- a/Test/BlingoEngine.Lingo.Core.Tests/BlingoToCSharpConverterTests.cs
+++ b/Test/BlingoEngine.Lingo.Core.Tests/BlingoToCSharpConverterTests.cs
@@ -614,8 +614,7 @@ end";
     {
         string root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory,
             "..", "..", "..", "..", ".."));
-        string ls = File.ReadAllText(Path.Combine(root, "Demo", "TetriGrounds",
-            "TetriGrounds.Lingo.Original", "13_B_NewGame.ls"));
+        string ls = File.ReadAllText(Path.Combine(TetriGroundsTestData.GetOriginalScriptsDirectory(), "13_B_NewGame.ls"));
         string expected = File.ReadAllText(Path.Combine(root, "Demo",
             "TetriGrounds", "BlingoEngine.Demo.TetriGrounds.Core", "Sprites",
             "Behaviors", "NewGameBehavior.cs"));

--- a/Test/BlingoEngine.Lingo.Core.Tests/BundleConversionTests.cs
+++ b/Test/BlingoEngine.Lingo.Core.Tests/BundleConversionTests.cs
@@ -22,7 +22,7 @@ public class BundleConversionTests
     [Fact]
     public void DemoScriptsAreConvertedToValidClasses()
     {
-        var baseDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "Demo", "TetriGrounds", "TetriGrounds.Lingo.Original"));
+        var baseDir = TetriGroundsTestData.GetOriginalScriptsDirectory();
         var files = Directory.GetFiles(baseDir, "*.ls");
         var scripts = files
             .Select(f =>
@@ -50,7 +50,7 @@ public class BundleConversionTests
     [Fact]
     public void DemoScriptsAreWrittenToGeneratedFolder()
     {
-        var baseDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "Demo", "TetriGrounds", "TetriGrounds.Lingo.Original"));
+        var baseDir = TetriGroundsTestData.GetOriginalScriptsDirectory();
         var generatedDir = Path.Combine(baseDir, "Generated");
         if (Directory.Exists(generatedDir))
             Directory.Delete(generatedDir, true);
@@ -82,7 +82,7 @@ public class BundleConversionTests
     [Fact]
     public void SpriteManagerScriptIsConverted()
     {
-        var baseDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "Demo", "TetriGrounds", "TetriGrounds.Lingo.Original"));
+        var baseDir = TetriGroundsTestData.GetOriginalScriptsDirectory();
         var path = Path.Combine(baseDir, "3_SpriteManager.ls");
         var script = new BlingoScriptFile("3_SpriteManager", File.ReadAllText(path)) { RelativeDirectory = null };
         _converter.Convert(new[] { script }, new ConversionOptions { Namespace = "Demo.TetriGrounds" });
@@ -117,7 +117,7 @@ public class BundleConversionTests
     [Fact]
     public void ConstructorParameterTypesAreInferred()
     {
-        var baseDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "Demo", "TetriGrounds", "TetriGrounds.Lingo.Original"));
+        var baseDir = TetriGroundsTestData.GetOriginalScriptsDirectory();
         var path = Path.Combine(baseDir, "3_SpriteManager.ls");
         var script = new BlingoScriptFile("3_SpriteManager", File.ReadAllText(path), ScriptDetectionType.Parent);
         _converter.Convert(new[] { script });
@@ -128,7 +128,7 @@ public class BundleConversionTests
     [Fact]
     public void ParameterAssignedAfterVoidCheckIsInferred()
     {
-        var baseDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "Demo", "TetriGrounds", "TetriGrounds.Lingo.Original"));
+        var baseDir = TetriGroundsTestData.GetOriginalScriptsDirectory();
         var path = Path.Combine(baseDir, "10_Block.ls");
         var script = new BlingoScriptFile("10_Block", File.ReadAllText(path), ScriptDetectionType.Parent);
         _converter.Convert(new[] { script });

--- a/Test/BlingoEngine.Lingo.Core.Tests/TetriGroundsTestData.cs
+++ b/Test/BlingoEngine.Lingo.Core.Tests/TetriGroundsTestData.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace BlingoEngine.Lingo.Core.Tests;
+
+internal static class TetriGroundsTestData
+{
+    private static string _cachedOriginalScriptsDirectory = string.Empty;
+
+    public static string GetOriginalScriptsDirectory()
+    {
+        if (!string.IsNullOrEmpty(_cachedOriginalScriptsDirectory))
+            return _cachedOriginalScriptsDirectory;
+
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory,
+            "..", "..", "..", "..", "..", "Demo", "TetriGrounds"));
+        var candidates = new[]
+        {
+            "TetriGrounds.Lingo.Original",
+            "TetriGrounds.Blingo.Original"
+        };
+
+        foreach (var name in candidates)
+        {
+            var candidate = Path.Combine(root, name);
+            if (Directory.Exists(candidate) && Directory.EnumerateFiles(candidate, "*.ls", SearchOption.TopDirectoryOnly).Any())
+            {
+                _cachedOriginalScriptsDirectory = candidate;
+                return candidate;
+            }
+        }
+
+        throw new DirectoryNotFoundException($"Could not locate TetriGrounds original scripts under '{root}'.");
+    }
+}

--- a/Test/BlingoEngine.Tests/RtfToMarkdownTests.cs
+++ b/Test/BlingoEngine.Tests/RtfToMarkdownTests.cs
@@ -358,7 +358,7 @@ public class RtfToMarkdownTests
 
         var data = RtfToMarkdown.Convert(rtf);
 
-        data.PlainText.Should().Be("Â© 2005 by Emmanuel The Creator\n");
+        data.PlainText.Should().Be("\u00A9 2005 by Emmanuel The Creator\n");
     }
 
     [Fact]

--- a/src/BlingoEngine/Animations/BlingoSpriteAnimatorProperties.cs
+++ b/src/BlingoEngine/Animations/BlingoSpriteAnimatorProperties.cs
@@ -58,8 +58,8 @@ namespace BlingoEngine.Animations
             }
         }
 
-        internal IReadOnlyCollection<BlingoKeyFrameSetting>? GetKeyFrames() => _settings.Values;
-        internal void MoveKeyFrame(int from, int to)
+        public IReadOnlyCollection<BlingoKeyFrameSetting>? GetKeyFrames() => _settings.Values;
+        public void MoveKeyFrame(int from, int to)
         {
             if (from == to)
                 return;

--- a/src/BlingoEngine/FilmLoops/BlingoFilmLoopMemberSprite.cs
+++ b/src/BlingoEngine/FilmLoops/BlingoFilmLoopMemberSprite.cs
@@ -80,7 +80,7 @@ namespace BlingoEngine.FilmLoops
             _animatorProperties = new BlingoSpriteAnimatorProperties();
         }
 
-        public BlingoFilmLoopMemberSprite(IBlingoMember member, int channel=0, int begin = 0, int end = 0, int locH = 0, int locV=0) : this()
+        public BlingoFilmLoopMemberSprite(IBlingoMember member, int channel = 0, int begin = 0, int end = 0, int locH = 0, int locV = 0) : this()
         {
             if (member != null)
                 SetMember(member);
@@ -89,8 +89,10 @@ namespace BlingoEngine.FilmLoops
             Channel = channel;
             LocH = locH;
             LocV = locV;
-            Width = 50;
-            Height = 50;
+            if (Width == 0)
+                Width = 50;
+            if (Height == 0)
+                Height = 50;
             InkType = BlingoInkType.Matte;
         }
 

--- a/src/BlingoEngine/Sprites/BlingoSprite2DManager.cs
+++ b/src/BlingoEngine/Sprites/BlingoSprite2DManager.cs
@@ -179,14 +179,14 @@ namespace BlingoEngine.Sprites
         internal void SetSpriteMember(int number, int memberNumber) => CallActiveSprite(number, s => s.SetMember(memberNumber));
 
 
-        internal bool RollOver(int spriteNumber)
+        public bool RollOver(int spriteNumber)
         {
             if (!_activeSprites.TryGetValue(spriteNumber, out var sprite))
                 return false;
             return sprite.IsMouseInsideBoundingBox(_blingoMouse);
         }
 
-        internal int RollOver()
+        public int RollOver()
         {
             var sprite = GetSpriteUnderMouse();
             return sprite?.SpriteNum ?? 0;


### PR DESCRIPTION
## Summary
- add a TetriGroundsTestData helper and update the Lingo conversion tests to locate whichever original script folder exists
- expose the sprite manager roll-over checks and keyframe accessors while keeping film loop sprites aligned with their member dimensions
- correct the Unicode expectation in the RtfToMarkdown test

## Testing
- dotnet test Test/BlingoEngine.Lingo.Core.Tests/BlingoEngine.Lingo.Core.Tests.csproj
- dotnet test Test/BlingoEngine.Blingo.Tests/BlingoEngine.Blingo.Tests.csproj
- dotnet test Test/BlingoEngine.Tests/BlingoEngine.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cabbe25c08833281eaede16b30146f