### PR TITLE
Restore top-left default reg point and center Pac-Man sprites

### DIFF
--- a/Demo/LPacMan/Blingo.PacMan.Core/BlPacManProjectFactory.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/BlPacManProjectFactory.cs
@@ -196,7 +196,7 @@ public class BlPacManProjectFactory : IBlingoProjectFactory
             {
                 sprite.Name = "ContinousBackground";
                 sprite.Lock = true;
-                sprite.MemberSourceRect = ARect.New(0, 0, 10, 10);
+                sprite.SetMemberRect(ARect.New(0, 0, 10, 10));
                 sprite.Width = GameWidth;
                 sprite.Height = GameHeight;
             })
@@ -248,7 +248,7 @@ public class BlPacManProjectFactory : IBlingoProjectFactory
         var roamingBonus = _movie.AddSprite(PCSpriteNums.BonusesRoaming, GameStartFrame, frameCount, sprStartX, sprStartY + sprSize*2, sprite =>
             {
                 sprite.Name = "Bonuses.Roaming";
-                sprite.MemberSourceRect = BlPacManRoamingBonusBehavior.DefaultAnimationRect;
+                sprite.SetMemberRect(BlPacManRoamingBonusBehavior.DefaultAnimationRect);
             })
             .SetMember("misc")
             .AddBehavior<BlPacManAnimationBehavior>()
@@ -258,7 +258,8 @@ public class BlPacManProjectFactory : IBlingoProjectFactory
             {
                 //sprite.Visibility = false;
                 sprite.Name = "PacMan";
-                sprite.MemberSourceRect = new ARect(0, 0, sprSize, sprSize);
+                var rect = new ARect(0, 0, sprSize, sprSize);
+                sprite.SetMemberRect(rect, new APoint(rect.Width / 2f, rect.Height / 2f));
             })
             .SetMember("sprites")
             .AddBehavior<BlPacManAnimationBehavior>()
@@ -270,7 +271,8 @@ public class BlPacManProjectFactory : IBlingoProjectFactory
             var ghost = _movie.AddSprite(PCSpriteNums.GhostStart + i, GameStartFrame, frameCount, sprStartX + i* sprSize, sprStartY, sprite =>
                 {
                     sprite.Name = $"Ghost.{ghostNames[i]}";
-                    sprite.MemberSourceRect = ARect.New(i * sprSize, (i + 1) * sprSize, sprSize, sprSize);
+                    var rect = ARect.New(i * sprSize, (i + 1) * sprSize, sprSize, sprSize);
+                    sprite.SetMemberRect(rect, new APoint(rect.Width / 2f, rect.Height / 2f));
                 })
                 .SetMember("sprites")
                 .AddBehavior<BlPacManAnimationBehavior>()

--- a/Demo/LPacMan/Blingo.PacMan.Core/Game/BlPacManBonusAvailableManager.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Game/BlPacManBonusAvailableManager.cs
@@ -92,7 +92,7 @@ namespace Blingo.PacMan.Core.Game
             sprite2D.LocV = y;
             sprite2D.SetMember("misc");
             var frameSize = TileMath.SpriteSize - 1;
-            sprite2D.MemberSourceRect = ARect.New(frameSize * index, 0, frameSize, frameSize);
+            sprite2D.SetMemberRect(ARect.New(frameSize * index, 0, frameSize, frameSize));
 
             return new BonusSprite(name, sprite2D);
         }

--- a/Demo/LPacMan/Blingo.PacMan.Core/Game/BlPacManLivesManager.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Game/BlPacManLivesManager.cs
@@ -144,7 +144,8 @@ public sealed class BlPacManLivesManager
         sprite2D.SetMember("sprites");
 
         var frameSize = TileMath.SpriteSize;
-        sprite2D.MemberSourceRect = ARect.New(0,0, frameSize, frameSize);
+        var rect = ARect.New(0,0, frameSize, frameSize);
+        sprite2D.SetMemberRect(rect, new APoint(rect.Width / 2f, rect.Height / 2f));
 
 
         if (Math.Abs(ScaleFactor - 1f) > float.Epsilon)

