### PR TITLE
Center icon-only Abst buttons across frameworks

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Buttons/AbstGodotButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Components/Buttons/AbstGodotButton.cs
@@ -64,7 +64,15 @@ namespace AbstUI.LGodot.Components
             }
         }
 
-        public new string Text { get => base.Text; set => base.Text = value; }
+        public new string Text
+        {
+            get => base.Text;
+            set
+            {
+                base.Text = value ?? string.Empty;
+                UpdateIconLayout();
+            }
+        }
         public bool Enabled { get => !Disabled; set => Disabled = !value; }
         public AColor BorderColor { get => _borderColor; set { _borderColor = value; UpdateStyle(); } }
         public AColor BackgroundColor { get => _backgroundColor; set { _backgroundColor = value; UpdateStyle(); } }
@@ -82,8 +90,11 @@ namespace AbstUI.LGodot.Components
             set
             {
                 _texture = value;
-                if (_texture != null && _texture is AbstGodotTexture2D tex)
+                if (value is AbstGodotTexture2D tex)
                     Icon = tex.Texture;
+                else
+                    Icon = null;
+                UpdateIconLayout();
             }
         }
 
@@ -125,6 +136,14 @@ namespace AbstUI.LGodot.Components
             style.ContentMarginTop = style.ContentMarginBottom = 0;
             style.BorderWidthBottom = style.BorderWidthRight = style.BorderWidthLeft = style.BorderWidthTop = 0;
             style.SetBorderWidthAll(0);
+        }
+
+        private void UpdateIconLayout()
+        {
+            if (Icon != null && string.IsNullOrWhiteSpace(Text))
+                IconAlignment = HorizontalAlignment.Center;
+            else
+                IconAlignment = HorizontalAlignment.Left;
         }
 
     }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Buttons/AbstSdlButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Buttons/AbstSdlButton.cs
@@ -146,7 +146,8 @@ namespace AbstUI.SDL2.Components.Buttons
                 SDL.SDL_RenderClear(context.Renderer);
 
                 int tw = 0, th = 0, tx = 0, ty = 0;
-                if (!string.IsNullOrEmpty(Text))
+                bool hasText = !string.IsNullOrWhiteSpace(Text);
+                if (hasText)
                 {
                     SDL_ttf.TTF_SizeUTF8(_font!.FontHandle, Text, out tw, out th);
                     int baseline = (h - (SDL_ttf.TTF_FontAscent(_font.FontHandle) - SDL_ttf.TTF_FontDescent(_font.FontHandle))) / 2
@@ -154,7 +155,7 @@ namespace AbstUI.SDL2.Components.Buttons
                     ty = baseline - SDL_ttf.TTF_FontAscent(_font.FontHandle);
                 }
 
-                if (_iconTexture != null && !string.IsNullOrEmpty(Text))
+                if (_iconTexture != null && hasText)
                 {
                     SDL.SDL_QueryTexture(_iconTexture.Handle, out _, out _, out int iw, out int ih);
                     int totalW = iw + 4 + tw;
@@ -169,12 +170,12 @@ namespace AbstUI.SDL2.Components.Buttons
                     SDL.SDL_Rect idst = new SDL.SDL_Rect { x = (w - iw) / 2, y = (h - ih) / 2, w = iw, h = ih };
                     SDL.SDL_RenderCopy(context.Renderer, _iconTexture.Handle, nint.Zero, ref idst);
                 }
-                else if (!string.IsNullOrEmpty(Text))
+                else if (hasText)
                 {
                     tx = (w - tw) / 2;
                 }
 
