### PR TITLE
Add RNet pipe coverage and fix command serialization

### DIFF
--- a/Test/BlingoEngine.Net.RNetPipe.Tests/BlingoEngine.Net.RNetPipe.Tests.csproj
+++ b/Test/BlingoEngine.Net.RNetPipe.Tests/BlingoEngine.Net.RNetPipe.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Net\BlingoEngine.Net.RNetPipeClient\BlingoEngine.Net.RNetPipeClient.csproj" />
+    <ProjectReference Include="..\..\src\Net\BlingoEngine.Net.RNetPipeServer\BlingoEngine.Net.RNetPipeServer.csproj" />
+    <ProjectReference Include="..\..\src\Net\BlingoEngine.Net.RNetContracts\BlingoEngine.Net.RNetContracts.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/Test/BlingoEngine.Net.RNetPipe.Tests/Fakes/FakeBlingoPlayer.cs
+++ b/Test/BlingoEngine.Net.RNetPipe.Tests/Fakes/FakeBlingoPlayer.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BlingoEngine.Casts;
+using BlingoEngine.Core;
+using BlingoEngine.Members;
+using BlingoEngine.Movies;
+using BlingoEngine.Sounds;
+using BlingoEngine.Stages;
+
+namespace BlingoEngine.Net.RNetPipe.Tests.Fakes;
+
+internal sealed class FakeBlingoPlayer : IBlingoPlayer
+{
+    private IBlingoMovie? _activeMovie;
+
+    public IBlingoCast ActiveCastLib => throw new NotSupportedException();
+
+    public IBlingoMovie? ActiveMovie => _activeMovie;
+
+    public event Action<IBlingoMovie?>? ActiveMovieChanged;
+
+    public void SetActiveMovie(IBlingoMovie? movie)
+    {
+        _activeMovie = movie;
+        ActiveMovieChanged?.Invoke(movie);
+    }
+
+    public IBlingoSound Sound => throw new NotSupportedException();
+
+    public bool MediaRequiresAsyncPreload { get; set; }
+
+    public int CurrentSpriteNum => 0;
+
+    public bool NetPreset => false;
+
+    public bool ActiveWindow => false;
+
+    public bool SafePlayer { get; set; }
+
+    public string OrganizationName { get; set; } = string.Empty;
+
+    public string ApplicationName { get; set; } = string.Empty;
+
+    public string ApplicationPath { get; set; } = string.Empty;
+
+    public string ProductName { get; set; } = string.Empty;
+
+    public int LastClick => 0;
+
+    public int LastEvent => 0;
+
+    public int LastKey => 0;
+
+    public Version ProductVersion { get; set; } = new(1, 0);
+
+    public IBlingoCastLibsContainer CastLibs => throw new NotSupportedException();
+
+    public IBlingoMember? GetMember(BlingoMemberRef memberRef) => throw new NotSupportedException();
+
+    public T? GetMember<T>(BlingoMemberRef memberRef) where T : class, IBlingoMember => throw new NotSupportedException();
+
+    public IBlingoCast? GetCast(BlingoCastRef castRef) => throw new NotSupportedException();
+
+    public Func<string> AlertHook { get; set; } = () => string.Empty;
+
+    public IBlingoStage Stage => throw new NotSupportedException();
+
+    public void Alert(string message)
+    {
+    }
+
+    public void AppMinimize()
+    {
+    }
+
+    public void Halt()
+    {
+    }
+
+    public void Cursor(int cursorNum)
+    {
+    }
+
+    public void Open(string applicationName)
+    {
+    }
+
+    public void Quit()
+    {
+    }
+
+    public bool WindowPresent() => false;
+
+    public IBlingoCast CastLib(int number) => throw new NotSupportedException();
+
+    public IBlingoCast CastLib(string name) => throw new NotSupportedException();
+
+    public IBlingoPlayer LoadCastLibFromCsv(string castlibName, string pathAndFilenameToCsv, bool isInternal = false) => this;
+
+    public Task<IBlingoPlayer> LoadAsync<TBlingoCastLibBuilder>() where TBlingoCastLibBuilder : class, IBlingoCastLibBuilder, new()
+        => Task.FromResult<IBlingoPlayer>(this);
+
+    public Task<IBlingoPlayer> LoadCastLibFromCsvAsync(string castlibName, string pathAndFilenameToCsv, bool isInternal = false)
+        => Task.FromResult<IBlingoPlayer>(this);
+
+    public IBlingoPlayer AddCastLib(string name, bool isInternal = false, Action<IBlingoCast>? configure = null) => this;
+
+    public IBlingoMovie NewMovie(string movieName, bool andActivate = true) => throw new NotSupportedException();
+
+    public IBlingoMovie? GetMovie(BlingoMovieRef movieRef) => null;
+
+    public Task<IBlingoMovie> LoadMovieAsync(IBlingoMovieBuilder builder) => throw new NotSupportedException();
+
+    public void RunDelayed(Action action, int milliseconds, CancellationTokenSource? cts = null) => action();
+
+    public Task RunOnUIThreadAsync(Action action, CancellationToken ct = default)
+    {
+        action();
+        return Task.CompletedTask;
+    }
+
+    public Task<T> RunOnUIThreadAsync<T>(Func<T> func, CancellationToken ct = default)
+        => Task.FromResult(func());
+
+    public Task<T> RunOnUIThreadAsync<T>(Func<Task<T>> func, CancellationToken ct = default)
+        => func();
+
+    public void RunOnUIThread(Action action) => action();
+}

