### PR TITLE
Document ScummVM director docs review checkpoint

### DIFF
--- a/docs/DirDissasembly/ScummVm/readme.md
+++ b/docs/DirDissasembly/ScummVm/readme.md
@@ -18,3 +18,21 @@
 - [Movie Cast Members](./Movie%20Members.md)
 - [Digital Video Cast Members](./Video%20Members.md)
 - [Script Cast Members](./Script%20Members.md)
+
+---
+
+## Update Tracking
+
+- **Last verified:** 2025-09-18 07:01 UTC
+- **ScummVM reference:** [`4eb06084a8449d8c8e5060d8611bd101c6b39cee`](https://github.com/scummvm/scummvm/tree/4eb06084a8449d8c8e5060d8611bd101c6b39cee/engines/director)
+
+To refresh these notes in the future, fetch the latest `master` branch from the ScummVM repository and diff the Director engine folder against commit `4eb06084a8449d8c8e5060d8611bd101c6b39cee`:
+
+```bash
+git clone https://github.com/scummvm/scummvm.git  # or reuse an existing clone
+cd scummvm
+git fetch origin                                  # ensure origin/master is current when reusing a clone
+git diff 4eb06084a8449d8c8e5060d8611bd101c6b39cee..origin/master -- engines/director
+```
+
+Review any changes the diff reports, update the documentation accordingly, and then bump the timestamp and commit hash above so the next scan has an exact comparison point.


### PR DESCRIPTION
## Summary
- record the 2025-09-18 audit timestamp and the upstream ScummVM commit hash for the Director documentation set
- explain how to diff the Director folder against that commit so future reviews can zero in on upstream changes quickly

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cbadc7ec648332be81831909a88a85