### PR TITLE
Improve legacy Lingo inline conditionals and type inference

### DIFF
--- a/Test/BlingoEngine.Legacy.Lingo.Tests/BlLegacyClassGeneratorTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/BlLegacyClassGeneratorTests.cs
@@ -90,6 +90,30 @@ public class MyParentParent : BlingoParentScript
     }
 
     [Fact]
+    public void Properties_InferTypesFromMemberAccess()
+    {
+        const string source = """
+property key1
+property key2
+property key3
+on beginSprite
+  key1 = member("parameters").line[21]
+  key2 = member("parameters").line[21].word[2]
+  key3 = value(member("parameters").line[21].word[2])
+end
+""";
+
+        var code = _generator.GenerateClass("KeyReader", source, BlLingoScriptKind.Behavior);
+
+        Assert.Contains("public string key1 { get; set; }", code);
+        Assert.Contains("public string key2 { get; set; }", code);
+        Assert.Contains("public int key3 { get; set; }", code);
+        Assert.Contains(
+            "key3 = Convert.ToInt32(Member<IBlingoMemberTextBase>(\"parameters\").Line[21].Word[2]);",
+            code);
+    }
+
+    [Fact]
     public void Handlers_AppearInSourceOrder()
     {
         const string source = "on startMovie\nend\n" +

--- a/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerConditionalTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerConditionalTests.cs
@@ -40,6 +40,34 @@ public class TestScriptBehavior : BlingoSpriteBehavior
     }
 
     [Fact]
