### PR TITLE
Add MemberSourceRect cropping support for bitmap sprites

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIScriptResolver.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUIScriptResolver.cs
@@ -36,6 +36,9 @@ public class AbstUIScriptResolver : IAsyncDisposable
     public async ValueTask CanvasAddToElement(ElementReference element, ElementReference canvas)
         => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.addCanvasToElement", element, canvas);
 
+    public async ValueTask CanvasSetOffset(ElementReference canvas, double offsetX, double offsetY)
+        => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.setCanvasOffset", canvas, offsetX, offsetY);
+
     public async ValueTask CanvasSetVisible(ElementReference canvas, bool visible)
         => await (await GetModuleAsync()).InvokeVoidAsync("abstCanvas.setCanvasVisible", canvas, visible);
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/wwwroot/scripts/abstUIScripts.js
@@ -22,6 +22,13 @@ export class abstCanvas {
         }
     }
 
+    static setCanvasOffset(canvas, x, y) {
+        if (!canvas) return;
+        canvas.style.position = 'absolute';
+        canvas.style.left = `${-x}px`;
+        canvas.style.top = `${-y}px`;
+    }
+
     static setCanvasVisible(canvas, visible) {
         canvas.style.display = visible ? 'block' : 'none';
     }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Core/AbstSDLComponentContext.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Core/AbstSDLComponentContext.cs
@@ -29,6 +29,7 @@ public class AbstSDLComponentContext : IDisposable
     public float OffsetY { get; set; }
     public bool FlipH { get; set; }
     public bool FlipV { get; set; }
+    public SDL.SDL_Rect? SourceRect { get; set; }
     public bool AlwaysOnTop { get; set; }
     public int ZIndex { get; private set; }
     public SDL.SDL_BlendMode BlendMode { get; set; } = SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND;
@@ -121,7 +122,14 @@ public class AbstSDLComponentContext : IDisposable
         if (Component is AbstSdlComponent comp) name = comp.Name;
         //Console.WriteLine($"SDL CTX BLIT dst=({drawX},{drawY},{TargetWidth},{TargetHeight}) {name}");
 
-        SDL.SDL_RenderCopyEx(Renderer, Texture, nint.Zero, ref dst, 0, nint.Zero, flip);
+        if (SourceRect is SDL.SDL_Rect src)
+        {
+            SDL.SDL_RenderCopyEx(Renderer, Texture, ref src, ref dst, 0, nint.Zero, flip);
+        }
+        else
+        {
+            SDL.SDL_RenderCopyEx(Renderer, Texture, nint.Zero, ref dst, 0, nint.Zero, flip);
+        }
     }
 
     public void Dispose()

