### PR TITLE
Add tests for classic Director data block parsing

### DIFF
--- a/Test/BlingoEngine.IO.Legacy.Tests/Data/BlDataBlockExtractionTests.cs
+++ b/Test/BlingoEngine.IO.Legacy.Tests/Data/BlDataBlockExtractionTests.cs
@@ -1,0 +1,186 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using BlingoEngine.IO.Legacy.Core;
+using BlingoEngine.IO.Legacy.Data;
+using BlingoEngine.IO.Legacy.Files;
+using BlingoEngine.IO.Legacy.Tools;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace BlingoEngine.IO.Legacy.Tests.Data;
+
+public class BlDataBlockExtractionTests
+{
+    [Theory]
+    [MemberData(nameof(ClassicDirectorCases))]
+    public void ReadDirFilesContainer_ExtractsResourceTagsAcrossDirectorVersions(ClassicDirectorCase scenario)
+    {
+        var movieBytes = BuildClassicMovieBytes(scenario);
+        using var stream = new MemoryStream(movieBytes, writable: false);
+        using var context = new ReaderContext(stream, $"{scenario.Name}.dir", leaveOpen: true);
+
+        var container = context.ReadDirFilesContainer();
+
+        context.DataBlock.Should().NotBeNull();
+        var block = context.DataBlock!;
+
+        block.PayloadStart.Should().Be(12);
+        block.DeclaredSize.Should().Be((uint)(movieBytes.Length - 12));
+        block.PayloadEnd.Should().Be(block.PayloadStart + block.DeclaredSize);
+
+        var format = block.Format;
+        format.Codec.Should().Be(scenario.ExpectedCodec);
+        format.ArchiveVersion.Should().Be(scenario.ArchiveVersion);
+        format.MapVersion.Should().Be(scenario.MapVersion);
+        format.DirectorVersion.Should().Be(scenario.ExpectedDirectorVersion);
+        format.DirectorVersionLabel.Should().Be($"Director {scenario.ExpectedDirectorVersion}");
+
+        var resourceTags = context.Resources.Entries.Select(entry => entry.Tag.Value).ToList();
+        resourceTags.Should().BeEquivalentTo(scenario.ResourceTags);
+
+        container.Files.Should().BeEmpty();
+    }
+
+    public static IEnumerable<object[]> ClassicDirectorCases()
+    {
+        yield return new object[]
+        {
+            new ClassicDirectorCase(
+                Name: "director4-little",
+                Magic: "XFIR",
+                CodecTag: "MV93",
+                ArchiveVersion: 0x00000000,
+                MapVersion: 0,
+                ExpectedDirectorVersion: 4,
+                ExpectedCodec: BlRifxCodec.MV93,
+                ResourceTags: new[] { "CASt", "Lscr" })
+        };
+
+        yield return new object[]
+        {
+            new ClassicDirectorCase(
+                Name: "director5-big",
+                Magic: "RIFX",
+                CodecTag: "MC95",
+                ArchiveVersion: 0x000004C1,
+                MapVersion: 1,
+                ExpectedDirectorVersion: 5,
+                ExpectedCodec: BlRifxCodec.MC95,
+                ResourceTags: new[] { "CASt", "Lscr", "KEY*" })
+        };
+
+        yield return new object[]
+        {
+            new ClassicDirectorCase(
+                Name: "director6-little",
+                Magic: "XFIR",
+                CodecTag: "MC95",
+                ArchiveVersion: 0x000004C7,
+                MapVersion: 1,
+                ExpectedDirectorVersion: 6,
+                ExpectedCodec: BlRifxCodec.MC95,
+                ResourceTags: new[] { "CASt" })
+        };
+
+        yield return new object[]
+        {
+            new ClassicDirectorCase(
+                Name: "director85-big",
+                Magic: "RIFX",
+                CodecTag: "MV93",
+                ArchiveVersion: 0x00000708,
+                MapVersion: 1,
+                ExpectedDirectorVersion: 8,
+                ExpectedCodec: BlRifxCodec.MV93,
+                ResourceTags: new[] { "CASt", "Lscr", "VWFI" })
+        };
+
+        yield return new object[]
+        {
+            new ClassicDirectorCase(
+                Name: "director10-little",
+                Magic: "XFIR",
+                CodecTag: "APPL",
+                ArchiveVersion: 0x00000742,
+                MapVersion: 1,
+                ExpectedDirectorVersion: 10,
+                ExpectedCodec: BlRifxCodec.APPL,
+                ResourceTags: new[] { "CASt", "Lscr", "STXT" })
+        };
+    }
+
+    private static byte[] BuildClassicMovieBytes(ClassicDirectorCase scenario)
+    {
+        var littleEndian = scenario.Magic is "XFIR" or "RIFF";
+        using var stream = new MemoryStream();
+        var endianness = littleEndian ? BlEndianness.LittleEndian : BlEndianness.BigEndian;
+        var writer = new BlStreamWriter(stream)
+        {
+            Endianness = endianness
+        };
+
+        writer.WriteAscii(scenario.Magic);
+        var sizeOffset = writer.Position;
+        writer.WriteUInt32(0); // placeholder
+        writer.WriteTag(scenario.CodecTag);
+
+        var payloadStart = writer.Position;
+
+        writer.WriteTag("imap");
+        writer.WriteUInt32(16);
+        writer.WriteUInt32(16);
+        writer.WriteUInt32(scenario.MapVersion);
+        var mapOffsetPosition = writer.Position;
+        writer.WriteUInt32(0); // patched later
+        writer.WriteUInt32(scenario.ArchiveVersion);
+
+        var mmapChunkStart = writer.Position;
+        writer.WriteTag("mmap");
+
+        const ushort headerSize = 12;
+        const ushort entrySize = 20;
+        var entryCount = scenario.ResourceTags.Count;
+        var mmapPayloadLength = headerSize + entryCount * entrySize;
+
+        writer.WriteUInt32((uint)mmapPayloadLength);
+        writer.WriteUInt16(headerSize);
+        writer.WriteUInt16(entrySize);
+        writer.WriteUInt32((uint)entryCount);
+        writer.WriteUInt32((uint)entryCount);
+
+        foreach (var tag in scenario.ResourceTags)
+        {
+            writer.WriteTag(tag);
+            writer.WriteUInt32(0);
+            writer.WriteUInt32(0);
+            writer.WriteUInt16(0);
+            writer.WriteUInt16(0);
+            writer.WriteUInt32(0);
+        }
+
+        var mapOffset = (uint)(mmapChunkStart - payloadStart);
+        var payloadLength = (uint)(writer.Position - payloadStart);
+
+        writer.Position = mapOffsetPosition;
+        writer.WriteUInt32(mapOffset);
+
+        writer.Position = sizeOffset;
+        writer.WriteUInt32(payloadLength);
+
+        return stream.ToArray();
+    }
+
+    public sealed record ClassicDirectorCase(
+        string Name,
+        string Magic,
+        string CodecTag,
+        uint ArchiveVersion,
+        uint MapVersion,
+        int ExpectedDirectorVersion,
+        BlRifxCodec ExpectedCodec,
+        IReadOnlyList<string> ResourceTags);
+}

