### PR TITLE
Handle case-insensitive property format parsing in legacy converter

### DIFF
--- a/WillMoveToOwnRepo/Old/OldBlingoEngine.Lingo.Core.Tests/BlingoToCSharpConverterTests.cs
+++ b/WillMoveToOwnRepo/Old/OldBlingoEngine.Lingo.Core.Tests/BlingoToCSharpConverterTests.cs
@@ -1398,6 +1398,43 @@ end",
     }
 
     [Fact]
+    public void PropertyDescriptionFormatsSetPropertyTypesInBatch()
+    {
+        var scripts = new[]
+        {
+            new BlingoScriptFile
+            {
+                Name = "FormatScript",
+                Source = @"property myFunction, mySpriteNum, myVar1, myVar2, myEnableMouseClick, myRollOverMember, myRollOverColor
+on getPropertyDescriptionList
+  description = [:]
+  addProp description,#myFunction, [#default:0, #format:#symbol, #comment:""Function:""]
+  addProp description,#mySpriteNum, [#default:4, #format:#integer, #comment:""Sprite Num:""]
+  addProp description,#myVar1, [#default:0, #format:#integer, #comment:""Var 1:""]
+  addProp description,#myVar2, [#default:0, #format:#float, #comment:""Var 2:""]
+  addProp description,#myEnableMouseClick, [#default:true, #format:#boolean, #comment:""Enable Mouseclick:""]
+  addProp description,#myRollOverMember, [#default:0, #format:#string, #comment:""Rollover member:""]
+  addProp description,#myRollOverColor, [#default:rgb(1,2,3), #format:#color, #comment:""Rollover color:""]
+  return description
+end",
+                Type = BlingoScriptType.Behavior
+            }
+        };
+
+        var batch = _converter.Convert(scripts);
+        Assert.True(batch.Properties.ContainsKey("FormatScript"));
+        var propertyTypes = batch.Properties["FormatScript"].ToDictionary(p => p.Name, p => p.Type, StringComparer.OrdinalIgnoreCase);
+
+        Assert.Equal("string", propertyTypes["myFunction"]);
+        Assert.Equal("int", propertyTypes["mySpriteNum"]);
+        Assert.Equal("int", propertyTypes["myVar1"]);
+        Assert.Equal("float", propertyTypes["myVar2"]);
+        Assert.Equal("bool", propertyTypes["myEnableMouseClick"]);
+        Assert.Equal("string", propertyTypes["myRollOverMember"]);
+        Assert.Equal("AColor", propertyTypes["myRollOverColor"]);
+    }
+
+    [Fact]
     public void RefreshCaseIsConverted()
     {
         var lingo = @"on refresh me

--- a/WillMoveToOwnRepo/Old/OldBlingoEngine.Lingo.Core.Tests/ClassGenerationTests.cs
+++ b/WillMoveToOwnRepo/Old/OldBlingoEngine.Lingo.Core.Tests/ClassGenerationTests.cs
@@ -332,6 +332,38 @@ end",
     }
 
     [Fact]
+    public void PropertyDescriptionFormatsDefinePropertyTypes()
+    {
+        var file = new BlingoScriptFile
+        {
+            Name = "FormatTypes",
+            Source = @"property myFunction, mySpriteNum, myVar1, myVar2, myEnableMouseClick, myRollOverMember, myRollOverColor
+on getPropertyDescriptionList
+  description = [:]
+  addProp description,#myFunction, [#default:0, #format:#symbol, #comment:""Function:""]
+  addProp description,#mySpriteNum, [#default:4, #format:#integer, #comment:""Sprite Num:""]
+  addProp description,#myVar1, [#default:0, #format:#integer, #comment:""Var 1:""]
+  addProp description,#myVar2, [#default:0, #format:#float, #comment:""Var 2:""]
+  addProp description,#myEnableMouseClick, [#default:true, #format:#boolean, #comment:""Enable Mouseclick:""]
+  addProp description,#myRollOverMember, [#default:0, #format:#string, #comment:""Rollover member:""]
+  addProp description,#myRollOverColor, [#default:rgb(1,2,3), #format:#color, #comment:""Rollover color:""]
+  return description
+end",
+            Type = BlingoScriptType.Behavior
+        };
+
+        var result = _converter.ConvertClass(file);
+
+        Assert.Contains("public string myFunction { get; set; } = \"0\";", result);
+        Assert.Contains("public int mySpriteNum { get; set; } = 4;", result);
+        Assert.Contains("public int myVar1 { get; set; } = 0;", result);
+        Assert.Contains("public float myVar2 { get; set; } = 0;", result);
+        Assert.Contains("public bool myEnableMouseClick { get; set; } = true;", result);
+        Assert.Contains("public string myRollOverMember { get; set; } = \"0\";", result);
+        Assert.Contains("public AColor myRollOverColor { get; set; } = AColor.FromCode(1,2,3);", result);
+    }
+
+    [Fact]
     public void AppendInfersBlingoList()
     {
         var file = new BlingoScriptFile

--- a/WillMoveToOwnRepo/Old/OldBlingoEngine.Lingo.Core/BlingoToCSharpConverter.cs
+++ b/WillMoveToOwnRepo/Old/OldBlingoEngine.Lingo.Core/BlingoToCSharpConverter.cs
@@ -614,9 +614,9 @@ public class BlingoToCSharpConverter
         {
             var name = m.Groups["name"].Value;
             var body = m.Groups["body"].Value;
-            var defMatch = Regex.Match(body, @"#default:(?<val>[^#\]]+)");
-            var fmtMatch = Regex.Match(body, @"#format:#(?<fmt>\w+)");
-            var commentMatch = Regex.Match(body, @"#comment:""(.*?)""", RegexOptions.Singleline);
+            var defMatch = Regex.Match(body, @"#default\s*:\s*(?<val>[^,\]]+)", RegexOptions.IgnoreCase);
+            var fmtMatch = Regex.Match(body, @"#format\s*:\s*#(?<fmt>\w+)", RegexOptions.IgnoreCase);
+            var commentMatch = Regex.Match(body, @"#comment\s*:\s*""(.*?)""", RegexOptions.IgnoreCase | RegexOptions.Singleline);
             var def = defMatch.Success ? defMatch.Groups["val"].Value.Trim().TrimEnd(',') : "0";
             var fmt = fmtMatch.Success ? fmtMatch.Groups["fmt"].Value.Trim().ToLowerInvariant() : string.Empty;
             if (Regex.IsMatch(def, @"(?i)rgb\s*\((.+)\)"))


### PR DESCRIPTION
## Summary
- relax parsing of property description metadata so `#format`, `#default`, and `#comment` tags are detected even with varied casing
- allow symbol defaults to be captured by stopping at commas or closing brackets when extracting `#default` values
- add regression tests verifying property description formats drive the expected generated C# property types

## Testing
- `dotnet test WillMoveToOwnRepo/Old/OldBlingoEngine.Lingo.Core.Tests/OldBlingoEngine.Lingo.Core.Tests.csproj` *(fails: missing OldBlingoEngine references in the legacy test project)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb209db288332bd33a4e597d19767