### PR TITLE
Support configuring project settings window on new project

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Windowing/AbstWindowManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Windowing/AbstWindowManager.cs
@@ -33,6 +33,8 @@ public interface IAbstWindowManager
     public event Action<IAbstWindow>? WindowClosed;
 
     bool OpenWindow(string windowCode);
+    bool OpenWindow<TWindow>(string windowCode, Action<TWindow>? actionOnOpen = null)
+        where TWindow : class, IAbstWindow;
     bool SwapWindowOpenState(string windowCode);
     bool CloseWindow(string windowCode);
     void Init(IAbstFrameworkWindowManager frameworkWindowManager);
@@ -128,11 +130,29 @@ public class AbstWindowManager : IAbstWindowManager, IDisposable,
         return true;
     }
 
-    public bool OpenWindow(string windowCode)
+    public bool OpenWindow(string windowCode) => OpenWindow(windowCode, (Action<IAbstWindow>?)null);
+
+    public bool OpenWindow<TWindow>(string windowCode, Action<TWindow>? actionOnOpen = null)
+        where TWindow : class, IAbstWindow
+        => OpenWindow(
+            windowCode,
+            actionOnOpen is null
+                ? null
+                : window =>
+                {
+                    if (window is not TWindow typedWindow)
+                    {
+                        throw new InvalidOperationException($"Window '{windowCode}' is not of type {typeof(TWindow).FullName}.");
+                    }
+
+                    actionOnOpen(typedWindow);
+                });
+
+    private bool OpenWindow(string windowCode, Action<IAbstWindow>? actionOnOpen)
     {
         if (!_windowFactory.TryGetRegistration(windowCode, out var registration)) return false;
         var instance = registration.Instance;
-        bool wasOpen = instance.IsOpen;
+        actionOnOpen?.Invoke(instance);
         instance.OpenWindow();
         SetActiveWindow(registration);
         WindowOpened?.Invoke(registration.Instance);

--- a/src/Director/BlingoEngine.Director.Core/Projects/Commands/SaveDirProjectSettingsCommand.cs
+++ b/src/Director/BlingoEngine.Director.Core/Projects/Commands/SaveDirProjectSettingsCommand.cs
@@ -5,5 +5,6 @@ namespace BlingoEngine.Director.Core.Projects.Commands;
 
 public sealed record SaveDirProjectSettingsCommand(
     DirectorProjectSettings? DirSettings = null,
-    BlingoProjectSettings? ProjectSettings = null) : IAbstCommand;
+    BlingoProjectSettings? ProjectSettings = null,
+    bool StartNewProjectAfterSave = false) : IAbstCommand;
 

--- a/src/Director/BlingoEngine.Director.Core/Projects/DirectorProjectManager.cs
+++ b/src/Director/BlingoEngine.Director.Core/Projects/DirectorProjectManager.cs
@@ -10,6 +10,7 @@ using BlingoEngine.IO;
 using BlingoEngine.Movies;
 using BlingoEngine.Projects;
 using BlingoEngine.Net.RNetContracts;
+using System.IO;
 
 namespace BlingoEngine.Director.Core.Projects;
 
@@ -233,7 +234,37 @@ public class DirectorProjectManager : IAbstCommandHandler<SaveDirProjectSettings
             return false;
         }
         SaveProjectSettings();
+
+        if (command.StartNewProjectAfterSave)
+            StartNewProject();
+
         return true;
+    }
+
+    private void StartNewProject()
+    {
+        if (!_settings.HasValidSettings)
+            return;
+
+        if (_player.ActiveMovie is BlingoMovie activeMovie)
+        {
+            _player.CloseMovie(activeMovie);
+            _player.SetActiveMovie(null);
+        }
+
+        if (_settings.StageWidth > 0 && _settings.StageHeight > 0)
+            _player.LoadStage(_settings.StageWidth, _settings.StageHeight, _player.Stage.BackgroundColor);
+
+        var projectName = _settings.ProjectName;
+        var newMovie = (BlingoMovie)_player.NewMovie(projectName);
+        newMovie.MaxSpriteChannelCount = _settings.MaxSpriteChannelCount;
+
+        var settingsPath = GetSettingsPath();
+        if (!Directory.Exists(settingsPath))
+            Directory.CreateDirectory(settingsPath);
+
+        _repo.Save(GetMoviePath(projectName), newMovie);
+        SaveDirectorSettings();
     }
 }
 