--- a/src/BlingoEngine.IO.Legacy/Tools/BlStreamWriter.cs
+++ b/src/BlingoEngine.IO.Legacy/Tools/BlStreamWriter.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.Text;
+
+using BlingoEngine.IO.Legacy.Data;
+
+namespace BlingoEngine.IO.Legacy.Tools;
+
+/// <summary>
+/// Wraps a <see cref="Stream"/> with endian-aware helpers for producing Director byte sequences.
+/// </summary>
+public sealed class BlStreamWriter
+{
+    private readonly Stream _baseStream;
+    private readonly byte[] _scratch = new byte[8];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlStreamWriter"/> class.
+    /// </summary>
+    /// <param name="stream">Underlying stream that receives the Director bytes.</param>
+    public BlStreamWriter(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        if (!stream.CanWrite)
+        {
+            throw new ArgumentException("Stream must be writable.", nameof(stream));
+        }
+
+        if (!stream.CanSeek)
+        {
+            throw new ArgumentException("Stream must support seeking.", nameof(stream));
+        }
+
+        _baseStream = stream;
+    }
+
+    /// <summary>
+    /// Gets the underlying stream receiving the Director bytes.
+    /// </summary>
+    public Stream BaseStream => _baseStream;
+
+    /// <summary>
+    /// Gets or sets the byte ordering used when encoding multi-byte values.
+    /// </summary>
+    public BlEndianness Endianness { get; set; } = BlEndianness.BigEndian;
+
+    /// <summary>
+    /// Gets or sets the current byte offset within the stream.
+    /// </summary>
+    public long Position
+    {
+        get => _baseStream.Position;
+        set => _baseStream.Seek(value, SeekOrigin.Begin);
+    }
+
+    /// <summary>
+    /// Gets the total stream length in bytes.
+    /// </summary>
+    public long Length => _baseStream.Length;
+
+    /// <summary>
+    /// Flushes the underlying stream.
+    /// </summary>
+    public void Flush() => _baseStream.Flush();
+
+    /// <summary>
+    /// Writes an unsigned byte to the current stream position.
+    /// </summary>
+    /// <param name="value">The byte value to write.</param>
+    public void WriteByte(byte value) => _baseStream.WriteByte(value);
+
+    /// <summary>
+    /// Writes a signed byte to the current stream position.
+    /// </summary>
+    /// <param name="value">The signed byte value to write.</param>
+    public void WriteSByte(sbyte value) => WriteByte(unchecked((byte)value));
+
+    /// <summary>
+    /// Writes the provided bytes directly to the underlying stream.
+    /// </summary>
+    /// <param name="source">Bytes to copy into the stream.</param>
+    public void WriteBytes(ReadOnlySpan<byte> source) => _baseStream.Write(source);
+
+    /// <summary>
+    /// Writes the specified text using ASCII encoding without any endianness conversion.
+    /// </summary>
+    /// <param name="text">Text to encode using ASCII.</param>
+    public void WriteAscii(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        if (text.Length == 0)
+        {
+            return;
+        }
+
+        var bytes = Encoding.ASCII.GetBytes(text);
+        _baseStream.Write(bytes, 0, bytes.Length);
+    }
+
+    /// <summary>
+    /// Writes a four-character tag using the writer's configured endianness.
+    /// </summary>
+    /// <param name="tag">Tag value to encode.</param>
+    public void WriteTag(string tag) => WriteTag(tag, Endianness);
+
+    /// <summary>
+    /// Writes a four-character tag using the specified byte ordering.
+    /// </summary>
+    /// <param name="tag">Tag value to encode.</param>
+    /// <param name="endianness">Byte ordering used when writing the tag.</param>
+    public void WriteTag(string tag, BlEndianness endianness)
+    {
+        ArgumentNullException.ThrowIfNull(tag);
+        if (tag.Length != 4)
+        {
+            throw new ArgumentException("Tags must contain exactly four characters.", nameof(tag));
+        }
+
+        Span<byte> buffer = stackalloc byte[4];
+        Encoding.ASCII.GetBytes(tag, buffer);
+
+        if (endianness == BlEndianness.LittleEndian)
+        {
+            buffer.Reverse();
+        }
+
+        _baseStream.Write(buffer);
+    }
+
+    /// <summary>
+    /// Writes a four-character tag using the writer's configured endianness.
+    /// </summary>
+    /// <param name="tag">Tag to encode.</param>
+    public void WriteTag(BlTag tag) => WriteTag(tag, Endianness);
+
+    /// <summary>
+    /// Writes a four-character tag using the specified byte ordering.
+    /// </summary>
+    /// <param name="tag">Tag to encode.</param>
+    /// <param name="endianness">Byte ordering used when writing the tag.</param>
+    public void WriteTag(BlTag tag, BlEndianness endianness) => WriteTag(tag.Value, endianness);
+
+    /// <summary>
+    /// Writes an unsigned 16-bit integer respecting the writer's configured endianness.
+    /// </summary>
+    /// <param name="value">Value to encode.</param>
+    public void WriteUInt16(ushort value) => WriteUInt16(value, Endianness);
+
+    /// <summary>
+    /// Writes an unsigned 16-bit integer using the specified byte ordering.
+    /// </summary>
+    /// <param name="value">Value to encode.</param>
+    /// <param name="endianness">Byte ordering used when writing the value.</param>
+    public void WriteUInt16(ushort value, BlEndianness endianness)
+    {
+        var span = _scratch.AsSpan(0, 2);
+        if (endianness == BlEndianness.LittleEndian)
+        {
+            BinaryPrimitives.WriteUInt16LittleEndian(span, value);
+        }
+        else
+        {
+            BinaryPrimitives.WriteUInt16BigEndian(span, value);
+        }
+
+        _baseStream.Write(span);
+    }
+
+    /// <summary>
+    /// Writes a signed 16-bit integer respecting the writer's configured endianness.
+    /// </summary>
+    /// <param name="value">Value to encode.</param>
+    public void WriteInt16(short value) => WriteUInt16(unchecked((ushort)value));
+
+    /// <summary>
+    /// Writes a signed 16-bit integer using the specified byte ordering.
+    /// </summary>
+    /// <param name="value">Value to encode.</param>
+    /// <param name="endianness">Byte ordering used when writing the value.</param>
+    public void WriteInt16(short value, BlEndianness endianness) => WriteUInt16(unchecked((ushort)value), endianness);
+
+    /// <summary>
+    /// Writes an unsigned 32-bit integer respecting the writer's configured endianness.
+    /// </summary>
+    /// <param name="value">Value to encode.</param>
+    public void WriteUInt32(uint value) => WriteUInt32(value, Endianness);
+
+    /// <summary>
+    /// Writes an unsigned 32-bit integer using the specified byte ordering.
+    /// </summary>
+    /// <param name="value">Value to encode.</param>
+    /// <param name="endianness">Byte ordering used when writing the value.</param>
+    public void WriteUInt32(uint value, BlEndianness endianness)
+    {
+        var span = _scratch.AsSpan(0, 4);
+        if (endianness == BlEndianness.LittleEndian)
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(span, value);
+        }
+        else
+        {
+            BinaryPrimitives.WriteUInt32BigEndian(span, value);
+        }
+
+        _baseStream.Write(span);
+    }
+
+    /// <summary>
+    /// Writes a signed 32-bit integer respecting the writer's configured endianness.
+    /// </summary>
+    /// <param name="value">Value to encode.</param>
+    public void WriteInt32(int value) => WriteUInt32(unchecked((uint)value));
+
+    /// <summary>
+    /// Writes a signed 32-bit integer using the specified byte ordering.
+    /// </summary>
+    /// <param name="value">Value to encode.</param>
+    /// <param name="endianness">Byte ordering used when writing the value.</param>
+    public void WriteInt32(int value, BlEndianness endianness) => WriteUInt32(unchecked((uint)value), endianness);
+
+    /// <summary>
+    /// Writes an unsigned 64-bit integer respecting the writer's configured endianness.
+    /// </summary>
+    /// <param name="value">Value to encode.</param>
+    public void WriteUInt64(ulong value) => WriteUInt64(value, Endianness);
+
+    /// <summary>
+    /// Writes an unsigned 64-bit integer using the specified byte ordering.
+    /// </summary>
+    /// <param name="value">Value to encode.</param>
+    /// <param name="endianness">Byte ordering used when writing the value.</param>
+    public void WriteUInt64(ulong value, BlEndianness endianness)
+    {
+        var span = _scratch.AsSpan(0, 8);
+        if (endianness == BlEndianness.LittleEndian)
+        {
+            BinaryPrimitives.WriteUInt64LittleEndian(span, value);
+        }
+        else
+        {
+            BinaryPrimitives.WriteUInt64BigEndian(span, value);
+        }
+
+        _baseStream.Write(span);
+    }
+
+    /// <summary>
+    /// Writes a signed 64-bit integer respecting the writer's configured endianness.
+    /// </summary>
+    /// <param name="value">Value to encode.</param>
+    public void WriteInt64(long value) => WriteUInt64(unchecked((ulong)value));
+
+    /// <summary>
+    /// Writes a signed 64-bit integer using the specified byte ordering.
+    /// </summary>
+    /// <param name="value">Value to encode.</param>
+    /// <param name="endianness">Byte ordering used when writing the value.</param>
+    public void WriteInt64(long value, BlEndianness endianness) => WriteUInt64(unchecked((ulong)value), endianness);
+}