-                if (!string.IsNullOrEmpty(Text))
+                if (hasText)
                 {
                     nint textSurf = SDL_ttf.TTF_RenderUTF8_Blended(_font!.FontHandle, Text, TextColor.ToSDLColor());
                     nint textTex = SDL.SDL_CreateTextureFromSurface(context.Renderer, textSurf);

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Components/Buttons/RmlUiButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/Components/Buttons/RmlUiButton.cs
@@ -1,4 +1,5 @@
 using AbstUI.Components;
+using AbstUI.Components.Buttons;
 using AbstUI.Primitives;
 using AbstUI.SDL2.Bitmaps;
 using RmlUiNet;
@@ -20,6 +21,10 @@ public class RmlUiButton : IAbstFrameworkButton, IDisposable
     private event Action? _pressed;
     private Element? _iconElement;
     private IAbstTexture2D? _iconTexture;
+    private string _text = string.Empty;
+    private string? _iconDataUrl;
+    private int _iconWidth;
+    private int _iconHeight;
 
     public RmlUiButton(ElementDocument document, nint renderer)
     {
@@ -83,8 +88,18 @@ public class RmlUiButton : IAbstFrameworkButton, IDisposable
 
     public string Text
     {
-        get => _element.GetInnerRml();
-        set => _element.SetInnerRml(value);
+        get
+        {
+            _text = _element.GetInnerRml();
+            return _text;
+        }
+        set
+        {
+            _text = value ?? string.Empty;
+            _element.SetInnerRml(_text);
+            UpdateIconElement();
+            UpdateContentLayout();
+        }
     }
 
     public bool Enabled
@@ -103,23 +118,9 @@ public class RmlUiButton : IAbstFrameworkButton, IDisposable
         set
         {
             _iconTexture = value;
-
-            // Remove previous icon element if present
-            if (_iconElement != null)
-            {
-                _element.RemoveChild(_iconElement);
-                _iconElement = null;
-            }
-
-            // Only SDL2 textures are supported for now
-            if (value is SdlTexture2D tex)
-            {
-                var base64 = tex.ToPngBase64(_renderer);
-                _iconElement = _element.AppendChildTag("img");
-                _iconElement.SetAttribute("src", $"data:image/png;base64,{base64}");
-                _iconElement.SetAttribute("width", tex.Width.ToString());
-                _iconElement.SetAttribute("height", tex.Height.ToString());
-            }
+            UpdateIconSource(value);
+            UpdateIconElement();
+            UpdateContentLayout();
         }
     }
 
@@ -130,4 +131,47 @@ public class RmlUiButton : IAbstFrameworkButton, IDisposable
     }
 
     public void Dispose() { }
+
+    private void UpdateIconSource(IAbstTexture2D? texture)
+    {
+        if (texture is SdlTexture2D tex)
+        {
+            _iconDataUrl = $"data:image/png;base64,{tex.ToPngBase64(_renderer)}";
+            _iconWidth = tex.Width;
+            _iconHeight = tex.Height;
+        }
+        else
+        {
+            _iconDataUrl = null;
+            _iconWidth = 0;
+            _iconHeight = 0;
+        }
+    }
+
+    private void UpdateIconElement()
+    {
+        if (_iconElement != null)
+        {
+            if (_iconElement.GetParentNode() == _element)
+                _element.RemoveChild(_iconElement);
+            _iconElement = null;
+        }
+
+        if (_iconDataUrl != null)
+        {
+            _iconElement = _element.AppendChildTag("img");
+            _iconElement.SetAttribute("src", _iconDataUrl);
+            if (_iconWidth > 0)
+                _iconElement.SetAttribute("width", _iconWidth.ToString());
+            if (_iconHeight > 0)
+                _iconElement.SetAttribute("height", _iconHeight.ToString());
+        }
+    }
+
+    private void UpdateContentLayout()
+    {
+        bool hasIcon = _iconElement != null && _iconElement.GetParentNode() == _element;
+        bool hasText = !string.IsNullOrWhiteSpace(_text);
+        _element.SetProperty("text-align", hasIcon && !hasText ? "center" : "left");
+    }
 }


### PR DESCRIPTION
## Summary
- treat whitespace-only button labels as empty in the SDL renderer so icon-only buttons stay centered
- adjust the Godot button implementation to reset its icon when text changes and center icons when no caption is present
- rework the RmlUi button to rebuild cached icon elements and force centered alignment whenever an icon is shown without text

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2RmlUi/AbstUI.SDL2RmlUi.csproj` *(fails: missing framework/interface references in project, pre-existing)*
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/AbstUI.LGodot.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68d18f3238408332b0fabce06a9e42d2