### PR TITLE
Fix Pac-Man ghost placement and orientation

### DIFF
--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGhostBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGhostBehavior.cs
@@ -288,9 +288,6 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
         //}
 
         
-        SetStartposition();
-
-
         if (_ghostRects.TryGetValue(GhostName, out var rect))
         {
             Me.MemberSourceRect = rect;
@@ -300,6 +297,8 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
             var size = BlPacManTheme.Ghosts.SpriteSize;
             Me.MemberSourceRect = new ARect(0, 0, size, size);
         }
+
+        SetStartposition();
 
         _initialDirection = DetermineInitialDirection();
         _requestedDirection = _initialDirection;

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/ParentScripts/BlPacManCharacter.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/ParentScripts/BlPacManCharacter.cs
@@ -300,9 +300,12 @@ internal sealed class BlPacManCharacter : BlingoParentScript
                     X += distance;
                     break;
                 case BlPacManDirection.Down:
+                    if (RotateSprite)
+                    {
+                        _sprite.Rotation = 90;
+                        _sprite.FlipH = false;
+                    }
                     Y += distance;
-                    _sprite.Rotation = 90;
-                    _sprite.FlipH = false;
                     break;
                 case BlPacManDirection.Left:
                     if (RotateSprite)


### PR DESCRIPTION
## Summary
- ensure ghost sprites are positioned after their sprite dimensions are applied so they spawn inside the house
- guard the downward movement rotation behind the RotateSprite flag to keep ghosts upright

## Testing
- dotnet build Demo/LPacMan/Blingo.PacMan.Core/Blingo.PacMan.Core.csproj

------
https://chatgpt.com/codex/tasks/task_e_68da8d37df808332a7b4f594cba8d09c