--- a/src/BlingoEngine.IO.Legacy/docs/dir-format.md
+++ b/src/BlingoEngine.IO.Legacy/docs/dir-format.md
@@ -113,6 +113,17 @@ Classic Director movies expose two control blocks before the resource entries.
 | `mmap` offset | 4 bytes | File position of the resource table. |
 | Archive version | 4 bytes | Director release marker (`0x00000000`, `0x000004C1`, `0x000004C7`, `0x00000708`, `0x00000742`). |
 
+The observed archive versions map to specific Director generations. Director MX 2004 (the final "Director 10" release) reuses
+the same map layout as the Director 10 entry below, so no additional parsing rules are required.
+
+| Value | Director release |
+| --- | --- |
+| `0x00000000` | Director 4 |
+| `0x000004C1` | Director 5 |
+| `0x000004C7` | Director 6 |
+| `0x00000708` | Director 8.5 |
+| `0x00000742` | Director 10 / Director MX 2004 |
+
 ### `mmap` resource table
 
 | Field | Length | Notes |


### PR DESCRIPTION
## Summary
- add BlDataBlockExtractionTests to verify the legacy reader extracts map metadata and resource tags for Director 4, 5, 6, 8.5, and 10 payloads
- document the archive version to Director release mapping, noting that Director MX 2004 reuses the Director 10 layout
- introduce an endian-aware BlStreamWriter helper and refactor the tests to build Director fixtures with it instead of bespoke helpers

## Testing
- dotnet test Test/BlingoEngine.IO.Legacy.Tests/BlingoEngine.IO.Legacy.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cbd09b85ec83329809e76ffd1fceb4