--- a/Demo/LPacMan/Blingo.PacMan.Core/Game/BlPacManPelletManager.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Game/BlPacManPelletManager.cs
@@ -54,7 +54,7 @@ internal sealed class BlPacManPelletManager
         sprite2D.LocH = tile.CenterX;
         sprite2D.LocV = tile.CenterY;
         sprite2D.SetMember("pills");
-        sprite2D.MemberSourceRect = _pelletRect;
+        sprite2D.SetMemberRect(_pelletRect);
 
         var behavior = sprite2D.SetBehavior<BlPacManPelletBehavior>();
         behavior.Component.SetGlobals(_globals);

--- a/Demo/LPacMan/Blingo.PacMan.Core/Game/BlPacManPowerPillManager.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Game/BlPacManPowerPillManager.cs
@@ -50,7 +50,7 @@ internal sealed class BlPacManPowerPillManager
         sprite2D.LocH = tile.CenterX-2;
         sprite2D.LocV = tile.CenterY-2;
         sprite2D.SetMember("pills");
-        sprite2D.MemberSourceRect = new(0, 0, 6, 6);
+        sprite2D.SetMemberRect(new(0, 0, 6, 6));
 
         var behavior = sprite2D.SetBehavior<BlPacManPowerPillBehavior>();
         behavior.Component.SetGlobals(_globals);

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGhostBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGhostBehavior.cs
@@ -290,12 +290,13 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
         
         if (_ghostRects.TryGetValue(GhostName, out var rect))
         {
-            Me.MemberSourceRect = rect;
+            Me.SetMemberRect(rect, new APoint(rect.Width / 2f, rect.Height / 2f));
         }
         else
         {
             var size = BlPacManTheme.Ghosts.SpriteSize;
-            Me.MemberSourceRect = new ARect(0, 0, size, size);
+            var fallbackRect = new ARect(0, 0, size, size);
+            Me.SetMemberRect(fallbackRect, new APoint(fallbackRect.Width / 2f, fallbackRect.Height / 2f));
         }
 
         SetStartposition();

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManRoamingBonusBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManRoamingBonusBehavior.cs
@@ -192,7 +192,7 @@ internal sealed class BlPacManRoamingBonusBehavior : BlingoSpriteBehavior,
         if (member != null)
         {
             Me.Member = member;
-            Me.MemberSourceRect = BlPacManTheme.Bonus.DefaultFrame;
+            Me.SetMemberRect(BlPacManTheme.Bonus.DefaultFrame);
         }
 
         ParseMap();

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GeneralBehaviors/BlPacManAnimationBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GeneralBehaviors/BlPacManAnimationBehavior.cs
@@ -147,7 +147,13 @@ internal sealed class BlPacManAnimationBehavior : BlingoSpriteBehavior,
 
     private void ApplyFrame(in ARect rect)
     {
-        Me.MemberSourceRect = rect;
+        APoint? regPoint = null;
+        if (string.Equals(Me.Member?.Name, "sprites", StringComparison.OrdinalIgnoreCase))
+        {
+            regPoint = new APoint(rect.Width / 2f, rect.Height / 2f);
+        }
+
+        Me.SetMemberRect(rect, regPoint);
     }
 
     private readonly struct AnimationSequence

--- a/Test/BlingoEngine.Tests/Casts/DummyCast.cs
+++ b/Test/BlingoEngine.Tests/Casts/DummyCast.cs
@@ -1,4 +1,7 @@
-﻿using AbstUI.Primitives;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AbstUI.Primitives;
 using BlingoEngine.Casts;
 using BlingoEngine.Core;
 using BlingoEngine.Members;
@@ -46,6 +49,9 @@ internal class DummyCast : IBlingoCast
     public IEnumerable<IBlingoMember> GetAll() => Array.Empty<IBlingoMember>();
     public void SwapMembers(int slot1, int slot2) { }
     public void Save() { }
