### PR TITLE
Fix Pac-Man map pixel lookup to match JS floor semantics

### DIFF
--- a/Demo/LPacMan/Blingo.PacMan.Core/Game/Map.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Game/Map.cs
@@ -65,7 +65,24 @@ public sealed class Map
         }
     }
 
-    public Tile? GetTile(float column, float row, bool inPixels = false) => GetTile((int)column, (int)row, inPixels);
+    public Tile? GetTile(float column, float row, bool inPixels = false)
+    {
+        if (!inPixels)
+        {
+            return GetTile((int)MathF.Floor(column), (int)MathF.Floor(row));
+        }
+
+        if (_tiles.Count == 0)
+            return null;
+
+        if (TileWidth == 0 || TileHeight == 0)
+            return null;
+
+        var columnIndex = (int)MathF.Floor(column / TileWidth);
+        var rowIndex = (int)MathF.Floor(row / TileHeight);
+
+        return GetTile(columnIndex, rowIndex);
+    }
 
     public Tile? GetTile(int column, int row, bool inPixels = false)
     {
@@ -74,15 +91,13 @@ public sealed class Map
 
         if (inPixels)
         {
-            if (TileWidth == 0 || TileHeight == 0)
-                return null;
-
-            column /= TileWidth;
-            row /= TileHeight;
+            return GetTile((float)column, (float)row, true);
         }
 
         column = WrapColumn(column);
-        row = WrapRow(row);
+
+        if (row < 0 || row >= Height)
+            return null;
 
         var index = row * Width + column;
         if ((uint)index >= (uint)_tiles.Count)
@@ -116,16 +131,4 @@ public sealed class Map
         return column;
     }
 
-    private int WrapRow(int row)
-    {
-        if (Height == 0)
-            return row;
-
-        if (row > Height - 1)
-            row = 0;
-        else if (row < 0)
-            row = Height - 1;
-
-        return row;
-    }
 }

--- a/Demo/LPacMan/Blingo.PacMan.Core/Game/Tile.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Game/Tile.cs
@@ -46,6 +46,18 @@ internal static class TileMath
 
         return MathF.Max(1f, baseSize / 4f);
     }
+
+    public static float ClampVerticalPosition(float y, int mapHeight)
+    {
+        if (mapHeight <= 0)
+            return y;
+
+        if (y < 0)
+            return 0f;
+
+        var max = MathF.Max(0f, mapHeight - 1f);
+        return y >= mapHeight ? max : y;
+    }
 }
 public sealed class Tile
 {

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGhostBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGhostBehavior.cs
@@ -770,6 +770,15 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
             }
         }
 
+        if (float.IsPositiveInfinity(bestDistance))
+        {
+            var reverse = currentDirection.GetOpposite();
+            if (reverse != BlPacManDirection.None && CanMove(reverse, nextTile))
+            {
+                return reverse;
+            }
+        }
+
         return best;
     }
 

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/ParentScripts/BlPacManCharacter.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/ParentScripts/BlPacManCharacter.cs
@@ -613,13 +613,7 @@ internal sealed class BlPacManCharacter : BlingoParentScript
         }
 
         var mapHeight = Map.Height * Map.TileHeight;
-        if (mapHeight > 0)
-        {
-            if (Y < 0)
-                Y = mapHeight;
-            else if (Y > mapHeight)
-                Y = 0;
-        }
+        Y = TileMath.ClampVerticalPosition(Y, mapHeight);
     }
 
     private void OnTileEntered(Tile tile)

--- a/Test/Blingo.PacMan.Tests/BlPacManGhostBehaviorTests.cs
+++ b/Test/Blingo.PacMan.Tests/BlPacManGhostBehaviorTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Blingo.PacMan.Core.Datas;
@@ -21,6 +23,10 @@ public sealed class BlPacManGhostBehaviorTests
     private static readonly MethodInfo CanMoveMethod = typeof(BlPacManGhostBehavior)
         .GetMethod("CanMove", BindingFlags.Instance | BindingFlags.NonPublic)
         ?? throw new InvalidOperationException("Unable to access CanMove method for testing.");
+
+    private static readonly MethodInfo DetermineNextDirectionMethod = typeof(BlPacManGhostBehavior)
+        .GetMethod("DetermineNextDirection", BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("Unable to access DetermineNextDirection method for testing.");
 
     [Fact]
     public void CanMove_allows_ghosts_to_leave_house_through_doorway()
@@ -49,6 +55,31 @@ public sealed class BlPacManGhostBehaviorTests
         var canMove = (bool)CanMoveMethod.Invoke(behavior, new object[] { BlPacManDirection.Down, outside })!;
 
         canMove.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DetermineNextDirection_reverses_when_forward_is_blocked()
+    {
+        var layout = new[]
+        {
+            "===",
+            "=.=",
+            "=.=",
+            "===",
+        };
+
+        var globals = PrepareGlobalsWithMap(layout);
+        var ghost = CreateBehavior(globals);
+        SetField(ghost, "_mode", GhostMode.Scatter);
+
+        var deadEnd = globals.Map.GetTile(1, 1) ?? throw new InvalidOperationException();
+
+        SetField(ghost, "_dir", BlPacManDirection.Up);
+        SetField(ghost, "_scatterTarget", deadEnd);
+
+        var direction = (BlPacManDirection)DetermineNextDirectionMethod.Invoke(ghost, new object[] { deadEnd })!;
+
+        direction.Should().Be(BlPacManDirection.Down);
     }
 
     [Fact]
@@ -163,10 +194,10 @@ public sealed class BlPacManGhostBehaviorTests
         closeTarget.Should().BeSameAs(scatter);
     }
 