--- a/Test/BlingoEngine.Net.RNetPipe.Tests/Fakes/FakePublisher.cs
+++ b/Test/BlingoEngine.Net.RNetPipe.Tests/Fakes/FakePublisher.cs
@@ -1,0 +1,79 @@
+using System;
+using BlingoEngine.Core;
+using BlingoEngine.Net.RNetContracts;
+using BlingoEngine.Net.RNetHost.Common;
+
+namespace BlingoEngine.Net.RNetPipe.Tests.Fakes;
+
+internal sealed class FakePublisher : IRNetPublisherEngineBridge
+{
+    public void Enable(IBlingoPlayer player)
+    {
+    }
+
+    public void Disable()
+    {
+    }
+
+    public void TryPublishFrame(StageFrameDto frame)
+    {
+    }
+
+    public void TryPublishDelta(SpriteDeltaDto delta)
+    {
+    }
+
+    public void TryPublishKeyframe(KeyframeDto keyframe)
+    {
+    }
+
+    public void TryPublishFilmLoop(FilmLoopDto filmLoop)
+    {
+    }
+
+    public void TryPublishSound(SoundEventDto sound)
+    {
+    }
+
+    public void TryPublishTempo(TempoDto tempo)
+    {
+    }
+
+    public void TryPublishColorPalette(ColorPaletteDto palette)
+    {
+    }
+
+    public void TryPublishFrameScript(FrameScriptDto script)
+    {
+    }
+
+    public void TryPublishTransition(TransitionDto transition)
+    {
+    }
+
+    public void TryPublishMemberProperty(RNetMemberPropertyDto property)
+    {
+    }
+
+    public void TryPublishMovieProperty(RNetMoviePropertyDto property)
+    {
+    }
+
+    public void TryPublishStageProperty(RNetStagePropertyDto property)
+    {
+    }
+
+    public void TryPublishTextStyle(TextStyleDto style)
+    {
+    }
+
+    public void TryPublishSpriteCollectionEvent(RNetSpriteCollectionEventDto evt)
+    {
+    }
+
+    public void FlushQueuedProperties()
+    {
+    }
+
+    public bool TryDrainCommands(Action<IRNetCommand> apply) => false;
+}

