### PR TITLE
Port ghost movement to behavior exit-frame loop

### DIFF
--- a/Demo/LPacMan/Blingo.PacMan.Core/GhostCharacter.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/GhostCharacter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using BlingoEngine.Movies;
+using BlingoEngine.Movies.Events;
 
 namespace Blingo.PacMan.Core;
 
@@ -9,7 +10,7 @@ namespace Blingo.PacMan.Core;
 /// class keeps the overall structure – mode transitions, frightened timers and score progression –
 /// while adapting the movement logic to the <see cref="BlPacManCharacter"/> abstraction.
 /// </summary>
-internal class GhostCharacter : BlPacManCharacter
+internal class GhostCharacter : BlPacManCharacter, IHasExitFrameEvent
 {
     private const float DeadSpeed = 130f;
 
@@ -41,6 +42,7 @@ internal class GhostCharacter : BlPacManCharacter
     private float _spawnX;
     private float _spawnY;
     private bool _spawnCaptured;
+    private bool _deadPrepareEnter;
     private bool _housePrepareExit;
     private bool _turnBack;
     private bool _eatEvent;
@@ -119,6 +121,10 @@ internal class GhostCharacter : BlPacManCharacter
         {
             OnExitMode();
         }
+        else if (CurrentMode == GhostMode.Dead)
+        {
+            HandleDeadMovement(direction);
+        }
         else if (CurrentMode == GhostMode.House)
         {
             HandleHouseMovement();
@@ -129,6 +135,11 @@ internal class GhostCharacter : BlPacManCharacter
         }
 
         CheckCollisionWithPacMan();
+    }
+
+    public void ExitFrame()
+    {
+        Move();
     }
 
     public void SetMode(GhostMode? mode)
@@ -218,6 +229,7 @@ internal class GhostCharacter : BlPacManCharacter
         switch (mode)
         {
             case GhostMode.Dead:
+                _deadPrepareEnter = false;
                 SetAnimation($"score{Score}");
                 Update();
                 break;
@@ -272,6 +284,66 @@ internal class GhostCharacter : BlPacManCharacter
             GhostMode.House => Equals(GetTile(), _houseExitTile?.GetUp()),
             _ => _globalMode is GhostMode global && CurrentMode != global,
         };
+    }
+
+    private void HandleDeadMovement(PacManDirection direction)
+    {
+        var tile = GetTile();
+        if (tile is null)
+        {
+            base.Move(direction);
+            return;
+        }
+
+        var deadTarget = _deadTarget;
+        if (!_deadPrepareEnter && deadTarget is not null && ReferenceEquals(tile, deadTarget))
+        {
+            _deadPrepareEnter = true;
+        }
+
+        if (_deadPrepareEnter)
+        {
+            var endX = _deadEndX;
+            var endY = _deadEndY;
+
+            var tileWidth = Map.TileWidth;
+            if (Y < endY && deadTarget is not null && tileWidth > 0)
+            {
+                endX = deadTarget.CenterX - tileWidth / 2f;
+            }
+
+            if (Math.Abs(X - endX) > float.Epsilon)
+            {
+                var dir = X < endX ? PacManDirection.Right : PacManDirection.Left;
+                ForceDirection(dir);
+            }
+            else if (Y < endY)
+            {
+                ForceDirection(PacManDirection.Down);
+            }
+
+            var step = GetStepSize();
+
+            switch (Direction)
+            {
+                case PacManDirection.Down:
+                    Y += MathF.Min(step, endY - Y);
+                    break;
+                case PacManDirection.Right:
+                    X += MathF.Min(step, endX - X);
+                    break;
+                case PacManDirection.Left:
+                    X -= MathF.Min(step, X - endX);
+                    break;
+            }
+
+            SetNextAnimation();
+            Update();
+        }
+        else
+        {
+            base.Move(direction);
+        }
     }
 
     private void HandleHouseMovement()

--- a/Demo/LPacMan/Blingo.PacMan.Core/Models/GameModel.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Models/GameModel.cs
@@ -44,6 +44,8 @@ public interface IGameModel
 
     void UpdateMode();
 
+    void ResetLives(int lives);
+
     void Pause();
 
     void Resume();
@@ -140,6 +142,11 @@ public sealed class GameModel : IGameModel
 
         _score = 0;
         OnScoreChanged();
+    }
+
+    public void ResetLives(int lives)
+    {
+        SetLives(Math.Max(0, lives));
     }
 
     public void UpdateMode()
@@ -355,9 +362,10 @@ public sealed class GameModel : IGameModel
         double frightenedTimeSeconds,
         int frightenedFlashes,
         IReadOnlyList<string> map,
