### PR TITLE
Implement movie rewind command and behavior

### DIFF
--- a/src/BlingoEngine/Core/BlingoPlayer.cs
+++ b/src/BlingoEngine/Core/BlingoPlayer.cs
@@ -24,7 +24,7 @@ namespace BlingoEngine.Core
 
 
     public class BlingoPlayer : IBlingoPlayer, IDisposable,
-        IAbstCommandHandler<RewindMovieCommand>,
+        IAbstCommandHandler<MovieRewindCommand>,
         IAbstCommandHandler<PlayMovieCommand>,
         IAbstCommandHandler<StepFrameCommand>
     {
@@ -280,12 +280,12 @@ namespace BlingoEngine.Core
 
 
         #region Commands
-        public bool CanExecute(RewindMovieCommand command) => ActiveMovie is BlingoMovie;
+        public bool CanExecute(MovieRewindCommand command) => ActiveMovie is BlingoMovie;
 
-        public bool Handle(RewindMovieCommand command)
+        public bool Handle(MovieRewindCommand command)
         {
             if (ActiveMovie is BlingoMovie movie)
-                movie.GoTo(1);
+                movie.Rewind();
             return true;
         }
 

--- a/src/BlingoEngine/Movies/BlingoMovie.cs
+++ b/src/BlingoEngine/Movies/BlingoMovie.cs
@@ -475,6 +475,31 @@ namespace BlingoEngine.Movies
         {
             OnStop();
         }
+
+        public void Rewind()
+        {
+            RemoveAllPuppetSprites();
+
+            if (FrameCount == 0)
+            {
+                Halt();
+                return;
+            }
+
+            _nextFrame = 1;
+            AdvanceFrame();
+            Halt();
+        }
+
+        private void RemoveAllPuppetSprites()
+        {
+            for (int channelIndex = 0; channelIndex < _sprite2DManager.MaxSpriteChannelCount; channelIndex++)
+            {
+                var channel = _sprite2DManager.Channel(channelIndex);
+                if (channel.Puppet)
+                    channel.Puppet = false;
+            }
+        }
         public void NextFrame()
         {
             if (_isPlaying)

--- a/src/BlingoEngine/Movies/Commands/MovieRewindCommand.cs
+++ b/src/BlingoEngine/Movies/Commands/MovieRewindCommand.cs
@@ -1,0 +1,5 @@
+using AbstUI.Commands;
+
+namespace BlingoEngine.Movies.Commands;
+
+public sealed record MovieRewindCommand() : IAbstCommand;

--- a/src/BlingoEngine/Movies/Commands/RewindMovieCommand.cs
+++ b/src/BlingoEngine/Movies/Commands/RewindMovieCommand.cs
@@ -1,6 +1,0 @@
-﻿using AbstUI.Commands;
-
-namespace BlingoEngine.Movies.Commands;
-
-public sealed record RewindMovieCommand() : IAbstCommand;
-

--- a/src/BlingoEngine/Movies/IBlingoMovie.cs
+++ b/src/BlingoEngine/Movies/IBlingoMovie.cs
@@ -85,6 +85,12 @@ namespace BlingoEngine.Movies
         void Halt();
 
         /// <summary>
+        /// Rewinds the movie to the first frame and stops playback.
+        /// Lingo: rewind
+        /// </summary>
+        void Rewind();
+
+        /// <summary>
         /// Starts or resumes playback.
         /// Lingo: play
         /// </summary>

--- a/src/BlingoEngine/Setup/BlingoEngineRegistration.cs
+++ b/src/BlingoEngine/Setup/BlingoEngineRegistration.cs
@@ -348,7 +348,7 @@ namespace BlingoEngine.Setup
             LoadFonts(_blingoServiceProvider);
             _buildActions.ForEach(b => b(_blingoServiceProvider));
             _blingoServiceProvider.GetRequiredService<IAbstCommandManager>()
-                 .Register<BlingoPlayer, RewindMovieCommand>()
+                 .Register<BlingoPlayer, MovieRewindCommand>()
                  .Register<BlingoPlayer, PlayMovieCommand>()
                  .Register<BlingoPlayer, StepFrameCommand>()
 

--- a/src/Director/BlingoEngine.Director.Core/Stages/StageIconBar.cs
+++ b/src/Director/BlingoEngine.Director.Core/Stages/StageIconBar.cs
@@ -55,7 +55,7 @@ public class StageIconBar : IDisposable
         _rewindButton = factory.CreateButton("RewindButton", "|<");
         _rewindButton.Width = 20;
         _rewindButton.Height = iconBarHeight;
-        _rewindButton.Pressed += () => commandManager.Handle(new RewindMovieCommand());
+        _rewindButton.Pressed += () => commandManager.Handle(new MovieRewindCommand());
         container.AddItem(_rewindButton);
 
         _playButton = factory.CreateButton("PlayButton", "Play");


### PR DESCRIPTION
## Summary
- add a dedicated `MovieRewindCommand` and update registrations and tooling to use it
- expose a `Rewind` API on `IBlingoMovie` that clears puppet sprites, sends the playhead to frame 1, advances once, and halts playback
- route the new command through `BlingoPlayer` so rewinding stops playback via the movie implementation

## Testing
- dotnet test Test/BlingoEngine.Lingo.Core.Tests/BlingoEngine.Lingo.Core.Tests.csproj *(fails: ClassGenerationTests.NewHandlerBecomesConstructor string comparison)*

------
https://chatgpt.com/codex/tasks/task_e_68d1916787188332a8a97a18529840d0