+
+    public IReadOnlyList<int> ResolveFreeSlotNumbers(int startSlot, int requiredCount)
+        => Enumerable.Range(startSlot, requiredCount).ToArray();
 
     private class DummyMembersContainer : IBlingoMembersContainer
     {

--- a/Test/BlingoEngine.Tests/Sprites/BlingoSprite2DMemberRectTests.cs
+++ b/Test/BlingoEngine.Tests/Sprites/BlingoSprite2DMemberRectTests.cs
@@ -43,6 +43,21 @@ public sealed class BlingoSprite2DMemberRectTests
     }
 
     [Fact]
+    public void SetMemberRectDefaultsRegPointToTopLeft()
+    {
+        var sprite = CreateSprite();
+        var member = CreateMember(new APoint(10, 20));
+        sprite.SetMember(member);
+
+        var rect = ARect.New(4, 6, 12, 14);
+
+        sprite.SetMemberRect(rect);
+
+        sprite.MemberSourceRect.Should().Be(rect);
+        sprite.RegPoint.Should().Be(new APoint(0f, 0f));
+    }
+
+    [Fact]
     public void ClearingMemberRectRestoresMembersRegPoint()
     {
         var sprite = CreateSprite();

--- a/src/BlingoEngine.LGodot/Sprites/BlingoGodotSprite2D.cs
+++ b/src/BlingoEngine.LGodot/Sprites/BlingoGodotSprite2D.cs
@@ -95,8 +95,10 @@ namespace BlingoEngine.LGodot.Sprites
             get => (_container2D.Position.X, _container2D.Position.Y);
             set
             {
-                if (_x == value.X && _y == value.Y) return;
+                var currentPosition = _container2D.Position;
+                if (currentPosition.X == value.X && currentPosition.Y == value.Y) return;
                 _container2D.Position = new Vector2(value.X, value.Y);
+                _sprite2D.PivotOffset = new Vector2(value.X, value.Y);
                 SetDirty();
             }
         }

--- a/src/BlingoEngine.SDL2/Sprites/SdlSprite.cs
+++ b/src/BlingoEngine.SDL2/Sprites/SdlSprite.cs
@@ -336,20 +336,21 @@ public class SdlSprite : IBlingoFrameworkSprite, IBlingoFrameworkSpriteVideo, IA
             
             float scaleX = 1f;
             float scaleY = 1f;
-            float pivotX = 0;
-            float pivotY = 0;
+            float targetWidth = Width != 0 ? Width : ComponentContext.TargetWidth;
+            float targetHeight = Height != 0 ? Height : ComponentContext.TargetHeight;
             if (Rotation == 0)
             {
                 if (sourceWidth != 0 && sourceHeight != 0)
                 {
-                    scaleX = Width / sourceWidth;
-                    scaleY = Height / sourceHeight;
+                    if (targetWidth == 0) targetWidth = sourceWidth;
+                    if (targetHeight == 0) targetHeight = sourceHeight;
+
+                    scaleX = sourceWidth != 0 ? targetWidth / sourceWidth : 1f;
+                    scaleY = sourceHeight != 0 ? targetHeight / sourceHeight : 1f;
                 }
             }
             else
             {
-                float targetWidth = Width != 0 ? Width : ComponentContext.TargetWidth;
-                float targetHeight = Height != 0 ? Height : ComponentContext.TargetHeight;
                 if (targetWidth == 0 && member.Width != 0) targetWidth = member.Width;
                 if (targetHeight == 0 && member.Height != 0) targetHeight = member.Height;
                 if (targetWidth == 0) targetWidth = 1f;
@@ -360,11 +361,10 @@ public class SdlSprite : IBlingoFrameworkSprite, IBlingoFrameworkSpriteVideo, IA
 
                 scaleX = sourceWidth != 0 ? targetWidth / sourceWidth : 1f;
                 scaleY = sourceHeight != 0 ? targetHeight / sourceHeight : 1f;
-                pivotX = sourceWidth / 2f; // (baseOffset.X + sourceWidth / 2f) * scaleX;
-                pivotY = sourceHeight / 2f; //(baseOffset.Y + sourceHeight / 2f) * scaleY;
-
-
             }