--- a/Test/BlingoEngine.Net.RNetPipe.Tests/Fakes/TestConfig.cs
+++ b/Test/BlingoEngine.Net.RNetPipe.Tests/Fakes/TestConfig.cs
@@ -1,0 +1,15 @@
+using BlingoEngine.Net.RNetContracts;
+using BlingoEngine.Net.RNetHost.Common;
+
+namespace BlingoEngine.Net.RNetPipe.Tests.Fakes;
+
+internal sealed class TestConfig : IRNetConfiguration
+{
+    public TestConfig(int port) => Port = port;
+
+    public int Port { get; set; }
+    public bool AutoStartRNetHostOnStartup { get; set; }
+    public string ClientName { get; set; } = "PipeHost";
+    public RNetRemoteRole RemoteRole { get; set; } = RNetRemoteRole.Host;
+    public RNetClientType ClientType { get; set; } = RNetClientType.Pipe;
+}

--- a/Test/BlingoEngine.Net.RNetPipe.Tests/Fakes/TestPipeBus.cs
+++ b/Test/BlingoEngine.Net.RNetPipe.Tests/Fakes/TestPipeBus.cs
@@ -1,0 +1,37 @@
+using System.Threading.Channels;
+using BlingoEngine.Net.RNetContracts;
+using BlingoEngine.Net.RNetPipeServer;
+
+namespace BlingoEngine.Net.RNetPipe.Tests.Fakes;
+
+internal sealed class TestPipeBus : IRNetPipeBus
+{
+    public Channel<StageFrameDto> Frames { get; } = CreateChannel<StageFrameDto>();
+    public Channel<SpriteDeltaDto> Deltas { get; } = CreateChannel<SpriteDeltaDto>();
+    public Channel<KeyframeDto> Keyframes { get; } = CreateChannel<KeyframeDto>();
+    public Channel<FilmLoopDto> FilmLoops { get; } = CreateChannel<FilmLoopDto>();
+    public Channel<SoundEventDto> Sounds { get; } = CreateChannel<SoundEventDto>();
+    public Channel<TempoDto> Tempos { get; } = CreateChannel<TempoDto>();
+    public Channel<ColorPaletteDto> ColorPalettes { get; } = CreateChannel<ColorPaletteDto>();
+    public Channel<FrameScriptDto> FrameScripts { get; } = CreateChannel<FrameScriptDto>();
+    public Channel<TransitionDto> Transitions { get; } = CreateChannel<TransitionDto>();
+    public Channel<RNetMemberPropertyDto> MemberProperties { get; } = CreateChannel<RNetMemberPropertyDto>();
+    public Channel<TextStyleDto> TextStyles { get; } = CreateChannel<TextStyleDto>();
+    public Channel<RNetMoviePropertyDto> MovieProperties { get; } = CreateChannel<RNetMoviePropertyDto>();
+    public Channel<RNetStagePropertyDto> StageProperties { get; } = CreateChannel<RNetStagePropertyDto>();
+    public Channel<RNetSpriteCollectionEventDto> SpriteCollectionEvents { get; } = CreateChannel<RNetSpriteCollectionEventDto>();
+    public Channel<IRNetCommand> Commands { get; } = CreateUnboundedCommandChannel();
+
+    private static Channel<T> CreateChannel<T>() => Channel.CreateUnbounded<T>(new UnboundedChannelOptions
+    {
+        SingleReader = false,
+        SingleWriter = false
+    });
+
+    private static Channel<IRNetCommand> CreateUnboundedCommandChannel()
+        => Channel.CreateUnbounded<IRNetCommand>(new UnboundedChannelOptions
+        {
+            SingleReader = false,
+            SingleWriter = false
+        });
+}

