### PR TITLE
Add legacy script reader

### DIFF
--- a/src/BlingoEngine.IO.Legacy/Scripts/BlLegacyScript.cs
+++ b/src/BlingoEngine.IO.Legacy/Scripts/BlLegacyScript.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace BlingoEngine.IO.Legacy.Scripts;
+
+/// <summary>
+/// Represents the compiled Lingo payload stored inside an <c>Lscr</c> resource.
+/// The loader preserves the raw bytes so higher layers can decompile handlers or
+/// rebuild property tables without re-reading the Director container.
+/// </summary>
+internal sealed class BlLegacyScript
+{
+    /// <summary>
+    /// Gets the resource identifier associated with the <c>Lscr</c> entry.
+    /// </summary>
+    public int ResourceId { get; }
+
+    /// <summary>
+    /// Gets the script category resolved from the <c>CASt</c> selector word.
+    /// </summary>
+    public BlLegacyScriptFormatKind Format { get; }
+
+    /// <summary>
+    /// Gets the compiled <c>Lscr</c> payload exactly as exported by Director. The
+    /// buffer retains the header fields (duplicate length words, script and parent
+    /// identifiers, and flag values) followed by the offset tables for handler
+    /// vectors, property/global name lists, literal pools, and the bytecode stream.
+    /// This mirrors the layout documented in the project notes so tooling can walk
+    /// the individual sections without depending on the original map.
+    /// </summary>
+    public byte[] Bytes { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlLegacyScript"/> class.
+    /// </summary>
+    public BlLegacyScript(int resourceId, BlLegacyScriptFormatKind format, byte[] bytes)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        ResourceId = resourceId;
+        Format = format;
+        Bytes = bytes;
+    }
+}

--- a/src/BlingoEngine.IO.Legacy/Scripts/BlLegacyScriptFormat.cs
+++ b/src/BlingoEngine.IO.Legacy/Scripts/BlLegacyScriptFormat.cs
@@ -1,0 +1,105 @@
+using System;
+
+namespace BlingoEngine.IO.Legacy.Scripts;
+
+/// <summary>
+/// Enumerates the legacy Lingo script categories encoded inside the <c>CASt</c>
+/// specific data block. Director stores a 16-bit selector whose low byte
+/// distinguishes behaviour, movie, and parent scripts.
+/// </summary>
+internal enum BlLegacyScriptFormatKind
+{
+    /// <summary>
+    /// The selector could not be resolved to a known script category.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Behaviour (score) script identified by selector code <c>0x01</c>.
+    /// </summary>
+    Behavior = 1,
+
+    /// <summary>
+    /// Movie script that listens for global events (<c>0x03</c> selector).
+    /// </summary>
+    Movie = 3,
+
+    /// <summary>
+    /// Parent script that defines factory prototypes (<c>0x07</c> selector).
+    /// </summary>
+    Parent = 7
+}
+
+/// <summary>
+/// Provides helpers for interpreting script selectors stored alongside
+/// compiled <c>Lscr</c> resources.
+/// </summary>
+internal static class BlLegacyScriptFormat
+{
+    /// <summary>
+    /// Attempts to resolve the script category from the raw selector bytes.
+    /// Director writes a 16-bit value where the active code normally lives in the
+    /// low byte while the high byte stays at zero. Both big- and little-endian
+    /// encodings are tolerated.
+    /// </summary>
+    public static BlLegacyScriptFormatKind Detect(ReadOnlySpan<byte> selectorData)
+    {
+        if (selectorData.IsEmpty)
+        {
+            return BlLegacyScriptFormatKind.Unknown;
+        }
+
+        var code = ExtractSelector(selectorData);
+        return MapSelector(code);
+    }
+
+    /// <summary>
+    /// Maps the selector byte to a script category.
+    /// </summary>
+    public static BlLegacyScriptFormatKind MapSelector(byte selector)
+    {
+        return selector switch
+        {
+            0x01 => BlLegacyScriptFormatKind.Behavior,
+            0x03 => BlLegacyScriptFormatKind.Movie,
+            0x07 => BlLegacyScriptFormatKind.Parent,
+            _ => BlLegacyScriptFormatKind.Unknown
+        };
+    }
+
+    private static byte ExtractSelector(ReadOnlySpan<byte> data)
+    {
+        if (data.Length >= 2)
+        {
+            var first = data[0];
+            var second = data[1];
+
+            if (first == 0 && second != 0)
+            {
+                return second;
+            }
+
+            if (second == 0 && first != 0)
+            {
+                return first;
+            }
+
+            if (first == second)
+            {
+                return first;
+            }
+
+            if (first != 0)
+            {
+                return first;
+            }
+
+            if (second != 0)
+            {
+                return second;
+            }
+        }
+
+        return data[0];
+    }
+}

