### PR TITLE
Ensure RNet terminal loads project before streaming deltas

### DIFF
--- a/Test/BlingoEngine.Net.RNetProjectHost.Tests/RNetProjectHostIntegrationTests.cs
+++ b/Test/BlingoEngine.Net.RNetProjectHost.Tests/RNetProjectHostIntegrationTests.cs
@@ -42,6 +42,25 @@ public class RNetProjectHostIntegrationTests
             }
         });
 
+    [Fact]
+    public Task HttpClientAndServer_ForwardSpriteDeltas()
+        => WithServerAndClientAsync(async (scenario, token) =>
+        {
+            var delta = new SpriteDeltaDto(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+
+            await using var enumerator = scenario.Client.StreamDeltasAsync(token).GetAsyncEnumerator(token);
+
+            await scenario.Bus.Deltas.Writer.WriteAsync(delta, token);
+
+            Assert.True(await enumerator.MoveNextAsync());
+            var received = enumerator.Current;
+
+            Assert.Equal(delta.SpriteNum, received.SpriteNum);
+            Assert.Equal(delta.BeginFrame, received.BeginFrame);
+            Assert.Equal(delta.CastLibNum, received.CastLibNum);
+            Assert.Equal(delta.MemberNum, received.MemberNum);
+        });
+
     public static IEnumerable<object[]> CommandData()
     {
         yield return new object[] { new SetSpritePropCmd(3, 1, RNetSpriteTypeDto.Sprite2D, "LocH", "123") };

--- a/Test/BlingoEngine.Net.RNetTerminal.Tests/Fakes/FakeRNetClient.cs
+++ b/Test/BlingoEngine.Net.RNetTerminal.Tests/Fakes/FakeRNetClient.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using BlingoEngine.IO.Data.DTO;
+using BlingoEngine.Net.RNetClient.Common;
+using BlingoEngine.Net.RNetContracts;
+
+namespace BlingoEngine.Net.RNetTerminal.Tests.Fakes;
+
+internal sealed class FakeRNetClient : IBlingoRNetClient
+{
+    private readonly Channel<SpriteDeltaDto> _deltaChannel;
+    private readonly TaskCompletionSource<bool> _deltaEnumerationStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly string _projectJson;
+    private readonly MovieStateDto _movieState;
+
+    public FakeRNetClient(BlingoProjectDTO project, MovieStateDto movieState)
+    {
+        if (project is null)
+        {
+            throw new ArgumentNullException(nameof(project));
+        }
+
+        _projectJson = JsonSerializer.Serialize(project);
+        _movieState = movieState;
+        _deltaChannel = Channel.CreateUnbounded<SpriteDeltaDto>(new UnboundedChannelOptions
+        {
+            SingleReader = false,
+            SingleWriter = false
+        });
+    }
+
+    public event Action<BlingoNetConnectionState>? ConnectionStatusChanged;
+
+    public event Action<IRNetCommand>? NetCommandReceived;
+
+    public BlingoNetConnectionState ConnectionState { get; private set; } = BlingoNetConnectionState.Disconnected;
+
+    public bool IsConnected => ConnectionState == BlingoNetConnectionState.Connected;
+
+    public Task ConnectAsync(Uri hubUrl, HelloDto hello, CancellationToken ct = default)
+    {
+        ConnectionState = BlingoNetConnectionState.Connected;
+        ConnectionStatusChanged?.Invoke(ConnectionState);
+        return Task.CompletedTask;
+    }
+
+    public Task DisconnectAsync()
+    {
+        ConnectionState = BlingoNetConnectionState.Disconnected;
+        ConnectionStatusChanged?.Invoke(ConnectionState);
+        _deltaChannel.Writer.TryComplete();
+        return Task.CompletedTask;
+    }
+
+    public IAsyncEnumerable<StageFrameDto> StreamFramesAsync(CancellationToken ct = default)
+        => EmptyAsync<StageFrameDto>(ct);
+
+    public IAsyncEnumerable<SpriteDeltaDto> StreamDeltasAsync(CancellationToken ct = default)
+        => ReadChannelAsync(_deltaChannel.Reader, ct, _deltaEnumerationStarted);
+
+    public IAsyncEnumerable<KeyframeDto> StreamKeyframesAsync(CancellationToken ct = default)
+        => EmptyAsync<KeyframeDto>(ct);
+
+    public IAsyncEnumerable<TempoDto> StreamTemposAsync(CancellationToken ct = default)
+        => EmptyAsync<TempoDto>(ct);
+
+    public IAsyncEnumerable<ColorPaletteDto> StreamColorPalettesAsync(CancellationToken ct = default)
+        => EmptyAsync<ColorPaletteDto>(ct);
+
+    public IAsyncEnumerable<FrameScriptDto> StreamFrameScriptsAsync(CancellationToken ct = default)
+        => EmptyAsync<FrameScriptDto>(ct);
+
+    public IAsyncEnumerable<TransitionDto> StreamTransitionsAsync(CancellationToken ct = default)
+        => EmptyAsync<TransitionDto>(ct);
+
+    public IAsyncEnumerable<RNetMemberPropertyDto> StreamMemberPropertiesAsync(CancellationToken ct = default)
+        => EmptyAsync<RNetMemberPropertyDto>(ct);
+
+    public IAsyncEnumerable<RNetMoviePropertyDto> StreamMoviePropertiesAsync(CancellationToken ct = default)
+        => EmptyAsync<RNetMoviePropertyDto>(ct);
+
+    public IAsyncEnumerable<RNetStagePropertyDto> StreamStagePropertiesAsync(CancellationToken ct = default)
+        => EmptyAsync<RNetStagePropertyDto>(ct);
+
+    public IAsyncEnumerable<RNetSpriteCollectionEventDto> StreamSpriteCollectionEventsAsync(CancellationToken ct = default)
+        => EmptyAsync<RNetSpriteCollectionEventDto>(ct);
+
+    public IAsyncEnumerable<TextStyleDto> StreamTextStylesAsync(CancellationToken ct = default)
+        => EmptyAsync<TextStyleDto>(ct);
+
+    public IAsyncEnumerable<FilmLoopDto> StreamFilmLoopsAsync(CancellationToken ct = default)
+        => EmptyAsync<FilmLoopDto>(ct);
+
+    public IAsyncEnumerable<SoundEventDto> StreamSoundsAsync(CancellationToken ct = default)
+        => EmptyAsync<SoundEventDto>(ct);
+
+    public Task<MovieStateDto> GetMovieSnapshotAsync(CancellationToken ct = default)
+        => Task.FromResult(_movieState);
+
+    public Task<BlingoProjectJsonDto> GetCurrentProjectAsync(CancellationToken ct = default)
+        => Task.FromResult(new BlingoProjectJsonDto(_projectJson));
+
+    public Task SendCommandAsync(RNetCommand cmd, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    public Task SendHeartbeatAsync(TimeSpan? timeout = null, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    public ValueTask DisposeAsync()
+        => new(DisconnectAsync());
+
+    public void PublishDelta(SpriteDeltaDto delta)
+    {
+        if (!_deltaChannel.Writer.TryWrite(delta))
+        {
+            throw new InvalidOperationException("Failed to publish delta to fake client channel.");
+        }
+    }
+
+    public Task WaitForDeltaEnumerationAsync(CancellationToken ct = default)
+        => _deltaEnumerationStarted.Task.WaitAsync(ct);
+
+    private static async IAsyncEnumerable<T> EmptyAsync<T>([EnumeratorCancellation] CancellationToken ct)
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    private static async IAsyncEnumerable<T> ReadChannelAsync<T>(
+        ChannelReader<T> reader,
+        [EnumeratorCancellation] CancellationToken ct,
+        TaskCompletionSource<bool>? started = null)
+    {
+        started?.TrySetResult(true);
+
+        while (await reader.WaitToReadAsync(ct).ConfigureAwait(false))
+        {
+            while (reader.TryRead(out var item))
+            {
+                yield return item;
+            }
+        }
+    }
+}

--- a/Test/BlingoEngine.Net.RNetTerminal.Tests/RNetTerminalConnectionTests.cs
+++ b/Test/BlingoEngine.Net.RNetTerminal.Tests/RNetTerminalConnectionTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BlingoEngine.IO.Data.DTO;
+using BlingoEngine.IO.Data.DTO.Members;
+using BlingoEngine.IO.Data.DTO.Sprites;
+using BlingoEngine.Net.RNetContracts;
+using BlingoEngine.Net.RNetTerminal.Datas;
+using BlingoEngine.Net.RNetTerminal.Tests.Fakes;
+using Xunit;
+
+namespace BlingoEngine.Net.RNetTerminal.Tests;
+
+public class RNetTerminalConnectionTests
+{
+    [Fact]
+    public async Task ConnectAsync_ProcessesSpriteDeltas()
+    {
+        var delta = new SpriteDeltaDto(
+            Frame: 2,
+            SpriteNum: 7,
+            BeginFrame: 2,
+            Z: 3,
+            CastLibNum: 4,
+            MemberNum: 5,
+            LocH: 200,
+            LocV: 300,
+            Width: 150,
+            Height: 220,
+            Rotation: 15,
+            Skew: 5,
+            Blend: 90,
+            Ink: 2);
+
+        var project = CreateProject(delta);
+        var movieState = new MovieStateDto(delta.Frame, 30, false);
+        var fakeClient = new FakeRNetClient(project, movieState);
+        var store = TerminalDataStore.Instance;
+
+        await using var connection = new RNetTerminalConnection(store, _ => fakeClient, action => action());
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await connection.ConnectAsync(new RNetTerminalConnectionOptions(1234, RNetTerminalTransport.Http), cts.Token);
+        await fakeClient.WaitForDeltaEnumerationAsync(cts.Token);
+
+        var spriteUpdated = new TaskCompletionSource<Blingo2DSpriteDTO>(TaskCreationOptions.RunContinuationsAsynchronously);
+        void Handler(Blingo2DSpriteDTO dto)
+        {
+            if (dto.SpriteNum == delta.SpriteNum)
+            {
+                spriteUpdated.TrySetResult(dto);
+            }
+        }
+
+        store.SpriteChanged += Handler;
+        try
+        {
+            fakeClient.PublishDelta(delta);
+            var updated = await spriteUpdated.Task.WaitAsync(cts.Token);
+
+            Assert.Equal(delta.BeginFrame, updated.BeginFrame);
+            Assert.Equal(delta.LocH, updated.LocH);
+            Assert.Equal(delta.LocV, updated.LocV);
+            Assert.Equal(delta.Width, updated.Width);
+            Assert.Equal(delta.Height, updated.Height);
+            Assert.Equal(delta.Blend, updated.Blend);
+            Assert.Equal(delta.Ink, updated.Ink);
+        }
+        finally
+        {
+            store.SpriteChanged -= Handler;
+        }
+    }
+
+    private static BlingoProjectDTO CreateProject(SpriteDeltaDto delta)
+    {
+        var sprite = new Blingo2DSpriteDTO
+        {
+            Name = "Sprite",
+            SpriteNum = delta.SpriteNum,
+            BeginFrame = 1,
+            EndFrame = 1,
+            LocH = 0,
+            LocV = 0,
+            LocZ = delta.Z,
+            Width = delta.Width,
+            Height = delta.Height,
+            Rotation = 0,
+            Skew = 0,
+            Blend = delta.Blend,
+            Ink = delta.Ink,
+            Member = new BlingoMemberRefDTO(delta.MemberNum, delta.CastLibNum)
+        };
+
+        var cast = new BlingoCastDTO
+        {
+            Name = "Cast",
+            Number = delta.CastLibNum,
+            Members =
+            {
+                new BlingoMemberDTO
+                {
+                    Name = "Member",
+                    CastLibNum = delta.CastLibNum,
+                    NumberInCast = delta.MemberNum,
+                    Type = BlingoMemberTypeDTO.Bitmap,
+                    Width = delta.Width,
+                    Height = delta.Height,
+                    RegPoint = new BlingoPointDTO { X = 0, Y = 0 }
+                }
+            }
+        };
+
+        var movie = new BlingoMovieDTO
+        {
+            Name = "Movie",
+            Number = 1,
+            Tempo = 30,
+            FrameCount = 120,
+            MaxSpriteChannelCount = 120,
+            Sprite2Ds = { sprite },
+            Casts = { cast }
+        };
+
+        return new BlingoProjectDTO
+        {
+            Stage = new BlingoStageDTO { Width = 640, Height = 480 },
+            Movies = { movie }
+        };
+    }
+}

--- a/src/Net/BlingoEngine.Net.RNetTerminal/RNetTerminalConnection.cs
+++ b/src/Net/BlingoEngine.Net.RNetTerminal/RNetTerminalConnection.cs
@@ -26,6 +26,8 @@ public sealed record class RNetTerminalConnectionOptions(int Port, RNetTerminalT
 public sealed class RNetTerminalConnection : IAsyncDisposable
 {
     private readonly TerminalDataStore _store;
+    private readonly Func<RNetTerminalTransport, IBlingoRNetClient> _clientFactory;
+    private readonly Action<Action> _dispatcher;
     private IBlingoRNetClient? _client;
     private CancellationTokenSource? _cts;
     private Timer? _heartbeatTimer;
@@ -43,8 +45,18 @@ public sealed class RNetTerminalConnection : IAsyncDisposable
     public BlingoNetConnectionState ConnectionState { get; private set; } = BlingoNetConnectionState.Disconnected;
 
     public RNetTerminalConnection()
+        : this(TerminalDataStore.Instance, CreateClient, EnqueueOnApplication)
     {
-        _store = TerminalDataStore.Instance;
+    }
+
+    internal RNetTerminalConnection(
+        TerminalDataStore store,
+        Func<RNetTerminalTransport, IBlingoRNetClient> clientFactory,
+        Action<Action> dispatcher)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
         _store.SpriteMoveRequested += OnSpriteMoveRequested;
     }
 
@@ -57,7 +69,7 @@ public sealed class RNetTerminalConnection : IAsyncDisposable
 
         await DisconnectAsync().ConfigureAwait(false);
 
-        var client = CreateClient(options.Transport);
+        var client = _clientFactory(options.Transport);
         _client = client;
         client.ConnectionStatusChanged += HandleClientConnectionStatus;
 
@@ -77,10 +89,10 @@ public sealed class RNetTerminalConnection : IAsyncDisposable
             throw;
         }
 
+        await LoadProjectDataAsync(client).ConfigureAwait(false);
+
         StartBackgroundReaders(client);
         StartHeartbeat();
-
-        await LoadProjectDataAsync(client).ConfigureAwait(false);
     }
 
     public async Task DisconnectAsync()
@@ -161,6 +173,16 @@ public sealed class RNetTerminalConnection : IAsyncDisposable
             RNetTerminalTransport.Pipe => new RNetPipeClient.RNetPipeClient(),
             _ => throw new ArgumentOutOfRangeException(nameof(transport), transport, null)
         };
+
+    private static void EnqueueOnApplication(Action action)
+    {
+        Application.AddTimeout(TimeSpan.Zero, () =>
+        {
+            action();
+
+            return false; // do not repeat
+        });
+    }
 
     private static Uri BuildUri(RNetTerminalConnectionOptions options)
         => options.Transport switch
@@ -380,14 +402,7 @@ public sealed class RNetTerminalConnection : IAsyncDisposable
         }
     }
 
-    private static void Dispatch(Action action)
-    {
-        Application.AddTimeout(System.TimeSpan.Zero, () =>
-        {
-            action();
-
-            return false; // do not repeat
-        });
-    }
+    private void Dispatch(Action action)
+        => _dispatcher(action);
 }
 


### PR DESCRIPTION
## Summary
- load project data before starting the terminal delta readers so the sprite store is ready when events arrive
- inject the RNet client factory/dispatcher so the connection can be exercised in tests
- add regression tests for HTTP delta forwarding and the terminal connection using a fake client

## Testing
- dotnet test Test/BlingoEngine.Net.RNetTerminal.Tests/BlingoEngine.Net.RNetTerminal.Tests.csproj
- dotnet test Test/BlingoEngine.Net.RNetProjectHost.Tests/BlingoEngine.Net.RNetProjectHost.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d3e7b87764833290ceffa356725062