--- a/Test/BlingoEngine.Net.RNetPipe.Tests/RNetPipeIntegrationTests.cs
+++ b/Test/BlingoEngine.Net.RNetPipe.Tests/RNetPipeIntegrationTests.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using BlingoEngine.Core;
+using BlingoEngine.Net.RNetContracts;
+using BlingoEngine.Net.RNetHost.Common;
+using BlingoEngine.Net.RNetPipeServer;
+using BlingoEngine.Net.RNetPipe.Tests.Fakes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using PipeClient = BlingoEngine.Net.RNetPipeClient.RNetPipeClient;
+using PipeServer = BlingoEngine.Net.RNetPipeServer.RNetPipeServer;
+
+namespace BlingoEngine.Net.RNetPipe.Tests;
+
+public class RNetPipeIntegrationTests
+{
+    private static int _portSeed = 62000;
+
+    [Fact]
+    public Task PipeClientAndServer_ExchangeFramesAndCommands()
+        => WithPipeServerAndClientAsync(async (scenario, token) =>
+        {
+            var expectedFrame = new StageFrameDto(
+                4,
+                4,
+                42,
+                new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                new byte[] { 1, 2, 3, 4 });
+
+            await AssertBusForwardingAsync(
+                scenario,
+                token,
+                expectedFrame,
+                (client, ct) => client.StreamFramesAsync(ct),
+                (bus, frame, ct) => bus.Frames.Writer.WriteAsync(frame, ct),
+                (expected, actual) =>
+                {
+                    Assert.Equal(expected.Width, actual.Width);
+                    Assert.Equal(expected.Height, actual.Height);
+                    Assert.Equal(expected.FrameId, actual.FrameId);
+                    Assert.Equal(expected.TimestampUtc, actual.TimestampUtc);
+                    Assert.Equal(expected.Argb32, actual.Argb32);
+                });
+
+            await scenario.Client.SendCommandAsync(new PauseCmd(), token);
+            var receivedCommand = await scenario.Bus.Commands.Reader.ReadAsync(token);
+            Assert.IsType<PauseCmd>(receivedCommand);
+        });
+
+    [Fact]
+    public Task PipeClientAndServer_ForwardAllMessagesFromBus()
+        => WithPipeServerAndClientAsync(async (scenario, token) =>
+        {
+            var frame = new StageFrameDto(
+                8,
+                6,
+                7,
+                new DateTime(2024, 2, 2, 0, 0, 0, DateTimeKind.Utc),
+                new byte[] { 5, 6, 7, 8 });
+
+            await AssertBusForwardingAsync(
+                scenario,
+                token,
+                frame,
+                (client, ct) => client.StreamFramesAsync(ct),
+                (bus, payload, ct) => bus.Frames.Writer.WriteAsync(payload, ct),
+                (expected, actual) =>
+                {
+                    Assert.Equal(expected.Width, actual.Width);
+                    Assert.Equal(expected.Height, actual.Height);
+                    Assert.Equal(expected.FrameId, actual.FrameId);
+                    Assert.Equal(expected.TimestampUtc, actual.TimestampUtc);
+                    Assert.Equal(expected.Argb32, actual.Argb32);
+                });
+
+            var delta = new SpriteDeltaDto(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
+            await AssertBusForwardingAsync(
+                scenario,
+                token,
+                delta,
+                (client, ct) => client.StreamDeltasAsync(ct),
+                (bus, payload, ct) => bus.Deltas.Writer.WriteAsync(payload, ct));
+
+            var keyframe = new KeyframeDto(5, 2, 3, "Blend", "50");
+            await AssertBusForwardingAsync(
+                scenario,
+                token,
+                keyframe,
+                (client, ct) => client.StreamKeyframesAsync(ct),
+                (bus, payload, ct) => bus.Keyframes.Writer.WriteAsync(payload, ct));
+
+            var filmLoop = new FilmLoopDto(2, 4, 10, 20, true);
+            await AssertBusForwardingAsync(
+                scenario,
+                token,
+                filmLoop,
+                (client, ct) => client.StreamFilmLoopsAsync(ct),
+                (bus, payload, ct) => bus.FilmLoops.Writer.WriteAsync(payload, ct));
+
+            var sound = new SoundEventDto(12, 7, 9, true);
+            await AssertBusForwardingAsync(
+                scenario,
+                token,
+                sound,
+                (client, ct) => client.StreamSoundsAsync(ct),
+                (bus, payload, ct) => bus.Sounds.Writer.WriteAsync(payload, ct));
+
+            var tempo = new TempoDto(15, 120);
+            await AssertBusForwardingAsync(
+                scenario,
+                token,
+                tempo,
+                (client, ct) => client.StreamTemposAsync(ct),
+                (bus, payload, ct) => bus.Tempos.Writer.WriteAsync(payload, ct));
+
+            var palette = new ColorPaletteDto(18, new byte[] { 9, 10, 11, 12 });
+            await AssertBusForwardingAsync(
+                scenario,
+                token,
+                palette,
+                (client, ct) => client.StreamColorPalettesAsync(ct),
+                (bus, payload, ct) => bus.ColorPalettes.Writer.WriteAsync(payload, ct),
+                (expected, actual) =>
+                {
+                    Assert.Equal(expected.Frame, actual.Frame);
+                    Assert.Equal(expected.Argb32, actual.Argb32);
+                });
+
+            var script = new FrameScriptDto(21, "go to frame 5");
+            await AssertBusForwardingAsync(
+                scenario,
+                token,
+                script,
+                (client, ct) => client.StreamFrameScriptsAsync(ct),
+                (bus, payload, ct) => bus.FrameScripts.Writer.WriteAsync(payload, ct));
+
+            var transition = new TransitionDto(24, "crossfade", 6);
+            await AssertBusForwardingAsync(
+                scenario,
+                token,
+                transition,
+                (client, ct) => client.StreamTransitionsAsync(ct),
+                (bus, payload, ct) => bus.Transitions.Writer.WriteAsync(payload, ct));
+
+            var memberProperty = new RNetMemberPropertyDto(3, 8, "Name", "Hero");
+            await AssertBusForwardingAsync(
+                scenario,
+                token,
+                memberProperty,
+                (client, ct) => client.StreamMemberPropertiesAsync(ct),
+                (bus, payload, ct) => bus.MemberProperties.Writer.WriteAsync(payload, ct));
+
+            var textStyle = new TextStyleDto(3, 8, 0, 5, "FontWeight", "Bold");
+            await AssertBusForwardingAsync(
+                scenario,
+                token,
+                textStyle,
+                (client, ct) => client.StreamTextStylesAsync(ct),
+                (bus, payload, ct) => bus.TextStyles.Writer.WriteAsync(payload, ct));
+
+            var movieProperty = new RNetMoviePropertyDto("Duration", "90");
+            await AssertBusForwardingAsync(
+                scenario,
+                token,
+                movieProperty,
+                (client, ct) => client.StreamMoviePropertiesAsync(ct),
+                (bus, payload, ct) => bus.MovieProperties.Writer.WriteAsync(payload, ct));
+
+            var stageProperty = new RNetStagePropertyDto("BackColor", "#112233");
+            await AssertBusForwardingAsync(
+                scenario,
+                token,
+                stageProperty,
+                (client, ct) => client.StreamStagePropertiesAsync(ct),
+                (bus, payload, ct) => bus.StageProperties.Writer.WriteAsync(payload, ct));
+
+            var spriteEvent = new RNetSpriteCollectionEventDto("Sprite2D", RNetSpriteCollectionEventType.Added, 5, 1, null);
+            await AssertBusForwardingAsync(
+                scenario,
+                token,
+                spriteEvent,
+                (client, ct) => client.StreamSpriteCollectionEventsAsync(ct),
+                (bus, payload, ct) => bus.SpriteCollectionEvents.Writer.WriteAsync(payload, ct));
+        });
+
+    [Theory]
+    [MemberData(nameof(CommandData))]
+    public Task PipeClientAndServer_RelayAllCommandTypes(RNetCommand command)
+        => WithPipeServerAndClientAsync(async (scenario, token) =>
+        {
+            await scenario.Client.SendCommandAsync(command, token);
+            var received = await scenario.Bus.Commands.Reader.ReadAsync(token);
+            var actual = Assert.IsAssignableFrom<RNetCommand>(received);
+            Assert.IsType(command.GetType(), actual);
+            Assert.Equal(command, actual);
+        });
+
+    public static IEnumerable<object[]> CommandData()
+    {
+        yield return new object[] { new SetSpritePropCmd(3, 1, RNetSpriteTypeDto.Sprite2D, "LocH", "123") };
+        yield return new object[] { new SetMemberPropCmd(1, 5, RNetMemberTypeDto.Bitmap, "Name", "MyBitmap") };
+        yield return new object[] { new SetCastPropCmd(2, "Title", "Cast A") };
+        yield return new object[] { new GoToFrameCmd(42) };
+        yield return new object[] { new RewindCmd() };
+        yield return new object[] { new PauseCmd() };
+        yield return new object[] { new ResumeCmd() };
+    }
+
+    private sealed record PipeScenario(PipeClient Client, TestPipeBus Bus);
+
+    private static async Task WithPipeServerAndClientAsync(Func<PipeScenario, CancellationToken, Task> testBody)
+    {
+        var services = new ServiceCollection();
+        var bus = new TestPipeBus();
+        services.AddSingleton<IRNetPipeBus>(bus);
+        services.AddSingleton<IBlingoPlayer>(new FakeBlingoPlayer());
+        services.AddSingleton<IRNetPublisherEngineBridge>(new FakePublisher());
+        using var provider = services.BuildServiceProvider();
+
+        var port = Interlocked.Increment(ref _portSeed);
+        var server = new PipeServer(new TestConfig(port), NullLogger<PipeServer>.Instance, provider);
+        await server.StartAsync();
+
+        var client = new PipeClient();
+        var hello = new HelloDto("test-project", "client-id", "1.0", "PipeTest");
+        var uri = new Uri($"pipe://localhost:{port}");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        try
+        {
+            await ConnectWithRetryAsync(client, uri, hello, cts.Token);
+            var scenario = new PipeScenario(client, bus);
+            await testBody(scenario, cts.Token);
+        }
+        finally
+        {
+            await client.DisposeAsync();
+            await server.StopAsync();
+        }
+    }
+
+    private static async Task AssertBusForwardingAsync<T>(
+        PipeScenario scenario,
+        CancellationToken ct,
+        T payload,
+        Func<PipeClient, CancellationToken, IAsyncEnumerable<T>> streamFactory,
+        Func<TestPipeBus, T, CancellationToken, ValueTask> writeAsync,
+        Action<T, T>? assert = null)
+    {
+        var readTask = ReadFirstAsync(streamFactory(scenario.Client, ct), ct);
+        await writeAsync(scenario.Bus, payload, ct);
+        var actual = await readTask;
+        if (assert is null)
+        {
+            Assert.Equal(payload, actual);
+        }
+        else
+        {
+            assert(payload, actual);
+        }
+    }
+
+    private static async Task<T> ReadFirstAsync<T>(IAsyncEnumerable<T> source, CancellationToken ct)
+    {
+        await foreach (var item in source.WithCancellation(ct))
+        {
+            return item;
+        }
+
+        throw new InvalidOperationException("Sequence completed without emitting a value.");
+    }
+
+    private static async Task ConnectWithRetryAsync(PipeClient client, Uri uri, HelloDto hello, CancellationToken ct)
+    {
+        const int maxAttempts = 5;
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            try
+            {
+                await client.ConnectAsync(uri, hello, ct);
+                return;
+            }
+            catch (SocketException ex) when (attempt < maxAttempts - 1 &&
+                (ex.SocketErrorCode == SocketError.AddressNotAvailable || ex.SocketErrorCode == SocketError.ConnectionRefused))
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(50), ct);
+            }
+        }
+    }
+}

