### PR TITLE
Fix boolean operator translation in Lingo converter

### DIFF
--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
@@ -877,6 +877,18 @@ public sealed class BlLegacyExpressionConverter
             return;
         }
 
+        if (string.Equals(op, "or", StringComparison.OrdinalIgnoreCase))
+        {
+            AppendRaw("||");
+            return;
+        }
+
+        if (string.Equals(op, "and", StringComparison.OrdinalIgnoreCase))
+        {
+            AppendRaw("&&");
+            return;
+        }
+
         AppendRaw(op);
     }
 


### PR DESCRIPTION
## Summary
- map the legacy Lingo logical operators `or` and `and` to their C# counterparts when emitting code
- keep existing handling for other special operators in the expression converter

## Testing
- dotnet test Test/BlingoEngine.Legacy.Lingo.Tests/BlingoEngine.Legacy.Lingo.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68dfaa204c588332a9d16f9bd58c1350