### PR TITLE
Fix Pac-Man ghost house exit logic

### DIFF
--- a/Demo/LPacMan/Blingo.PacMan.Core/Game/Tile.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Game/Tile.cs
@@ -88,6 +88,27 @@ public sealed class Tile
 
     public bool IsHouse() => Code == 'h';
 
+    /// <summary>
+    /// Determines whether the tile is part of the ghost house doorway, allowing
+    /// ghosts to exit without re-entering from outside the maze.
+    /// </summary>
+    public bool IsGhostHouseEntrance()
+    {
+        var houseCenter = Map.HouseCenter;
+        if (houseCenter is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, houseCenter))
+        {
+            return true;
+        }
+
+        var doorway = houseCenter.GetUp();
+        return doorway is not null && ReferenceEquals(this, doorway);
+    }
+
     public bool IsTunnel() => Code == 't';
 
     public bool HasDot() => Item is not null && Code == '.';

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGhostBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGhostBehavior.cs
@@ -635,7 +635,13 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
             return !next.IsWall();
         }
 
-        if (next.IsWall() || next.IsHouse())
+        if (next.IsWall())
+        {
+            return false;
+        }
+
+        var insideHouseRegion = tile.IsHouse() || tile.IsGhostHouseEntrance();
+        if (next.IsHouse() && !insideHouseRegion)
         {
             return false;
         }

--- a/Test/Blingo.PacMan.Tests/BlPacManGameBehaviorTests.cs
+++ b/Test/Blingo.PacMan.Tests/BlPacManGameBehaviorTests.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using AbstUI.Resources;
-using Blingo.PacMan.Core.Datas;
+using Blingo.PacMan.Core.Enums;
+using Blingo.PacMan.Core.Game;
 using Blingo.PacMan.Core.Models;
 using FluentAssertions;
 using Xunit;
@@ -14,8 +13,8 @@ public sealed class BlPacManGameBehaviorTests
     [Fact]
     public void GameModel_follows_default_mode_sequence()
     {
-        var repository = new GameModelRepository(new InMemoryResourceManager());
-        var model = new GameModel(repository);
+        var globals = new GlobalVars();
+        var model = globals.GameModel ?? throw new InvalidOperationException("Game model was not initialised.");
         var recorded = new List<GhostMode>();
 
         model.SubscribeModeChanged(mode =>
@@ -64,62 +63,4 @@ public sealed class BlPacManGameBehaviorTests
         }
     }
 
-    private sealed class InMemoryResourceManager : IAbstResourceManager
-    {
-        private readonly Dictionary<string, object> _storage = new(StringComparer.OrdinalIgnoreCase);
-
-        public string ProjectFolder { get; set; } = string.Empty;
-
-        public bool FileExists(string fileName) => false;
-
-        public Task<bool> FileExistsAsync(string fileName) => Task.FromResult(false);
-
-        public string? ReadTextFile(string fileName) => null;
-
-        public Task<string?> ReadTextFileAsync(string fileName) => Task.FromResult<string?>(null);
-
-        public byte[]? ReadBytes(string fileName) => null;
-
-        public Task<byte[]?> ReadBytesAsync(string fileName) => Task.FromResult<byte[]?>(null);
-
-        public void StorageWrite<T>(string key, T data)
-        {
-            if (key is null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-
-            _storage[key] = data!;
-        }
-
-        public Task StorageWriteAsync<T>(string key, T data)
-        {
-            StorageWrite(key, data);
-            return Task.CompletedTask;
-        }
-
-        public T? StorageRead<T>(string key)
-        {
-            if (key is null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-
-            if (_storage.TryGetValue(key, out var value))
-            {
-                return (T?)value;
-            }
-
-            return default;
-        }
-
-        public Task<T?> StorageReadAsync<T>(string key)
-        {
-            return Task.FromResult(StorageRead<T>(key));
-        }
-
-        public string Serialize<T>(T data) => throw new NotSupportedException();
-
-        public T? Deserialize<T>(string content) => throw new NotSupportedException();
-    }
 }

--- a/Test/Blingo.PacMan.Tests/BlPacManGhostBehaviorTests.cs
+++ b/Test/Blingo.PacMan.Tests/BlPacManGhostBehaviorTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Blingo.PacMan.Core.Datas;
+using Blingo.PacMan.Core.Enums;
+using Blingo.PacMan.Core.Game;
+using Blingo.PacMan.Core.Sprites.GameObjectBehaviors;
+using FluentAssertions;
+using Xunit;
+
+namespace Blingo.PacMan.Tests;
+
+public sealed class BlPacManGhostBehaviorTests
+{
+    private static readonly MethodInfo CanMoveMethod = typeof(BlPacManGhostBehavior)
+        .GetMethod("CanMove", BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("Unable to access CanMove method for testing.");
+
+    [Fact]
+    public void CanMove_allows_ghosts_to_leave_house_through_doorway()
+    {
+        var map = new Map(Maps.Map1);
+        var houseCenter = map.HouseCenter ?? throw new InvalidOperationException("House center tile was not found.");
+        var doorway = houseCenter.GetUp() ?? throw new InvalidOperationException("House doorway tile was not found.");
+
+        var behavior = (BlPacManGhostBehavior)RuntimeHelpers.GetUninitializedObject(typeof(BlPacManGhostBehavior));
+
+        var canMove = (bool)CanMoveMethod.Invoke(behavior, new object[] { BlPacManDirection.Up, doorway })!;
+
+        canMove.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanMove_prevents_reentry_into_house_from_outside()
+    {
+        var map = new Map(Maps.Map1);
+        var houseCenter = map.HouseCenter ?? throw new InvalidOperationException("House center tile was not found.");
+        var doorway = houseCenter.GetUp() ?? throw new InvalidOperationException("House doorway tile was not found.");
+        var outside = doorway.GetUp()?.GetUp() ?? throw new InvalidOperationException("Outside doorway tile was not found.");
+
+        var behavior = (BlPacManGhostBehavior)RuntimeHelpers.GetUninitializedObject(typeof(BlPacManGhostBehavior));
+
+        var canMove = (bool)CanMoveMethod.Invoke(behavior, new object[] { BlPacManDirection.Down, outside })!;
+
+        canMove.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- treat the doorway tiles as part of the ghost house so living ghosts can exit but not re-enter
- gate ghost movement on the new entrance helper and adjust the Pac-Man mode test to use GlobalVars
- add regression tests covering doorway traversal behaviour

## Testing
- dotnet test Test/Blingo.PacMan.Tests/Blingo.PacMan.Tests.csproj --logger "console;verbosity=normal"


------
https://chatgpt.com/codex/tasks/task_e_68da9ac35d60833294b1f737620f3fd7