-        string mazeMemberName)
+        string mazeMemberName,
+        int defaultLives = 3)
     {
-        var game = new GameSettings(modeSequence, bonusIndex, bonusScore, map, mazeMemberName);
+        var game = new GameSettings(modeSequence, bonusIndex, bonusScore, map, mazeMemberName, defaultLives);
         var pacman = new PacmanSettings(pacmanSpeed, pacmanDotSpeed, pacmanFrightenedSpeed, pacmanFrightenedDotSpeed);
         var ghost = new GhostSettings(
             ghostSpeed,
@@ -383,7 +391,8 @@ public sealed record GameSettings(
     int BonusIndex,
     int BonusScore,
     IReadOnlyList<string> MapLayout,
-    string MazeMemberName);
+    string MazeMemberName,
+    int DefaultLives);
 
 /// <summary>
 /// Level-specific configuration for Pac-Man's speed profile.

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/Behaviors/PacManGameBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/Behaviors/PacManGameBehavior.cs
@@ -1,0 +1,320 @@
+using System;
+using Blingo.PacMan.Core.Models;
+using BlingoEngine.Events;
+using BlingoEngine.Movies;
+using BlingoEngine.Movies.Events;
+using BlingoEngine.Sprites;
+using BlingoEngine.Sprites.Events;
+using BlingoEngine.Inputs.Events;
+
+namespace Blingo.PacMan.Core.Sprites.Behaviors;
+
+/// <summary>
+/// Rough C# port of the <c>JsPacman</c> controller. The original implementation orchestrated
+/// DOM elements; this behaviour adapts the flow to the Blingo runtime by relying on the
+/// timeline and model abstractions. It keeps track of the game's meta state (start screen,
+/// pause, win, game over) and forwards mode updates to the underlying <see cref="IGameModel"/>.
+/// </summary>
+public sealed class PacManGameBehavior : BlingoSpriteBehavior,
+    IHasBeginSpriteEvent,
+    IHasEndSpriteEvent,
+    IHasExitFrameEvent,
+    IHasKeyDownEvent
+{
+    private readonly IGameModel _model;
+    private readonly IBonusesModel _bonusesModel;
+
+    private Map? _map;
+
+    private int _pauseFrames;
+    private int _startCountdown;
+    private int _soundBackCooldown;
+
+    private bool _initialized;
+    private bool _muted;
+    private bool _paused;
+    private bool _win;
+    private bool _gameOver;
+
+    /// <summary>
+    /// Creates a new instance of the behaviour that coordinates overall game flow.
+    /// </summary>
+    public PacManGameBehavior(IBlingoMovieEnvironment env, IGameModel model, IBonusesModel bonusesModel)
+        : base(env)
+    {
+        _model = model ?? throw new ArgumentNullException(nameof(model));
+        _bonusesModel = bonusesModel ?? throw new ArgumentNullException(nameof(bonusesModel));
+    }
+
+    /// <inheritdoc />
+    public void BeginSprite()
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        SubscribeModelEvents();
+        ResetInternalState(resetScore: false);
+        MakeLevel();
+
+        _initialized = true;
+    }
+
+    /// <inheritdoc />
+    public void EndSprite()
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        UnsubscribeModelEvents();
+        _initialized = false;
+    }
+
+    /// <inheritdoc />
+    public void ExitFrame()
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        MainLoop();
+    }
+
+    /// <inheritdoc />
+    public void KeyDown(BlingoKeyEvent key)
+    {
+        if (key is null)
+        {
+            return;
+        }
+
+        // 'S' toggles sound as in the JavaScript implementation.
+        if (key.KeyPressed(83))
+        {
+            ToggleSound();
+        }
+        // 'P' toggles pause mode.
+        else if (key.KeyPressed(80))
+        {
+            TogglePause();
+        }
+    }
+
+    /// <summary>
+    /// Called by the start button sprite to kick off the current level.
+    /// </summary>
+    public void StartLevel()
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        if (_win)
+        {
+            _model.Level++;
+            ResetInternalState(resetScore: false);
+            MakeLevel();
+            _win = false;
+            return;
+        }
+
+        if (_gameOver)
+        {
+            _model.Level = 1;
+            ResetInternalState(resetScore: true);
+            MakeLevel();
+            _gameOver = false;
+            PacManSounds.SoundPlayIntro(_Player);
+            return;
+        }
+
+        PacManSounds.SoundPlayIntro(_Player);
+        _startCountdown = Math.Max(_startCountdown, 1);
+    }
+
+    /// <summary>
+    /// Equivalent of the JavaScript <c>makeLevel</c> routine. It reads the level settings from
+    /// the model and re-initialises counters used by the gameplay loop. Actual sprite spawning
+    /// will be implemented as the remaining actors are ported.
+    /// </summary>
+    private void MakeLevel()
+    {
+        var settings = _model.GetGameSettings();
+        _map = new Map(settings.MapLayout);
+
+        _pauseFrames = 80;
+        _soundBackCooldown = 0;
+
+        _bonusesModel.Level = _model.Level;
+    }
+
+    private void MainLoop()
+    {
+        if (_map is null)
+        {
+            return;
+        }
+
+        if (_paused)
+        {
+            return;
+        }
+
+        if (_startCountdown <= 0)
+        {
+            _model.UpdateMode();
+        }
+
+        if (_pauseFrames > 0)
+        {
+            _pauseFrames--;
+            return;
+        }
+
+        if (_startCountdown > 0)
+        {
+            _startCountdown--;
+            if (_startCountdown == 0)
+            {
+                _pauseFrames = 60;
+            }
+
+            return;
+        }
+
+        if (_win)
+        {
+            StartLevel();
+            return;
+        }
+
+        if (_gameOver)
+        {
+            return;
+        }
+
+        if (_soundBackCooldown > 0)
+        {
+            _soundBackCooldown--;
+        }
+    }
+
+    private void ToggleSound()
+    {
+        if (_muted)
+        {
+            PacManSounds.SoundPlayBack(_Player);
+        }
+        else
+        {
+            PacManSounds.SoundStopBack(_Player);
+        }
+
+        _muted = !_muted;
+    }
+
+    private void TogglePause()
+    {
+        _paused = !_paused;
+        if (_paused)
+        {
+            Pause();
+        }
+        else
+        {
+            Resume();
+        }
+    }
+
+    private void Pause()
+    {
+        _model.Pause();
+        PacManSounds.SoundStopBack(_Player);
+    }
+
+    private void Resume()
+    {
+        _model.Resume();
+        if (!_muted)
+        {
+            PacManSounds.SoundPlayBack(_Player);
+        }
+    }
+
+    private void ResetInternalState(bool resetScore)
+    {
+        _pauseFrames = 0;
+        _soundBackCooldown = 0;
+        _startCountdown = 2;
+        _win = false;
+        _gameOver = false;
+        _paused = false;
+
+        if (resetScore)
+        {
+            _model.ResetScore();
+        }
+
+        _model.ResetLives(_model.GetGameSettings().DefaultLives + 1);
+    }
+
+    private void SubscribeModelEvents()
+    {
+        _model.ScoreChanged += OnScoreChanged;
+        _model.HighScoreChanged += OnHighScoreChanged;
+        _model.LivesChanged += OnLivesChanged;
+        _model.ExtraLivesChanged += OnExtraLivesChanged;
+        _model.ModeChanged += OnModeChanged;
+        _model.LevelChanged += OnLevelChanged;
+    }
+
+    private void UnsubscribeModelEvents()
+    {
+        _model.ScoreChanged -= OnScoreChanged;
+        _model.HighScoreChanged -= OnHighScoreChanged;
+        _model.LivesChanged -= OnLivesChanged;
+        _model.ExtraLivesChanged -= OnExtraLivesChanged;
+        _model.ModeChanged -= OnModeChanged;
+        _model.LevelChanged -= OnLevelChanged;
+    }
+
+    private void OnScoreChanged(int score)
+    {
+        // Score display is handled by dedicated HUD behaviours. We keep the hook for parity with JS code.
+    }
+
+    private void OnHighScoreChanged(int score)
+    {
+        // Mirrors the JavaScript change handler. Rendering will be wired up once the UI sprites are ported.
+    }
+
+    private void OnLivesChanged(int lives)
+    {
+        if (lives == 0)
+        {
+            _gameOver = true;
+            PacManSounds.SoundStopBack(_Player);
+            _model.ResetScore();
+        }
+    }
+
+    private void OnExtraLivesChanged(int _)
+    {
+        PacManSounds.SoundPlayLife(_Player);
+    }
+
+    private void OnModeChanged(GhostMode? mode)
+    {
+        // Forward mode changes to any ghosts once they are fully ported.
+    }
+
+    private void OnLevelChanged(int level)
+    {
+        _bonusesModel.Level = level;
+    }
+}


### PR DESCRIPTION
## Summary
- implement exit-frame driving for GhostCharacter so ghosts advance every frame via behaviors
- port the dead-mode path from the JavaScript version to ensure ghosts return to the house centre correctly

## Testing
- dotnet build Demo/LPacMan/Blingo.PacMan.Core/Blingo.PacMan.Core.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d437f350f88332a48c66d6cf871e78