+
+            var pivotX = _blingoSprite2D.RegPoint.X * scaleX;
+            var pivotY = _blingoSprite2D.RegPoint.Y * scaleY;
 
             offset = new APoint(baseOffset.X * scaleX, baseOffset.Y * scaleY);
 
@@ -397,10 +397,12 @@ public class SdlSprite : IBlingoFrameworkSprite, IBlingoFrameworkSpriteVideo, IA
         }
         else if (Width > 0f && Height > 0f)
         {
+            var pivotX = _blingoSprite2D.RegPoint.X;
+            var pivotY = _blingoSprite2D.RegPoint.Y;
             rotationCenter = new SDL.SDL_Point
             {
-                x = (int)MathF.Round(Width / 2f),
-                y = (int)MathF.Round(Height / 2f)
+                x = (int)MathF.Round(pivotX),
+                y = (int)MathF.Round(pivotY)
             };
             ComponentContext.RotationCenter = rotationCenter;
         }

--- a/src/BlingoEngine/Sprites/BlingoSprite2D.cs
+++ b/src/BlingoEngine/Sprites/BlingoSprite2D.cs
@@ -228,20 +228,36 @@ namespace BlingoEngine.Sprites
         public APoint RegPoint
         {
             get => _regPoint;
-            set
+            private set => SetRegPointInternal(value, respectMemberRegPoint: true);
+        }
+        internal void SetRegPoint(APoint value, bool respectMemberRegPoint = true)
+            => SetRegPointInternal(value, respectMemberRegPoint);
+
+        APoint IBlingoSprite.RegPoint
+        {
+            get => RegPoint;
+            set => SetRegPoint(value);
+        }
+
+        APoint IBlingoSprite2DLight.RegPoint
+        {
+            get => RegPoint;
+            set => SetRegPoint(value);
+        }
+
+        private void SetRegPointInternal(APoint value, bool respectMemberRegPoint)
+        {
+            var target = value;
+            if (respectMemberRegPoint && _member != null && MemberSourceRect is null)
             {
-                var target = value;
-                if (_member != null && MemberSourceRect is null)
-                {
-                    target = _member.RegPoint;
-                }
-
-                if (_regPoint.Equals(target))
-                    return;
-
-                _regPoint = target;
-                OnPropertyChanged();
+                target = _member.RegPoint;
             }
+
+            if (_regPoint.Equals(target))
+                return;
+
+            _regPoint = target;
+            OnPropertyChanged();
         }
         public AColor ForeColor
         {
@@ -317,11 +333,15 @@ namespace BlingoEngine.Sprites
             if (memberRect is null)
             {
                 MemberSourceRect = null;
+                var fallbackRegPoint = _member?.RegPoint ?? default;
+                SetRegPointInternal(fallbackRegPoint, respectMemberRegPoint: false);
                 return;
             }
 
-            MemberSourceRect = memberRect;
-            RegPoint = regPoint ?? _member?.RegPoint ?? default;
+            var rectValue = memberRect.Value;
+            MemberSourceRect = rectValue;
+            var targetRegPoint = regPoint ?? default;
+            SetRegPointInternal(targetRegPoint, respectMemberRegPoint: false);
         }
 
         public int Size => Media.Length;


### PR DESCRIPTION
## Summary
- restore the default SetMemberRect registration point to the top-left and remove automatic SDL pivot centering
- update Pac-Man sprites that use the shared "sprites" member to explicitly center their registration points during setup and animation
- adjust the member rect regression test to match the top-left default

## Testing
- dotnet test Test/BlingoEngine.Tests/BlingoEngine.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68da924e32248332bd28ddc2a4fe8bcc