### PR TITLE
Move legacy class member analysis into analysis pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,3 +97,6 @@ These instructions apply to the entire repository.
 - The solution file is `BlingoEngine.sln`. But avoid using it, its big.
 - Keep cross-platform compatibility in mind when making changes.
 
+## Generated Code
+- Do **not** modify files under any `Generated/` directory. These files are produced for UI verification and should remain unchanged.
+

--- a/Test/BlingoEngine.Legacy.Lingo.Tests/BlLegacyClassGeneratorTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/BlLegacyClassGeneratorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using BlingoEngine.Legacy.Lingo.Analysis;
 using BlingoEngine.Legacy.Lingo.CodeGen;
 using Xunit;
@@ -23,9 +24,28 @@ public class MyBehaviorBehavior : BlingoSpriteBehavior
     }
 
     [Fact]
-    public void ParentScript_IncludesGlobalFieldAndConstructor()
+    public void ParentScriptWithoutGlobals_UsesBasicConstructor()
     {
         var code = _generator.GenerateClass("MyParent", string.Empty, BlLingoScriptKind.Parent);
+        const string expected = """
+public class MyParentParent : BlingoParentScript
+{
+    public MyParentParent(IBlingoMovieEnvironment env) : base(env) { }
+}
+""";
+
+        LegacyCodeAssert.AreEqual(expected, code);
+    }
+
+    [Fact]
+    public void ParentScriptWithGlobals_IncludesGlobalField()
+    {
+        const string source = "global gValue\n" +
+            "on startMovie\n" +
+            "  gValue = 1\n" +
+            "end";
+
+        var code = _generator.GenerateClass("MyParent", source, BlLingoScriptKind.Parent);
         const string expected = """
 public class MyParentParent : BlingoParentScript
 {
@@ -35,10 +55,53 @@ public class MyParentParent : BlingoParentScript
     {
         _global = global;
     }
+    public void StartMovie()
+    {
+        gValue = 1;
+    }
 }
 """;
 
         LegacyCodeAssert.AreEqual(expected, code);
+    }
+
+    [Fact]
+    public void Properties_AreDeclaredWithInferredTypesAndComments()
+    {
+        const string source = "property myStartX -- start X\n" +
+            "property myStartY\n" +
+            "on new me\n" +
+            "  myStartX = 250\n" +
+            "  myStartY = 45\n" +
+            "end";
+
+        var code = _generator.GenerateClass("Mover", source, BlLingoScriptKind.Behavior);
+
+        Assert.Contains("public int myStartX { get; set; } // start X", code);
+        Assert.Contains("public int myStartY { get; set; }", code);
+
+        var propertyIndex = code.IndexOf("public int myStartX { get; set; } // start X", StringComparison.Ordinal);
+        var constructorIndex = code.IndexOf("public MoverBehavior(IBlingoMovieEnvironment env) : base(env) { }", StringComparison.Ordinal);
+        var handlerIndex = code.IndexOf("public void New()", StringComparison.Ordinal);
+
+        Assert.True(propertyIndex >= 0, "Properties were not generated");
+        Assert.True(constructorIndex > propertyIndex, "Constructor should appear after properties");
+        Assert.True(handlerIndex > constructorIndex, "Handler should appear after constructor");
+    }
+
+    [Fact]
+    public void Handlers_AppearInSourceOrder()
+    {
+        const string source = "on startMovie\nend\n" +
+            "on stopMovie\nend";
+
+        var code = _generator.GenerateClass("Order", source, BlLingoScriptKind.Movie);
+        var startIndex = code.IndexOf("public void StartMovie", StringComparison.Ordinal);
+        var stopIndex = code.IndexOf("public void StopMovie", StringComparison.Ordinal);
+
+        Assert.True(startIndex >= 0, "StartMovie handler not found");
+        Assert.True(stopIndex >= 0, "StopMovie handler not found");
+        Assert.True(startIndex < stopIndex, "Handlers are not in source order");
     }
 
     [Fact]