--- a/Test/BlingoEngine.Net.RNetPipe.Tests/RNetPipePublisherTests.cs
+++ b/Test/BlingoEngine.Net.RNetPipe.Tests/RNetPipePublisherTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using BlingoEngine.Net.RNetContracts;
+using BlingoEngine.Net.RNetPipe.Tests.Fakes;
+using BlingoEngine.Net.RNetPipeServer;
+
+namespace BlingoEngine.Net.RNetPipe.Tests;
+
+public class RNetPipePublisherTests
+{
+    [Fact]
+    public void TryPublish_PushesImmediateMessagesToBus()
+    {
+        var bus = new TestPipeBus();
+        var publisher = new RNetPipePublisher(bus);
+
+        var frame = new StageFrameDto(320, 240, 7, new DateTime(2024, 3, 1, 0, 0, 0, DateTimeKind.Utc), new byte[] { 1, 2, 3 });
+        publisher.TryPublishFrame(frame);
+        Assert.True(bus.Frames.Reader.TryRead(out var actualFrame));
+        Assert.Equal(frame.Width, actualFrame.Width);
+        Assert.Equal(frame.Height, actualFrame.Height);
+        Assert.Equal(frame.FrameId, actualFrame.FrameId);
+        Assert.Equal(frame.TimestampUtc, actualFrame.TimestampUtc);
+        Assert.Equal(frame.Argb32, actualFrame.Argb32);
+
+        var keyframe = new KeyframeDto(12, 3, 1, "Blend", "80");
+        publisher.TryPublishKeyframe(keyframe);
+        Assert.True(bus.Keyframes.Reader.TryRead(out var actualKeyframe));
+        Assert.Equal(keyframe, actualKeyframe);
+
+        var filmLoop = new FilmLoopDto(1, 2, 5, 15, true);
+        publisher.TryPublishFilmLoop(filmLoop);
+        Assert.True(bus.FilmLoops.Reader.TryRead(out var actualFilmLoop));
+        Assert.Equal(filmLoop, actualFilmLoop);
+
+        var sound = new SoundEventDto(9, 4, 6, true);
+        publisher.TryPublishSound(sound);
+        Assert.True(bus.Sounds.Reader.TryRead(out var actualSound));
+        Assert.Equal(sound, actualSound);
+
+        var tempo = new TempoDto(18, 144);
+        publisher.TryPublishTempo(tempo);
+        Assert.True(bus.Tempos.Reader.TryRead(out var actualTempo));
+        Assert.Equal(tempo, actualTempo);
+
+        var palette = new ColorPaletteDto(21, new byte[] { 10, 20, 30, 40 });
+        publisher.TryPublishColorPalette(palette);
+        Assert.True(bus.ColorPalettes.Reader.TryRead(out var actualPalette));
+        Assert.Equal(palette.Frame, actualPalette.Frame);
+        Assert.Equal(palette.Argb32, actualPalette.Argb32);
+
+        var script = new FrameScriptDto(24, "go to frame 30");
+        publisher.TryPublishFrameScript(script);
+        Assert.True(bus.FrameScripts.Reader.TryRead(out var actualScript));
+        Assert.Equal(script, actualScript);
+
+        var transition = new TransitionDto(27, "iris", 8);
+        publisher.TryPublishTransition(transition);
+        Assert.True(bus.Transitions.Reader.TryRead(out var actualTransition));
+        Assert.Equal(transition, actualTransition);
+
+        var textStyle = new TextStyleDto(2, 6, 0, 4, "FontStyle", "Italic");
+        publisher.TryPublishTextStyle(textStyle);
+        Assert.True(bus.TextStyles.Reader.TryRead(out var actualTextStyle));
+        Assert.Equal(textStyle, actualTextStyle);
+
+        var spriteEvent = new RNetSpriteCollectionEventDto("Sprite2D", RNetSpriteCollectionEventType.Cleared, 0, 0, null);
+        publisher.TryPublishSpriteCollectionEvent(spriteEvent);
+        Assert.True(bus.SpriteCollectionEvents.Reader.TryRead(out var actualSpriteEvent));
+        Assert.Equal(spriteEvent, actualSpriteEvent);
+    }
+
+    [Fact]
+    public void TryPublish_FlushesQueuedMessagesAndDrainsCommands()
+    {
+        var bus = new TestPipeBus();
+        var publisher = new RNetPipePublisher(bus);
+
+        var delta = new SpriteDeltaDto(3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+        publisher.TryPublishDelta(delta);
+        Assert.False(bus.Deltas.Reader.TryRead(out _));
+
+        var memberProperty = new RNetMemberPropertyDto(5, 9, "Score", "1000");
+        publisher.TryPublishMemberProperty(memberProperty);
+        Assert.False(bus.MemberProperties.Reader.TryRead(out _));
+
+        var movieProperty = new RNetMoviePropertyDto("Title", "TestMovie");
+        publisher.TryPublishMovieProperty(movieProperty);
+        Assert.False(bus.MovieProperties.Reader.TryRead(out _));
+
+        var stageProperty = new RNetStagePropertyDto("Background", "Black");
+        publisher.TryPublishStageProperty(stageProperty);
+        Assert.False(bus.StageProperties.Reader.TryRead(out _));
+
+        publisher.FlushQueuedProperties();
+
+        Assert.True(bus.Deltas.Reader.TryRead(out var actualDelta));
+        Assert.Equal(delta, actualDelta);
+
+        Assert.True(bus.MemberProperties.Reader.TryRead(out var actualMember));
+        Assert.Equal(memberProperty, actualMember);
+
+        Assert.True(bus.MovieProperties.Reader.TryRead(out var actualMovie));
+        Assert.Equal(movieProperty, actualMovie);
+
+        Assert.True(bus.StageProperties.Reader.TryRead(out var actualStage));
+        Assert.Equal(stageProperty, actualStage);
+
+        var commands = new List<IRNetCommand>
+        {
+            new GoToFrameCmd(12),
+            new ResumeCmd()
+        };
+
+        foreach (var cmd in commands)
+        {
+            Assert.True(bus.Commands.Writer.TryWrite(cmd));
+        }
+
+        var drained = new List<IRNetCommand>();
+        Assert.True(publisher.TryDrainCommands(drained.Add));
+        Assert.Equal(commands, drained);
+        Assert.False(publisher.TryDrainCommands(_ => throw new InvalidOperationException("should not drain")));
+    }
+}
+

--- a/src/Net/BlingoEngine.Net.RNetPipeClient/RNetPipeClient.cs
+++ b/src/Net/BlingoEngine.Net.RNetPipeClient/RNetPipeClient.cs
@@ -22,7 +22,10 @@ public interface IBlingoRNetPipeClient : IBlingoRNetClient { }
 /// <inheritdoc />
 public sealed class RNetPipeClient : IBlingoRNetPipeClient
 {
-    private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
     private readonly SemaphoreSlim _sendLock = new(1, 1);
     private readonly Dictionary<string, Func<string, bool>> _inboundHandlers;
     private readonly Dictionary<string, Type> _commandTypes;
@@ -348,7 +351,9 @@ public sealed class RNetPipeClient : IBlingoRNetPipeClient
             throw new ArgumentNullException(nameof(cmd));
         }
 
-        return SendAsync(cmd.GetType().Name, cmd, ct);
+        var type = cmd.GetType();
+        var json = JsonSerializer.Serialize(cmd, type, _jsonOptions);
+        return SendRawAsync(type.Name, json, ct);
     }
 
     /// <inheritdoc />

--- a/src/Net/BlingoEngine.Net.RNetPipeServer/RNetPipeServer.cs
+++ b/src/Net/BlingoEngine.Net.RNetPipeServer/RNetPipeServer.cs
@@ -28,7 +28,10 @@ public sealed class RNetPipeServer : IRNetPipeServer
     private readonly IRNetConfiguration _config;
     private readonly ILogger<RNetPipeServer> _logger;
     private readonly IServiceProvider _serviceProvider;
-    private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
     private readonly ConcurrentDictionary<string, Type> _commandTypes;
     private CancellationTokenSource? _cts;
     private Task? _listenerTask;


### PR DESCRIPTION
## Summary
- restructure the RNet pipe integration tests with shared setup, add coverage for all outbound bus message types, and verify command relay for every command
- add dedicated unit tests for the RNet pipe publisher to confirm it pushes queued messages and drains commands
- update the pipe client/server JSON handling and connection helper so command payloads serialize correctly and connections retry reliably

## Testing
- dotnet test Test/BlingoEngine.Net.RNetPipe.Tests/BlingoEngine.Net.RNetPipe.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d21dbf67d88332baba17958d234b39