--- a/src/Director/BlingoEngine.Director.Core/Projects/DirectorProjectSettingsWindow.cs
+++ b/src/Director/BlingoEngine.Director.Core/Projects/DirectorProjectSettingsWindow.cs
@@ -27,6 +27,7 @@ public class DirectorProjectSettingsWindow : DirectorWindow<IDirFrameworkProject
     private readonly IAbstCommandManager _commandManager;
     private readonly BlingoProjectSettings _settings;
     private readonly DirectorProjectSettings _dirSettings;
+    private bool _startNewProjectOnNextSave;
 
     private readonly AbstWrapPanel _root;
     private AbstWrapPanel? _vsCodePathRow;
@@ -191,6 +192,19 @@ public class DirectorProjectSettingsWindow : DirectorWindow<IDirFrameworkProject
         Title = "Project Settings";
     }
 
+    public void PrepareForNewProject()
+    {
+        _startNewProjectOnNextSave = true;
+        ProjectName = string.Empty;
+        FolderName = string.Empty;
+        CsProjFile = string.Empty;
+    }
+
+    public override void CloseWindow()
+    {
+        base.CloseWindow();
+        _startNewProjectOnNextSave = false;
+    }
 
 
     private void UpdateSlnPreview()
@@ -214,8 +228,9 @@ public class DirectorProjectSettingsWindow : DirectorWindow<IDirFrameworkProject
 
         SaveState();
         _state.SaveTo(_settings, _dirSettings);
-        _commandManager.Handle(new SaveDirProjectSettingsCommand(_dirSettings, _settings));
-        CloseWindow();
+        var handled = _commandManager.Handle(new SaveDirProjectSettingsCommand(_dirSettings, _settings, _startNewProjectOnNextSave));
+        if (handled)
+            CloseWindow();
     }
     private void LoadState(ProjectSettingsEditorState state)
     {

--- a/src/Director/BlingoEngine.Director.Core/UI/DirectorMainMenu.cs
+++ b/src/Director/BlingoEngine.Director.Core/UI/DirectorMainMenu.cs
@@ -237,6 +237,10 @@ namespace BlingoEngine.Director.Core.UI
         private void CreateFileMenu(IBlingoFrameworkFactory factory)
         {
             // File Menu
+            var newProject = factory.CreateMenuItem("New...");
+            newProject.Activated += OpenNewProjectSettings;
+            _fileMenu.AddItem(newProject);
+
             var load = factory.CreateMenuItem("Load");
             load.Activated += () => _projectManager.LoadMovie();
             _fileMenu.AddItem(load);
@@ -256,6 +260,13 @@ namespace BlingoEngine.Director.Core.UI
             var quit = factory.CreateMenuItem("Quit");
             quit.Activated += () => Environment.Exit(0);
             _fileMenu.AddItem(quit);
+        }
+
+        private void OpenNewProjectSettings()
+        {
+            _windowManager.OpenWindow<DirectorProjectSettingsWindow>(
+                DirectorMenuCodes.ProjectSettingsWindow,
+                settingsWindow => settingsWindow.PrepareForNewProject());
         }
 
         private void CreateEditMenu(IBlingoFrameworkFactory factory)


### PR DESCRIPTION
## Summary
- add a generic action-enabled overload for IAbstWindowManager.OpenWindow so callers can prime a window instance during activation
- use the new overload when launching the Director project settings from File > New so it prepares the dialog before showing

## Testing
- dotnet build src/Director/BlingoEngine.Director.Core/BlingoEngine.Director.Core.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d7613f8a848332b91dbd239bc2157a