--- a/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerMovieCallTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerMovieCallTests.cs
@@ -38,12 +38,7 @@ public class P1Behavior : BlingoSpriteBehavior, IHasBeginSpriteEvent
         const string expectedMovie = """
 public class M1MovieScript : BlingoMovieScript
 {
-    private readonly GlobalVars _global;
-
-    public M1MovieScript(IBlingoMovieEnvironment env, GlobalVars global) : base(env)
-    {
-        _global = global;
-    }
+    public M1MovieScript(IBlingoMovieEnvironment env) : base(env) { }
     public int MyMovieHandler()
     {
         return 42;
@@ -87,12 +82,7 @@ public class P1Behavior : BlingoSpriteBehavior, IHasBeginSpriteEvent
         const string expectedMovie = """
 public class M1MovieScript : BlingoMovieScript
 {
-    private readonly GlobalVars _global;
-
-    public M1MovieScript(IBlingoMovieEnvironment env, GlobalVars global) : base(env)
-    {
-        _global = global;
-    }
+    public M1MovieScript(IBlingoMovieEnvironment env) : base(env) { }
     public int MyMovieHandler()
     {
         return 42;
@@ -136,12 +126,7 @@ public class P1Behavior : BlingoSpriteBehavior, IHasBeginSpriteEvent
         const string expectedMovie = """
 public class M1MovieScript : BlingoMovieScript
 {
-    private readonly GlobalVars _global;
-
-    public M1MovieScript(IBlingoMovieEnvironment env, GlobalVars global) : base(env)
-    {
-        _global = global;
-    }
+    public M1MovieScript(IBlingoMovieEnvironment env) : base(env) { }
     public int MyMovieHandler()
     {
         return 42;

--- a/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyClassMemberInfo.cs
+++ b/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyClassMemberInfo.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+namespace BlingoEngine.Legacy.Lingo.Analysis;
+
+/// <summary>
+/// Aggregates analysis data about class members that code generation consumes.
+/// </summary>
+public sealed class BlLegacyClassMemberInfo
+{
+    public static BlLegacyClassMemberInfo Empty { get; } = new(
+        Array.Empty<BlLegacyPropertyInfo>(),
+        Array.Empty<BlLingoHandlerSymbolTable>(),
+        false);
+
+    public BlLegacyClassMemberInfo(
+        IReadOnlyList<BlLegacyPropertyInfo> properties,
+        IReadOnlyList<BlLingoHandlerSymbolTable> handlerOrder,
+        bool hasGlobalDeclarations)
+    {
+        Properties = properties ?? throw new ArgumentNullException(nameof(properties));
+        HandlerOrder = handlerOrder ?? throw new ArgumentNullException(nameof(handlerOrder));
+        HasGlobalDeclarations = hasGlobalDeclarations;
+    }
+
+    /// <summary>
+    /// Gets the ordered properties discovered for the class.
+    /// </summary>
+    public IReadOnlyList<BlLegacyPropertyInfo> Properties { get; }
+
+    /// <summary>
+    /// Gets the handlers in the order they appear in source.
+    /// </summary>
+    public IReadOnlyList<BlLingoHandlerSymbolTable> HandlerOrder { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the class declares global variables.
+    /// </summary>
+    public bool HasGlobalDeclarations { get; }
+}

--- a/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyHandlerFilters.cs
+++ b/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyHandlerFilters.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace BlingoEngine.Legacy.Lingo.Analysis;
+
+internal static class BlLegacyHandlerFilters
+{
+    public static bool ShouldSkipHandler(BlLingoHandlerSymbolTable handler)
+    {
+        if (handler is null)
+        {
+            return true;
+        }
+
+        if (string.Equals(handler.OriginalName, BlLingoHandlerSymbolTable.ImplicitHandlerName, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (IsPropertyDescriptionHandler(handler.OriginalName) || IsPropertyDescriptionHandler(handler.Symbol.Name))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsPropertyDescriptionHandler(string? name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return false;
+        }
+
+        return name.Equals("getPropertyDescriptionList", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("getBehaviorDescription", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("getBehaviorTooltip", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("isOKToAttach", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyPropertyInfo.cs
+++ b/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyPropertyInfo.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace BlingoEngine.Legacy.Lingo.Analysis;
+
+/// <summary>
+/// Describes a property declared within a legacy Lingo class, including its inferred type and trailing comment.
+/// </summary>
+public sealed class BlLegacyPropertyInfo
+{
+    public BlLegacyPropertyInfo(string name, string type, string? comment)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(type);
+
+        Name = name;
+        Type = type;
+        Comment = comment;
+    }
+
+    /// <summary>
+    /// Gets the property name as it should appear in generated C# code.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the inferred property type.
+    /// </summary>
+    public string Type { get; }
+
+    /// <summary>
+    /// Gets the trailing comment associated with the property declaration, if any.
+    /// </summary>
+    public string? Comment { get; }
+}

--- a/src/BlingoEngine.Legacy.Lingo/Analysis/BlLingoAnalyzer.cs
+++ b/src/BlingoEngine.Legacy.Lingo/Analysis/BlLingoAnalyzer.cs
@@ -30,6 +30,7 @@ public sealed class BlLingoAnalyzer
         analyzer.AddPass(new BlLingoTypeLinkPass());
         analyzer.AddPass(new BlLingoClassLinkPass());
         analyzer.AddPass(new BlLingoHandlerCodeBlockPass());
+        analyzer.AddPass(new BlLegacyClassMemberPass());
         return analyzer;
     }
 

--- a/src/BlingoEngine.Legacy.Lingo/Analysis/Passes/BlLegacyClassMemberPass.cs
+++ b/src/BlingoEngine.Legacy.Lingo/Analysis/Passes/BlLegacyClassMemberPass.cs
@@ -1,0 +1,633 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using BlingoEngine.Legacy.Lingo.CodeGen;
+using BlingoEngine.Legacy.Lingo.Syntax;
+
+namespace BlingoEngine.Legacy.Lingo.Analysis.Passes;
+
+/// <summary>
+/// Aggregates class member metadata such as property declarations, handler order, and global usage.
+/// </summary>
+public sealed class BlLegacyClassMemberPass : BlLingoAnalysisPass
+{
+    public const string ClassMemberInfoKey = "Legacy.ClassMembers";
+
+    public BlLegacyClassMemberPass()
+        : base("LegacyClassMembers")
+    {
+    }
+
+    public override void Execute(BlLingoAnalysisContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var tokens = context.Tokens;
+        var symbols = context.Symbols;
+        var classData = new Dictionary<BlLingoClassSymbolTable, ClassData>();
+
+        foreach (var scope in EnumerateClasses(symbols))
+        {
+            classData[scope] = new ClassData(scope);
+        }
+
+        if (classData.Count == 0)
+        {
+            context.SetData<IReadOnlyDictionary<BlLingoClassSymbolTable, BlLegacyClassMemberInfo>>(ClassMemberInfoKey, new Dictionary<BlLingoClassSymbolTable, BlLegacyClassMemberInfo>());
+            return;
+        }
+
+        var currentClass = symbols.MovieScript;
+        for (var index = 0; index < tokens.Count; index++)
+        {
+            var token = tokens[index];
+            if (token.Kind != BlSyntaxKind.KeywordToken)
+            {
+                continue;
+            }
+
+            var keyword = token.ValueText;
+            if (keyword.Equals("script", StringComparison.OrdinalIgnoreCase))
+            {
+                if (TryGetClassName(tokens, index + 1, out var className) &&
+                    symbols.ClassScopes.TryGetValue(className, out var scope))
+                {
+                    currentClass = scope;
+                }
+                else
+                {
+                    currentClass = symbols.MovieScript;
+                }
+
+                continue;
+            }
+
+            if (!classData.TryGetValue(currentClass, out var data))
+            {
+                continue;
+            }
+
+            if (keyword.Equals("property", StringComparison.OrdinalIgnoreCase))
+            {
+                index = CollectPropertyDeclarations(tokens, index + 1, data);
+                continue;
+            }
+
+            if (keyword.Equals("global", StringComparison.OrdinalIgnoreCase))
+            {
+                if (HasIdentifiersBeforeNewLine(tokens, index + 1))
+                {
+                    data.HasGlobalDeclarations = true;
+                }
+
+                continue;
+            }
+
+            if (!keyword.Equals("on", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!TryGetHandlerNameToken(tokens, index + 1, out var handlerToken))
+            {
+                continue;
+            }
+
+            if (!data.Scope.Handlers.TryGetValue(handlerToken.ValueText, out var handler) || handler is null)
+            {
+                continue;
+            }
+
+            if (BlLegacyHandlerFilters.ShouldSkipHandler(handler))
+            {
+                continue;
+            }
+
+            data.TryAddHandler(handler);
+        }
+
+        foreach (var entry in classData.Values)
+        {
+            EnsureDeclaredProperties(entry);
+        }
+
+        IReadOnlyDictionary<BlLingoHandlerSymbolTable, IReadOnlyList<BlLingoHandlerCodeBlock>>? handlerBlocks = null;
+        if (context.TryGetData(BlLingoHandlerCodeBlockPass.HandlerCodeBlocksKey, out IReadOnlyDictionary<BlLingoHandlerSymbolTable, IReadOnlyList<BlLingoHandlerCodeBlock>>? retrieved))
+        {
+            handlerBlocks = retrieved;
+        }
+
+        var results = new Dictionary<BlLingoClassSymbolTable, BlLegacyClassMemberInfo>();
+        foreach (var pair in classData)
+        {
+            var data = pair.Value;
+            InferPropertyTypes(data, handlerBlocks);
+
+            var orderedProperties = new List<PropertyState>(data.Properties.Values);
+            orderedProperties.Sort(static (left, right) => left.Order.CompareTo(right.Order));
+
+            var propertyInfos = new List<BlLegacyPropertyInfo>(orderedProperties.Count);
+            foreach (var property in orderedProperties)
+            {
+                propertyInfos.Add(new BlLegacyPropertyInfo(property.Name, property.Type, property.Comment));
+            }
+
+            results[pair.Key] = new BlLegacyClassMemberInfo(
+                new ReadOnlyCollection<BlLegacyPropertyInfo>(propertyInfos),
+                new ReadOnlyCollection<BlLingoHandlerSymbolTable>(data.HandlerOrder),
+                data.HasGlobalDeclarations);
+        }
+
+        context.SetData<IReadOnlyDictionary<BlLingoClassSymbolTable, BlLegacyClassMemberInfo>>(ClassMemberInfoKey, results);
+    }
+
+    private static IEnumerable<BlLingoClassSymbolTable> EnumerateClasses(BlLingoSymbolTable symbols)
+    {
+        yield return symbols.MovieScript;
+        foreach (var scope in symbols.ClassScopes.Values)
+        {
+            yield return scope;
+        }
+    }
+
+    private static void EnsureDeclaredProperties(ClassData data)
+    {
+        foreach (var property in data.Scope.Properties.Values)
+        {
+            if (property is null)
+            {
+                continue;
+            }
+
+            var order = property.Declarations.Count > 0 ? property.Declarations[0].Span.Start : int.MaxValue;
+            data.GetOrAddProperty(property.Name, order);
+        }
+    }
+
+    private static int CollectPropertyDeclarations(IReadOnlyList<BlSyntaxToken> tokens, int startIndex, ClassData data)
+    {
+        var lastIndex = startIndex - 1;
+        for (var index = startIndex; index < tokens.Count; index++)
+        {
+            var current = tokens[index];
+            if (ContainsNewLine(current.LeadingTrivia))
+            {
+                break;
+            }
+
+            if (current.Kind == BlSyntaxKind.IdentifierToken)
+            {
+                var name = current.ValueText;
+                if (!string.IsNullOrWhiteSpace(name) && data.Scope.Properties.TryGetValue(name, out var symbol))
+                {
+                    var info = data.GetOrAddProperty(symbol.Name, current.Span.Start);
+                    var comment = ExtractTrailingComment(current);
+                    if (!string.IsNullOrWhiteSpace(comment) && info.Comment is null)
+                    {
+                        info.Comment = comment;
+                    }
+                }
+
+                lastIndex = index;
+                continue;
+            }
+
+            if (current.Kind == BlSyntaxKind.CommaToken)
+            {
+                lastIndex = index;
+                continue;
+            }
+
+            break;
+        }
+
+        return lastIndex;
+    }
+
+    private static void InferPropertyTypes(
+        ClassData data,
+        IReadOnlyDictionary<BlLingoHandlerSymbolTable, IReadOnlyList<BlLingoHandlerCodeBlock>>? handlerBlocks)
+    {
+        foreach (var property in data.Properties.Values)
+        {
+            property.Type = "object";
+        }
+
+        if (handlerBlocks is null || handlerBlocks.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var handler in data.Scope.Handlers.Values)
+        {
+            if (handler is null || !handlerBlocks.TryGetValue(handler, out var blocks))
+            {
+                continue;
+            }
+
+            foreach (var block in blocks)
+            {
+                switch (block.Kind)
+                {
+                    case BlLingoHandlerCodeBlockKind.Put when block.Data is BlLingoPutBlockData put:
+                        ProcessPutBlock(data.Properties, put);
+                        break;
+                    case BlLingoHandlerCodeBlockKind.Expression:
+                        ProcessExpressionBlock(data.Properties, block);
+                        break;
+                }
+            }
+        }
+    }
+
+    private static void ProcessPutBlock(
+        IDictionary<string, PropertyState> propertyMap,
+        BlLingoPutBlockData data)
+    {
+        if (data is null || data.Kind != BlLingoPutAssignmentKind.Direct)
+        {
+            return;
+        }
+
+        var target = NormalizePropertyTarget(data.TargetExpression);
+        if (string.IsNullOrEmpty(target) || !propertyMap.TryGetValue(target, out var property))
+        {
+            return;
+        }
+
+        var typeName = NormalizeTypeName(BlLegacyReturnTypeHelper.InferLiteral(data.ValueExpression));
+        if (typeName.Length == 0)
+        {
+            return;
+        }
+
+        property.Type = MergePropertyTypes(property.Type, typeName);
+    }
+
+    private static void ProcessExpressionBlock(
+        IDictionary<string, PropertyState> propertyMap,
+        BlLingoHandlerCodeBlock block)
+    {
+        if (block is null || block.Tokens.Count == 0)
+        {
+            return;
+        }
+
+        if (!TryExtractAssignment(block.Tokens, out var propertyName, out var valueTokens))
+        {
+            return;
+        }
+
+        if (!propertyMap.TryGetValue(propertyName, out var property))
+        {
+            return;
+        }
+
+        var expression = BlLegacyExpressionConverter.Convert(valueTokens);
+        var typeName = NormalizeTypeName(BlLegacyReturnTypeHelper.InferLiteral(expression));
+        if (typeName.Length == 0)
+        {
+            return;
+        }
+
+        property.Type = MergePropertyTypes(property.Type, typeName);
+    }
+
+    private static string NormalizePropertyTarget(string? target)
+    {
+        if (string.IsNullOrWhiteSpace(target))
+        {
+            return string.Empty;
+        }
+
+        var trimmed = target.Trim();
+        if (trimmed.StartsWith("this.", StringComparison.OrdinalIgnoreCase))
+        {
+            return trimmed[5..];
+        }
+
+        return trimmed;
+    }
+
+    private static string NormalizeTypeName(string? typeName)
+    {
+        if (string.IsNullOrWhiteSpace(typeName))
+        {
+            return string.Empty;
+        }
+
+        var trimmed = typeName.Trim();
+        if (string.Equals(trimmed, "object?", StringComparison.Ordinal))
+        {
+            return "object";
+        }
+
+        return trimmed;
+    }
+
+    private static string MergePropertyTypes(string currentType, string candidate)
+    {
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return currentType;
+        }
+
+        if (string.IsNullOrWhiteSpace(currentType) || string.Equals(currentType, "object", StringComparison.Ordinal))
+        {
+            return candidate;
+        }
+
+        if (string.Equals(currentType, candidate, StringComparison.Ordinal))
+        {
+            return currentType;
+        }
+
+        if ((string.Equals(currentType, "int", StringComparison.Ordinal) && string.Equals(candidate, "double", StringComparison.Ordinal)) ||
+            (string.Equals(currentType, "double", StringComparison.Ordinal) && string.Equals(candidate, "int", StringComparison.Ordinal)))
+        {
+            return "double";
+        }
+
+        if (string.Equals(candidate, "object", StringComparison.Ordinal))
+        {
+            return currentType;
+        }
+
+        return "object";
+    }
+
+    private static bool TryExtractAssignment(
+        IReadOnlyList<BlSyntaxToken> tokens,
+        out string propertyName,
+        out IReadOnlyList<BlSyntaxToken> valueTokens)
+    {
+        propertyName = string.Empty;
+        valueTokens = Array.Empty<BlSyntaxToken>();
+
+        if (tokens is null || tokens.Count < 3)
+        {
+            return false;
+        }
+
+        var index = 0;
+        string? candidate = null;
+
+        if (IsMeToken(tokens[index]))
+        {
+            index++;
+            if (index >= tokens.Count || tokens[index].Kind != BlSyntaxKind.PeriodToken)
+            {
+                return false;
+            }
+
+            index++;
+            if (index >= tokens.Count || tokens[index].Kind != BlSyntaxKind.IdentifierToken)
+            {
+                return false;
+            }
+
+            candidate = tokens[index].ValueText;
+            index++;
+        }
+        else if (tokens[index].Kind == BlSyntaxKind.IdentifierToken)
+        {
+            candidate = tokens[index].ValueText;
+            index++;
+        }
+        else
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(candidate) || index >= tokens.Count)
+        {
+            return false;
+        }
+
+        var token = tokens[index];
+        if (token.Kind != BlSyntaxKind.OperatorToken || !string.Equals(token.ValueText, "=", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        index++;
+        if (index >= tokens.Count)
+        {
+            return false;
+        }
+
+        var values = new List<BlSyntaxToken>(tokens.Count - index);
+        for (; index < tokens.Count; index++)
+        {
+            values.Add(tokens[index]);
+        }
+
+        if (values.Count == 0)
+        {
+            return false;
+        }
+
+        propertyName = candidate!;
+        valueTokens = values;
+        return true;
+    }
+
+    private static bool IsMeToken(BlSyntaxToken token)
+    {
+        if (token.Kind is BlSyntaxKind.KeywordToken or BlSyntaxKind.IdentifierToken)
+        {
+            return string.Equals(token.ValueText, "me", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    private static string? ExtractTrailingComment(BlSyntaxToken token)
+    {
+        if (token.TrailingTrivia is null || token.TrailingTrivia.Count == 0)
+        {
+            return null;
+        }
+
+        string? comment = null;
+        foreach (var trivia in token.TrailingTrivia)
+        {
+            if (trivia.Kind == BlSyntaxKind.CommentTrivia)
+            {
+                comment = trivia.ValueText?.Trim();
+            }
+        }
+
+        return string.IsNullOrWhiteSpace(comment) ? null : comment;
+    }
+
+    private static bool HasIdentifiersBeforeNewLine(IReadOnlyList<BlSyntaxToken> tokens, int startIndex)
+    {
+        for (var index = startIndex; index < tokens.Count; index++)
+        {
+            var token = tokens[index];
+            if (ContainsNewLine(token.LeadingTrivia))
+            {
+                break;
+            }
+
+            if (token.Kind == BlSyntaxKind.IdentifierToken)
+            {
+                return true;
+            }
+
+            if (token.Kind != BlSyntaxKind.CommaToken)
+            {
+                break;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsNewLine(IReadOnlyList<BlSyntaxTrivia> trivia)
+    {
+        if (trivia is null)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < trivia.Count; index++)
+        {
+            if (trivia[index].Kind == BlSyntaxKind.NewLineTrivia)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryGetClassName(IReadOnlyList<BlSyntaxToken> tokens, int index, out string name)
+    {
+        name = string.Empty;
+        if (!TryGetToken(tokens, index, out var token))
+        {
+            return false;
+        }
+
+        if (ContainsNewLine(token.LeadingTrivia))
+        {
+            return false;
+        }
+
+        if (token.Kind is BlSyntaxKind.IdentifierToken or BlSyntaxKind.SymbolToken or BlSyntaxKind.StringLiteralToken)
+        {
+            if (!string.IsNullOrWhiteSpace(token.ValueText))
+            {
+                name = token.ValueText;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryGetHandlerNameToken(
+        IReadOnlyList<BlSyntaxToken> tokens,
+        int index,
+        out BlSyntaxToken handlerToken)
+    {
+        handlerToken = default!;
+        if (!TryGetToken(tokens, index, out var token))
+        {
+            return false;
+        }
+
+        if (ContainsNewLine(token.LeadingTrivia))
+        {
+            return false;
+        }
+
+        if (token.Kind is BlSyntaxKind.IdentifierToken or BlSyntaxKind.KeywordToken)
+        {
+            handlerToken = token;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryGetToken(IReadOnlyList<BlSyntaxToken> tokens, int index, out BlSyntaxToken token)
+    {
+        if (tokens is not null && index >= 0 && index < tokens.Count)
+        {
+            token = tokens[index];
+            return true;
+        }
+
+        token = default!;
+        return false;
+    }
+
+    private sealed class ClassData
+    {
+        private readonly HashSet<BlLingoHandlerSymbolTable> _seenHandlers = new();
+
+        public ClassData(BlLingoClassSymbolTable scope)
+        {
+            Scope = scope ?? throw new ArgumentNullException(nameof(scope));
+            Properties = new Dictionary<string, PropertyState>(StringComparer.OrdinalIgnoreCase);
+            HandlerOrder = new List<BlLingoHandlerSymbolTable>();
+        }
+
+        public BlLingoClassSymbolTable Scope { get; }
+
+        public Dictionary<string, PropertyState> Properties { get; }
+
+        public List<BlLingoHandlerSymbolTable> HandlerOrder { get; }
+
+        public bool HasGlobalDeclarations { get; set; }
+
+        public PropertyState GetOrAddProperty(string name, int order)
+        {
+            if (!Properties.TryGetValue(name, out var info))
+            {
+                info = new PropertyState(name, order);
+                Properties[name] = info;
+            }
+            else if (info.Order == int.MaxValue)
+            {
+                info.Order = order;
+            }
+
+            return info;
+        }
+
+        public void TryAddHandler(BlLingoHandlerSymbolTable handler)
+        {
+            if (handler is null)
+            {
+                return;
+            }
+
+            if (_seenHandlers.Add(handler))
+            {
+                HandlerOrder.Add(handler);
+            }
+        }
+    }
+
+    private sealed class PropertyState
+    {
+        public PropertyState(string name, int order)
+        {
+            Name = name;
+            Order = order;
+            Type = "object";
+        }
+
+        public string Name { get; }
+
+        public int Order { get; set; }
+
+        public string Type { get; set; }
+
+        public string? Comment { get; set; }
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyClassGenerator.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyClassGenerator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using BlingoEngine.Legacy.Lingo.Analysis;
+using BlingoEngine.Legacy.Lingo.Analysis.Passes;
 using BlingoEngine.Legacy.Lingo.Syntax;
 
 namespace BlingoEngine.Legacy.Lingo.CodeGen;
@@ -82,37 +83,30 @@ public sealed class BlLegacyClassGenerator
 
         using (writer.IndentScope())
         {
-            var needsGlobal = scriptKind is BlLingoScriptKind.Parent or BlLingoScriptKind.Movie;
+            var memberInfo = ResolveClassMemberInfo(classScope, analysis);
+            var needsGlobal = memberInfo.HasGlobalDeclarations &&
+                scriptKind is BlLingoScriptKind.Parent or BlLingoScriptKind.Movie;
+
+            WritePropertyDeclarations(writer, memberInfo.Properties);
+            if (memberInfo.Properties.Count > 0)
+            {
+                writer.WriteLine();
+            }
+
             if (needsGlobal)
             {
                 writer.WriteLine("private readonly GlobalVars _global;");
                 writer.WriteLine();
             }
 
-            writer.Write($"public {className}(IBlingoMovieEnvironment env");
-            if (needsGlobal)
-            {
-                writer.Write(", GlobalVars global");
-                writer.WriteLine(") : base(env)");
-                writer.WriteLine("{");
-                using (writer.IndentScope())
-                {
-                    writer.WriteLine("_global = global;");
-                }
-
-                writer.WriteLine("}");
-            }
-            else
-            {
-                writer.WriteLine(") : base(env) { }");
-            }
+            WriteConstructor(writer, className, needsGlobal);
 
             if (interfaces.Contains("IBlingoPropertyDescriptionList"))
             {
                 WritePropertyDescriptionListStubs(writer);
             }
 
-            WriteHandlers(writer, classScope, handlerConverter);
+            WriteHandlers(writer, classScope, handlerConverter, memberInfo.HandlerOrder);
         }
 
         writer.WriteLine("}");
@@ -128,6 +122,22 @@ public sealed class BlLegacyClassGenerator
         }
 
         return analysis.Symbols.MovieScript;
+    }
+
+    private static BlLegacyClassMemberInfo ResolveClassMemberInfo(
+        BlLingoClassSymbolTable classScope,
+        BlLingoAnalysisResult analysis)
+    {
+        if (analysis.TryGetData<IReadOnlyDictionary<BlLingoClassSymbolTable, BlLegacyClassMemberInfo>>(BlLegacyClassMemberPass.ClassMemberInfoKey, out var map) &&
+            map is not null &&
+            classScope is not null &&
+            map.TryGetValue(classScope, out var info) &&
+            info is not null)
+        {
+            return info;
+        }
+
+        return BlLegacyClassMemberInfo.Empty;
     }
 
     private static BlLingoScriptKind DetermineScriptKind(BlLingoScriptKind declaredKind, BlLingoClassSymbolTable classScope)
@@ -188,6 +198,41 @@ public sealed class BlLegacyClassGenerator
         };
     }
 
+    private static void WriteConstructor(BlCSharpCodeWriter writer, string className, bool needsGlobal)
+    {
+        writer.Write($"public {className}(IBlingoMovieEnvironment env");
+        if (needsGlobal)
+        {
+            writer.Write(", GlobalVars global");
+            writer.WriteLine(") : base(env)");
+            writer.WriteLine("{");
+            using (writer.IndentScope())
+            {
+                writer.WriteLine("_global = global;");
+            }
+
+            writer.WriteLine("}");
+        }
+        else
+        {
+            writer.WriteLine(") : base(env) { }");
+        }
+    }
+
+    private static void WritePropertyDeclarations(BlCSharpCodeWriter writer, IReadOnlyList<BlLegacyPropertyInfo> properties)
+    {
+        if (properties is null || properties.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var property in properties)
+        {
+            var commentSuffix = string.IsNullOrWhiteSpace(property.Comment) ? string.Empty : " // " + property.Comment;
+            writer.WriteLine($"public {property.Type} {property.Name} {{ get; set; }}{commentSuffix}");
+        }
+    }
+
     private static void WritePropertyDescriptionListStubs(BlCSharpCodeWriter writer)
     {
         writer.WriteLine();
@@ -210,17 +255,42 @@ public sealed class BlLegacyClassGenerator
     private static void WriteHandlers(
         BlCSharpCodeWriter writer,
         BlLingoClassSymbolTable classScope,
-        BlLegacyHandlerConverter handlerConverter)
+        BlLegacyHandlerConverter handlerConverter,
+        IReadOnlyList<BlLingoHandlerSymbolTable> orderedHandlers)
     {
         if (classScope is null || classScope.Handlers.Count == 0)
         {
             return;
         }
 
-        var handlers = new List<BlLingoHandlerSymbolTable>();
+        var classHandlers = new HashSet<BlLingoHandlerSymbolTable>();
         foreach (var handler in classScope.Handlers.Values)
         {
-            if (ShouldSkipHandler(handler))
+            if (handler is not null)
+            {
+                classHandlers.Add(handler);
+            }
+        }
+
+        var handlers = new List<BlLingoHandlerSymbolTable>();
+        var seen = new HashSet<BlLingoHandlerSymbolTable>();
+
+        if (orderedHandlers is not null)
+        {
+            foreach (var handler in orderedHandlers)
+            {
+                if (handler is null || !classHandlers.Contains(handler) || BlLegacyHandlerFilters.ShouldSkipHandler(handler) || !seen.Add(handler))
+                {
+                    continue;
+                }
+
+                handlers.Add(handler);
+            }
+        }
+
+        foreach (var handler in classScope.Handlers.Values)
+        {
+            if (handler is null || BlLegacyHandlerFilters.ShouldSkipHandler(handler) || !seen.Add(handler))
             {
                 continue;
             }
@@ -233,9 +303,6 @@ public sealed class BlLegacyClassGenerator
             return;
         }
 
-        handlers.Sort(static (left, right) => string.Compare(left.Symbol.Name, right.Symbol.Name, StringComparison.Ordinal));
-
-        var first = true;
         var resolvedReturnTypes = new Dictionary<BlLingoHandlerSymbolTable, string>();
         foreach (var handler in handlers)
         {
@@ -243,6 +310,7 @@ public sealed class BlLegacyClassGenerator
             resolvedReturnTypes[handler] = type;
         }
 
+        var first = true;
         foreach (var handler in handlers)
         {
             if (!first)
@@ -254,39 +322,6 @@ public sealed class BlLegacyClassGenerator
             var returnType = resolvedReturnTypes.TryGetValue(handler, out var resolved) ? resolved : "void";
             WriteHandler(writer, classScope, handler, handlerConverter, returnType);
         }
-    }
-
-    private static bool ShouldSkipHandler(BlLingoHandlerSymbolTable handler)
-    {
-        if (handler is null)
-        {
-            return true;
-        }
-
-        if (string.Equals(handler.OriginalName, BlLingoHandlerSymbolTable.ImplicitHandlerName, StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        if (IsPropertyDescriptionHandler(handler.OriginalName) || IsPropertyDescriptionHandler(handler.Symbol.Name))
-        {
-            return true;
-        }
-
-        return false;
-    }
-
-    private static bool IsPropertyDescriptionHandler(string? name)
-    {
-        if (string.IsNullOrEmpty(name))
-        {
-            return false;
-        }
-
-        return name.Equals("getPropertyDescriptionList", StringComparison.OrdinalIgnoreCase)
-            || name.Equals("getBehaviorDescription", StringComparison.OrdinalIgnoreCase)
-            || name.Equals("getBehaviorTooltip", StringComparison.OrdinalIgnoreCase)
-            || name.Equals("isOKToAttach", StringComparison.OrdinalIgnoreCase);
     }
 
     private static void WriteHandler(
@@ -384,4 +419,5 @@ public sealed class BlLegacyClassGenerator
 
         return parameters;
     }
+
 }


### PR DESCRIPTION
## Summary
- add a legacy class member analysis pass that records property declarations, handler ordering, and global usage for each class
- expose immutable member/property info types and handler skip helpers consumed during generation
- update the legacy class generator to rely on the precomputed analysis data instead of re-analyzing tokens

## Testing
- dotnet test Test/BlingoEngine.Legacy.Lingo.Tests/BlingoEngine.Legacy.Lingo.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d3e391b58883329eeac5199f6dd184