### PR TITLE
Improve RNetTerminal log view scrolling and wrapping

### DIFF
--- a/src/Net/BlingoEngine.Net.RNetTerminal/Views/RootWindow.cs
+++ b/src/Net/BlingoEngine.Net.RNetTerminal/Views/RootWindow.cs
@@ -20,9 +20,8 @@ namespace BlingoEngine.Net.RNetTerminal.Views
     {
        
         private readonly List<string> _logs = new();
-       
-        private ListView? _logList = new ListView();
-        private View? _logWindow;
+
+        private TextView? _logTextView;
         private PropertyInspector? _propertyInspector;
         private Label? _connectionStatusLabel;
         private Label? _infoItem;
@@ -248,14 +247,23 @@ namespace BlingoEngine.Net.RNetTerminal.Views
             return _propertyInspector;
         }
         private View CreateLog()
-{
+        {
 
-            _logWindow = new View { X =0, Y = 0, Width = Dim.Fill(), Height = Dim.Fill() };
-            _logWindow.HorizontalScrollBar.Visible = true;
-            _logWindow.VerticalScrollBar.Visible = true;
-            _logList = RUI.NewListView(_logs, 0,0, Dim.Fill(), Dim.Fill());
-            _logWindow.Add(_logList);
-            return _logWindow;
+            _logTextView = new TextView
+            {
+                X = 0,
+                Y = 0,
+                Width = Dim.Fill(),
+                Height = Dim.Fill(),
+                ReadOnly = true,
+                Multiline = true,
+                WordWrap = true
+            };
+            _logTextView.VerticalScrollBar.AutoShow = true;
+            _logTextView.VerticalScrollBar.Visible = true;
+            _logTextView.HorizontalScrollBar.AutoShow = false;
+            _logTextView.HorizontalScrollBar.Visible = false;
+            return _logTextView;
         }
 
       
@@ -439,10 +447,10 @@ namespace BlingoEngine.Net.RNetTerminal.Views
                 if (_logs.Count > 100)
                     _logs.RemoveAt(0);
                 
-                if (_logList != null)
+                if (_logTextView != null)
                 {
-                    _logList.SetSource(new System.Collections.ObjectModel.ObservableCollection<string>(_logs));
-                    _logList.MoveEnd();
+                    _logTextView.Text = string.Join(Environment.NewLine, _logs);
+                    _logTextView.MoveEnd();
                 }
             }
 


### PR DESCRIPTION
## Summary
- replace the log pane with a read-only `TextView` that wraps entries and configures scrollbars for the log tile
- refresh the log `TextView` content when new messages arrive and scroll to the latest entry

## Testing
- dotnet build src/Net/BlingoEngine.Net.RNetTerminal/BlingoEngine.Net.RNetTerminal.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d3a7a66f708332a71ba065ee721a10