### PR TITLE
Align Sprite2D reg point handling with member rects

### DIFF
--- a/Test/BlingoEngine.Tests/Fakes/ReflectionTestHelper.cs
+++ b/Test/BlingoEngine.Tests/Fakes/ReflectionTestHelper.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Reflection;
+
+namespace BlingoEngine.Tests.Fakes;
+
+internal static class ReflectionTestHelper
+{
+    public static void SetPrivateField(object target, string fieldName, object? value)
+    {
+        var type = target.GetType();
+        while (type != null)
+        {
+            var field = type.GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            if (field != null)
+            {
+                field.SetValue(target, value);
+                return;
+            }
+
+            type = type.BaseType;
+        }
+
+        throw new InvalidOperationException($"Field '{fieldName}' not found on type '{target.GetType()}'.");
+    }
+
+    public static void SetAutoProperty<T>(object target, string propertyName, T value)
+    {
+        SetPrivateField(target, $"<{propertyName}>k__BackingField", value);
+    }
+}

--- a/Test/BlingoEngine.Tests/Sprites/BlingoSprite2DMemberRectTests.cs
+++ b/Test/BlingoEngine.Tests/Sprites/BlingoSprite2DMemberRectTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using AbstUI.Primitives;
+using BlingoEngine.Events;
+using BlingoEngine.FrameworkCommunication;
+using BlingoEngine.Members;
+using BlingoEngine.Movies;
+using BlingoEngine.Sprites;
+using FluentAssertions;
+using static BlingoEngine.Tests.Fakes.ReflectionTestHelper;
+
+namespace BlingoEngine.Tests.Sprites;
+
+public sealed class BlingoSprite2DMemberRectTests
+{
+    [Fact]
+    public void RegPointDefaultsToMemberWhenNoMemberRect()
+    {
+        var sprite = CreateSprite();
+        var member = CreateMember(new APoint(10, 20));
+
+        sprite.SetMember(member);
+
+        sprite.RegPoint.Should().Be(member.RegPoint);
+    }
+
+    [Fact]
+    public void SetMemberRectOverridesRegPointWhenRectIsProvided()
+    {
+        var sprite = CreateSprite();
+        var member = CreateMember(new APoint(10, 20));
+        sprite.SetMember(member);
+
+        var customRect = new ARect(1, 2, 11, 12);
+        var customRegPoint = new APoint(3, 4);
+
+        sprite.SetMemberRect(customRect, customRegPoint);
+
+        sprite.MemberSourceRect.Should().Be(customRect);
+        sprite.RegPoint.Should().Be(customRegPoint);
+    }
+
+    [Fact]
+    public void ClearingMemberRectRestoresMembersRegPoint()
+    {
+        var sprite = CreateSprite();
+        var member = CreateMember(new APoint(5, 6));
+        sprite.SetMember(member);
+
+        sprite.SetMemberRect(new ARect(0, 0, 8, 8), new APoint(1, 1));
+
+        sprite.MemberSourceRect = null;
+
+        sprite.RegPoint.Should().Be(member.RegPoint);
+    }
+
+    private static BlingoSprite2D CreateSprite()
+    {
+        var sprite = (BlingoSprite2D)FormatterServices.GetUninitializedObject(typeof(BlingoSprite2D));
+        SetPrivateField(sprite, "_eventMediator", new BlingoEventMediator());
+        SetPrivateField(sprite, "_movie", (BlingoMovie)FormatterServices.GetUninitializedObject(typeof(BlingoMovie)));
+        SetPrivateField(sprite, "_spritesHolder", new DummySpritesPlayer());
+        SetPrivateField(sprite, "_frameworkFactory", null!);
+        SetPrivateField(sprite, "_environment", null!);
+        SetPrivateField(sprite, "_behaviors", new List<BlingoSpriteBehavior>());
+        SetPrivateField(sprite, "_regPoint", default(APoint));
+        SetPrivateField(sprite, "_memberSourceRect", null);
+        SetPrivateField(sprite, "_memberSourceRectChanged", false);
+        SetAutoProperty(sprite, nameof(BlingoSprite2D.ScriptInstanceList), new List<string>());
+        SetPrivateField(sprite, "_spriteActors", new List<object>());
+        return sprite;
+    }
+
+    private static BlingoMember CreateMember(APoint regPoint)
+    {
+        var member = (BlingoMember)FormatterServices.GetUninitializedObject(typeof(BlingoMember));
+        SetPrivateField(member, "_linkedMemberRefUsers", new List<IMemberRefUser>());
+        SetPrivateField(member, "_frameworkMember", new DummyFrameworkMember());
+        SetPrivateField(member, "_regPoint", regPoint);
+        SetPrivateField(member, "_width", 64);
+        SetPrivateField(member, "_height", 64);
+        SetAutoProperty(member, nameof(BlingoMember.Type), BlingoMemberType.Bitmap);
+
+        return member;
+    }
+
+    private sealed class DummyFrameworkMember : IBlingoFrameworkMember
+    {
+        public bool IsLoaded => true;
+        public void CopyToClipboard() { }
+        public void Erase() { }
+        public void ImportFileInto() { }
+        public void PasteClipboardInto() { }
+        public void Preload() { }
+        public Task PreloadAsync() => Task.CompletedTask;
+        public void ReleaseFromSprite(BlingoSprite2D blingoSprite) { }
+        public void Unload() { }
+        public bool IsPixelTransparent(int x, int y) => false;
+    }
+
+    private sealed class DummySpritesPlayer : IBlingoSpritesPlayer
+    {
+        public int CurrentFrame => 0;
+        public int GetMaxLocZ() => 0;
+    }
+}