--- a/src/BlingoEngine.Blazor/Sprites/BlingoBlazorSprite.razor
+++ b/src/BlingoEngine.Blazor/Sprites/BlingoBlazorSprite.razor
@@ -22,20 +22,45 @@
     {
         var drawW = Sprite.DesiredWidth > 0 ? Sprite.DesiredWidth : Sprite.Width;
         var drawH = Sprite.DesiredHeight > 0 ? Sprite.DesiredHeight : Sprite.Height;
-        var x = Sprite.X - Sprite.RegPoint.X;
-        var y = Sprite.Y - Sprite.RegPoint.Y;
-        var scaleX = Sprite.FlipH ? -1 : 1;
-        var scaleY = Sprite.FlipV ? -1 : 1;
-        var transform = $"translate({Sprite.RegPoint.X}px,{Sprite.RegPoint.Y}px) rotate({Sprite.Rotation}deg) scale({scaleX},{scaleY}) translate(-{Sprite.RegPoint.X}px,-{Sprite.RegPoint.Y}px)";
-        var style = $"position:absolute;left:{x}px;top:{y}px;width:{drawW}px;height:{drawH}px;z-index:{Sprite.ZIndex};opacity:{Sprite.Blend};transform:{transform};";
+
+        var (baseOffset, sourceWidth, sourceHeight) = Sprite.GetMemberSourceMetrics();
+        if (sourceWidth <= 0)
+            sourceWidth = drawW != 0 ? drawW : 1f;
+        if (sourceHeight <= 0)
+            sourceHeight = drawH != 0 ? drawH : 1f;
+
+        var scaleMagX = sourceWidth != 0 ? drawW / sourceWidth : 1f;
+        var scaleMagY = sourceHeight != 0 ? drawH / sourceHeight : 1f;
+
+        var offsetX = baseOffset.X * scaleMagX;
+        var offsetY = baseOffset.Y * scaleMagY;
+
+        var left = Sprite.X - offsetX - drawW / 2f;
+        var top = Sprite.Y - offsetY - drawH / 2f;
+
+        var regPointDisplayX = (baseOffset.X + sourceWidth / 2f) * scaleMagX;
+        var regPointDisplayY = (baseOffset.Y + sourceHeight / 2f) * scaleMagY;
+
+        var flipScaleX = Sprite.FlipH ? -1 : 1;
+        var flipScaleY = Sprite.FlipV ? -1 : 1;
+
+        var transform = $"translate({regPointDisplayX}px,{regPointDisplayY}px) rotate({Sprite.Rotation}deg) scale({flipScaleX},{flipScaleY}) translate(-{regPointDisplayX}px,-{regPointDisplayY}px)";
+        var style = $"position:absolute;left:{left}px;top:{top}px;width:{drawW}px;height:{drawH}px;z-index:{Sprite.ZIndex};opacity:{Sprite.Blend};transform:{transform};";
         if (!Sprite.Visibility) style += "display:none;";
+        if (Sprite.MemberSourceRect != null) style += "overflow:hidden;";
         return style;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (Sprite.Texture is AbstBlazorTexture2D tex)
+        {
             await Scripts.CanvasAddToElement(_host, tex.Canvas);
+            var rect = Sprite.MemberSourceRect;
+            var offsetX = rect?.Left ?? 0;
+            var offsetY = rect?.Top ?? 0;
+            await Scripts.CanvasSetOffset(tex.Canvas, offsetX, offsetY);
+        }
     }
 
     public void Dispose()

--- a/src/BlingoEngine.Blazor/Sprites/BlingoBlazorSprite2D.cs
+++ b/src/BlingoEngine.Blazor/Sprites/BlingoBlazorSprite2D.cs
@@ -81,6 +81,7 @@ public class BlingoBlazorSprite2D : IBlingoFrameworkSprite, IBlingoFrameworkSpri
     public float Y { get => _y; set { _y = value; MakeDirty(); } }
     public float Width { get; private set; }
     public float Height { get; private set; }
+    public ARect? MemberSourceRect => _blingoSprite.MemberSourceRect;
     private string _name = string.Empty;
     public string Name { get => _name; set { _name = value; MakeDirty(); } }
     private APoint _regPoint;
