### PR TITLE
Add legacy Director file format documentation

### DIFF
--- a/src/BlingoEngine.IO.Legacy/docs/README.md
+++ b/src/BlingoEngine.IO.Legacy/docs/README.md
@@ -1,0 +1,7 @@
+# Legacy Director File Documentation
+
+These notes summarize the on-disk formats handled by `BlingoEngine.IO.Legacy`. They focus on the structures that appear in classic Director movies, Shockwave exports, and cast libraries.
+
+- [Director Movie (`.dir`) Container](./dir-format.md)
+- [Shockwave Movie (`.dcr`) Container](./dcr-format.md)
+- [Cast Library (`.cst`) Resources](./cst-format.md)

--- a/src/BlingoEngine.IO.Legacy/docs/cst-format.md
+++ b/src/BlingoEngine.IO.Legacy/docs/cst-format.md
@@ -1,0 +1,76 @@
+# Cast Library (`.cst`) Resources
+
+## Overview
+
+Cast libraries hold the assets that populate a Director movie: sprites, scripts, sounds, and other cast members. Exported movies keep this information in `CASt` resources that are referenced through `KEY*` and `CAS*` tables. Understanding these tables makes it easier to resolve each cast slot back to the chunk that supplies its data.
+
+## `KEY*` – parent/child relationships
+
+`KEY*` resources are always read before any cast data is parsed. Each row in the table links a parent resource (movie or cast library) to a child resource (such as `CASt`, `Lscr`, or media chunks).
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| Entry size | 2 bytes | Confirms the 12-byte row layout. |
+| Reserved size | 2 bytes | Secondary size field stored alongside the entry size. |
+| Total rows | 4 bytes | Number of allocated rows in the table. |
+| Used rows | 4 bytes | Number of rows that contain actual data. |
+| Child resource id | 4 bytes per row | Resource index of the child chunk. |
+| Parent resource id | 4 bytes per row | Resource index of the owning movie or cast library. |
+| Child tag | 4 bytes per row | Four-character code that identifies the child resource type. |
+
+When a row references a `CAS*` resource, the loader records which library owns that table before continuing.
+
+## `CAS*` – cast slot lookup
+
+After the `KEY*` table is processed, each referenced `CAS*` chunk is opened. The chunk consists of a series of big-endian 32-bit cast indices:
+
+| Value | Meaning |
+| --- | --- |
+| `00 00 00 00` | Empty cast slot. |
+| Non-zero | Resource id of the `CASt` chunk that supplies the cast member. |
+
+The slot position in the table becomes the cast member number, and the parent id recorded from `KEY*` identifies the cast library that owns the slot.
+
+## `CASt` – cast member records
+
+Every cast member ultimately lives in a `CASt` resource. The header layout changes across Director releases, but the goal is the same: isolate a small block of cast-specific bytes ("cast data") and optional metadata ("cast info") before passing the payload to the appropriate loader.
+
+### Director 2–3 (`VWCR` entries)
+
+Earlier movies use the `VWCR` block instead of standalone `CASt` resources. Each entry is parsed as:
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| Entry size | 1 byte | Total length of the entry, including the type byte. |
+| Cast type | 1 byte | Enumerated cast type (bitmap, text, palette, etc.). |
+| Flags1 | 1 byte (optional) | Present when `entry size` is greater than 1. |
+| Cast payload | Remaining bytes | Forwarded directly to the cast-type loader. |
+
+### Director 4–5 (`CASt` header)
+
+Director 4 introduces explicit `CASt` chunks with a short header:
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| Cast data size | 2 bytes | Big-endian length of the cast-data section (includes the type byte). |
+| Cast info size | 4 bytes | Big-endian length of the metadata block that follows the cast data. |
+| Cast type | 1 byte | Identifies which cast subclass should parse the payload. |
+| Flags1 | 1 byte (optional) | Present when the cast data size exceeds one byte. |
+| Cast data payload | `cast data size` − consumed bytes | Bytes passed to the cast-specific parser. |
+| Cast info payload | `cast info size` bytes | Optional metadata strings or timestamps. |
+
+### Director 5–10 (`CASt` header)
+
+Later versions expand the header and reorder the fields:
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| Cast type | 4 bytes | Four-character tag stored in big endian. |
+| Cast info size | 4 bytes | Big-endian length of the metadata block that immediately follows. |
+| Cast data size | 4 bytes | Big-endian length of the cast-data section stored after the info block. |
+| Cast info payload | `cast info size` bytes | Optional metadata strings or timestamps. |
+| Cast data payload | `cast data size` bytes | Bytes forwarded to the cast-specific parser. |
+
+### Loading process
+
+Regardless of the version, the loader wraps the cast-data payload in a memory stream, instantiates the matching cast member class, and attaches any linked resources recorded in the `KEY*` table. This allows higher-level systems to fetch sprites, scripts, and media by cast member number without re-reading the tables.