-    private static GlobalVars PrepareGlobalsWithMap()
+    private static GlobalVars PrepareGlobalsWithMap(IEnumerable<string>? layout = null)
     {
         var globals = new GlobalVars();
-        var map = new Map(Maps.Map1);
+        var map = new Map(layout ?? Maps.Map1);
         var managerField = typeof(BlLevelManager).GetField("_map", BindingFlags.Instance | BindingFlags.NonPublic) ?? throw new InvalidOperationException();
         managerField.SetValue(globals.LevelManager, map);
         return globals;

--- a/Test/Blingo.PacMan.Tests/MapTests.cs
+++ b/Test/Blingo.PacMan.Tests/MapTests.cs
@@ -1,0 +1,39 @@
+using System;
+using Blingo.PacMan.Core.Game;
+using FluentAssertions;
+using Xunit;
+
+namespace Blingo.PacMan.Tests;
+
+public sealed class MapTests
+{
+    private static readonly string[] SimpleLayout =
+    {
+        "===",
+        "=.=",
+        "===",
+    };
+
+    [Fact]
+    public void GetTile_inPixels_returns_null_when_above_top_row()
+    {
+        var map = new Map(SimpleLayout);
+        var top = map.GetTile(1, 0) ?? throw new InvalidOperationException("Top tile was not found.");
+
+        var tile = map.GetTile(top.CenterX, -1f, true);
+
+        tile.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetTile_inPixels_wraps_negative_columns_like_reference_implementation()
+    {
+        var map = new Map(SimpleLayout);
+        var rowTile = map.GetTile(1, 1) ?? throw new InvalidOperationException("Row tile was not found.");
+        var expected = map.GetTile(map.Width - 1, rowTile.Row) ?? throw new InvalidOperationException("Expected tile was not found.");
+
+        var tile = map.GetTile(-1f, rowTile.CenterY, true);
+
+        tile.Should().BeSameAs(expected);
+    }
+}

--- a/Test/Blingo.PacMan.Tests/TileMathTests.cs
+++ b/Test/Blingo.PacMan.Tests/TileMathTests.cs
@@ -1,0 +1,41 @@
+using Blingo.PacMan.Core.Game;
+using FluentAssertions;
+using Xunit;
+
+namespace Blingo.PacMan.Tests;
+
+public sealed class TileMathTests
+{
+    [Theory]
+    [InlineData(-10f, 480, 0f)]
+    [InlineData(-0.1f, 320, 0f)]
+    public void ClampVerticalPosition_prevents_negative_values(float y, int mapHeight, float expected)
+    {
+        TileMath.ClampVerticalPosition(y, mapHeight).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(100f, 480)]
+    [InlineData(0f, 320)]
+    [InlineData(479f, 480)]
+    public void ClampVerticalPosition_preserves_in_bounds_values(float y, int mapHeight)
+    {
+        TileMath.ClampVerticalPosition(y, mapHeight).Should().Be(y);
+    }
+
+    [Theory]
+    [InlineData(480f, 480, 479f)]
+    [InlineData(960f, 480, 479f)]
+    [InlineData(1000f, 1, 0f)]
+    public void ClampVerticalPosition_caps_at_bottom_edge(float y, int mapHeight, float expected)
+    {
+        TileMath.ClampVerticalPosition(y, mapHeight).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ClampVerticalPosition_returns_original_when_height_is_not_positive()
+    {
+        TileMath.ClampVerticalPosition(25f, 0).Should().Be(25f);
+        TileMath.ClampVerticalPosition(25f, -10).Should().Be(25f);
+    }
+}


### PR DESCRIPTION
## Summary
- allow ghosts to fall back to reversing direction when every forward option is blocked so they keep moving inside the maze
- add a focused unit test that reproduces a dead-end scenario using a minimal map layout to guard the new behaviour
- let the Pac-Man test helper accept custom layouts to support the new scenario
- align Pac-Man's pixel-to-tile lookups with the JavaScript implementation so ghosts cannot drift through the top wall and stall outside the maze
- add regression tests covering pixel lookups that sit just outside the maze bounds and along wrapped tunnels

## Testing
- dotnet test Test/Blingo.PacMan.Tests/Blingo.PacMan.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68dbe63f83188332a80e1c0f5ba2cf96