@@ -118,11 +119,17 @@ public class BlingoBlazorSprite2D : IBlingoFrameworkSprite, IBlingoFrameworkSpri
     {
         if (_blingoSprite.Member is { } member)
         {
-            if (Width == 0 || Height == 0)
-            {
-                Width = member.Width;
-                Height = member.Height;
-            }
+            var (_, sourceWidth, sourceHeight) = _blingoSprite.GetMemberSourceMetrics();
+            if (sourceWidth <= 0)
+                sourceWidth = member.Width;
+            if (sourceHeight <= 0)
+                sourceHeight = member.Height;
+
+            if (Width == 0)
+                Width = sourceWidth;
+            if (Height == 0)
+                Height = sourceHeight;
+
             if (member is BlingoMemberMedia media)
             {
                 var blazorMedia = media.Framework<BlingoBlazorMemberMedia>();
@@ -152,15 +159,27 @@ public class BlingoBlazorSprite2D : IBlingoFrameworkSprite, IBlingoFrameworkSpri
     public void SetTexture(IAbstTexture2D texture)
     {
         _texture = texture;
-        if (Width == 0 || Height == 0)
+        if (_blingoSprite.MemberSourceRect is { } rect)
         {
-            Width = texture.Width;
-            Height = texture.Height;
+            if (Width == 0)
+                Width = rect.Width;
+            if (Height == 0)
+                Height = rect.Height;
+        }
+        else
+        {
+            if (Width == 0)
+                Width = texture.Width;
+            if (Height == 0)
+                Height = texture.Height;
         }
         _blingoSprite.FWTextureHasChanged(texture);
         IsDirtyMember = true;
         MakeDirty();
     }
+
+    public (APoint Offset, float SourceWidth, float SourceHeight) GetMemberSourceMetrics()
+        => _blingoSprite.GetMemberSourceMetrics();
 
     /// <inheritdoc/>
     public void Play()

--- a/src/BlingoEngine.LGodot/Sprites/BlingoGodotSprite2D.cs
+++ b/src/BlingoEngine.LGodot/Sprites/BlingoGodotSprite2D.cs
@@ -334,12 +334,18 @@ namespace BlingoEngine.LGodot.Sprites
             _filmloopPlayer = null;
             if (BlingoSprite.Member != null)
             {
-                if (Width == 0 || Height == 0)
-                {
-                    Width = BlingoSprite.Member.Width;
-                    Height = BlingoSprite.Member.Height;
-                }
+                var (_, sourceWidth, sourceHeight) = BlingoSprite.GetMemberSourceMetrics();
+                if (sourceWidth <= 0)
+                    sourceWidth = BlingoSprite.Member.Width;
+                if (sourceHeight <= 0)
+                    sourceHeight = BlingoSprite.Member.Height;
+
+                if (Width == 0)
+                    Width = sourceWidth;
+                if (Height == 0)
+                    Height = sourceHeight;
             }
+            UpdateTextureRegion();
             IsDirtyMember = true;
         }
         private void UpdateSizeFromTexture()
@@ -354,8 +360,15 @@ namespace BlingoEngine.LGodot.Sprites
 
             //if (Width == 0 || Height == 0)
             {
-                Width = _texture.Width;
-                Height = _texture.Height;
+                float baseWidth = _texture.Width;
+                float baseHeight = _texture.Height;
+                if (BlingoSprite.Member is BlingoMemberBitmap && BlingoSprite.MemberSourceRect is { } rect)
+                {
+                    baseWidth = rect.Width;
+                    baseHeight = rect.Height;
+                }
+                Width = baseWidth;
+                Height = baseHeight;
             }
         }
         internal void Update()
@@ -489,16 +502,43 @@ namespace BlingoEngine.LGodot.Sprites
             _texture = tex;
             // because we dont need to clone the textures, we dont need to subscribe unsubscribe to  texture.
             _blingoSprite2D.FWTextureHasChanged(tex, false);
-            if (Width == 0 || Height == 0)
+            UpdateTextureRegion();
+
+            float sourceWidth = tex.Width;
+            float sourceHeight = tex.Height;
+            if (_blingoSprite2D.Member is BlingoMemberBitmap && _blingoSprite2D.MemberSourceRect is { } rect)
             {
-                Width = tex.Width;
-                Height = tex.Height;
+                sourceWidth = rect.Width;
+                sourceHeight = rect.Height;
             }
+
+            if (Width == 0)
+                Width = sourceWidth;
+
+            if (Height == 0)
+                Height = sourceHeight;
         }
         public void SetTexture(IAbstTexture2D texture)
         {
             TextureHasChanged((AbstGodotTexture2D)texture);
         }