--- a/src/BlingoEngine.IO.Legacy/Scripts/BlLegacyScriptReader.cs
+++ b/src/BlingoEngine.IO.Legacy/Scripts/BlLegacyScriptReader.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+
+using BlingoEngine.IO.Legacy.Afterburner;
+using BlingoEngine.IO.Legacy.Classic;
+using BlingoEngine.IO.Legacy.Core;
+using BlingoEngine.IO.Legacy.Data;
+using BlingoEngine.IO.Legacy.Tools;
+
+namespace BlingoEngine.IO.Legacy.Scripts;
+
+/// <summary>
+/// Reads compiled <c>Lscr</c> resources and associates them with their script
+/// category by inspecting the owning <c>CASt</c> records. Director stores the
+/// selector word in the member-specific data while the info block records the
+/// script resource id, so the reader walks both regions to build a typed list of
+/// compiled scripts.
+/// </summary>
+internal sealed class BlLegacyScriptReader
+{
+    private static readonly BlTag ScriptTag = BlTag.Register("Lscr");
+    private static readonly BlTag CastTag = BlTag.Cast;
+    private static readonly BlTag LegacyCastTag = BlTag.Register("CASt");
+
+    private readonly ReaderContext _context;
+
+    public BlLegacyScriptReader(ReaderContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+    }
+
+    public IReadOnlyList<BlLegacyScript> Read()
+    {
+        var scripts = new List<BlLegacyScript>();
+        if (_context.Resources.Entries.Count == 0)
+        {
+            return scripts;
+        }
+
+        var classicLoader = new BlClassicPayloadLoader(_context);
+        BlAfterburnerPayloadLoader? afterburnerLoader = null;
+        if (_context.AfterburnerState is not null)
+        {
+            afterburnerLoader = new BlAfterburnerPayloadLoader(_context, _context.AfterburnerState);
+        }
+
+        var formatByResourceId = BuildScriptFormatMap(classicLoader, afterburnerLoader);
+
+        foreach (var entry in _context.Resources.Entries)
+        {
+            if (entry.Tag != ScriptTag)
+            {
+                continue;
+            }
+
+            var payload = LoadPayload(entry, classicLoader, afterburnerLoader);
+            if (payload.Length == 0)
+            {
+                continue;
+            }
+
+            formatByResourceId.TryGetValue(entry.Id, out var format);
+            scripts.Add(new BlLegacyScript(entry.Id, format, payload));
+        }
+
+        return scripts;
+    }
+
+    private Dictionary<int, BlLegacyScriptFormatKind> BuildScriptFormatMap(
+        BlClassicPayloadLoader classicLoader,
+        BlAfterburnerPayloadLoader? afterburnerLoader)
+    {
+        var result = new Dictionary<int, BlLegacyScriptFormatKind>();
+        var entriesById = _context.Resources.EntriesById;
+
+        foreach (var entry in _context.Resources.Entries)
+        {
+            if (entry.Tag != CastTag && entry.Tag != LegacyCastTag)
+            {
+                continue;
+            }
+
+            var payload = LoadPayload(entry, classicLoader, afterburnerLoader);
+            if (payload.Length == 0)
+            {
+                continue;
+            }
+
+            if (!TryReadScriptDescriptor(payload, entriesById, out var scriptId, out var format))
+            {
+                continue;
+            }
+
+            if (scriptId == 0)
+            {
+                continue;
+            }
+
+            if (!result.ContainsKey(scriptId))
+            {
+                result.Add(scriptId, format);
+            }
+        }
+
+        return result;
+    }
+
+    private static byte[] LoadPayload(
+        BlLegacyResourceEntry entry,
+        BlClassicPayloadLoader classicLoader,
+        BlAfterburnerPayloadLoader? afterburnerLoader)
+    {
+        return entry.StorageKind == BlResourceStorageKind.AfterburnerSegment
+            ? afterburnerLoader is null ? Array.Empty<byte>() : entry.LoadAfterburner(afterburnerLoader)
+            : entry.ReadClassicPayload(classicLoader);
+    }
+
+    private static bool TryReadScriptDescriptor(
+        byte[] payload,
+        IReadOnlyDictionary<int, BlLegacyResourceEntry> entriesById,
+        out int scriptResourceId,
+        out BlLegacyScriptFormatKind format)
+    {
+        scriptResourceId = 0;
+        format = BlLegacyScriptFormatKind.Unknown;
+
+        if (payload.Length < 12)
+        {
+            return false;
+        }
+
+        using var memory = new MemoryStream(payload, writable: false);
+        var reader = new BlStreamReader(memory)
+        {
+            Endianness = BlEndianness.BigEndian
+        };
+
+        var memberType = reader.ReadUInt32();
+        if (memberType != 11)
+        {
+            return false;
+        }
+
+        var infoLength = reader.ReadUInt32();
+        var specificLength = reader.ReadUInt32();
+
+        var infoBytesAvailable = payload.Length - (int)reader.Position;
+        if (infoBytesAvailable <= 0)
+        {
+            return false;
+        }
+
+        if (infoLength > (uint)infoBytesAvailable)
+        {
+            infoLength = (uint)infoBytesAvailable;
+        }
+
+        var infoData = infoLength > 0 ? reader.ReadBytes((int)infoLength) : Array.Empty<byte>();
+
+        var remaining = payload.Length - (int)reader.Position;
+        if (remaining <= 0)
+        {
+            specificLength = 0;
+        }
+        else if (specificLength > (uint)remaining)
+        {
+            specificLength = (uint)remaining;
+        }
+
+        var specificData = specificLength > 0 ? reader.ReadBytes((int)specificLength) : Array.Empty<byte>();
+
+        scriptResourceId = ResolveScriptResourceId(infoData, entriesById);
+        format = BlLegacyScriptFormat.Detect(specificData);
+
+        return scriptResourceId != 0;
+    }
+
+    private static int ResolveScriptResourceId(
+        byte[] infoData,
+        IReadOnlyDictionary<int, BlLegacyResourceEntry> entriesById)
+    {
+        if (infoData.Length < 12)
+        {
+            return 0;
+        }
+
+        var span = infoData.AsSpan(8);
+        if (span.Length < 4)
+        {
+            return 0;
+        }
+
+        var bigEndianValue = unchecked((int)BinaryPrimitives.ReadUInt32BigEndian(span));
+        if (bigEndianValue != 0 && entriesById.ContainsKey(bigEndianValue))
+        {
+            return bigEndianValue;
+        }
+
+        var littleEndianValue = unchecked((int)BinaryPrimitives.ReadUInt32LittleEndian(span));
+        if (littleEndianValue != 0 && entriesById.ContainsKey(littleEndianValue))
+        {
+            return littleEndianValue;
+        }
+
+        return 0;
+    }
+}
+
+/// <summary>
+/// Extension helpers exposing <see cref="BlLegacyScriptReader"/> through the
+/// shared <see cref="ReaderContext"/> used by the legacy pipeline.
+/// </summary>
+internal static class BlLegacyScriptReaderExtensions
+{
+    public static IReadOnlyList<BlLegacyScript> ReadScripts(this ReaderContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var reader = new BlLegacyScriptReader(context);
+        return reader.Read();
+    }
+}


### PR DESCRIPTION
## Summary
- add data model and format helpers for legacy Lingo scripts
- implement a reader that locates Lscr resources and classifies them as behaviour, parent, or movie scripts

## Testing
- dotnet build src/BlingoEngine.IO.Legacy/BlingoEngine.IO.Legacy.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cc30658d048332a145c2ac84367438