### PR TITLE
Fix NuGet version formatting in SetGodotVersion

### DIFF
--- a/scripts/SetGodotVersion.ps1
+++ b/scripts/SetGodotVersion.ps1
@@ -3,7 +3,7 @@ if(-not $VersionTag){
     $VersionTag = Read-Host 'Enter Godot version (e.g., 4.5-dev5)'
 }
 if($VersionTag -match '^(\d+\.\d+)-(.*)$'){
-    $NugetVersion = "$($Matches[1]).0-" + ($Matches[2] -replace '-', '.')
+    $NugetVersion = '{0}.0-{1}' -f $Matches[1], $Matches[2]
 }else{
     $NugetVersion = $VersionTag
 }


### PR DESCRIPTION
## Summary
- stop replacing hyphens with dots in SetGodotVersion.ps1 so the generated NuGet version keeps the expected pre-release tag (e.g. 4.5.0-dev5)

## Testing
- not run (PowerShell not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cac7ca633083328803760cabec1712