+
+        private void UpdateTextureRegion()
+        {
+            if (_sprite2D.Texture == null)
+                return;
+
+            if (_blingoSprite2D.Member is BlingoMemberBitmap && _blingoSprite2D.MemberSourceRect is { } rect)
+            {
+                _sprite2D.RegionEnabled = true;
+                _sprite2D.RegionRect = new Rect2(rect.Left, rect.Top, rect.Width, rect.Height);
+            }
+            else
+            {
+                _sprite2D.RegionEnabled = false;
+            }
+        }
+
         private void UpdateMemberFilmLoop(BlingoGodotFilmLoopMember filmLoop)
         {
             var size = filmLoop.GetBoundingBox();
@@ -544,28 +584,34 @@ namespace BlingoEngine.LGodot.Sprites
 
         public void Resize(float targetWidth, float targetHeight)
         {
-            var width = _sprite2D.Texture.GetWidth();
-            var height = _sprite2D.Texture.GetHeight();
-            float scaleFactorW = targetWidth / width;
-            float scaleFactorH = targetHeight / _sprite2D.Texture.GetHeight();
+            float sourceWidth = _texture?.Width ?? _sprite2D.Texture?.GetWidth() ?? 0f;
+            float sourceHeight = _texture?.Height ?? _sprite2D.Texture?.GetHeight() ?? 0f;
+            if (BlingoSprite.Member is BlingoMemberBitmap && BlingoSprite.MemberSourceRect is { } rect)
+            {
+                sourceWidth = rect.Width;
+                sourceHeight = rect.Height;
+            }
+
+            if (sourceWidth == 0 || sourceHeight == 0)
+                return;
+
+            float scaleFactorW = targetWidth / sourceWidth;
+            float scaleFactorH = targetHeight / sourceHeight;
             _sprite2D.Scale = new Vector2(scaleFactorW, scaleFactorH);
         }
 
         private APoint GetRegPointOffset()
         {
             if (_blingoSprite2D.Member == null) return new APoint();
-            if (_blingoSprite2D.Member is BlingoMemberBitmap member)
+
+            var (baseOffset, sourceWidth, sourceHeight) = _blingoSprite2D.GetMemberSourceMetrics();
+            if (sourceWidth != 0 && sourceHeight != 0)
             {
-                var baseOffset = member.CenterOffsetFromRegPoint();
-                if (member.Width != 0 && member.Height != 0)
-                {
-                    float scaleX = _sprite2D.Scale.X;
-                    float scaleY = _sprite2D.Scale.Y;
-                    return new APoint(baseOffset.X * scaleX, baseOffset.Y * scaleY);
-                }
-                return baseOffset;
+                float scaleX = Width / sourceWidth;
+                float scaleY = Height / sourceHeight;
+                return new APoint(baseOffset.X * scaleX, baseOffset.Y * scaleY);
             }
-            return _blingoSprite2D.Member.RegPoint;
+            return baseOffset;
         }
 
 

--- a/src/BlingoEngine.SDL2/Sprites/SdlSprite.cs
+++ b/src/BlingoEngine.SDL2/Sprites/SdlSprite.cs
@@ -1,4 +1,5 @@
-﻿using BlingoEngine.Bitmaps;
+﻿using System;
+using BlingoEngine.Bitmaps;
 using BlingoEngine.Members;
 using BlingoEngine.FilmLoops;
 using BlingoEngine.Medias;
@@ -280,11 +281,18 @@ public class SdlSprite : IBlingoFrameworkSprite, IBlingoFrameworkSpriteVideo, IA
     {
         if (_blingoSprite2D.Member is { } member)
         {
-            if(Width ==0)
-                Width = member.Width;
+            var (_, sourceWidth, sourceHeight) = _blingoSprite2D.GetMemberSourceMetrics();
+            if (sourceWidth <= 0)
+                sourceWidth = member.Width;
+            if (sourceHeight <= 0)
+                sourceHeight = member.Height;
+
+            if (Width == 0)
+                Width = sourceWidth;
             if (Height == 0)
-                Height = member.Height;
+                Height = sourceHeight;
         }
+        UpdateSourceRect();
         IsDirtyMember = true;
         ComponentContext.QueueRedraw(this);
     }
@@ -317,13 +325,13 @@ public class SdlSprite : IBlingoFrameworkSprite, IBlingoFrameworkSpriteVideo, IA
         var offset = new APoint();
         if (_blingoSprite2D.Member is { } member)
         {
-            var baseOffset = member.CenterOffsetFromRegPoint();
+            var (baseOffset, sourceWidth, sourceHeight) = _blingoSprite2D.GetMemberSourceMetrics();
             float scaleX = 1f;
             float scaleY = 1f;
-            if (member.Width != 0 && member.Height != 0)
+            if (sourceWidth != 0 && sourceHeight != 0)
             {
-                scaleX = Width / member.Width;
-                scaleY = Height / member.Height;
+                scaleX = Width / sourceWidth;
+                scaleY = Height / sourceHeight;
             }
             offset = new APoint(baseOffset.X * scaleX, baseOffset.Y * scaleY);
 
@@ -395,17 +403,45 @@ public class SdlSprite : IBlingoFrameworkSprite, IBlingoFrameworkSpriteVideo, IA
         if (_texture == nint.Zero)
             return;
         _textureOwned = true;
-        if (Width == 0 || Height == 0)
+        float sourceWidth = tex.Width;
+        float sourceHeight = tex.Height;
+        if (_blingoSprite2D.Member is BlingoMemberBitmap && _blingoSprite2D.MemberSourceRect is { } rect)
         {
-            Width = tex.Width;
-            Height = tex.Height;
+            sourceWidth = rect.Width;
+            sourceHeight = rect.Height;
         }
+
+        if (Width == 0)
+            Width = sourceWidth;
+
+        if (Height == 0)
+            Height = sourceHeight;
+
+        UpdateSourceRect();
     }
 
     public void SetTexture(IAbstTexture2D texture)
     {
         var tex = (SdlTexture2D)texture;
         TextureHasChanged(tex);
+    }
+
+    private void UpdateSourceRect()
+    {
+        if (_blingoSprite2D.Member is BlingoMemberBitmap && _blingoSprite2D.MemberSourceRect is { } rect)
+        {
+            ComponentContext.SourceRect = new SDL.SDL_Rect
+            {
+                x = (int)MathF.Round(rect.Left),
+                y = (int)MathF.Round(rect.Top),
+                w = Math.Max(0, (int)MathF.Round(rect.Width)),
+                h = Math.Max(0, (int)MathF.Round(rect.Height))
+            };
+        }
+        else
+        {
+            ComponentContext.SourceRect = null;
+        }
     }
 
     private static readonly SDL.SDL_BlendMode _subtractBlend = SDL.SDL_ComposeCustomBlendMode(

--- a/src/BlingoEngine.Unity/Sprites/BlingoUnitySprite2D.cs
+++ b/src/BlingoEngine.Unity/Sprites/BlingoUnitySprite2D.cs
@@ -162,11 +162,16 @@ public class BlingoUnitySprite2D : IBlingoFrameworkSprite, IBlingoFrameworkSprit
     {
         if (_blingoSprite.Member is { } member)
         {
-            if (Width == 0 || Height == 0)
-            {
-                Width = member.Width;
-                Height = member.Height;
-            }
+            var (_, sourceWidth, sourceHeight) = _blingoSprite.GetMemberSourceMetrics();
+            if (sourceWidth <= 0)
+                sourceWidth = member.Width;
+            if (sourceHeight <= 0)
+                sourceHeight = member.Height;
+
+            if (Width == 0)
+                Width = sourceWidth;
+            if (Height == 0)
+                Height = sourceHeight;
         }
         IsDirtyMember = true;
     }
@@ -179,20 +184,40 @@ public class BlingoUnitySprite2D : IBlingoFrameworkSprite, IBlingoFrameworkSprit
         if (!IsDirty) return;
         IsDirty = false;
 
-        var pos = new Vector3(_x - _regPoint.X, _y - _regPoint.Y, 0f);
-        _go.transform.localPosition = pos;
+        var (baseOffset, sourceWidth, sourceHeight) = _blingoSprite.GetMemberSourceMetrics();
+
+        float textureWidth = _texture?.Texture?.width ?? Width;
+        float textureHeight = _texture?.Texture?.height ?? Height;
+
+        float targetWidth = _desiredWidth == 0
+            ? (sourceWidth > 0 ? sourceWidth : textureWidth)
+            : _desiredWidth;
+        float targetHeight = _desiredHeight == 0
+            ? (sourceHeight > 0 ? sourceHeight : textureHeight)
+            : _desiredHeight;
+
+        if (sourceWidth <= 0)
+            sourceWidth = targetWidth != 0 ? targetWidth : 1f;
+        if (sourceHeight <= 0)
+            sourceHeight = targetHeight != 0 ? targetHeight : 1f;
+
+        float scaleMagnitudeX = sourceWidth != 0 ? targetWidth / sourceWidth : 1f;
+        float scaleMagnitudeY = sourceHeight != 0 ? targetHeight / sourceHeight : 1f;
+
+        var offset = new Vector3(baseOffset.X * scaleMagnitudeX, baseOffset.Y * scaleMagnitudeY, 0f);
+        _go.transform.localPosition = new Vector3(_x - offset.x, _y - offset.y, 0f);
         _go.transform.localEulerAngles = new Vector3(0, 0, _rotation);
 
-        if (_texture?.Texture is Texture2D tex)
-        {
-            float w = _desiredWidth == 0 ? tex.width : _desiredWidth;
-            float h = _desiredHeight == 0 ? tex.height : _desiredHeight;
-            float sx = w / tex.width;
-            float sy = h / tex.height;
-            if (_flipH) sx *= -1f;
-            if (_flipV) sy *= -1f;
-            _go.transform.localScale = new Vector3(sx, sy, 1f);
-        }
+        float scaleX = scaleMagnitudeX;
+        float scaleY = scaleMagnitudeY;
+        if (_flipH) scaleX *= -1f;
+        if (_flipV) scaleY *= -1f;
+        _go.transform.localScale = new Vector3(scaleX, scaleY, 1f);
+
+        if (targetWidth > 0)
+            Width = targetWidth;
+        if (targetHeight > 0)
+            Height = targetHeight;
     }
 
     private void UpdateMember()
@@ -339,11 +364,36 @@ public class BlingoUnitySprite2D : IBlingoFrameworkSprite, IBlingoFrameworkSprit
             var tex = ut.Texture;
             if (tex == null)
                 return;
-            _renderer.sprite = Sprite.Create(tex, new Rect(0, 0, tex.width, tex.height), new Vector2(0.5f, 0.5f));
-            Width = tex.width;
-            Height = tex.height;
+            Rect rect;
+            if (_blingoSprite.Member is BlingoMemberBitmap && _blingoSprite.MemberSourceRect is { } srcRect)
+            {
+                float bottom = srcRect.Bottom;
+                rect = new Rect(srcRect.Left, tex.height - bottom, srcRect.Width, srcRect.Height);
+            }
+            else
+            {
+                rect = new Rect(0, 0, tex.width, tex.height);
+            }
+
+            _renderer.sprite = Sprite.Create(tex, rect, new Vector2(0.5f, 0.5f));
             _texture = ut;
             _blingoSprite.FWTextureHasChanged(ut);
+
+            if (_blingoSprite.MemberSourceRect is { } rectSource)
+            {
+                if (Width == 0)
+                    Width = rectSource.Width;
+                if (Height == 0)
+                    Height = rectSource.Height;
+            }
+            else
+            {
+                if (Width == 0)
+                    Width = rect.width;
+                if (Height == 0)
+                    Height = rect.height;
+            }
+
             IsDirtyMember = true;
         }
     }