--- a/src/BlingoEngine.IO.Legacy/docs/dcr-format.md
+++ b/src/BlingoEngine.IO.Legacy/docs/dcr-format.md
@@ -1,0 +1,86 @@
+# Shockwave Movie (`.dcr`) Container
+
+## Overview
+
+Shockwave exports use the same RIFF foundation as classic movies but switch the archive type to `FGDM` or `FGDC`. These identifiers signal the "Afterburner" layout: the resource table is compressed, offsets are encoded with variable-length integers, and selected resources may be preloaded into memory.
+
+## Top-level structure
+
+The first twelve bytes match the standard RIFX layout:
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| `RIFX` / `XFIR` | 4 bytes | Container signature (`RIFX` = big-endian, `XFIR` = little-endian). |
+| Chunk size | 4 bytes | Total length of the movie chunk, including the header. |
+| Archive type | 4 bytes | `FGDM` or `FGDC` identifies an Afterburner archive. |
+
+The fields that follow are specific to Afterburner and appear in the order below.
+
+## `Fver` – Afterburner version header
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| `46 76 65 72` (`Fver`) | 4 bytes | Afterburner version tag. |
+| Encoded length | 1–5 bytes | Variable-length integer describing how many bytes belong to the version payload. |
+| Encoded version | 1–5 bytes | Variable-length integer that records the Afterburner build number. |
+
+The length byte tells the parser how many bytes to consume when decoding the version number.
+
+## `Fcdr` – compression descriptor
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| `46 63 64 72` (`Fcdr`) | 4 bytes | Descriptor tag. |
+| Encoded length | 1–5 bytes | Variable-length integer giving the number of bytes in the descriptor payload. |
+| Descriptor payload | `length` bytes | Compression descriptor bytes. The loader skips them after reading the length. |
+
+## `ABMP` – compressed resource map
+
+Afterburner compresses the resource metadata into the `ABMP` block. The outer header uses variable-length integers (varints) that pack seven payload bits per byte; the high bit indicates whether more bytes follow.
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| `41 42 4D 50` (`ABMP`) | 4 bytes | Afterburner map tag. |
+| Encoded map length | 1–5 bytes | Number of compressed bytes that follow. |
+| Encoded compression type | 1–5 bytes | Compression algorithm selector (0 = stored, non-zero = zlib). |
+| Encoded uncompressed size | 1–5 bytes | Expected size of the metadata after decompression. |
+
+The compressed payload inflates into a second stream of varints with the following layout:
+
+| Field | Notes |
+| --- | --- |
+| Encoded control value 1 | First control varint preserved for diagnostics. |
+| Encoded control value 2 | Second control varint preserved for diagnostics. |
+| Encoded resource count | Number of resource rows described by the metadata. |
+| Encoded resource id | Resource index for the current row. |
+| Encoded offset | Relative byte offset. A decoded value of `-1` flags an Initial Load Segment (ILS) resource stored in memory. |
+| Encoded compressed size | Length of the compressed payload. |
+| Encoded uncompressed size | Length expected after decompression. |
+| Encoded compression type | Algorithm selector for this row (0 = stored, non-zero = zlib). |
+| Resource tag | Four-character chunk identifier appended after the varints. |
+
+Offsets greater than or equal to zero point into the movie file. When the compression type is non-zero, the byte range is a zlib stream.
+
+## `FGEI` – Initial Load Segment (ILS)
+
+After the map, Afterburner provides an Initial Load Segment that stores resources whose offsets were marked as `-1`.
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| `46 47 45 49` (`FGEI`) | 4 bytes | ILS tag. |
+| Encoded control value | 1–5 bytes | Varint read before iterating the payload. |
+| Repeating: encoded resource id + raw bytes | Varies | Each varint resource id is followed by the raw chunk bytes for that resource. |
+
+The loader copies these byte blobs into memory so requests for ILS resources can be satisfied without seeking the file.
+
+## Resource access
+
+When a resource is requested:
+
+1. The reader locates the metadata row for the resource id.
+2. If the offset was `-1`, the bytes are pulled from the ILS buffer.
+3. Otherwise the reader seeks to `offset` in the movie file and reads `compressed size` bytes.
+4. When `compression type` is non-zero, the bytes are inflated with zlib before being returned.
+5. The resulting stream still begins with the 8-byte RIFF sub-header (`tag` + `length`). Most parsers skip this header before decoding the payload.
+
+This combination of varint metadata, optional compression, and the ILS block allows Shockwave movies to ship compact archives while keeping essential resources readily available.