--- a/src/BlingoEngine/Sprites/BlingoSprite2D.cs
+++ b/src/BlingoEngine/Sprites/BlingoSprite2D.cs
@@ -47,6 +47,7 @@ namespace BlingoEngine.Sprites
         private float _blend = 100f;
         private ARect? _memberSourceRect;
         private bool _memberSourceRectChanged;
+        private APoint _regPoint;
 
 
         #region Properties
@@ -224,7 +225,24 @@ namespace BlingoEngine.Sprites
             }
         }
 
-        public APoint RegPoint { get; set; }
+        public APoint RegPoint
+        {
+            get => _regPoint;
+            set
+            {
+                var target = value;
+                if (_member != null && MemberSourceRect is null)
+                {
+                    target = _member.RegPoint;
+                }
+
+                if (_regPoint.Equals(target))
+                    return;
+
+                _regPoint = target;
+                OnPropertyChanged();
+            }
+        }
         public AColor ForeColor
         {
             get => _foreColor;
@@ -281,11 +299,29 @@ namespace BlingoEngine.Sprites
             {
                 if (_memberSourceRect == value) return;
                 _memberSourceRect = value;
+
+                if (value is null)
+                {
+                    RegPoint = _member?.RegPoint ?? default;
+                }
+
                 _memberSourceRectChanged = true;
                 if (_frameworkSprite != null && _member != null)
                     MemberHasChanged(forceSizeUpdate: true);
                 OnPropertyChanged();
             }
+        }
+
+        public void SetMemberRect(ARect? memberRect, APoint? regPoint = null)
+        {
+            if (memberRect is null)
+            {
+                MemberSourceRect = null;
+                return;
+            }
+
+            MemberSourceRect = memberRect;
+            RegPoint = regPoint ?? _member?.RegPoint ?? default;
         }
 
         public int Size => Media.Length;
@@ -594,8 +630,8 @@ When a movie stops, events occur in the following order:
 
             if (_member is BlingoMemberBitmap && MemberSourceRect is { } rect)
             {
-                var regPoint = _member.RegPoint;
-                var baseOffset = new APoint(regPoint.X - rect.Width + (rect.Width/2), regPoint.Y - rect.Height + (rect.Height / 2));
+                var regPoint = RegPoint;
+                var baseOffset = new APoint(regPoint.X - rect.Width + (rect.Width / 2), regPoint.Y - rect.Height + (rect.Height / 2));
                 return (baseOffset, rect.Width, rect.Height);
             }
 
@@ -638,7 +674,8 @@ When a movie stops, events occur in the following order:
             if (_member != null)
             {
                 _member.UsedBy(this);
-                RegPoint = _member.RegPoint;
+                if (MemberSourceRect is null)
+                    RegPoint = _member.RegPoint;
             }
             if (member is BlingoFilmLoopMember filmLoop)
             {


### PR DESCRIPTION
## Summary
- ensure Sprite2D pulls its reg point from the member whenever no member rect is applied
- add a helper that sets member rect and reg point together and adjust cropping offset calculations
- add unit tests covering reg point defaulting, overrides, and reset behaviour when clearing member rects
- extract reflection helpers into a shared test utility for reuse

## Testing
- dotnet test Test/BlingoEngine.Tests/BlingoEngine.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d75fcff6a0833294bad90b45d787e1