--- a/src/BlingoEngine/Sprites/BlingoSprite2D.cs
+++ b/src/BlingoEngine/Sprites/BlingoSprite2D.cs
@@ -45,6 +45,8 @@ namespace BlingoEngine.Sprites
         private int _constraint;
         private bool _directToStage;
         private float _blend = 100f;
+        private ARect? _memberSourceRect;
+        private bool _memberSourceRectChanged;
 
 
         #region Properties
@@ -271,6 +273,20 @@ namespace BlingoEngine.Sprites
             }
         }
 
+        public ARect? MemberSourceRect
+        {
+            get => _memberSourceRect;
+            set
+            {
+                if (_memberSourceRect == value) return;
+                _memberSourceRect = value;
+                _memberSourceRectChanged = true;
+                if (_frameworkSprite != null && _member != null)
+                    MemberHasChanged(forceSizeUpdate: true);
+                OnPropertyChanged();
+            }
+        }
+
         public int Size => Media.Length;
 
         public byte[] Media { get; set; } = new byte[] { };
@@ -336,6 +352,8 @@ namespace BlingoEngine.Sprites
             _frameworkSprite = frameworkSprite;
             _frameworkSprite.Ink = _ink;
             ApplyBlend();
+            if (_memberSourceRectChanged && _member != null)
+                MemberHasChanged(forceSizeUpdate: true);
         }
 
         #region Behaviors