+    public void IfVoidPThenAlert_TranslatesToNullCheck()
+    {
+        const string source = """
+on test
+  if VoidP(key1) then alert "wrong keys"
+end
+""";
+
+        var code = GenerateBehavior(source);
+
+        const string expected = """
+public class TestScriptBehavior : BlingoSpriteBehavior
+{
+    public TestScriptBehavior(IBlingoMovieEnvironment env) : base(env) { }
+    public void Test()
+    {
+        if (key1 == null)
+        {
+            _Player.Alert("wrong keys");
+        }
+    }
+}
+""";
+
+        LegacyCodeAssert.AreEqual(expected, code);
+    }
+
+    [Fact]
     public void ElseIf_BecomesElseIf()
     {
         const string source = """
@@ -72,6 +100,39 @@ public class TestScriptBehavior : BlingoSpriteBehavior
         else
         {
             value = 3;
+        }
+    }
+}
+""";
+
+        LegacyCodeAssert.AreEqual(expected, code);
+    }
+
+    [Fact]
+    public void InlineIfWithSendSprite_TranslatesKeyPressedChecks()
+    {
+        const string source = """
+on keyDown me
+  if keyPressed(35) then sendSprite myTargetSprite, #PauseGame
+  if keyPressed(49) then sendSprite myTargetSprite, #SpaceBar
+end
+""";
+
+        var code = GenerateBehavior(source);
+
+        const string expected = """
+public class TestScriptBehavior : BlingoSpriteBehavior, IHasKeyDownEvent
+{
+    public TestScriptBehavior(IBlingoMovieEnvironment env) : base(env) { }
+    public void KeyDown()
+    {
+        if (_Key.KeyPressed(35))
+        {
+            SendSprite<PauseGameBehavior>(myTargetSprite, sprite => sprite.PauseGame());
+        }
+        if (_Key.KeyPressed(49))
+        {
+            SendSprite<SpaceBarBehavior>(myTargetSprite, sprite => sprite.SpaceBar());
         }
     }
 }

--- a/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyHandlerCodeBlockClassifier.cs
+++ b/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyHandlerCodeBlockClassifier.cs
@@ -30,6 +30,7 @@ internal static class BlLegacyHandlerCodeBlockClassifier
     {
         var result = new List<BlLingoHandlerCodeBlock>();
         var lines = HandlerLine.Split(tokens, endTrivia);
+        var inlineStack = new Stack<bool>();
         foreach (var line in lines)
         {
             switch (line.Kind)
@@ -43,7 +44,18 @@ internal static class BlLegacyHandlerCodeBlockClassifier
                 case HandlerLineKind.Tokens:
                     if (line.Tokens is { Count: > 0 })
                     {
-                        result.Add(ClassifyTokens(line.Tokens, symbols));
+                        var block = ClassifyTokens(line.Tokens, symbols);
+                        result.Add(block);
+                        if (line.BeginsInlineConditional && block.Kind == BlLingoHandlerCodeBlockKind.If)
+                        {
+                            inlineStack.Push(true);
+                        }
+
+                        if (line.EndsInlineConditional && inlineStack.Count > 0)
+                        {
+                            inlineStack.Pop();
+                            result.Add(new BlLingoHandlerCodeBlock(BlLingoHandlerCodeBlockKind.End, Array.Empty<BlSyntaxToken>()));
+                        }
                     }
                     else
                     {

--- a/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyReturnTypeHelper.cs
+++ b/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyReturnTypeHelper.cs
@@ -113,6 +113,11 @@ internal static class BlLegacyReturnTypeHelper
             return null;
         }
 
+        if (trimmed.StartsWith("Convert.ToInt32(", StringComparison.Ordinal))
+        {
+            return "int";
+        }
+
         if (trimmed.Equals("true", StringComparison.OrdinalIgnoreCase) ||
             trimmed.Equals("false", StringComparison.OrdinalIgnoreCase))
         {
@@ -210,4 +215,5 @@ internal static class BlLegacyReturnTypeHelper
 
         return depth == 0;
     }
+
 }

--- a/src/BlingoEngine.Legacy.Lingo/Analysis/Passes/BlLegacyClassMemberPass.cs
+++ b/src/BlingoEngine.Legacy.Lingo/Analysis/Passes/BlLegacyClassMemberPass.cs
@@ -255,7 +255,7 @@ public sealed class BlLegacyClassMemberPass : BlLingoAnalysisPass
             return;
         }
 
-        var typeName = NormalizeTypeName(BlLegacyReturnTypeHelper.InferLiteral(data.ValueExpression));
+        var typeName = DeterminePropertyType(data.ValueExpression);
         if (typeName.Length == 0)
         {
             return;
@@ -284,7 +284,7 @@ public sealed class BlLegacyClassMemberPass : BlLingoAnalysisPass
         }
 
         var expression = BlLegacyExpressionConverter.Convert(valueTokens);
-        var typeName = NormalizeTypeName(BlLegacyReturnTypeHelper.InferLiteral(expression));
+        var typeName = DeterminePropertyType(expression);
         if (typeName.Length == 0)
         {
             return;
@@ -354,6 +354,47 @@ public sealed class BlLegacyClassMemberPass : BlLingoAnalysisPass
         }
 
         return "object";
+    }
+
+    private static string DeterminePropertyType(string? expression)
+    {
+        var typeName = NormalizeTypeName(BlLegacyReturnTypeHelper.InferLiteral(expression));
+        if (!string.IsNullOrEmpty(typeName))
+        {
+            return typeName;
+        }
+
+        if (IsStringMemberAccess(expression))
+        {
+            return "string";
+        }
+
+        return string.Empty;
+    }
+
+    private static bool IsStringMemberAccess(string? expression)
+    {
+        if (string.IsNullOrWhiteSpace(expression))
+        {
+            return false;
+        }
+
+        var trimmed = expression.Trim();
+        if (!trimmed.StartsWith("Member<", StringComparison.Ordinal) &&
+            !trimmed.StartsWith("Member(", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return ContainsSegment(trimmed, ".Line") ||
+            ContainsSegment(trimmed, ".Word") ||
+            ContainsSegment(trimmed, ".Text") ||
+            ContainsSegment(trimmed, ".Char");
+    }
+
+    private static bool ContainsSegment(string expression, string segment)
+    {
+        return expression.IndexOf(segment, StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private static bool TryExtractAssignment(

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
@@ -143,6 +143,8 @@ public sealed class BlLegacyExpressionConverter
         {
             if (TryHandleVoidPredicate() ||
                 TryHandleScriptInstantiation() ||
+                TryHandleValueFunction() ||
+                TryHandleAlertCommand() ||
                 TryHandleMemberTypedAccess() ||
                 TryHandleListLiteral() ||
                 TryHandleTheKeywords())
@@ -272,6 +274,78 @@ public sealed class BlLegacyExpressionConverter
 
         AppendRaw(")");
         _index = argsClose + 1;
+        _afterDot = false;
+        return true;
+    }
+
+    private bool TryHandleValueFunction()
+    {
+        if (_index >= _tokens.Count ||
+            !string.Equals(_tokens[_index].ValueText, "value", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (_index + 1 >= _tokens.Count || _tokens[_index + 1].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return false;
+        }
+
+        var closeIndex = BlLegacyHandlerTokenUtilities.FindMatchingToken(
+            _tokens,
+            _index + 1,
+            BlSyntaxKind.LeftParenthesisToken,
+            BlSyntaxKind.RightParenthesisToken);
+
+        if (closeIndex < 0)
+        {
+            return false;
+        }
+
+        var argumentTokens = BlLegacyHandlerTokenUtilities.SliceTokens(
+            _tokens,
+            _index + 2,
+            closeIndex - (_index + 2));
+        var argument = Convert(argumentTokens);
+
+        AppendRaw("Convert.ToInt32");
+        AppendRaw("(");
+        if (!string.IsNullOrEmpty(argument))
+        {
+            AppendRaw(argument);
+        }
+
+        AppendRaw(")");
+        _index = closeIndex + 1;
+        _afterDot = false;
+        return true;
+    }
+
+    private bool TryHandleAlertCommand()
+    {
+        if (_index >= _tokens.Count ||
+            !string.Equals(_tokens[_index].ValueText, "alert", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        _index++;
+        var argumentTokens = new List<BlSyntaxToken>();
+        while (_index < _tokens.Count)
+        {
+            argumentTokens.Add(_tokens[_index]);
+            _index++;
+        }
+
+        var argument = Convert(argumentTokens);
+        AppendRaw("_Player.Alert");
+        AppendRaw("(");
+        if (!string.IsNullOrEmpty(argument))
+        {
+            AppendRaw(argument);
+        }
+
+        AppendRaw(")");
         _afterDot = false;
         return true;
     }
@@ -458,6 +532,13 @@ public sealed class BlLegacyExpressionConverter
         if (string.Equals(text, "sprite", StringComparison.OrdinalIgnoreCase))
         {
             AppendRaw("Sprite");
+            _afterDot = false;
+            return;
+        }
+
+        if (string.Equals(text, "keypressed", StringComparison.OrdinalIgnoreCase))
+        {
+            AppendRaw("_Key.KeyPressed");
             _afterDot = false;
             return;
         }

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/HandlerLine.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/HandlerLine.cs
@@ -6,11 +6,18 @@ namespace BlingoEngine.Legacy.Lingo.CodeGen;
 
 public sealed class HandlerLine
 {
-    private HandlerLine(HandlerLineKind kind, IReadOnlyList<BlSyntaxToken> tokens, string? commentText)
+    private HandlerLine(
+        HandlerLineKind kind,
+        IReadOnlyList<BlSyntaxToken> tokens,
+        string? commentText,
+        bool beginsInlineConditional = false,
+        bool endsInlineConditional = false)
     {
         Kind = kind;
         Tokens = tokens;
         CommentText = commentText;
+        BeginsInlineConditional = beginsInlineConditional;
+        EndsInlineConditional = endsInlineConditional;
     }
 
     public HandlerLineKind Kind { get; }
@@ -18,6 +25,10 @@ public sealed class HandlerLine
     public IReadOnlyList<BlSyntaxToken> Tokens { get; }
 
     public string? CommentText { get; }
+
+    public bool BeginsInlineConditional { get; }
+
+    public bool EndsInlineConditional { get; }
 
     public static List<HandlerLine> Split(IReadOnlyList<BlSyntaxToken> tokens, IReadOnlyList<BlSyntaxTrivia> endTrivia)
     {
@@ -101,7 +112,21 @@ public sealed class HandlerLine
             return;
         }
 
-        result.Add(new HandlerLine(HandlerLineKind.Tokens, currentTokens.ToArray(), null));
+        foreach (var segment in SplitInlineThenTokens(currentTokens))
+        {
+            if (segment.Tokens.Count == 0)
+            {
+                continue;
+            }
+
+            result.Add(new HandlerLine(
+                HandlerLineKind.Tokens,
+                segment.Tokens.ToArray(),
+                null,
+                segment.BeginsInline,
+                segment.EndsInline));
+        }
+
         currentTokens.Clear();
         lastWasBlank = false;
         lineBreakPending = false;
@@ -133,5 +158,67 @@ public sealed class HandlerLine
         }
 
         return text.Trim();
+    }
+
+    private static List<InlineSegment> SplitInlineThenTokens(List<BlSyntaxToken> tokens)
+    {
+        var segments = new List<InlineSegment>();
+        if (tokens.Count == 0)
+        {
+            return segments;
+        }
+
+        var splitIndex = FindInlineThenIndex(tokens);
+        if (splitIndex < 0)
+        {
+            segments.Add(new InlineSegment(new List<BlSyntaxToken>(tokens), beginsInline: false, endsInline: false));
+            return segments;
+        }
+
+        var head = new List<BlSyntaxToken>(tokens.GetRange(0, splitIndex + 1));
+        var tail = new List<BlSyntaxToken>(tokens.GetRange(splitIndex + 1, tokens.Count - (splitIndex + 1)));
+        segments.Add(new InlineSegment(head, beginsInline: true, endsInline: tail.Count == 0));
+        if (tail.Count > 0)
+        {
+            segments.Add(new InlineSegment(tail, beginsInline: false, endsInline: true));
+        }
+
+        return segments;
+    }
+
+    private static int FindInlineThenIndex(List<BlSyntaxToken> tokens)
+    {
+        for (var index = 0; index < tokens.Count; index++)
+        {
+            var token = tokens[index];
+            if (token.Kind != BlSyntaxKind.KeywordToken ||
+                !string.Equals(token.ValueText, "then", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (index + 1 < tokens.Count)
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private readonly struct InlineSegment
+    {
+        public InlineSegment(List<BlSyntaxToken> tokens, bool beginsInline, bool endsInline)
+        {
+            Tokens = tokens;
+            BeginsInline = beginsInline;
+            EndsInline = endsInline;
+        }
+
+        public List<BlSyntaxToken> Tokens { get; }
+
+        public bool BeginsInline { get; }
+
+        public bool EndsInline { get; }
     }
 }


### PR DESCRIPTION
## Summary
- map Lingo `value()` calls to `Convert.ToInt32` and surface `_Player.Alert(...)`/`_Key.KeyPressed(...)`
- infer string property types from text member access while keeping handler return types intact
- split inline `then` statements so inline conditionals emit their bodies and auto-close blocks
- add regression tests for property inference, voidP alert translation, and inline sendSprite key handlers

## Testing
- dotnet test Test/BlingoEngine.Legacy.Lingo.Tests/BlingoEngine.Legacy.Lingo.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d3f0896a788332a4343108da410909