### PR TITLE
Update go to conversion to use lowercase movie alias

### DIFF
--- a/Test/BlingoEngine.Legacy.Lingo.Tests/BlLegacyClassGeneratorTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/BlLegacyClassGeneratorTests.cs
@@ -108,7 +108,16 @@ public class MyParentParent : BlingoParentScript
         const string source = "on exitFrame me\n  go to the frame\nend";
         var code = _generator.GenerateClass("Stopper", source, BlLingoScriptKind.Behavior);
 
-        Assert.Contains("_Movie.GoTo(_Movie.CurrentFrame);", code);
+        Assert.Contains("_movie.GoTo(_movie.CurrentFrame);", code);
+    }
+
+    [Fact]
+    public void GoToLabel_UsesLowercaseMovieField()
+    {
+        const string source = "on exitFrame\n  go to \"Game\"\nend";
+        var code = _generator.GenerateClass("Navigator", source, BlLingoScriptKind.Behavior);
+
+        Assert.Contains("_movie.GoTo(\"Game\");", code);
     }
 
     [Fact]

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
@@ -263,6 +263,7 @@ public sealed class BlLegacyExpressionConverter
                 TryHandleScriptInstantiation() ||
                 TryHandleValueFunction() ||
                 TryHandleAlertCommand() ||
+                TryHandleGoToMovieNavigation() ||
                 TryHandleGoToCurrentFrame() ||
                 TryHandleMemberTypedAccess() ||
                 TryHandleListLiteral() ||
@@ -469,6 +470,68 @@ public sealed class BlLegacyExpressionConverter
         return true;
     }
 
+    private bool TryHandleGoToMovieNavigation()
+    {
+        if (_index >= _tokens.Count || !IsIdentifier(_tokens[_index], "go"))
+        {
+            return false;
+        }
+
+        if (_index + 1 >= _tokens.Count || !IsIdentifier(_tokens[_index + 1], "to"))
+        {
+            return false;
+        }
+
+        var argumentStart = _index + 2;
+        if (argumentStart >= _tokens.Count)
+        {
+            return false;
+        }
+
+        if (IsIdentifier(_tokens[argumentStart], "the"))
+        {
+            argumentStart++;
+            if (argumentStart >= _tokens.Count)
+            {
+                return false;
+            }
+        }
+
+        if (IsIdentifier(_tokens[argumentStart], "frame"))
+        {
+            var nextIndex = argumentStart + 1;
+            if (nextIndex >= _tokens.Count || ContainsNewLine(_tokens[nextIndex].LeadingTrivia))
+            {
+                return false;
+            }
+
+            var nextToken = _tokens[nextIndex];
+            if (IsValueToken(nextToken))
+            {
+                argumentStart = nextIndex;
+            }
+        }
+
+        if (argumentStart >= _tokens.Count)
+        {
+            return false;
+        }
+
+        var argumentTokens = BlLegacyHandlerTokenUtilities.SliceTokens(_tokens, argumentStart, _tokens.Count - argumentStart);
+        var argumentExpression = Convert(argumentTokens);
+        if (string.IsNullOrWhiteSpace(argumentExpression))
+        {
+            return false;
+        }
+
+        AppendRaw("_movie.GoTo(");
+        AppendRaw(argumentExpression);
+        AppendRaw(")");
+        _index = argumentStart + argumentTokens.Count;
+        _afterDot = false;
+        return true;
+    }
+
     private bool TryHandleGoToCurrentFrame()
     {
         if (_index >= _tokens.Count || !IsIdentifier(_tokens[_index], "go"))
@@ -499,7 +562,7 @@ public sealed class BlLegacyExpressionConverter
             return false;
         }
 
-        AppendRaw("_Movie.GoTo(_Movie.CurrentFrame)");
+        AppendRaw("_movie.GoTo(_movie.CurrentFrame)");
         _index += lookahead;
         _afterDot = false;
         return true;
@@ -860,6 +923,14 @@ public sealed class BlLegacyExpressionConverter
     {
         return token.Kind is BlSyntaxKind.IdentifierToken or BlSyntaxKind.KeywordToken &&
             string.Equals(token.ValueText, value, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsValueToken(BlSyntaxToken token)
+    {
+        return token.Kind is BlSyntaxKind.NumberToken or
+            BlSyntaxKind.StringLiteralToken or
+            BlSyntaxKind.IdentifierToken or
+            BlSyntaxKind.SymbolToken;
     }
 
     private static bool ContainsNewLine(IReadOnlyList<BlSyntaxTrivia> trivia)

--- a/src/BlingoEngine/Core/BlingoScriptBase.cs
+++ b/src/BlingoEngine/Core/BlingoScriptBase.cs
@@ -58,6 +58,7 @@ namespace BlingoEngine.Core
         /// Retrieves the current movie
         /// </summary>
         protected IBlingoMovie _Movie => _env.Movie;
+        protected IBlingoMovie _movie => _Movie;
         protected IBlingoSystem _System => _env.System;
 
         #endregion


### PR DESCRIPTION
## Summary
- update the legacy expression converter so `go to` commands emit `_movie.GoTo(...)`
- expose a lowercase `_movie` alias on `BlingoScriptBase` for generated code
- extend the legacy generator tests to cover the new casing

## Testing
- dotnet test Test/BlingoEngine.Legacy.Lingo.Tests/BlingoEngine.Legacy.Lingo.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68dfa6d665908332a83f5a02503be006