@@ -528,18 +546,62 @@ When a movie stops, events occur in the following order:
 
         private APoint GetRegPointOffset()
         {
-            if (_member is { } member)
+            if (_member is null)
+                return new APoint();
+
+            var (baseOffset, sourceWidth, sourceHeight) = GetMemberSourceMetrics();
+            if (sourceWidth != 0 && sourceHeight != 0)
             {
-                var baseOffset = member.CenterOffsetFromRegPoint();
-                if (member.Width != 0 && member.Height != 0)
-                {
-                    float scaleX = Width / member.Width;
-                    float scaleY = Height / member.Height;
-                    return new APoint(baseOffset.X * scaleX, baseOffset.Y * scaleY);
-                }
-                return baseOffset;
+                float scaleX = Width / sourceWidth;
+                float scaleY = Height / sourceHeight;
+                return new APoint(baseOffset.X * scaleX, baseOffset.Y * scaleY);
             }
-            return new APoint();
+            return baseOffset;
+        }
+
+
+        private void ApplyMemberSourceRectSize(bool force)
+        {
+            if (_frameworkSprite == null || _member == null)
+                return;
+
+            float targetWidth;
+            float targetHeight;
+
+            if (_member is BlingoMemberBitmap && MemberSourceRect is { } rect)
+            {
+                targetWidth = rect.Width;
+                targetHeight = rect.Height;
+            }
+            else
+            {
+                targetWidth = _member.Width;
+                targetHeight = _member.Height;
+            }
+
+            if (targetWidth > 0 && (force || Width == 0))
+                Width = targetWidth;
+
+            if (targetHeight > 0 && (force || Height == 0))
+                Height = targetHeight;
+        }
+
+        public (APoint offset, float sourceWidth, float sourceHeight) GetMemberSourceMetrics()
+        {
+            if (_member == null)
+                return (new APoint(), 0f, 0f);
+
+            if (_member is BlingoMemberBitmap && MemberSourceRect is { } rect)
+            {
+                var centerX = rect.Left + rect.Width / 2f;
+                var centerY = rect.Top + rect.Height / 2f;
+                var regPoint = _member.RegPoint;
+                var baseOffset = new APoint(regPoint.X - centerX, regPoint.Y - centerY);
+                return (baseOffset, rect.Width, rect.Height);
+            }
+
+            var defaultOffset = _member.CenterOffsetFromRegPoint();
+            return (defaultOffset, _member.Width, _member.Height);
         }
 
 