--- a/src/BlingoEngine.IO.Legacy/docs/dir-format.md
+++ b/src/BlingoEngine.IO.Legacy/docs/dir-format.md
@@ -1,0 +1,150 @@
+# Director Movie (`.dir`) Container
+
+## Overview
+
+Classic Director movies store their data in a RIFF-style container. Most exports use the big-endian `RIFX` tag, while little-endian bundles spell the signature backwards (`XFIR`) or use the standard `RIFF`/`FFIR` pair. The top-level chunk announces the archive subtype with a four-character code (`MV93`, `MC95`, `APPL`, `FGDM`, or `FGDC`) that decides how the resource map is parsed.
+
+## Detecting the container
+
+### Raw exports and plain archives
+
+Raw `.dir` files start directly with one of the container signatures:
+
+| Bytes | Meaning |
+| --- | --- |
+| `52 49 46 58` (`RIFX`) / `58 46 49 52` (`XFIR`) | Big-endian vs. little-endian Director movie. |
+| `52 49 46 46` (`RIFF`) / `46 46 49 52` (`FFIR`) | Little-endian RIFF movie bundle. |
+
+Once these four bytes are read, the loader can treat the remainder as a RIFX/RIFF stream and jump to the header described in [RIFX header and subtype](#rifx-header-and-subtype).
+
+### Windows projectors
+
+Self-contained Windows executables wrap the movie with a short projector header. The bytes immediately preceding the RIFX data identify the Director generation and provide the offset to the embedded archive.
+
+#### Director 2–3 projectors
+
+Older projectors keep an external movie list before the RIFX payload. The format repeats for every entry:
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| Entry count | 2 bytes (little-endian) | Number of MMM entries that follow. |
+| Unknown padding | 5 bytes | Reserved bytes skipped by the loader. |
+| MMM size | 4 bytes per entry (little-endian) | Stored size for each MMM file. |
+| MMM filename | Pascal string | Length-prefixed filename for the MMM resource. |
+| Directory name | Pascal string | Length-prefixed directory containing the MMM file. |
+
+After the directory listing, the reader seeks to the embedded RIFF/RIFX data.
+
+#### Director 4 projectors (`PJ93`)
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| `50 4A 39 33` (`PJ93`) | 4 bytes | Signature identifying a Director 4 projector. |
+| RIFX offset | 4 bytes (little-endian) | File position of the embedded movie. |
+| Font map offset | 4 bytes (little-endian) | Pointer to the bundled font map. |
+| Resource fork offset 1 | 4 bytes (little-endian) | First stored resource-fork pointer. |
+| Resource fork offset 2 | 4 bytes (little-endian) | Second stored resource-fork pointer. |
+| Graphics DLL offset | 4 bytes (little-endian) | Location of the graphics helper DLL. |
+| Sound DLL offset | 4 bytes (little-endian) | Location of the sound helper DLL. |
+| Alternate RIFX offset | 4 bytes (little-endian) | Duplicate copy of the movie offset. |
+| Projector flags | 4 bytes (little-endian) | Flag word preserved for compatibility. |
+
+The reader skips these fields and then seeks to the recorded RIFX offset.
+
+#### Director 5 projectors (`PJ95`)
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| `50 4A 39 35` (`PJ95`) | 4 bytes | Signature identifying a Director 5 projector. |
+| RIFX offset | 4 bytes (little-endian) | File position of the embedded movie. |
+| Projector flags | 4 bytes (little-endian) | Primary projector bitfield. |
+| Window flags | 4 bytes (little-endian) | Secondary window-behaviour flags. |
+| Window X | 2 bytes (little-endian) | Window X coordinate. |
+| Window Y | 2 bytes (little-endian) | Window Y coordinate. |
+| Window width | 2 bytes (little-endian) | Stored window width in pixels. |
+| Window height | 2 bytes (little-endian) | Stored window height in pixels. |
+| Component count | 4 bytes (little-endian) | Number of bundled projector components. |
+| Driver file count | 4 bytes (little-endian) | Count of driver filenames that follow. |
+| Font map offset | 4 bytes (little-endian) | Pointer to the font map data. |
+
+The embedded movie begins at the recorded offset immediately after this header.
+
+#### Director 7 projectors (`PJ00` / `PJ01`)
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| `50 4A 30 30` (`PJ00`) or `50 4A 30 31` (`PJ01`) | 4 bytes | Signature identifying a Director 7-era projector. |
+| RIFX offset | 4 bytes (little-endian) | File position of the embedded movie. |
+| Reserved dword 1 | 4 bytes (little-endian) | Unused header word. |
+| Reserved dword 2 | 4 bytes (little-endian) | Unused header word. |
+| Reserved dword 3 | 4 bytes (little-endian) | Unused header word. |
+| Reserved dword 4 | 4 bytes (little-endian) | Unused header word. |
+| DLL offset | 4 bytes (little-endian) | Pointer to the bundled DLL. |
+
+After skipping the reserved dwords, the reader jumps to the RIFX offset.
+
+### Mac projectors
+
+Macintosh projectors also begin with a `PJ**` header when compiled for PowerPC. The four-byte signature (`PJ93`, `PJ95`, or `PJ00`) is followed by a big-endian 32-bit offset to the embedded RIFX data. 68k exports omit the header and start with `RIFX`/`XFIR`, so the archive begins at offset zero.
+
+## RIFX header and subtype
+
+Immediately after the signature, the top-level chunk follows the standard RIFF layout:
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| `RIFX` / `XFIR` / `RIFF` / `FFIR` | 4 bytes | Container signature. |
+| Chunk size | 4 bytes | Unsigned 32-bit size of the entire movie chunk (header + payload). |
+| Archive type | 4 bytes | Determines the map format: `MV93`, `MC95`, or `APPL` for memory-map movies; `FGDM` or `FGDC` for Afterburner/ Shockwave movies. |
+
+The byte order depends on the signature (`RIFX` is big-endian, `XFIR` is little-endian).
+
+## Memory-map movies (`MV93`, `MC95`, `APPL`)
+
+Classic Director movies expose two control blocks before the resource entries.
+
+### `imap` header
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| `69 6D 61 70` (`imap`) | 4 bytes | Memory-map prologue tag. |
+| `imap` length | 4 bytes | Size of the `imap` block. |
+| Map version | 4 bytes | Observed values: `0` or `1`. |
+| `mmap` offset | 4 bytes | File position of the resource table. |
+| Archive version | 4 bytes | Director release marker (`0x00000000`, `0x000004C1`, `0x000004C7`, `0x00000708`, `0x00000742`). |
+
+### `mmap` resource table
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| `6D 6D 61 70` (`mmap`) | 4 bytes | Resource table signature. |
+| `mmap` length | 4 bytes | Size of the `mmap` chunk. |
+| Header size | 2 bytes | Number of bytes between the `mmap` header and the first entry. |
+| Entry size | 2 bytes | Size of each resource row. |
+| Total entries | 4 bytes | Count of allocated rows. |
+| Filled entries | 4 bytes | Number of populated rows. |
+| Padding | 8 bytes | All `0xFF`; separates the header from the freelist pointer. |
+| First free resource id | 4 bytes | Index of the first unused slot (`-1` when none). |
+
+Each table row then contributes:
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| Resource tag | 4 bytes | Four-character chunk type. |
+| Resource size | 4 bytes | Payload length excluding the 8-byte RIFX sub-header. |
+| Resource offset | 4 bytes | File offset of the chunk within the archive. |
+| Flags | 2 bytes | Attribute bitfield copied from Director. |
+| Unknown | 2 bytes | Placeholder that mirrors Director's layout. |
+| Next free index | 4 bytes | Chains unused rows inside the freelist. |
+
+## Chunk layout
+
+Each resource chunk inside the archive follows the RIFF convention:
+
+| Field | Length | Notes |
+| --- | --- | --- |
+| Chunk tag | 4 bytes | Four-character identifier such as `CASt`, `Lscr`, or `KEY*`. |
+| Chunk length | 4 bytes | Number of bytes that follow. |
+| Payload | `length` bytes | Resource data. Memory-map readers typically skip the 8-byte sub-header before handing the payload to higher-level parsers. |
+
+The resource map marks each chunk as it is accessed so tooling can report unused entries when the archive closes.


### PR DESCRIPTION
## Summary
- add a documentation index for the BlingoEngine.IO.Legacy package
- document the structure of classic Director `.dir` movie archives
- document the Shockwave `.dcr` Afterburner layout and `.cst` cast library records

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cbb73e4620833280c5d0ebb2420db5