### PR TITLE
Align ghost global mode handling with JavaScript logic

### DIFF
--- a/Demo/LPacMan/Blingo.PacMan.Core/Game/PMGhostManager.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Game/PMGhostManager.cs
@@ -17,6 +17,7 @@ namespace Blingo.PacMan.Core.Game
     {
         private static MrGhost[] _ghostNames = new[] { MrGhost.Blinky, MrGhost.Pinky, MrGhost.Inky, MrGhost.Sue };
         private GhostSettings? _ghostSettings;
+        private GhostMode? _currentGlobalMode;
         private static readonly int[] _ghostScoreChain = { 200, 400, 800, 1_600 };
         private readonly List<PMGhostBehavior> _ghosts = new();
         private readonly struct GhostHouseSetup
@@ -58,6 +59,8 @@ namespace Blingo.PacMan.Core.Game
                 return;
             _ghosts.Add(ghost);
             ApplyConfiguration(ghost);
+            if (_currentGlobalMode is { } mode)
+                ghost.SetGlobalMode(mode);
         }
         
         public int RegisterGhostEaten()
@@ -88,6 +91,20 @@ namespace Blingo.PacMan.Core.Game
 
             foreach (var ghost in _ghosts)
                 ghost.SetMode(mode);
+        }
+
+        /// <summary>
+        /// Mirrors the JavaScript global mode listener by updating the stored mode used when ghosts exit their current state.
+        /// </summary>
+        public void SetGlobalMode(GhostMode? mode)
+        {
+            if (mode is null || mode == GhostMode.Unknown)
+                return;
+
+            _currentGlobalMode = mode;
+
+            foreach (var ghost in _ghosts)
+                ghost.SetGlobalMode(mode.Value);
         }
         public bool HasDeathGhosts()=> _ghosts.Any(g => g.IsDead);
         public bool HasFrightenedGhosts()=> _ghosts.Any(g => g.IsFrightened);

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/PMGameBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/PMGameBehavior.cs
@@ -53,7 +53,7 @@ internal sealed class PMGameBehavior : BlingoSpriteBehavior,
     public void BeginSprite()
     {
         _globals.GameBehavior = this;
-        _modeSubscription ??= Model.SubscribeModeChanged(mode => _globals.GhostManager.SetMode(mode));
+        _modeSubscription ??= Model.SubscribeModeChanged(mode => _globals.GhostManager.SetGlobalMode(mode));
         if (_initialized)
             return;
         _gameBG = Sprite(PCSpriteNums.GameBG);
@@ -186,8 +186,8 @@ internal sealed class PMGameBehavior : BlingoSpriteBehavior,
         if (State.IsPaused)
             return;
 
-        //if (State.StartCountdown <= 0)
-          //  Model.UpdateMode();
+        if (State.StartCountdown <= 0)
+            Model.UpdateMode();
 
         if (State.WaitForPauseTick())
             return;

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/PMGhostBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/PMGhostBehavior.cs
@@ -345,6 +345,11 @@ internal sealed class PMGhostBehavior : BlingoSpriteBehavior,
         _character!.Update();
     }
 
+    internal void SetGlobalMode(GhostMode mode)
+    {
+        _globalMode = mode;
+    }
+
     public void SetMode(GhostMode? mode)
     {
         if (mode is null || mode == GhostMode.Unknown)
@@ -414,7 +419,6 @@ internal sealed class PMGhostBehavior : BlingoSpriteBehavior,
                 _turnBack = true;
             }
 
-            _globalMode = mode.Value;
             if (_mode == GhostMode.Frightened)
                 NotifyModeFrightenedExited();
             _character!.Mode = mode.Value;


### PR DESCRIPTION
## Summary
- track the latest global ghost mode in the manager so new ghosts inherit it and mirror the JavaScript event listener
- allow individual ghost behaviors to store the global mode separately from their active mode, preventing in-house ghosts from switching early
- wire the gameplay behavior to the new global mode updater instead of forcing immediate mode changes

## Testing
- dotnet test Test/Blingo.PacMan.Tests/Blingo.PacMan.Tests.csproj *(fails: BlPacManGhostBehavior type missing in test project)*

------
https://chatgpt.com/codex/tasks/task_e_68de50f4487c8332a3e27b5308ca619c