@@ -590,8 +652,9 @@ When a movie stops, events occur in the following order:
             return this;
         }
 
-        private void MemberHasChanged()
+        private void MemberHasChanged(bool forceSizeUpdate = false)
         {
+            var forceUpdate = forceSizeUpdate || _memberSourceRectChanged;
             var existingPlayer = GetActorsOfType<BlingoFilmLoopPlayer>().FirstOrDefault();
             if (_member is BlingoFilmLoopMember)
             {
@@ -610,7 +673,16 @@ When a movie stops, events occur in the following order:
                 RemoveActor(existingPlayer);
             }
 
-            _frameworkSprite.MemberChanged();
+            if (_frameworkSprite != null)
+            {
+                ApplyMemberSourceRectSize(forceUpdate);
+                _frameworkSprite.MemberChanged();
+                _memberSourceRectChanged = false;
+            }
+            else
+            {
+                _memberSourceRectChanged = forceUpdate;
+            }
 
             OnPropertyChanged();
         }
@@ -947,6 +1019,7 @@ When a movie stops, events occur in the following order:
         protected override void OnLoadState(BlingoSpriteState state)
         {
             if (state is not BlingoSprite2DState s || Puppet) return;
+            MemberSourceRect = s.MemberSourceRect;
             if (s.Width > 0) Width = s.Width;
             if (s.Height > 0) Height = s.Height;
             //SetMember(s.Member); // Gives problems in SDL
@@ -999,6 +1072,7 @@ When a movie stops, events occur in the following order:
             s.BackColor = BackColor;
             s.Editable = Editable;
             s.IsDraggable = IsDraggable;
+            s.MemberSourceRect = MemberSourceRect;
         }
 
         #endregion

--- a/src/BlingoEngine/Sprites/BlingoSpriteState.cs
+++ b/src/BlingoEngine/Sprites/BlingoSpriteState.cs
@@ -36,6 +36,7 @@ public class BlingoSprite2DState : BlingoSpriteState
     public AColor BackColor { get; set; }
     public bool Editable { get; set; }
     public bool IsDraggable { get; set; }
+    public ARect? MemberSourceRect { get; set; }
 }
 
 public class BlingoSprite2DVirtualState : BlingoSpriteState


### PR DESCRIPTION
## Summary
- add a MemberSourceRect property to `BlingoSprite2D`, persist it in state, and expose helper metrics for cropped bitmaps
- update SDL, Godot, Unity, and Blazor sprite implementations to render only the selected bitmap region and keep registration offsets correct
- extend Blazor hosting components and scripts to shift canvases when cropping is active

## Testing
- dotnet build src/BlingoEngine/BlingoEngine.csproj
- dotnet build src/BlingoEngine.SDL2/BlingoEngine.SDL2.csproj
- dotnet build src/BlingoEngine.LGodot/BlingoEngine.LGodot.csproj
- dotnet build src/BlingoEngine.Unity/BlingoEngine.Unity.csproj
- dotnet build src/BlingoEngine.Blazor/BlingoEngine.Blazor.csproj
- dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/AbstUI.Blazor.csproj
- dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d429bdbc008332b2a254c8d4674443